### PR TITLE
Add DRV832x driver

### DIFF
--- a/src/modm/driver/motor/drv832x_spi.cpp
+++ b/src/modm/driver/motor/drv832x_spi.cpp
@@ -1,0 +1,214 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "drv832x_spi.hpp"
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::FaultStatus1_t& c) {
+	os << "FaultStatus1(";
+	if(c & drv832xSpi::FaultStatus1::Fault)
+		os << "Fault ";
+	if(c & drv832xSpi::FaultStatus1::GateDriveFault)
+		os << "GateDriveFault ";
+	if(c & drv832xSpi::FaultStatus1::OvertemperatureShutdown)
+		os << "OvertemperatureShutdown ";
+	if(c & drv832xSpi::FaultStatus1::UndervoltageLockout)
+		os << "UndervoltageLockout ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentFault)
+		os << "VdsOvercurrentFault ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentHA)
+		os << "VdsOvercurrentHA ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentLA)
+		os << "VdsOvercurrentLA ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentHB)
+		os << "VdsOvercurrentHB ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentLB)
+		os << "VdsOvercurrentLB ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentHC)
+		os << "VdsOvercurrentHC ";
+	if(c & drv832xSpi::FaultStatus1::VdsOvercurrentLC)
+		os << "VdsOvercurrentLC ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::VgsStatus2_t& c) {
+	os << "VgsStatus2(";
+	if(c & drv832xSpi::VgsStatus2::ChargePumpUndervoltageFault)
+		os << "ChargePumpUndervoltageFault ";
+	if(c & drv832xSpi::VgsStatus2::OvertemperatureWarning)
+		os << "OvertemperatureWarning ";
+	if(c & drv832xSpi::VgsStatus2::SenseAOvercurrent)
+		os << "SenseAOvercurrent ";
+	if(c & drv832xSpi::VgsStatus2::SenseBOvercurrent)
+		os << "SenseBOvercurrent ";
+	if(c & drv832xSpi::VgsStatus2::SenseCOvercurrent)
+		os << "SenseCOvercurrent ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultHA)
+		os << "VgsGateDriveFaultHA ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultHB)
+		os << "VgsGateDriveFaultHB ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultHC)
+		os << "VgsGateDriveFaultHC ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultLA)
+		os << "VgsGateDriveFaultLA ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultLB)
+		os << "VgsGateDriveFaultLB ";
+	if(c & drv832xSpi::VgsStatus2::VgsGateDriveFaultLC)
+		os << "VgsGateDriveFaultLC ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::DriverControl_t& c) {
+	os << "DriverControl(";
+	if(c & drv832xSpi::DriverControl::Brake)
+		os << "Brake ";
+	if(c & drv832xSpi::DriverControl::ClearFaultBits)
+		os << "ClearFaultBits ";
+	if(c & drv832xSpi::DriverControl::Coast)
+		os << "Coast ";
+	if(c & drv832xSpi::DriverControl::DisableChargePumpUVLO)
+		os << "DisableChargePumpUVLO ";
+	if(c & drv832xSpi::DriverControl::DisableGateDriveFault)
+		os << "DisableGateDriveFault ";
+	if(c & drv832xSpi::DriverControl::OvertemperatureReport)
+		os << "OvertemperatureReport ";
+	if(c & drv832xSpi::DriverControl::Pwm1Com)
+		os << "Pwm1Com ";
+	if(c & drv832xSpi::DriverControl::Pwm1Dir)
+		os << "Pwm1Dir ";
+	if(c & drv832xSpi::DriverControl::PwmMode1)
+		os << "PwmMode1 ";
+	if(c & drv832xSpi::DriverControl::PwmMode2)
+		os << "PwmMode2 ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::GateDriveHS_t& c) {
+	os << "GateDriveHS(";
+	if(c & drv832xSpi::GateDriveHS::IDriveN0)
+		os << "IDriveN0 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveN1)
+		os << "IDriveN1 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveN2)
+		os << "IDriveN2 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveN3)
+		os << "IDriveN3 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveP0)
+		os << "IDriveP0 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveP1)
+		os << "IDriveP1 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveP2)
+		os << "IDriveP2 ";
+	if(c & drv832xSpi::GateDriveHS::IDriveP3)
+		os << "IDriveP3 ";
+	if(c & drv832xSpi::GateDriveHS::Lock0)
+		os << "Lock0 ";
+	if(c & drv832xSpi::GateDriveHS::Lock1)
+		os << "Lock1 ";
+	if(c & drv832xSpi::GateDriveHS::Lock2)
+		os << "Lock2 ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::GateDriveLS_t& c) {
+	os << "GateDriveLS(";
+	if(c & drv832xSpi::GateDriveLS::Cbc)
+		os << "Cbc ";
+	if(c & drv832xSpi::GateDriveLS::IDriveN0)
+		os << "IDriveN0 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveN1)
+		os << "IDriveN1 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveN2)
+		os << "IDriveN2 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveN3)
+		os << "IDriveN3 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveP0)
+		os << "IDriveP0 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveP1)
+		os << "IDriveP1 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveP2)
+		os << "IDriveP2 ";
+	if(c & drv832xSpi::GateDriveLS::IDriveP3)
+		os << "IDriveP3 ";
+	if(c & drv832xSpi::GateDriveLS::TDrive0)
+		os << "TDrive0 ";
+	if(c & drv832xSpi::GateDriveLS::TDrive1)
+		os << "TDrive1 ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::OcpControl_t& c) {
+	os << "OcpControl(";
+	if(c & drv832xSpi::OcpControl::Deadtime0)
+		os << "Deadtime0 ";
+	if(c & drv832xSpi::OcpControl::Deadtime1)
+		os << "Deadtime1 ";
+	if(c & drv832xSpi::OcpControl::OcpDeglitch0)
+		os << "OcpDeglitch0 ";
+	if(c & drv832xSpi::OcpControl::OcpDeglitch1)
+		os << "OcpDeglitch1 ";
+	if(c & drv832xSpi::OcpControl::OcpMode0)
+		os << "OcpMode0 ";
+	if(c & drv832xSpi::OcpControl::OcpMode1)
+		os << "OcpMode1 ";
+	if(c & drv832xSpi::OcpControl::TimeRetry)
+		os << "TimeRetry ";
+	if(c & drv832xSpi::OcpControl::VdsLevel0)
+		os << "VdsLevel0 ";
+	if(c & drv832xSpi::OcpControl::VdsLevel1)
+		os << "VdsLevel1 ";
+	if(c & drv832xSpi::OcpControl::VdsLevel2)
+		os << "VdsLevel2 ";
+	if(c & drv832xSpi::OcpControl::VdsLevel3)
+		os << "VdsLevel3 ";
+	os << ")";
+	return os;
+}
+
+modm::IOStream&
+modm::operator << (modm::IOStream& os, const drv832xSpi::CsaControl_t& c) {
+	os << "CsaControl(";
+	if(c & drv832xSpi::CsaControl::CsaCalibrationA)
+		os << "CsaCalibrationA ";
+	if(c & drv832xSpi::CsaControl::CsaCalibrationB)
+		os << "CsaCalibrationB ";
+	if(c & drv832xSpi::CsaControl::CsaCalibrationC)
+		os << "CsaCalibrationC ";
+	if(c & drv832xSpi::CsaControl::CsaFet)
+		os << "CsaFet ";
+	if(c & drv832xSpi::CsaControl::CsaGain0)
+		os << "CsaGain0 ";
+	if(c & drv832xSpi::CsaControl::CsaGain1)
+		os << "CsaGain1 ";
+	if(c & drv832xSpi::CsaControl::DisableOvercurrentSense)
+		os << "DisableOvercurrentSense ";
+	if(c & drv832xSpi::CsaControl::LowSideReference)
+		os << "LowSideReference ";
+	if(c & drv832xSpi::CsaControl::SenseOcpLevel0)
+		os << "SenseOcpLevel0 ";
+	if(c & drv832xSpi::CsaControl::SenseOcpLevel1)
+		os << "SenseOcpLevel1 ";
+	if(c & drv832xSpi::CsaControl::VrefDiv2)
+		os << "VrefDiv2 ";
+	os << ")";
+	return os;
+}

