### PR TITLE
[driver] SPI BitBangSpiMaster: Fix acquire()

### DIFF
--- a/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
@@ -94,7 +94,7 @@ template <typename Sck, typename Mosi, typename Miso>
 uint8_t
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::acquire(void *ctx, ConfigurationHandler handler)
 {
-	if (ctx == nullptr)
+	if (context == nullptr)
 	{
 		context = ctx;
 		count = 1;


### PR DESCRIPTION
In commit ff0823abdced91817a3af520cd87cbd5683e42ea the `SoftwareSpiMaster`/`BitBangSpiMaster` implementation was not fixed :unamused: 

```diff
[...]::acquire(void *ctx, ConfigurationHandler handler)
{
-	if (ctx == nullptr)
+	if (context == nullptr)
```