### PR TITLE
Simplify SConstruct for easier customizability

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -20,6 +20,7 @@ def init(module):
 
 
 def prepare(module, options):
+    _, default_project_name = os.path.split(os.getcwd())
     module.add_option(
         BooleanOption(name="include_demo_project", default=False,
                       description="Include a demo main file to get a full compilable project."))
@@ -31,7 +32,10 @@ def prepare(module, options):
                       description="Generate SConstruct file for modm unittests."))
 
     module.add_option(
-        StringOption(name="build.path", default="build",
+        StringOption(name="project.name", default=default_project_name,
+                     description="Project name for executable"))
+    module.add_option(
+        StringOption(name="build.path", default="build/"+default_project_name,
                      description="Path to the build folder"))
     module.add_option(
         StringOption(name="image.source", default="",
@@ -79,7 +83,6 @@ def build(env):
 
 
 def post_build(env, buildlog):
-    _, default_project_name = os.path.split(os.getcwd())
     target = env["modm:target"]
     platform = target.identifier["platform"]
     family = target.identifier["family"]
@@ -89,6 +92,14 @@ def post_build(env, buildlog):
     if len(env["image.source"]): build_tools.append("bitmap");
     if env["info.git"] or env["info.build"]: build_tools.append("info");
     if env["is_unittest"]: build_tools.append("unittest")
+    if platform in ["stm32"]:
+        build_tools.extend(["compiler_arm_none_eabi_gcc", "program_openocd", "utils_buildsize"])
+    elif platform in ["avr"]:
+        build_tools.extend(["compiler_avr_gcc", "program_avrdude"])
+    else:
+        build_tools.extend([
+            "compiler_hosted_" + ("llvm" if family == "darwin" else "gcc"),
+            "utils_buildsize"])
 
     # Extract all source code files
     env.outbasepath = "modm"
@@ -121,11 +132,9 @@ def post_build(env, buildlog):
         ])
 
     env.substitutions = {
-        "project_name": default_project_name,
         "partname": target.partname,
         "platform": platform,
         "family": family,
-        "compiler": "llvm" if family == "darwin" else "gcc",
         "core": core,
         "avrdude_mcu": avrdude_mcu,
         "files": files_to_build,

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -7,14 +7,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 
 Import("env")
 
 env.Append(CPPPATH=[
-%% for path in metadata.include_path
+%% for path in metadata.include_path | sort
     os.path.abspath("{{ path }}"),
 %% endfor
 ])
@@ -46,6 +46,60 @@ env.Append(CPPDEFINES=[
 ])
 %% endif
 
+# Toolchain configuration
+%# ================================== STM32 ===================================
+%% if platform in ["stm32"]
+env["CPU"] = "{{ core }}"
+env["LINKFLAGS_optimize"] = [
+    "-Wl,--relax",
+    "-Wl,--gc-sections",
+    "-Wl,-wrap,_malloc_r",
+    "-Wl,-wrap,_calloc_r",
+    "-Wl,-wrap,_realloc_r",
+    "-Wl,-wrap,_free_r",
+    "--specs=nano.specs",
+    "--specs=nosys.specs",
+    "-nostartfiles",
+]
+env.Append(LINKFLAGS_other=["-Wl,--no-wchar-size-warning"])
+%# =================================== AVR ====================================
+%% elif platform in ["avr"]
+env["CCFLAGS_target"] = [
+    "-mmcu={{ partname }}",
+    "-DF_CPU=${CONFIG_CLOCK_F_CPU}"
+]
+env.Append(ASFLAGS_target=[
+    "-mmcu={{ partname }}",
+    "-xassembler-with-cpp",
+])
+env["LINKFLAGS_other"] = ["-Wl,--fatal-warnings"]
+%# ================================== HOSTED ==================================
+%% elif platform in ["hosted"]
+%% if family in ["darwin"]
+env["CXXFLAGS_language"] = ["-std=c++1z"] # for clang 4 or earlier
+%% else
+env["CXXFLAGS_language"] = ["-std=c++17"]
+%% endif
+%% endif
+
+%# ============================================================================
+env["CFLAGS_language"] = ["-std=gnu11"]
+%% if platform in ["stm32", "avr"]
+env["CXXFLAGS_language"] = ["-std=c++17", "-fno-exceptions", "-fno-rtti"]
+env.Append(LINKFLAGS_target=[
+    "-Lmodm/link",
+    "-Tlinkerscript.ld"])
+%% endif
+env.RemoveFromList("CCFLAGS_warning", [
+    "-Wshadow",
+    "-Wcast-align",
+    "-Wmissing-declarations",
+    "-Wcast-qual",
+    "-Wredundant-decls",])
+env.RemoveFromList("CXXFLAGS_warning", [
+    "-Wold-style-cast",
+    "-Wnon-virtual-dtor"])
+
 # Device configuration
 env["CONFIG_DEVICE_NAME"] = "{{ partname }}"
 %% if memories | length
@@ -55,6 +109,7 @@ env["CONFIG_DEVICE_MEMORY"] = [
 %% endfor
 ]
 %% endif
+
 # Programming configuration
 %% if platform in ["avr"]
 env["CONFIG_AVRDUDE_DEVICE"] = "{{avrdude_mcu}}"
@@ -65,14 +120,18 @@ env["CONFIG_AVRDUDE_OPTIONS"] = "{{options["::avrdude.options"]}}"
 env["CONFIG_AVRDUDE_BAUDRATE"] = "{{options["::avrdude.baudrate"]}}"
 %% endif
 %% endif
-%% if "openocd.configfile" in metadata
+
 env["CONFIG_OPENOCD_SEARCHDIRS"] = [
+%% if "openocd.configfile" in metadata
     os.path.abspath("openocd")
+%% endif
 ]
 env["CONFIG_OPENOCD_CONFIGFILES"] = [
-%% for configfile in metadata["openocd.configfile"]
+%% if "openocd.configfile" in metadata
+    %% for configfile in metadata["openocd.configfile"]
     "{{ configfile }}",
-%% endfor
+    %% endfor
+%% endif
 ]
 env["CONFIG_OPENOCD_COMMANDS"] = [
     "init",
@@ -82,13 +141,12 @@ env["CONFIG_OPENOCD_COMMANDS"] = [
     "mww 0xE000EDF0 0xA05F0000",
     "shutdown"
 ]
-%% endif
 
 %% if ":platform:clock:f_cpu" in options
 env["CONFIG_CLOCK_F_CPU"] = "{{ options[":platform:clock:f_cpu"] }}"
 %% endif
 
-env['XPCC_SYSTEM_BUILDER'] = os.path.join("modm", "tools", "system_design", "builder")
+env['XPCC_SYSTEM_BUILDER'] = os.path.join(os.path.abspath("."), "tools", "system_design", "builder")
 
 %% if platform not in ["hosted"]
 # We need to link libmodm.a with --whole-archive, so that all weak symbols are visible to the linker.

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -11,116 +11,32 @@
 
 import os
 from os.path import join, abspath
+from pathlib import Path
 
-rootpath = "modm"
+# User Configurable Options
+project_name = "{{ options["::project.name"] }}"
+source_dirs = ["."]
+source_endings = ["cpp", "cxx", "cc", "c"]
+build_path = "{{ build_path }}"
+modm_path = "modm"
 
+# SCons environment with all tools
 env = Environment(
-        toolpath=[join(rootpath, "scons", "site_tools"),
-                  join(rootpath, "ext", "dlr", "scons-build-tools", "site_tools")],
-
-%# ================================== STM32 ===================================
-%% if platform in ["stm32"]
+        toolpath=[join(modm_path, "scons", "site_tools"),
+                  join(modm_path, "ext", "dlr", "scons-build-tools", "site_tools")],
         tools=[
-            "compiler_arm_none_eabi_gcc",
-            "settings_buildpath",
-            "utils_buildformat",
-            "utils_buildsize",
-            "program_openocd",
 %% for tool in build_tools
             "{{tool}}",
 %% endfor
-            ],
-        CPU="{{ core }}",
-        CFLAGS_language=["-std=gnu11"],
-        CXXFLAGS_language=["-std=c++17", "-fno-exceptions", "-fno-rtti"],
-        LINKFLAGS_optimize=[
-            "-Wl,--relax",
-            "-Wl,--gc-sections",
-            "-Wl,-wrap,_malloc_r",
-            "-Wl,-wrap,_calloc_r",
-            "-Wl,-wrap,_realloc_r",
-            "-Wl,-wrap,_free_r",
-            "--specs=nano.specs",
-            "--specs=nosys.specs",
-            "-nostartfiles",
-            ],
-        ENV=os.environ)
-
-#env.Append(CCFLAGS_warning=["-Werror"])
-env.Append(LINKFLAGS_other=["-Wl,--no-wchar-size-warning"])
-env.Append(LINKFLAGS_target=[
-    "-Lmodm/link",
-    "-Tlinkerscript.ld",
-    ])
-
-%# =================================== AVR ====================================
-%% elif platform in ["avr"]
-        tools=[
-            "compiler_avr_gcc",
             "settings_buildpath",
             "utils_buildformat",
-            # "utils_buildsize",
-            "program_avrdude",
-%% for tool in build_tools
-            "{{tool}}",
-%% endfor
-            ],
-        CCFLAGS_target=[
-            "-mmcu={{ partname }}",
-            "-DF_CPU=${CONFIG_CLOCK_F_CPU}"
-            ],
-        CFLAGS_language=["-std=gnu11"],
-        CXXFLAGS_language=["-std=c++17", "-fno-exceptions", "-fno-rtti"],
-        LINKFLAGS_other=[
-            "-Wl,--fatal-warnings",
             ],
         ENV=os.environ)
+env["BASEPATH"]  = abspath(modm_path)
+env["BUILDPATH"] = abspath(build_path)
 
-env.Append(ASFLAGS_target=[
-    "-mmcu={{ partname }}",
-    "-xassembler-with-cpp",
-    ])
-env.Append(LINKFLAGS_target=[
-    "-Lmodm/link",
-    "-Tlinkerscript.ld",
-    ])
-
-%# ================================== HOSTED ==================================
-%% elif platform in ["hosted"]
-        tools=[
-            "compiler_hosted_{{compiler}}",
-            "settings_buildpath",
-            "utils_buildformat",
-            "utils_buildsize",
-%% for tool in build_tools
-            "{{tool}}",
-%% endfor
-            ],
-        CFLAGS_language=["-std=gnu11"],
-%% if family in ["darwin"]
-        CXXFLAGS_language=["-std=c++1z"], # for clang 4 or earlier
-%% else
-        CXXFLAGS_language=["-std=c++17"],
-%% endif
-        ENV=os.environ)
-%% endif
-%# ============================================================================
-
-env.RemoveFromList("CCFLAGS_warning", [
-    "-Wshadow",
-    "-Wcast-align",
-    "-Wmissing-declarations",
-    "-Wcast-qual",
-    "-Wredundant-decls",])
-env.RemoveFromList("CXXFLAGS_warning", [
-    "-Wold-style-cast",
-    "-Wnon-virtual-dtor"])
-
-# User Config Options
-env["BASEPATH"]  = abspath(rootpath)
-env["BUILDPATH"] = abspath("{{ build_path }}")
-
-library = env.SConscript(join(rootpath, "SConscript"), exports="env")
+# Building all libraries
+env.SConscript(join(modm_path, "SConscript"), exports="env")
 
 %% if info_git
 env.InfoGit()
@@ -130,34 +46,40 @@ env.InfoBuild()
 %% endif
 
 %% if options["::is_unittest"]
-headers = env.Glob("modm/test/*.hpp")
-headers += env.Glob("modm/test/*/*.hpp")
-headers += env.Glob("modm/test/*/*/*.hpp")
-headers += env.Glob("modm/test/*/*/*/*.hpp")
+# Building unit tests
+headers = [env.File(str(f)) for f in Path(modm_path).glob("test/**/*.hpp")]
 files = env.UnittestRunner(target="main.cpp", source=headers, template="modm/test/runner.cpp.in")
 %% else
-# FIXME: better globbing! (recursive?)
-files = env.Glob("*.cpp")
-files += env.Glob("*/*.cpp")
-# Needed for communication examples for generated postman include paths!
-env.Append(CPPPATH=["."])
+# Finding application sources
+env.Append(CPPPATH=source_dirs)
+files = []
+for path in source_dirs:
+    for ending in source_endings:
+        files.extend(Path(path).glob("**/*.{}".format(ending)))
+files = [env.File(str(f)) for f in files if f.parts[0] != "modm"]
 %% endif
 
 %% if image_source != ""
-for image in Glob(abspath(join("{{image_source}}", "*.pbm"))):
-    source, header = env.Bitmap(image)
+# Finding image sources
+for image in Path("{{image_source}}").glob("**/*.pbm"):
+    source, header = env.Bitmap(str(image))
     files.append(source)
 %% endif
 %% if xpcc_source != ""
+# Generating XPCC files
 files += env.XpccCommunication(
     abspath("{{xpcc_source}}"),
     "{{xpcc_container}}",
-    dtdPath=abspath(join(rootpath, "tools", "system_design", "xml", "dtd")),
+    dtdPath=abspath(join(modm_path, "tools", "system_design", "xml", "dtd")),
     path=abspath("{{xpcc_generate}}"),
     namespace="{{xpcc_namespace}}")
 %% endif
-program = env.Program(target="{{project_name}}.elf", source=files)
+%#
+# Building application
+program = env.Program(target=project_name+".elf", source=files)
+hexfile = env.Hex(program)
 
+# SCons functions
 env.Alias("symbols", env.Symbols(program))
 env.Alias("listing", env.Listing(program))
 env.Alias("bin", env.Bin(program))
@@ -166,23 +88,19 @@ env.Alias("build", program)
 env.Alias("run", env.Run(program))
 env.Alias("all", ["build", "run"])
 %% else
-%% if platform in ["stm32"]
+    %% if platform in ["stm32"]
 env.Alias("size", env.Size(program))
-if "CONFIG_OPENOCD_COMMANDS" in env:
-    env.Alias("program", env.OpenOcd(program))
-%% endif
-%% if platform in ["avr"]
+env.Alias("program", env.OpenOcd(program))
+    %% elif platform in ["avr"]
 env.Alias("program", env.Avrdude(program))
-%% endif
-
-hexfile = env.Hex(program)
-
+    %% endif
+    %#
 env.Alias("build", [hexfile, "listing"])
-%% if platform in ["stm32"]
+    %% if platform in ["stm32"]
 env.Alias("all", ["build", "size"])
-%% else
+    %% else
 env.Alias("all", ["build"])
-%% endif
+    %% endif
 %% endif
 
 env.Default("all")


### PR DESCRIPTION
We're using lots of custom SConstructs in the RCA, so it would be nice to have the modm specific stuff in the generated modm/SConscript and keep the generated SConstruct as generic as possible.

cc @dergraaf @rleh 