--- a/src/modm/driver/motor/drv832x_spi.hpp
+++ b/src/modm/driver/motor/drv832x_spi.hpp
@@ -1,0 +1,426 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_DRV832X_SPI_HPP
+#define MODM_DRV832X_SPI_HPP
+
+#include <modm/architecture/interface/spi_device.hpp>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/gpio.hpp>
+#include <modm/processing/resumable.hpp>
+
+namespace modm
+{
+
+struct drv832xSpi
+{
+	enum class
+	Register : uint16_t
+	{
+		FaultStatus1		= 0x0,
+		VgsStatus2			= 0x1,
+		DriverControl		= 0x2,
+		GateDriveHS			= 0x3,
+		GateDriveLS			= 0x4,
+		OcpControl			= 0x5,
+		CsaControl			= 0x6,
+	};
+
+	enum class FaultStatus1 : uint16_t
+	{
+		VdsOvercurrentLC	= Bit0,
+		VdsOvercurrentHC	= Bit1,
+		VdsOvercurrentLB	= Bit2,
+		VdsOvercurrentHB	= Bit3,
+		VdsOvercurrentLA	= Bit4,
+		VdsOvercurrentHA	= Bit5,
+		OvertemperatureShutdown	= Bit6,
+		UndervoltageLockout		= Bit7,
+		GateDriveFault		= Bit8,
+		VdsOvercurrentFault	= Bit9,
+		Fault				= Bit10,
+	};
+	MODM_FLAGS16(FaultStatus1);
+
+	enum class VgsStatus2 : uint16_t
+	{
+		VgsGateDriveFaultLC	= Bit0,
+		VgsGateDriveFaultHC	= Bit1,
+		VgsGateDriveFaultLB	= Bit2,
+		VgsGateDriveFaultHB	= Bit3,
+		VgsGateDriveFaultLA	= Bit4,
+		VgsGateDriveFaultHA	= Bit5,
+		ChargePumpUndervoltageFault	= Bit6,
+		OvertemperatureWarning		= Bit7,
+		SenseCOvercurrent	= Bit8,
+		SenseBOvercurrent	= Bit9,
+		SenseAOvercurrent	= Bit10,
+	};
+	MODM_FLAGS16(VgsStatus2);
+
+	enum class DriverControl : uint16_t
+	{
+		ClearFaultBits		= Bit0,
+		Brake				= Bit1,
+		Coast				= Bit2,
+		Pwm1Dir				= Bit3,
+		Pwm1Com				= Bit4,
+		PwmMode1			= Bit5,
+		PwmMode2			= Bit6,
+		OvertemperatureReport	= Bit7,
+		DisableGateDriveFault	= Bit8,
+		DisableChargePumpUVLO	= Bit9,
+	};
+	MODM_FLAGS16(DriverControl);
+
+	enum class PwmMode : uint16_t
+	{
+		PwmMode6x			= 0b00,
+		PwmMode3x			= 0b01,
+		PwmMode1x			= 0b10,
+		PwmModeIndependent	= 0b11,
+	};
+	using PwmMode_t = Configuration< DriverControl_t, PwmMode, 0b11, 5 >; // Bit 5..6
+
+	enum class GateDriveHS : uint16_t
+	{
+		IDriveN0	= Bit0,
+		IDriveN1	= Bit1,
+		IDriveN2	= Bit2,
+		IDriveN3	= Bit3,
+
+		IDriveP0	= Bit4,
+		IDriveP1	= Bit5,
+		IDriveP2	= Bit6,
+		IDriveP3	= Bit7,
+
+		Lock0		= Bit8,
+		Lock1		= Bit9,
+		Lock2		= Bit10,
+	};
+	MODM_FLAGS16(GateDriveHS);
+
+	enum class Lock : uint16_t
+	{
+		Lock		= 0b110,
+		Unlock		= 0b011,
+	};
+	typedef Configuration< GateDriveHS_t, Lock, 0b111, 8 >  Lock_t; // Bit 8..10
+
+	enum class GateDriveLS : uint16_t
+	{
+		IDriveN0	= Bit0,
+		IDriveN1	= Bit1,
+		IDriveN2	= Bit2,
+		IDriveN3	= Bit3,
+
+		IDriveP0	= Bit4,
+		IDriveP1	= Bit5,
+		IDriveP2	= Bit6,
+		IDriveP3	= Bit7,
+
+		TDrive0		= Bit8,
+		TDrive1		= Bit9,
+
+		Cbc			= Bit10,	/// Cbc: In retry OCP_MODE,for both VDS_OCP and SEN_OCP,
+								/// the fault is automatically cleared when a PWM input is given
+	};
+	MODM_FLAGS16(GateDriveLS);
+
+	enum class TDrive : uint16_t
+	{
+		ns500		= 0b00,
+		ns1000		= 0b01,
+		ns2000		= 0b10,
+		ns4000		= 0b11,
+	};
+	typedef Configuration< GateDriveLS_t, TDrive, 0b11, 8 >  TDrive_t; // Bit 8..9
+
+	enum class IDriveN : uint16_t
+	{
+		mA20		= 0b0000,
+		mA60		= 0b0001,
+		mA120		= 0b0010,
+		mA160		= 0b0011,
+		mA240		= 0b0100,
+		mA280		= 0b0101,
+		mA340		= 0b0110,
+		mA380		= 0b0111,
+		mA520		= 0b1000,
+		mA660		= 0b1001,
+		mA740		= 0b1010,
+		mA880		= 0b1011,
+		mA1140		= 0b1100,
+		mA1360		= 0b1101,
+		mA1640		= 0b1110,
+		mA2000		= 0b1111,
+	};
+	typedef Configuration< GateDriveLS_t, IDriveN, 0b1111, 0 > LS_IDriveN_t; // Bit 0..3
+	typedef Configuration< GateDriveHS_t, IDriveN, 0b1111, 0 > HS_IDriveN_t; // Bit 0..3
+
+	enum class IDriveP : uint16_t
+	{
+		mA10		= 0b0000,
+		mA30		= 0b0001,
+		mA60		= 0b0010,
+		mA80		= 0b0011,
+		mA120		= 0b0100,
+		mA140		= 0b0101,
+		mA170		= 0b0110,
+		mA190		= 0b0111,
+		mA260		= 0b1000,
+		mA330		= 0b1001,
+		mA370		= 0b1010,
+		mA440		= 0b1011,
+		mA570		= 0b1100,
+		mA680		= 0b1101,
+		mA820		= 0b1110,
+		mA1000		= 0b1111,
+	};
+	typedef Configuration< GateDriveLS_t, IDriveP, 0b1111, 4 > LS_IDriveP_t; // Bit 4..7
+	typedef Configuration< GateDriveHS_t, IDriveP, 0b1111, 4 > HS_IDriveP_t; // Bit 4..7
+
+	enum class OcpControl : uint16_t
+	{
+		VdsLevel0		= Bit0,
+		VdsLevel1		= Bit1,
+		VdsLevel2		= Bit2,
+		VdsLevel3		= Bit3,
+
+		OcpDeglitch0	= Bit4,
+		OcpDeglitch1	= Bit5,
+
+		OcpMode0		= Bit6,
+		OcpMode1		= Bit7,
+
+		Deadtime0		= Bit8,
+		Deadtime1		= Bit9,
+
+		TimeRetry		= Bit10,
+	};
+	MODM_FLAGS16(OcpControl);
+
+	enum class VdsLevel : uint16_t
+	{
+		mV60		= 0b0000,
+		mV130		= 0b0001,
+		mV200		= 0b0010,
+		mV260		= 0b0011,
+		mV310		= 0b0100,
+		mV450		= 0b0101,
+		mV530		= 0b0110,
+		mV600		= 0b0111,
+		mV680		= 0b1000,
+		mV750		= 0b1001, /// default
+		mV940		= 0b1010,
+		mV1130		= 0b1011,
+		mV1300		= 0b1100,
+		mV1500		= 0b1101,
+		mV1700		= 0b1110,
+		mV1880		= 0b1111,
+	};
+	typedef Configuration< OcpControl_t, VdsLevel, 0b1111, 0 >  VdsLevel_t; // Bit 0..3
+
+	enum class OcpDeglitch : uint16_t
+	{
+		us2		= 0b00,
+		us4		= 0b01,
+		us6		= 0b10,
+		us8		= 0b11,
+	};
+	typedef Configuration< OcpControl_t, OcpDeglitch, 0b11, 4 >  OcpDeglitch_t; // Bit 4..5
+
+	enum class OcpMode : uint16_t
+	{
+		LatchedFault	= 0b00,
+		AutoRetryFault	= 0b01,
+		OnlyReport		= 0b10,
+		NoOcp			= 0b11,
+	};
+	typedef Configuration< OcpControl_t, OcpMode, 0b11, 6 >  OcpMode_t; // Bit 6..7
+
+	enum class CsaControl : uint16_t
+	{
+		SenseOcpLevel0		= Bit0,
+		SenseOcpLevel1		= Bit1,
+
+		CsaCalibrationC		= Bit2,
+
+		CsaCalibrationB		= Bit3,
+
+		CsaCalibrationA		= Bit4,
+
+		DisableOvercurrentSense	= Bit5,
+
+		CsaGain0			= Bit6,
+		CsaGain1			= Bit7,
+
+		LowSideReference	= Bit8,
+
+		VrefDiv2			= Bit9,
+
+		CsaFet				= Bit10,
+	};
+	MODM_FLAGS16(CsaControl);
+
+	enum class SenseOcpLevel : uint16_t
+	{
+		SenseOcp0V25	= 0b00,
+		SenseOcp0V5		= 0b01,
+		SenseOcp0V75	= 0b10,
+		SenseOcp1V		= 0b11,
+	};
+	typedef Configuration< CsaControl_t, SenseOcpLevel, 0b11, 0 >  SenseOcpLevel_t; // Bit 0..1
+
+	enum class CsaGain : uint16_t
+	{
+		Gain5		= 0b00,
+		Gain10		= 0b01,
+		Gain20		= 0b10,
+		Gain40		= 0b11,
+	};
+	typedef Configuration< CsaControl_t, CsaGain, 0b11, 6 >  CsaGain_t; // Bit 6..7
+};
+
+/**
+ * \brief	DRV832xS: 6 to 60-V Three-Phase Smart Gate Driver
+ *
+ * This driver only covers the gate driver configuration accessible via SPI interface.
+ *
+ * \see		<a href="http://www.ti.com/lit/ds/symlink/drv8320.pdf">DRV832x Datasheet</a>
+ *
+ * \ingroup	driver_motor
+ * \author	Raphael Lehmann
+ */
+template < class SpiMaster, class Cs >
+class Drv832xSpi : public drv832xSpi, public modm::SpiDevice< SpiMaster >, protected modm::NestedResumable<3>
+{
+public:
+	/**
+	 * \brief	Initialize
+	 *
+	 * Sets used pins as output. SPI must be initialized by the user!
+	 */
+	Drv832xSpi();
+
+	modm::ResumableResult<void>
+	readFaultStatus1();
+
+	modm::ResumableResult<void>
+	readVgsStatus2();
+
+	modm::ResumableResult<void>
+	readDriverControl();
+
+	modm::ResumableResult<void>
+	readGateDriveHS();
+
+	modm::ResumableResult<void>
+	readGateDriveLS();
+
+	modm::ResumableResult<void>
+	readOcpControl();
+
+	modm::ResumableResult<void>
+	readCsaControl();
+
+	modm::ResumableResult<void>
+	readAll();
+
+	modm::ResumableResult<void>
+	initialize();
+
+private:
+	FaultStatus1_t _faultStatus1;
+	VgsStatus2_t _vgsStatus2;
+	DriverControl_t _driverControl;
+	GateDriveHS_t _gateDriveHS;
+	GateDriveLS_t _gateDriveLS;
+	OcpControl_t _ocpControl;
+	CsaControl_t _csaControl;
+
+	// access bitmap for variables above
+	uint8_t accessBitmap = 0;
+public:
+	const FaultStatus1_t& faultStatus1() {
+		return _faultStatus1;
+	}
+	const VgsStatus2_t& vgsStatus2() {
+		return _vgsStatus2;
+	}
+	DriverControl_t& driverControl() {
+		accessBitmap |= 0b0000100;
+		return _driverControl;
+	}
+	GateDriveHS_t& gateDriveHS() {
+		accessBitmap |= 0b0001000;
+		return _gateDriveHS;
+	}
+	GateDriveLS_t& gateDriveLS() {
+		accessBitmap |= 0b0010000;
+		return _gateDriveLS;
+	}
+	OcpControl_t& ocpControl() {
+		accessBitmap |= 0b0100000;
+		return _ocpControl;
+	}
+	CsaControl_t& csaControl() {
+		accessBitmap |= 0b1000000;
+		return _csaControl;
+	}
+
+	modm::ResumableResult<void>
+	commit();
+
+protected:
+	modm::ResumableResult<void>
+	writeData(Register address, uint16_t data);
+
+	modm::ResumableResult<uint16_t>
+	readData(Register address);
+
+	modm::ResumableResult<void>
+	readData(Register address, uint16_t& data);
+
+private:
+	uint8_t inBuffer[2];
+	uint8_t outBuffer[2];
+};
+
+// ------------------------------------------------------------------------
+// Output operators
+IOStream&
+operator << (IOStream& os, const drv832xSpi::FaultStatus1_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::VgsStatus2_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::DriverControl_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::GateDriveHS_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::GateDriveLS_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::OcpControl_t& c);
+
+IOStream&
+operator << (IOStream& os, const drv832xSpi::CsaControl_t& c);
+
+}
+
+#include "drv832x_spi_impl.hpp"
+
+#endif // MODM_DRV832X_SPI_HPP

