### PR TITLE
[build.scons] Move tools discovery into SConscript

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -91,7 +91,10 @@ def post_build(env, buildlog):
     platform = target.identifier["platform"]
     family = target.identifier["family"]
 
-    build_tools = []
+    build_tools = [
+        "settings_buildpath",
+        "utils_buildformat",
+        "find_files"]
     if len(env["xpcc.source"]): build_tools.append("system_design");
     if len(env["image.source"]): build_tools.append("bitmap");
     if env["info.git"] or env["info.build"]: build_tools.append("info");

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -12,6 +12,12 @@ from os.path import join, abspath
 
 Import("env")
 
+env.Append(toolpath=[abspath("scons/site_tools"), abspath("ext/dlr/scons-build-tools/site_tools")])
+%% for tool in build_tools | sort
+env.Tool("{{tool}}")
+%% endfor
+env["BASEPATH"] = abspath(".")
+
 env.Append(CPPPATH=[
 %% for path in metadata.include_path | sort
     abspath("{{ path }}"),
@@ -28,18 +34,18 @@ library = env.StaticLibrary(target="modm", source=files)
 
 env.Append(LIBS=[
     library,
-%% for library in metadata.required_library
+%% for library in metadata.required_library | sort
     "{{ library }}",
 %% endfor
 ])
 env.AppendUnique(LIBPATH=[abspath(str(library[0].get_dir()))])
 %% if "required_pkg" in metadata
-env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | join(" ") }}")
+env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
 %% endif
 
 %% if "cpp.define" in metadata
 env.Append(CPPDEFINES=[
-%% for define in metadata["cpp.define"]
+%% for define in metadata["cpp.define"] | sort
     "{{ define }}",
 %% endfor
 ])

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -17,19 +17,7 @@ build_path = "{{ build_path }}"
 modm_path = "modm"
 
 # SCons environment with all tools
-env = Environment(
-        toolpath=[join(modm_path, "scons", "site_tools"),
-                  join(modm_path, "ext", "dlr", "scons-build-tools", "site_tools")],
-        tools=[
-%% for tool in build_tools
-            "{{tool}}",
-%% endfor
-            "settings_buildpath",
-            "utils_buildformat",
-            "find_files",
-            ],
-        ENV=os.environ)
-env["BASEPATH"]  = abspath(modm_path)
+env = Environment(ENV=os.environ)
 env["BUILDPATH"] = abspath(build_path)
 
 # Building all libraries
@@ -63,7 +51,6 @@ for image in env.FindFiles("{{image_source}}", ".pbm"):
 files += env.XpccCommunication(
     xmlfile=abspath("{{xpcc_source}}"),
     container="{{xpcc_container}}",
-    dtdPath=abspath(join(modm_path, "tools", "system_design", "xml", "dtd")),
     path=abspath("{{xpcc_generate}}"),
     namespace="{{xpcc_namespace}}")
 %% endif


### PR DESCRIPTION
This moves the build tool construction into the generated SConscript to make it simpler to have custom SConstruct files.