### PR TITLE
Enable C11 and C++17 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!--/webignore-->
 
 modm (Modular Object-oriented Development for Microcontrollers) is a toolbox for
-building custom C++14 libraries tailored to your embedded device.
+building custom C++17 libraries tailored to your embedded device.
 modm generates startup code, HALs and their implementations, communication
 protocols, drivers for external devices, BSPs, etc… in a modular, customizable
 process that you can fine-tune to your needs.
@@ -45,7 +45,7 @@ git clone --recursive https://github.com/modm-io/modm.git
 
 ## Features
 
-- Efficient and fast object-oriented C++14 API.
+- Efficient and fast object-oriented C++17 API.
 - Support for hundreds of AVR and ARM Cortex-M microcontrollers from Atmel and ST.
 - Build system agnostic: We use SCons by default, but you don't have to.
 - Data-driven HAL generation using the library-builder engine.

--- a/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake
+++ b/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake
@@ -102,7 +102,7 @@ SET(CXX_LANG_FLAGS "\
     -fno-threadsafe-statics \
     -fuse-cxa-atexit \
     -Woverloaded-virtual \
-    -std=c++14")
+    -std=c++17")
 
 SET(LINK_FLAGS "\
     -Llink \

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -112,6 +112,7 @@ def post_build(env, buildlog):
     env.substitutions = {
         "partname": target.partname,
         "platform": platform,
+        "family": family,
         "compiler": "llvm" if family == "darwin" else "gcc",
         "core": core,
         "files": files_to_build,

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -31,7 +31,8 @@ env = Environment(
 %% endfor
             ],
         CPU="{{ core }}",
-        CFLAGS_language=["-std=gnu99"],
+        CFLAGS_language=["-std=gnu11"],
+        CXXFLAGS_language=["-std=c++17", "-fno-exceptions", "-fno-rtti"],
         LINKFLAGS_optimize=[
             "-Wl,--relax",
             "-Wl,--gc-sections",
@@ -68,7 +69,8 @@ env.Append(LINKFLAGS_target=[
             "-mmcu={{ partname }}",
             "-DF_CPU=${CONFIG_CLOCK_F_CPU}"
             ],
-        CFLAGS_language=["-std=gnu99"],
+        CFLAGS_language=["-std=gnu11"],
+        CXXFLAGS_language=["-std=c++17", "-fno-exceptions", "-fno-rtti"],
         LINKFLAGS_other=[
             "-Wl,--fatal-warnings",
             ],
@@ -94,9 +96,12 @@ env.Append(LINKFLAGS_target=[
             "{{tool}}",
 %% endfor
             ],
-        CXXFLAGS_language=[
-            "-std=c++14",
-            ],
+        CFLAGS_language=["-std=gnu11"],
+%% if family in ["darwin"]
+        CXXFLAGS_language=["-std=c++1z"], # for clang 4 or earlier
+%% else
+        CXXFLAGS_language=["-std=c++17"],
+%% endif
         ENV=os.environ)
 %% endif
 %# ============================================================================


### PR DESCRIPTION
Let's use some modern standards. 

- C11 requires at least GCC 4.9  (we already require GCC 5 anyways).
- C++17 requires at least GCC 7.

Closes #18. See issue for discussion on compiler availability.
cc @rleh @siy @dergraaf @strongly-typed 