--- a/src/modm/driver/motor/drv832x_spi.lb
+++ b/src/modm/driver/motor/drv832x_spi.lb
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.parent = "driver"
+    module.name = "drv832x_spi"
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:gpio",
+        ":architecture:register",
+        ":architecture:spi.device",
+        ":processing:resumable")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/motor"
+    env.copy("drv832x_spi.hpp")
+    env.copy("drv832x_spi.cpp")
+    env.copy("drv832x_spi_impl.hpp")

--- a/src/modm/driver/motor/drv832x_spi_impl.hpp
+++ b/src/modm/driver/motor/drv832x_spi_impl.hpp
@@ -1,0 +1,176 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_DRV832X_SPI_HPP
+	#error	"Don't include this file directly, use 'drv832x_spi.hpp' instead!"
+#endif
+#include "drv832x_spi.hpp"
+
+// ----------------------------------------------------------------------------
+template < class SpiMaster, class Cs >
+modm::Drv832xSpi<SpiMaster, Cs>::Drv832xSpi()
+{
+	this->attachConfigurationHandler([]() {
+		SpiMaster::setDataMode(SpiMaster::DataMode::Mode1);
+		SpiMaster::setDataOrder(SpiMaster::DataOrder::MsbFirst);
+	});
+	Cs::setOutput(modm::Gpio::High);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::initialize()
+{
+	return readAll();
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readAll()
+{
+	RF_BEGIN();
+	RF_CALL(readFaultStatus1());
+	RF_CALL(readVgsStatus2());
+	RF_CALL(readDriverControl());
+	RF_CALL(readGateDriveHS());
+	RF_CALL(readGateDriveLS());
+	RF_CALL(readOcpControl());
+	RF_CALL(readCsaControl());
+	RF_END();
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readFaultStatus1()
+{
+	return readData(Register::FaultStatus1, _faultStatus1.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readVgsStatus2()
+{
+	return readData(Register::VgsStatus2, _vgsStatus2.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readDriverControl()
+{
+	return readData(Register::DriverControl, _driverControl.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readGateDriveHS()
+{
+	return readData(Register::GateDriveHS, _gateDriveHS.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readGateDriveLS()
+{
+	return readData(Register::GateDriveLS, _gateDriveLS.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readOcpControl()
+{
+	return readData(Register::OcpControl, _ocpControl.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readCsaControl()
+{
+	return readData(Register::CsaControl, _csaControl.value);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::commit()
+{
+	RF_BEGIN();
+	if(accessBitmap & 0b0000100) {
+		RF_CALL(writeData(Register::DriverControl, _driverControl.value));
+	}
+	if(accessBitmap & 0b0001000) {
+		RF_CALL(writeData(Register::GateDriveHS, _gateDriveHS.value));
+	}
+	if(accessBitmap & 0b0010000) {
+		RF_CALL(writeData(Register::GateDriveLS, _gateDriveLS.value));
+	}
+	if(accessBitmap & 0b0100000) {
+		RF_CALL(writeData(Register::OcpControl, _ocpControl.value));
+	}
+	if(accessBitmap & 0b1000000) {
+		RF_CALL(writeData(Register::CsaControl, _csaControl.value));
+	}
+	accessBitmap = 0;
+	RF_END();
+}
+
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::writeData(Register address, uint16_t data)
+{
+	RF_BEGIN();
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+	Cs::reset();
+
+	inBuffer[0] = 0;
+	inBuffer[1] = 0;
+
+	static constexpr uint8_t writeBit = (0 << 7); // 0 = write
+
+	outBuffer[0] = writeBit | (static_cast<uint8_t>(address) << 3) | ((data >> 8) & 0b111);
+	outBuffer[1] = data & 0xff;
+
+	RF_CALL(SpiMaster::transfer(outBuffer, inBuffer, 2));
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	RF_END();
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<void>
+modm::Drv832xSpi<SpiMaster, Cs>::readData(Register address, uint16_t& data)
+{
+	RF_BEGIN();
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+	Cs::reset();
+
+	inBuffer[0] = 0x00;
+	inBuffer[1] = 0x00;
+
+	static constexpr uint8_t writeBit = (1 << 7); // 1 = read
+
+	outBuffer[0] = writeBit | (static_cast<uint8_t>(address) << 3);
+	outBuffer[1] = 0;
+
+	RF_CALL(SpiMaster::transfer(outBuffer, inBuffer, 2));
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	data = static_cast<uint16_t>(inBuffer[1]) | (static_cast<uint16_t>(inBuffer[0] & 0b111) << 8);
+	RF_END();
+}

--- a/test/modm/driver/module.lb
+++ b/test/modm/driver/module.lb
@@ -25,6 +25,7 @@ def prepare(module, options):
         ":driver:bmp085",
         ":driver:lawicel",
         ":driver:ltc2984",
+        ":driver:drv832x_spi",
         ":driver:mcp2515",
         "modm:test:platform:spi",
         ":platform:gpio")

--- a/test/modm/driver/motor/drv832x_spi_test.cpp
+++ b/test/modm/driver/motor/drv832x_spi_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/driver/motor/drv832x_spi.hpp>
+#include <modm/debug/logger/logger.hpp>
+
+#include <modm/platform/spi/mock/spi_master.hpp>
+#include <modm/platform/gpio/unused.hpp>
+
+#include "drv832x_spi_test.hpp"
+
+#undef  MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::DISABLED
+
+void
+Drv832xSpiTest::testRegister()
+{
+	// Some random tests
+	// Todo (?): Add systematic tests
+	using SpiMaster = modm::platform::SpiMasterMock;
+	modm::Drv832xSpi<SpiMaster, modm::platform::GpioUnused> gateDriver;
+
+	gateDriver.driverControl().value = 0b1111111111; // All bits set
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::ClearFaultBits));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::Brake));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::Coast));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::Pwm1Dir));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::Pwm1Com));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode1));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode2));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::OvertemperatureReport));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::DisableGateDriveFault));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::DisableChargePumpUVLO));
+
+	// Reset some bits
+	gateDriver.driverControl() &= ~modm::drv832xSpi::DriverControl::Coast;
+	gateDriver.driverControl() &= ~modm::drv832xSpi::PwmMode_t::mask();
+	gateDriver.driverControl() &= ~modm::drv832xSpi::DriverControl::DisableChargePumpUVLO;
+	TEST_ASSERT_FALSE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::Coast));
+	TEST_ASSERT_FALSE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode1));
+	TEST_ASSERT_FALSE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode2));
+	TEST_ASSERT_FALSE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::DisableChargePumpUVLO));
+	TEST_ASSERT_FALSE(gateDriver.driverControl().any(modm::drv832xSpi::DriverControl::Coast | modm::drv832xSpi::DriverControl::PwmMode1 | modm::drv832xSpi::DriverControl::PwmMode2 | modm::drv832xSpi::DriverControl::DisableChargePumpUVLO));
+	uint16_t value = gateDriver.driverControl().value;
+	TEST_ASSERT_EQUALS(value, 0b0110011011);
+
+	gateDriver.driverControl() |= modm::drv832xSpi::PwmMode_t(modm::drv832xSpi::PwmMode::PwmModeIndependent);
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode1));
+	TEST_ASSERT_TRUE(bool(gateDriver.driverControl() & modm::drv832xSpi::DriverControl::PwmMode2));
+
+	modm::drv832xSpi::CsaControl_t csaControl(0b00011000011);
+	modm::drv832xSpi::CsaGain gain = modm::drv832xSpi::CsaGain_t::get(csaControl);
+	TEST_ASSERT_TRUE(gain == modm::drv832xSpi::CsaGain::Gain40);
+	modm::drv832xSpi::SenseOcpLevel level = modm::drv832xSpi::SenseOcpLevel_t::get(csaControl);
+	TEST_ASSERT_TRUE(level == modm::drv832xSpi::SenseOcpLevel::SenseOcp1V);
+}
+
+void
+Drv832xSpiTest::testSpi()
+{
+	// Test Spi with MockSpiMaster
+	using SpiMaster = modm::platform::SpiMasterMock;
+	modm::Drv832xSpi<SpiMaster, modm::platform::GpioUnused> gateDriver;
+
+	// Real DRV832x device has default register values, but we expect all flags zero because SpiMasterMock reads zero per default
+	RF_CALL_BLOCKING(gateDriver.initialize());
+	// initialize reads 14 bytes, but we don't care
+	SpiMaster::clearBuffers();
+
+	// Test csa control register write
+	gateDriver.driverControl() |= modm::drv832xSpi::PwmMode_t(modm::drv832xSpi::PwmMode::PwmModeIndependent);
+	// Spi transfer should not occure before commit()
+	TEST_ASSERT_EQUALS(SpiMaster::getTxBufferLength(), 0u);
+	RF_CALL_BLOCKING(gateDriver.commit());
+	TEST_ASSERT_EQUALS(SpiMaster::getTxBufferLength(), 2u);
+	uint8_t txBuffer[2];
+	SpiMaster::popTxBuffer(txBuffer);
+	uint8_t txBufferCompare[] = {(0x2 << 3), (0b11 << 5)};
+	TEST_ASSERT_EQUALS_ARRAY(txBuffer, txBufferCompare, 2u);
+
+	// Test csa control register write
+	gateDriver.csaControl() |= modm::drv832xSpi::CsaControl::DisableOvercurrentSense | modm::drv832xSpi::CsaControl::VrefDiv2;
+	RF_CALL_BLOCKING(gateDriver.commit());
+	TEST_ASSERT_EQUALS(SpiMaster::getTxBufferLength(), 2u);
+	SpiMaster::popTxBuffer(txBuffer);
+	uint8_t txBufferCompare2[] = {(0x6 << 3 | 0b1 << 1), (0b1 << 5)};
+	TEST_ASSERT_EQUALS_ARRAY(txBuffer, txBufferCompare2, 2u);
+
+	// Test fault status register read
+	RF_CALL_BLOCKING(gateDriver.readFaultStatus1());
+	TEST_ASSERT_EQUALS(SpiMaster::getTxBufferLength(), 2u);
+	SpiMaster::popTxBuffer(txBuffer);
+	uint8_t txBufferCompare3[] = {(0b1 << 7 | 0x0 << 3), 0x00};
+	TEST_ASSERT_EQUALS_ARRAY(txBuffer, txBufferCompare3, 2u);
+}
+
+void
+Drv832xSpiTest::tearDown() {
+	modm::platform::SpiMasterMock::clearBuffers();
+}

