### PR TITLE
[system_design] Implement array types for C++

### DIFF
--- a/tools/system_design/builder/templates/robot_packets.hpp.tpl
+++ b/tools/system_design/builder/templates/robot_packets.hpp.tpl
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include <cstdlib>
+#include <cstring>
 #include <modm/io/iostream.hpp>
 #include <modm/container/smart_pointer.hpp>
 
@@ -90,12 +91,12 @@ namespace {{ namespace }}
 	{% elif packet.isStruct %}
 		struct {{ packet.name | typeName }}
 		{
-			constexpr {{ packet.flattened() | generateConstructor }}:
+			{{ packet.flattened() | generateConstructor }}
 				{{ packet.flattened() | generateInitializationList }} {}
 
 			{% if packet.flattened().size > 0 -%}
-			constexpr {{ packet.flattened() | generateConstructor(default=False) }} :
-				{{ packet.flattened() | generateInitializationList(default=False) }} {}
+			{{ packet.flattened() | generateConstructor(default=False) }}
+				{{ packet.flattened() | generateInitializationList(default=False) }} { {{ packet.flattened() | generateArrayCopyCode(default=False) }} }
 			{%- endif %}
 			{% for element in packet.flattened().iter() %}
 			{%- if element.description %}


### PR DESCRIPTION
This adds a C++ implementation for arrays in packet definitions.
The constructor uses a `memcpy` analog to how all other constructors copy the data.
Maybe I need to implement the copy constructor as well for when a packet with arrays is used within another packet?

cc @dergraaf @georgi-g 