### PR TITLE
[build.scons] Make git status optional

### DIFF
--- a/examples/linux/git/project.xml
+++ b/examples/linux/git/project.xml
@@ -11,7 +11,7 @@
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build.scons:build.path">../../../build/linux/git</option>
-    <option name=":build.scons:info.git">True</option>
+    <option name=":build.scons:info.git">Info+Status</option>
   </options>
   <modules>
     <module>:platform:core</module>

--- a/test/al-avreb-can.xml
+++ b/test/al-avreb-can.xml
@@ -9,7 +9,7 @@
     <option name=":build.scons:include_sconstruct">True</option>
     <option name=":build.scons:is_unittest">True</option>
     <option name=":build.scons:info.build">True</option>
-    <!-- <option name=":build.scons:info.git">True</option> -->
+    <!-- <option name=":build.scons:info.git">Info+Status</option> -->
   </options>
 
   <modules>

--- a/test/hosted.xml
+++ b/test/hosted.xml
@@ -13,7 +13,7 @@
     <option name=":build.scons:include_sconstruct">True</option>
     <option name=":build.scons:is_unittest">True</option>
     <option name=":build.scons:info.build">True</option>
-    <option name=":build.scons:info.git">True</option>
+    <option name=":build.scons:info.git">Info+Status</option>
   </options>
 
   <modules>

--- a/test/nucleo-f103.xml
+++ b/test/nucleo-f103.xml
@@ -7,7 +7,7 @@
     <option name=":build.scons:include_sconstruct">True</option>
     <option name=":build.scons:is_unittest">True</option>
     <option name=":build.scons:info.build">True</option>
-    <option name=":build.scons:info.git">True</option>
+    <option name=":build.scons:info.git">Info+Status</option>
   </options>
   <modules>
     <module>:build.scons</module>

--- a/test/nucleo-f411.xml
+++ b/test/nucleo-f411.xml
@@ -7,7 +7,7 @@
     <option name=":build.scons:include_sconstruct">True</option>
     <option name=":build.scons:is_unittest">True</option>
     <option name=":build.scons:info.build">True</option>
-    <option name=":build.scons:info.git">True</option>
+    <option name=":build.scons:info.git">Info+Status</option>
   </options>
   <modules>
     <module>:build.scons</module>

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -54,8 +54,9 @@ def prepare(module, options):
                      description="Namespace of the generated XPCC communications"))
 
     module.add_option(
-        BooleanOption(name="info.git", default=False,
-                      description="Generate CPP defines about the git repository state"))
+        EnumerationOption(name="info.git", default="Disabled",
+                          enumeration=["Disabled", "Info", "Info+Status"],
+                          description="Generate CPP defines about the git repository state"))
     module.add_option(
         BooleanOption(name="info.build", default=False,
                       description="Generate CPP defines about the build state"))
@@ -97,7 +98,7 @@ def post_build(env, buildlog):
         "find_files"]
     if len(env["xpcc.source"]): build_tools.append("system_design");
     if len(env["image.source"]): build_tools.append("bitmap");
-    if env["info.git"] or env["info.build"]: build_tools.append("info");
+    if env["info.git"] != "Disabled" or env["info.build"]: build_tools.append("info");
     if env["is_unittest"]: build_tools.append("unittest")
     if platform in ["stm32"]:
         build_tools.extend(["compiler_arm_none_eabi_gcc", "program_openocd", "utils_buildsize"])

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -24,8 +24,8 @@ env["CONFIG_PROJECT_NAME"] = project_name
 # Building all libraries
 env.SConscript(dirs=[modm_path], exports="env")
 
-%% if info_git
-env.InfoGit()
+%% if info_git != "Disabled"
+env.InfoGit({{ "True" if "Status" in info_git else "False" }})
 %% endif
 %% if info_build
 env.InfoBuild()


### PR DESCRIPTION
The git status information changes frequently when working on a 
repository, due to the nature of modifying the code base.
However, this may trigger a complete rebuild every time you change a
file since this information is passed as defines via the command line.