### PR TITLE
Fix env.InfoGit() with cwd and add Project Name define

### DIFF
--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -19,6 +19,7 @@ modm_path = "modm"
 # SCons environment with all tools
 env = Environment(ENV=os.environ)
 env["BUILDPATH"] = abspath(build_path)
+env["CONFIG_PROJECT_NAME"] = project_name
 
 # Building all libraries
 env.SConscript(join(modm_path, "SConscript"), exports="env")

--- a/tools/build_script_generator/scons/site_tools/info.py
+++ b/tools/build_script_generator/scons/site_tools/info.py
@@ -92,6 +92,7 @@ def git_info_defines(env):
 def build_info_defines(env):
 	cwd = env.Dir('#').abspath
 	defines = {}
+	defines['MODM_BUILD_PROJECT_NAME'] = env.get('CONFIG_PROJECT_NAME', 'Unknown')
 	defines['MODM_BUILD_MACHINE'] = platform.node()
 	defines['MODM_BUILD_USER'] = getpass.getuser()
 	# Generate OS String


### PR DESCRIPTION
The current working directory for the `env.InfoGit()` needs to be the SConstruct location, otherwise duplicate and conflicting defines are included when the tool is called from SConscripts that reside in different git repositories.

Behavior of `MODM_BUILD_PROJECT_NAME` is restored to get feature parity with xpcc.