### PR TITLE
 [build.scons] Separate ignore path and file patterns

### DIFF
--- a/src/modm/math/math.hpp.in
+++ b/src/modm/math/math.hpp.in
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_MATH_HPP
+#define	MODM_MATH_HPP
+
+%% for header in headers
+#include "{{header}}"
+%% endfor
+
+#endif	// MODM_MATH_HPP

--- a/src/modm/math/math.lb
+++ b/src/modm/math/math.lb
@@ -20,3 +20,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/math"
     env.copy("tolerance.hpp")
+
+    env.outbasepath = "modm/src/modm"
+    headers = env.get_generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
+    env.template("math.hpp.in", substitutions={"headers": sorted(headers)})

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -22,7 +22,7 @@ env["BUILDPATH"] = abspath(build_path)
 env["CONFIG_PROJECT_NAME"] = project_name
 
 # Building all libraries
-env.SConscript(join(modm_path, "SConscript"), exports="env")
+env.SConscript(dirs=[modm_path], exports="env")
 
 %% if info_git
 env.InfoGit()
@@ -37,8 +37,8 @@ headers = env.FindHeaderFiles(join(modm_path, "test"))
 files = env.UnittestRunner(target="main.cpp", source=headers, template="modm/test/runner.cpp.in")
 %% else
 # Finding application sources
-env.Append(CPPPATH=["."])
-files = env.FindSourceFiles(".", ignore="modm/**/*")
+env.Append(CPPPATH=".")
+files = env.FindSourceFiles(".", ignorePaths="modm")
 %% endif
 
 %% if image_source != ""


### PR DESCRIPTION
Needed for old code-bases that mix source code with unit tests:
```py
files = env.FindSourceFiles(".", ignorePaths="modm", ignoreFiles="*_test.cpp")
```