### PR TITLE
[test] SpiMasterMock for device driver unittests

### DIFF
--- a/test/modm/driver/module.lb
+++ b/test/modm/driver/module.lb
@@ -26,6 +26,7 @@ def prepare(module, options):
         ":driver:lawicel",
         ":driver:ltc2984",
         ":driver:mcp2515",
+        "modm:test:platform:spi",
         ":platform:gpio")
     return True
 

--- a/test/modm/driver/temperature/ltc2984_test.hpp
+++ b/test/modm/driver/temperature/ltc2984_test.hpp
@@ -18,4 +18,7 @@ public:
 
 	void
 	testDataTemperature();
+
+	void
+	testSpi();
 };

--- a/test/modm/platform/spi/mock/module.lb
+++ b/test/modm/platform/spi/mock/module.lb
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = "spi"
+    module.parent = "test:platform"
+
+def prepare(module, options):
+    module.depends(
+		"modm:architecture:spi",
+        "modm:container")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/test/modm/platform/spi/mock"
+    env.copy("spi_master.hpp")
+    env.copy("spi_master.cpp")

--- a/test/modm/platform/spi/mock/spi_master.cpp
+++ b/test/modm/platform/spi/mock/spi_master.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "spi_master.hpp"
+
+uint8_t
+modm::platform::SpiMasterMock::count = 0;
+
+void *
+modm::platform::SpiMasterMock::context = nullptr;
+
+modm::Spi::ConfigurationHandler
+modm::platform::SpiMasterMock::configuration = nullptr;
+
+modm::Spi::DataMode
+modm::platform::SpiMasterMock::dataMode = modm::Spi::DataMode::Mode0;
+
+modm::Spi::DataOrder
+modm::platform::SpiMasterMock::dataOrder = modm::Spi::DataOrder::MsbFirst;
+
+modm::DoublyLinkedList<uint8_t>
+modm::platform::SpiMasterMock::txBuffer;
+
+modm::DoublyLinkedList<uint8_t>
+modm::platform::SpiMasterMock::rxBuffer;
+
+uint8_t
+modm::platform::SpiMasterMock::tmp = 0;
+
+uint8_t
+modm::platform::SpiMasterMock::acquire(void *ctx, ConfigurationHandler handler)
+{
+	if (context == nullptr)
+	{
+		context = ctx;
+		count = 1;
+		// if handler is not nullptr and is different from previous configuration
+		if (handler and configuration != handler) {
+			configuration = handler;
+			configuration();
+		}
+		return 1;
+	}
+
+	if (ctx == context)
+		return ++count;
+
+	return 0;
+}
+
+uint8_t
+modm::platform::SpiMasterMock::release(void *ctx)
+{
+	if (ctx == context)
+	{
+		if (--count == 0)
+			context = nullptr;
+	}
+	return count;
+}
+// ----------------------------------------------------------------------------
+
+modm::ResumableResult<uint8_t>
+modm::platform::SpiMasterMock::transfer(uint8_t data)
+{
+	txBuffer.append(data);
+
+	if(!rxBuffer.isEmpty()) {
+		tmp = rxBuffer.getFront();
+		rxBuffer.removeFront();
+	}
+	else {
+		tmp = 0;
+	}
+
+	return {modm::rf::Stop, tmp};
+}
+
+modm::ResumableResult<void>
+modm::platform::SpiMasterMock::transfer(uint8_t * tx, uint8_t * rx, std::size_t length)
+{
+	for(std::size_t i = 0; i < length; ++i) {
+		//if(tx != nullptr)
+		//	txVector.push_back(tx[i]);
+
+		//txBuffer.append(tx != nullptr ? tx[i] : 0);
+
+		if(tx != nullptr) {
+			txBuffer.append(tx[i]);
+		}
+		else {
+			txBuffer.append(0);
+		}
+
+		if(rx != nullptr) {
+			if(!rxBuffer.isEmpty()) {
+				rx[i] = rxBuffer.getFront();
+			}
+			else {
+				rx[i] = 0;
+			}
+		}
+		if(!rxBuffer.isEmpty()) {
+			rxBuffer.removeFront();
+		}
+	}
+
+	return {modm::rf::Stop};
+}

