### PR TITLE
[build.scons] Add OpenOCD script option and better defaults for env.XpccCommunication

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -37,6 +37,7 @@ def prepare(module, options):
     module.add_option(
         StringOption(name="build.path", default="build/"+default_project_name,
                      description="Path to the build folder"))
+
     module.add_option(
         StringOption(name="image.source", default="",
                      description="Path to the image folder"))
@@ -75,6 +76,10 @@ def prepare(module, options):
         module.add_option(
             StringOption(name="avrdude.options", default="",
                          description="AvrDude programmer options"))
+    elif options[":target"].identifier["platform"] == "stm32":
+        module.add_option(
+            StringOption(name="openocd.cfg", default="",
+                         description="Path to the OpenOCD configuration file"))
     return True
 
 
@@ -137,6 +142,8 @@ def post_build(env, buildlog):
         "family": family,
         "core": core,
         "avrdude_mcu": avrdude_mcu,
+        "openocd_base_dir": os.path.dirname(env.get_option("::openocd.cfg", "")),
+        "openocd_file": os.path.basename(env.get_option("::openocd.cfg", "")),
         "files": files_to_build,
         "metadata": buildlog.metadata,
         "memories": memories,

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -146,7 +146,7 @@ env.SetDefault(CONFIG_OPENOCD_COMMANDS = [
 env["CONFIG_CLOCK_F_CPU"] = "{{ options[":platform:clock:f_cpu"] }}"
 %% endif
 
-env['XPCC_SYSTEM_BUILDER'] = os.path.join(os.path.abspath("."), "tools", "system_design", "builder")
+env['XPCC_SYSTEM_DESIGN'] = os.path.join(os.path.abspath("."), "tools", "system_design")
 
 %% if platform not in ["hosted"]
 # We need to link libmodm.a with --whole-archive, so that all weak symbols are visible to the linker.

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -121,26 +121,26 @@ env["CONFIG_AVRDUDE_BAUDRATE"] = "{{options["::avrdude.baudrate"]}}"
 %% endif
 %% endif
 
-env["CONFIG_OPENOCD_SEARCHDIRS"] = [
+env.SetDefault(CONFIG_OPENOCD_SEARCHDIRS = [
 %% if "openocd.configfile" in metadata
     os.path.abspath("openocd")
 %% endif
-]
-env["CONFIG_OPENOCD_CONFIGFILES"] = [
+])
+env.SetDefault(CONFIG_OPENOCD_CONFIGFILES = [
 %% if "openocd.configfile" in metadata
     %% for configfile in metadata["openocd.configfile"]
     "{{ configfile }}",
     %% endfor
 %% endif
-]
-env["CONFIG_OPENOCD_COMMANDS"] = [
+])
+env.SetDefault(CONFIG_OPENOCD_COMMANDS = [
     "init",
     "reset halt",
     "flash write_image erase $SOURCE",
     "reset halt",
     "mww 0xE000EDF0 0xA05F0000",
     "shutdown"
-]
+])
 
 %% if ":platform:clock:f_cpu" in options
 env["CONFIG_CLOCK_F_CPU"] = "{{ options[":platform:clock:f_cpu"] }}"

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -68,11 +68,16 @@ for image in Path("{{image_source}}").glob("**/*.pbm"):
 %% if xpcc_source != ""
 # Generating XPCC files
 files += env.XpccCommunication(
-    abspath("{{xpcc_source}}"),
-    "{{xpcc_container}}",
+    xmlfile=abspath("{{xpcc_source}}"),
+    container="{{xpcc_container}}",
     dtdPath=abspath(join(modm_path, "tools", "system_design", "xml", "dtd")),
     path=abspath("{{xpcc_generate}}"),
     namespace="{{xpcc_namespace}}")
+%% endif
+%% if openocd_file != ""
+# Using a custom OpenOCD script
+env.Append(CONFIG_OPENOCD_SEARCHDIRS=[abspath("{{openocd_base_dir}}")])
+env.Append(CONFIG_OPENOCD_CONFIGFILES=["{{openocd_file}}"])
 %% endif
 %#
 # Building application

--- a/tools/build_script_generator/scons/site_tools/system_design.py
+++ b/tools/build_script_generator/scons/site_tools/system_design.py
@@ -122,7 +122,9 @@ def xpcc_task_caller_emitter(target, source, env):
 	target = [os.path.join(path, "caller.hpp")]
 	return (target, source)
 
-def xpcc_communication_header(env, xmlfile, container, path='.', dtdPath=None, namespace='robot'):
+def xpcc_communication_header(env, xmlfile, container, path='.', dtdPath='default', namespace='robot'):
+	if dtdPath == 'default':
+		dtdPath = os.path.join(env['XPCC_SYSTEM_DESIGN'], "xml/dtd")
 	files  = env.SystemCppPackets(xmlfile, path=path, dtdPath=dtdPath, namespace=namespace)
 	files += env.SystemCppIdentifier(xmlfile, path=path, dtdPath=dtdPath, namespace=namespace)
 	files += env.SystemCppCommunication(xmlfile, path=path, dtdPath=dtdPath, namespace=namespace)
@@ -151,7 +153,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppPackets'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_BUILDER}/cpp_packets.py" ' \
+				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_packets.py" ' \
 					'--source_path ${TARGETS[0].dir} ' \
 					'--header_path ${TARGETS[1].dir} ' \
 					'--dtdpath "${dtdPath}" ' \
@@ -167,7 +169,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppIdentifier'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_BUILDER}/cpp_identifier.py" ' \
+				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_identifier.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \
@@ -182,7 +184,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppPostman'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_BUILDER}/cpp_postman.py" ' \
+				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_postman.py" ' \
 					'--container "${container}" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
@@ -198,7 +200,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppCommunication'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_BUILDER}/cpp_communication.py" ' \
+				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_communication.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \
@@ -213,7 +215,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppXpccTaskCaller'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_BUILDER}/cpp_xpcc_task_caller.py" ' \
+				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_xpcc_task_caller.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \


### PR DESCRIPTION
This simply adds a shortcut option for declaring your own custom `openocd.cfg` script in the `project.xml` so that simple project don't need their own custom SConstruct file.

In addition the dtdPath for the `env.XpccCommunication` builder is defaulted to the dtd of XPCC.