### PR TITLE
[STM32] Timer: Rename OutputCompareMode::ForceHigh to ForceActive

### DIFF
--- a/examples/nucleo_l432kc/pwm_advanced/main.cpp
+++ b/examples/nucleo_l432kc/pwm_advanced/main.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+#undef  MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	initialize();
+
+	MODM_LOG_INFO << "Nucleo L432KC Advanced PWM example" << modm::endl << modm::endl;
+	MODM_LOG_INFO << "Connect an oscilloscope to \"D9\"/GpioA8 (Timer Ch1)," << modm::endl;
+	MODM_LOG_INFO << "\"A6\"/GpioA7 (Timer Ch1n complementary) and \"D13\"/GpioB3 (trigger out)." << modm::endl;
+	MODM_LOG_INFO << "Setup the oscilloscope to trigger on \"D13\"," << modm::endl;
+	MODM_LOG_INFO << "this pin generates a rising edge every second when to PWM state begins." << modm::endl;
+	MODM_LOG_INFO << "The following states are configured sequentially (each for 250 ms):" << modm::endl;
+	MODM_LOG_INFO << " * PWM" << modm::endl;
+	MODM_LOG_INFO << " * High-Z" << modm::endl;
+	MODM_LOG_INFO << " * High" << modm::endl;
+	MODM_LOG_INFO << " * Low " << modm::endl;
+
+	using TriggerOut = LedD13;
+	TriggerOut::setOutput(modm::Gpio::Low);
+
+	Timer1::connect<GpioOutputA8::Ch1, GpioOutputA7::Ch1n>();
+
+	Timer1::enable();
+	Timer1::setMode(Timer1::Mode::UpCounter);
+
+	// 80 MHz / 80 / 2^16 = ~15 Hz
+	Timer1::setPrescaler(80);
+	Timer1::setOverflow(65535);
+	Timer1::start();
+	Timer1::enableOutput();
+
+	constexpr uint32_t compareValue = 32767;
+
+	uint32_t state = 0;
+
+	while (true)
+	{
+		switch(state) {
+			case 0:
+				// Trigger only on state 0
+				TriggerOut::set();
+
+				MODM_LOG_INFO << "Mode: PWM" << modm::endl;
+				Timer1::configureOutputChannel(1,
+						Timer1::OutputCompareMode::Pwm,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveHigh,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveHigh,
+						Timer1::OutputComparePreload::Disable
+						);
+				break;
+			case 1:
+				MODM_LOG_INFO << "Mode: HiZ" << modm::endl;
+				Timer1::configureOutputChannel(1,
+						Timer1::OutputCompareMode::ForceActive,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveLow,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveHigh,
+						Timer1::OutputComparePreload::Disable
+						);
+				break;
+			case 2:
+				MODM_LOG_INFO << "Mode: High" << modm::endl;
+				Timer1::configureOutputChannel(1,
+						Timer1::OutputCompareMode::ForceActive,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveHigh,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveHigh,
+						Timer1::OutputComparePreload::Disable
+						);
+				break;
+			case 3:
+				MODM_LOG_INFO << "Mode: Low" << modm::endl;
+				Timer1::configureOutputChannel(1,
+						Timer1::OutputCompareMode::ForceActive,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveLow,
+						Timer1::PinState::Enable,
+						Timer1::OutputComparePolarity::ActiveLow,
+						Timer1::OutputComparePreload::Disable
+						);
+				break;
+		}
+		Timer1::setCompareValue(1, compareValue);
+		Timer1::applyAndReset();
+
+		// Go to next state after 250 ms
+		if(++state > 3) {
+			state = 0;
+		}
+		modm::delayMilliseconds(250);
+
+		TriggerOut::reset();
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <options>
+    <option name=":build.scons:build.path">../../../build/nucleo_l432kc/blink</option>
+  </options>
+  <modules>
+    <module>:build.scons</module>
+    <module>:platform:timer:1</module>
+  </modules>
+</library>

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -296,7 +296,7 @@ public:
 		channel -= 1;	// 1..2 -> 0..1
 
 		{
-			uint32_t flags = static_cast<uint32_t>(OutputCompareMode::ForceLow);
+			uint32_t flags = static_cast<uint32_t>(OutputCompareMode::ForceInactive);
 
 			if (channel <= 1)
 			{
@@ -327,7 +327,7 @@ public:
 		channel -= 1;	// 1..2 -> 0..1
 
 		{
-			uint32_t flags = static_cast<uint32_t>(OutputCompareMode::ForceHigh);
+			uint32_t flags = static_cast<uint32_t>(OutputCompareMode::ForceActive);
 
 			if (channel <= 1)
 			{

--- a/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
@@ -105,9 +105,11 @@ public:
 		/// Output is toggled on match
 		Toggle = TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0,
 		/// Output is forced low
-		ForceLow = TIM_CCMR1_OC1M_2,
+		ForceInactive = TIM_CCMR1_OC1M_2,
 		/// Output is forced high
-		ForceHigh = TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0,
+		ForceActive = TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0,
+		ForceLow  [[deprecated("Use ForceInactive instead.")]] = ForceInactive,
+		ForceHigh [[deprecated("Use ForceActive instead.")]]   = ForceActive,
 
 		/**
 		 * PWM Mode 1.


### PR DESCRIPTION
... and `OutputCompareMode::ForceHigh` to `ForceActive`.
Aliases for backward compatibility exist.

This naming is closer to the ST datasheets:
```
TIM1 capture/compare mode register 1 (TIMx_CCMR1)
  [...]
  Bits 6:4 OC1M: Output Compare 1 mode
    [...]
    0100: Force inactive level - OC1REF is forced low.
    0101: Force active level - OC1REF is forced high.
    [...]
```
---

Bonus: Nucleo-L432KC example demonstrating the complementary output of Timer 1.