--- a/test/modm/platform/spi/mock/spi_master.hpp
+++ b/test/modm/platform/spi/mock/spi_master.hpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_TEST_MOCK_SPI_MASTER_HPP
+#define MODM_TEST_MOCK_SPI_MASTER_HPP
+
+#include <modm/architecture/interface/spi_master.hpp>
+#include <modm/container/doubly_linked_list.hpp>
+
+namespace modm
+{
+
+namespace platform
+{
+
+/**
+ * Mock serial peripheral interface for unittests.
+ *
+ * @author	Raphael Lehmann
+ * @ingroup	test
+ */
+class SpiMasterMock : public modm::SpiMaster
+{
+private:
+	static uint8_t count;
+	static void* context;
+	static ConfigurationHandler configuration;
+
+	static DataMode dataMode;
+	static DataOrder dataOrder;
+
+public:
+	using ArrayContainer = modm::DoublyLinkedList<uint8_t>;
+
+private:
+	static ArrayContainer rxBuffer;
+	static ArrayContainer txBuffer;
+
+	static uint8_t tmp;
+
+public:
+	static void
+	initialize()
+	{
+	}
+
+	static void
+	setDataMode(DataMode mode)
+	{
+		dataMode = mode;
+	}
+
+	static void
+	setDataOrder(DataOrder order)
+	{
+		dataOrder = order;
+	}
+
+
+	static uint8_t
+	acquire(void *ctx, ConfigurationHandler handler = nullptr);
+
+	static uint8_t
+	release(void *ctx);
+
+
+	static uint8_t
+	transferBlocking(uint8_t data)
+	{
+		return RF_CALL_BLOCKING(transfer(data));
+	}
+
+	static void
+	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	{
+		RF_CALL_BLOCKING(transfer(tx, rx, length));
+	}
+
+
+	static modm::ResumableResult<uint8_t>
+	transfer(uint8_t data);
+
+	static modm::ResumableResult<void>
+	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+
+public:
+	static std::size_t getTxBufferLength() {
+		return txBuffer.getSize();
+	}
+
+	static void popTxBuffer(uint8_t* buf)
+	{
+		std::size_t j = 0;
+		for(ArrayContainer::iterator i = txBuffer.begin(); i != txBuffer.end(); ++i) {
+			buf[j++] = (*i);
+		}
+		while(txBuffer.getSize() > 0) {
+			txBuffer.removeFront();
+		}
+	}
+	static void appendRxBuffer(uint8_t* data, std::size_t length)
+	{
+		for(std::size_t i = 0; i < length; ++i) {
+			rxBuffer.append(data[i]);
+		}
+	}
+};
+
+} // namespace platform
+
+} // namespace modm
+
+#endif // MODM_TEST_MOCK_SPI_MASTER_HPP


### PR DESCRIPTION
To be able to test drivers for external peripherals connected via SPI to the microcontroller I propose `SpiMasterMock`.

`SpiMasterMock` utilizes the same interface as all *SpiMaster*-implementations (`BitBangSpiMaster`, `SpiMasterX`, ...), has no hardware dependencies and buffers the data sent from the device driver.

Unittests can access the buffer using
```C++
std::size_t length = SpiMasterMock::getTxBufferLength();

uint8_t buffer[length];
SpiMasterMock::popTxBuffer(buffer);
```
and compare it to the expected byte-sequence.

Additionally the unittest may inject data that the device driver reads from *SpiMasterMock*:
```C++
uint8_t buffer[] = {0x80, 0xFF, 0x00, 0x42};
SpiMasterMock::appendRxBuffer(buffer, 4);
```
---
As an example the unittest for the Ltc2984 driver is extended.