### PR TITLE
Cloning modm fails

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,15 @@
 [submodule "ext/st/stm32"]
 	path = ext/st/stm32
 	url = https://github.com/modm-io/cmsis-header-stm32.git
-	shallow = true
 [submodule "ext/modm-devices"]
 	path = ext/modm-devices
 	url = https://github.com/modm-io/modm-devices.git
-	shallow = true
 [submodule "ext/dlr/scons-build-tools"]
 	path = ext/dlr/scons-build-tools
 	url = https://github.com/modm-io/scons-build-tools.git
-	shallow = true
 [submodule "ext/ros/ros_lib"]
 	path = ext/ros/ros_lib
 	url = https://github.com/modm-io/xpcc_ros_lib.git
-	shallow = true
 [submodule "ext/arm/cmsis"]
 	path = ext/arm/cmsis
 	url = https://github.com/modm-io/CMSIS_5.git


### PR DESCRIPTION
Cloning this repository with `--recurse-submodules` or initializing the `modm-devices` submodule (`git submodule update --init ext/modm-devices`) fails:
```
error: Server does not allow request for unadvertised object df93200271cf554747a596274a90b6debc00c273
Fetched in submodule path 'ext/modm-devices', but it did not contain df93200271cf554747a596274a90b6debc00c273. Direct fetching of that commit failed.
```

Another option, other than updating the submodule every time, is to [revert `shallow = true`](https://github.com/modm-io/modm/commit/76c1a4e906ffc48d56b4ccf38fe21c2cd03c9270).