### PR TITLE
[xpcc] Acknowledge responses based on entry list

### DIFF
--- a/src/modm/communication/xpcc/dispatcher.hpp.in
+++ b/src/modm/communication/xpcc/dispatcher.hpp.in
@@ -50,7 +50,7 @@ namespace xpcc
 
 	private:
 		/// Does not handle requests which are not acknowledge.
-		void
+		bool
 		handlePacket(const Header& header, const modm::SmartPointer& payload);
 
 		/// Sends messages which are waiting in the list.


### PR DESCRIPTION
When using the DynamicPostman for sending requests but without ever
registering an action with it, `Postman::isComponentAvailable()` always
returns `false`. The Dispatcher then cannot acknowledge any responses,
and they time out on the remote component.
This has been changed to also check if the response is expected in the entry list.