--- a/test/modm/driver/motor/drv832x_spi_test.hpp
+++ b/test/modm/driver/motor/drv832x_spi_test.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <unittest/testsuite.hpp>
+
+class Drv832xSpiTest : public unittest::TestSuite
+{
+public:
+	void
+	testRegister();
+
+	void
+	testSpi();
+
+	void
+	tearDown();
+};

--- a/test/modm/driver/temperature/ltc2984_test.cpp
+++ b/test/modm/driver/temperature/ltc2984_test.cpp
@@ -173,3 +173,8 @@ Ltc2984Test::testSpi()
 	TEST_ASSERT_EQUALS_ARRAY(txBuffer, txBufferCompare6, 7u);
 	TEST_ASSERT_EQUALS(temperature.getTemperatureFixed(), 2 * 1024);
 }
+
+void
+Ltc2984Test::tearDown() {
+	modm::platform::SpiMasterMock::clearBuffers();
+}

--- a/test/modm/driver/temperature/ltc2984_test.hpp
+++ b/test/modm/driver/temperature/ltc2984_test.hpp
@@ -21,4 +21,7 @@ public:
 
 	void
 	testSpi();
+
+	void
+	tearDown();
 };

--- a/test/modm/platform/spi/mock/spi_master.hpp
+++ b/test/modm/platform/spi/mock/spi_master.hpp
@@ -106,10 +106,21 @@ public:
 			txBuffer.removeFront();
 		}
 	}
+
 	static void appendRxBuffer(uint8_t* data, std::size_t length)
 	{
 		for(std::size_t i = 0; i < length; ++i) {
 			rxBuffer.append(data[i]);
+		}
+	}
+
+	static void clearBuffers()
+	{
+		while(txBuffer.getSize() > 0) {
+			txBuffer.removeFront();
+		}
+		while(rxBuffer.getSize() > 0) {
+			rxBuffer.removeFront();
 		}
 	}
 };


### PR DESCRIPTION
[DRV832xS](http://www.ti.com/product/drv8323): 6 to 60-V Three-Phase Smart Gate Driver With Three Current Shunt Amplifiers

This driver only covers the gate driver configuration accessible via SPI interface. (Devices with S suffix.)

[Datasheet](http://www.ti.com/lit/ds/symlink/drv8320.pdf)
