### PR TITLE
[stm32] Add comparator platform driver for f3 and l4

### DIFF
--- a/examples/nucleo_l432kc/comp/main.cpp
+++ b/examples/nucleo_l432kc/comp/main.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+#include <modm/platform/comp/comp_1.hpp>
+
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	using Comparator = modm::platform::Comp1;
+
+	Comparator::connect<GpioA0::Out, GpioA1::Inp>();
+
+	Comparator::initialize(
+			Comparator::InvertingInput::Vref1Div2,
+			Comparator::NonInvertingInput::GpioA1,
+			Comparator::Hysteresis::NoHysteresis,
+			Comparator::Mode::HighSpeed,
+			Comparator::Polarity::NonInverted,
+			false);
+
+	while (1)
+	{
+		modm::delayMilliseconds(250);
+		MODM_LOG_INFO << "Comparator: " << Comparator::getOutput() << modm::endl;
+		Board::LedD13::set(Comparator::getOutput());
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <options>
+    <option name=":build.scons:build.path">../../../build/nucleo_l432kc/blink</option>
+  </options>
+  <modules>
+    <module>modm:platform:comp:*</module>
+    <module>:build.scons</module>
+  </modules>
+</library>

--- a/examples/stm32f3_discovery/comp/main.cpp
+++ b/examples/stm32f3_discovery/comp/main.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+
+#include <modm/platform/comp/comp_2.hpp>
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+modm::IODeviceWrapper< Usart2, modm::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+modm::log::Logger modm::log::debug(loggerDevice);
+modm::log::Logger modm::log::info(loggerDevice);
+modm::log::Logger modm::log::warning(loggerDevice);
+modm::log::Logger modm::log::error(loggerDevice);
+
+int
+main()
+{
+	Board::initialize();
+	Board::LedNorth::setOutput();
+
+	// initialize Uart2 for MODM_LOG_
+	Usart2::connect<GpioOutputA2::Tx>();
+	Usart2::initialize<Board::systemClock, 115200>();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	using Comparator = modm::platform::Comp2;
+
+	Comparator::connect<GpioA7::Inp, GpioA2::Out>();
+
+	Comparator::initialize(
+			Comparator::InvertingInput::Vref1Div2,
+			Comparator::NonInvertingInput::BitUnset, // GpioA7
+			Comparator::Output::Tim1Or8BkIn2,
+			Comparator::Hysteresis::NoHysteresis,
+			Comparator::Mode::HighSpeed,
+			Comparator::Polarity::NonInverted,
+			false);
+
+	while (1)
+	{
+		modm::delayMilliseconds(250);
+		MODM_LOG_INFO << "Comparator: " << Comparator::getOutput() << modm::endl;
+		Board::LedNorth::set(Comparator::getOutput());
+	}
+
+	return 0;
+}

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <options>
+    <option name=":build.scons:build.path">../../../build/stm32f3_discovery/blink</option>
+  </options>
+  <modules>
+    <module>:debug</module>
+    <module>:platform:uart:2</module>
+    <module>modm:platform:comp:*</module>
+    <module>:build.scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/comp/stm32/base.hpp.in
+++ b/src/modm/platform/comp/stm32/base.hpp.in
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_COMP_BASE_HPP
+#define MODM_STM32_COMP_BASE_HPP
+
+/**
+ * @ingroup 	{{partname}}
+ * @defgroup	{{partname}}_comp Comparator
+ */
+namespace modm::platform
+{
+	class CompBase
+	{
+	public:
+		enum class
+		Mode
+		{
+			{% if driver.type in ["stm32-v1.3"] -%}
+			UltraLowPower	= 0b00 << 2,
+			LowPower		= 0b01 << 2,
+			MediumSpeed		= 0b10 << 2,
+			HighSpeed		= 0b11 << 2,
+			{% elif driver.type in ["stm32-tsmc90_cube"] -%}
+			HighSpeed		= 0b00 << 2,
+			MediumSpeed		= 0b01 << 2,
+			//MediumSpeed2	= 0b10 << 2,
+			UltraLowPower	= 0b11 << 2,
+			{% endif -%}
+		};
+	protected:
+		static constexpr uint32_t ModeMask = 0b11 << 2;
+
+	public:
+		enum class
+		Polarity
+		{
+			NonInverted	= 0b0 << 15,
+			Inverted	= 0b1 << 15,
+		};
+	protected:
+		static constexpr uint32_t PolarityMask = 0b1 << 15;
+
+	public:
+		enum class
+		Hysteresis
+		{
+			NoHysteresis		= 0b00 << 16,
+			LowHysteresis		= 0b01 << 16,
+			MediumHysteresis	= 0b10 << 16,
+			HighHysteresis		= 0b11 << 16,
+		};
+	protected:
+		static constexpr uint32_t HysteresisMask = 0b11 << 16;
+	};
+}
+
+#endif	//  MODM_STM32_COMP_BASE_HPP

--- a/src/modm/platform/comp/stm32/comp.hpp.in
+++ b/src/modm/platform/comp/stm32/comp.hpp.in
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2013, Kevin Läufer
- * Copyright (c) 2014-2015, 2017, Niklas Hauser
- * Copyright (c) 2017, Fabian Greif
+ * Copyright (c) 2018, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -14,701 +12,449 @@
 #ifndef MODM_STM32_COMP{{ id }}_HPP
 #define MODM_STM32_COMP{{ id }}_HPP
 
+#include "base.hpp"
+
+#include <modm/platform/gpio/connector.hpp>
+
 /**
  * @ingroup 	{{partname}}
  * @defgroup	{{partname}}_comp Comparator
  */
 
-#if defined(STM32F3XX)
-namespace modm
+
+namespace modm::platform
 {
-	namespace platform
+	/**
+	 * @brief		Comparator Class for STM32
+	 *
+	 * @internal
+	 * @ingroup		{{partname}}_comp
+	 */
+	class Comp{{ id }} : public CompBase
 	{
-		/**
-		 * @brief		Comparator Class for STM32F3 series
-		 *
-		 * The class provides an interface to the comparators 1-7 availably on
-		 * ST's STM32F3 microcontroller series.
-		 *
-		 * @internal
-		 * @ingroup		{{partname}}_comp
-		 */
-		class Comp{{ id }}
+	public:
+		enum class
+		InvertingInput
 		{
-		public:
-			enum Mode
-			{
-				ULTRA_LOW_POWER = 0b00,
-				LOW_POWER = COMP{{ id }}_CSR_COMP{{ id }}MODE_0,		//0b01
-				MEDIUM_POWER = COMP{{ id }}_CSR_COMP{{ id }}MODE_1,		//0b10
-				HIGH_SPEED = 	COMP{{ id }}_CSR_COMP{{ id }}MODE_0 |
-								COMP{{ id }}_CSR_COMP{{ id }}MODE_1		//0b11
-			};
-
-			enum InvertingInput
-			{
-				VREF_1_4 = 0b000,	//0b000 1/4 of Vrefint
-				VREF_1_2 =			// 1/2 of Vrefint
-							COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b001
-				VREF_3_4 =			// 3/4 of Vrefint
-							COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b010
-				VREF = 				// Vrefint
-							COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-							COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b011
-				// Common Port Aliases
-				PA4 =	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,		//0b100
-				DAC1 =	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,		//0b100
-				PA5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-						COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,		//0b101
-				DAC2 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-						COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,		//0b101
-			{% if id == 1 -%}
-				// PA4 or DAC1 output if enabled
-				COMP1_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP1_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PA0
-				COMP1_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// Port Alias
-				PA0 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1	//0b110
-			{% elif id == 2 -%}
-				// PA4 or DAC1 output if enabled
-				COMP2_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP2_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PA2
-				COMP2_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// Port Alias
-				PA2 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1	//0b110
-			{% elif id == 3 -%}
-				// PA4 or DAC1 output if enabled
-				COMP3_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP3_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PD15
-				COMP3_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// PB12
-				COMP3_INM7 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b111
-				// Port Alias
-				PD15 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				PB12 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0	//0b111
-			{% elif id == 4 -%}
-				// PA4 or DAC1 output if enabled
-				COMP4_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP4_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PE8
-				COMP4_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// PB2
-				COMP4_INM7 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b111
-				// Port Alias
-				PE8 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				PB2 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0	//0b111
-			{% elif id == 5 -%}
-				// PA4 or DAC1 output if enabled
-				COMP5_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP5_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PD13
-				COMP5_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// PB10
-				COMP5_INM7 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b111
-				// Port Alias
-				PD13 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				PB10 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0	//0b111
-			{% elif id == 6 -%}
-				// While they are named COMP4_.. in the reference manual, this
-				// does not make any sense and is assumed to be an error
-				// PA4 or DAC1 output if enabled
-				COMP6_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP6_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PD10
-				COMP6_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// PB15
-				COMP6_INM7 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b111
-				// Port Alias
-				PD10 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				PB15 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0	//0b111
-			{% elif id == 7 -%}
-				// While they are named COMP5_.. in the reference manual, this
-				// does not make any sense and is assumed to be an error
-				// PA4 or DAC1 output if enabled
-				COMP7_INM4 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2,	//0b100
-				// PA5 or DAC2 output if enabled
-				COMP7_INM5 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_0,	//0b101
-				// PC0
-				COMP7_INM6 = 	COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1,	//0b110
-				// Port Alias
-				PC0 = 			COMP{{ id }}_CSR_COMP{{ id }}INSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}INSEL_1	//0b110
-			{% endif -%}
-			};
-
-{% if id > 1 -%}
-			enum NonInvertingInput
-			{
-			{% if id == 2 -%}
-				PA7 = 0b0,
-				PA3 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL		//0b1
-			{% elif id == 3 -%}
-				PB14 = 0b0,
-				PD14 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL	//0b1
-			{% elif id == 4 -%}
-				PB0 = 0b0,
-				PE7 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL		//0b1
-			{% elif id == 5 -%}
-				PD12 = 0b0,
-				PB13 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL	//0b1
-			{% elif id == 6 -%}
-				PD11 = 0b0,
-				PB11 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL	//0b1
-			{% elif id == 7 -%}
-				PA0 = 0b0,
-				PC1 = COMP{{ id }}_CSR_COMP{{ id }}NONINSEL		//0b1
-			{% endif -%}
-			};
-{% endif -%}
-
-			enum Output
-			{
-				NOT_CONNECTED = 0b0000,
-				TIMER_1_BREAK_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0001
-				TIMER_1_BREAK_INPUT_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0010
-				TIMER_8_BREAK_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0011
-				TIMER_8_BREAK_INPUT_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2,	//0b0100
-				TIMER_8_OR_1_BREAK_INPUTS_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0101
-
-			{% if id == 1 -%}
-				TIMER_1_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_1_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_1_INPUT_CAPTURE_4 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_2_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_3_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_3_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 2 -%}
-				TIMER_1_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_1_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_2_INPUT_CAPTURE_4 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_2_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_3_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_3_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 3 -%}
-				TIMER_1_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_4_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_3_INPUT_CAPTURE_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_2_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_15_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_15_BREAK_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 4 -%}
-				TIMER_3_INPUT_CAPTURE_3 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_8_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_15_INPUT_CAPTURE_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_4_INPUT_CAPTURE_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_15_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_3_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 5 -%}
-				TIMER_2_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_8_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_17_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000,
-				TIMER_4_INPUT_CAPTURE_3 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_16_BREAK_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_3_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 6 -%}
-				TIMER_2_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_8_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111
-				TIMER_2_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_16_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_16_INPUT_CAPTURE_1 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_4_INPUT_CAPTURE_4 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% elif id == 7 -%}
-				TIMER_1_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b0110
-				TIMER_8_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_2 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b0111,
-				TIMER_2_INPUT_CAPTURE_3 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3,	//0b1000
-				TIMER_1_INPUT_CAPTURE_2 =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0,	//0b1001
-				TIMER_17_OCREF_CLEAR_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1,	//0b1010
-				TIMER_17_BREAK_INPUT =
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_3 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}OUTSEL_0	//0b1011
-			{% endif -%}
-			};
-
-			enum Polarity
-			{
-				NOT_INVERTED = 0b0,
-				INVERTED = COMP{{ id }}_CSR_COMP{{ id }}POL		//0b1
-			};
-
-			enum Hysteresis
-			{
-				NO_HYSTERESIS = 0b00,
-				LOW_HYSTERESIS = COMP{{ id }}_CSR_COMP{{ id }}HYST_0,	//0b01
-				MEDIUM_HYSTERESIS = COMP{{ id }}_CSR_COMP{{ id }}HYST_1,//0b10
-				HIGH_HYSTERESIS = COMP{{ id }}_CSR_COMP{{ id }}HYST_1 |
-									COMP{{ id }}_CSR_COMP{{ id }}HYST_0	//0b11
-			};
-
-			enum BlankingSource
-			{
-				NO_BLANKING = 0b000,
-			{% if id <= 2 -%}
-				TIMER_1_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0,	// 0b001
-				TIMER_2_OC3 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1,	// 0b010
-				TIMER_3_OC3 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0	// 0b011
-			{% elif id == 3 -%}
-				TIMER_1_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0,	// 0b001
-				TIMER_2_OC4 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0	// 0b011
-			{% elif id == 4 -%}
-				TIMER_3_OC4 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0,	// 0b001
-				TIMER_8_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1,	// 0b010
-				TIMER_15_OC1 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0	// 0b011
-			{% elif id == 5 -%}
-				TIMER_8_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1,	// 0b010
-				TIMER_3_OC3 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0	// 0b011
-			{% elif id == 6 -%}
-				TIMER_8_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1,	// 0b010
-				TIMER_2_OC4 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1 |
-								COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0,// 0b011
-				TIMER_15_OC2 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_2	// 0b100
-			{% elif id == 7 -%}
-				TIMER_1_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_0,	// 0b001
-				TIMER_8_OC5 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_1,	// 0b010
-				TIMER_15_OC2 = COMP{{ id }}_CSR_COMP{{ id }}BLANKING_2	// 0b100
-			{% endif -%}
-			};
-
-		public:
-
-			/**
-			 * Initialize and enable the comparator.
-			 *
-			 * Enables the comperator and sets important values.
-			 *
-			 * Do NOT set lock = true if you want to be able to set other values
-			 * later.
-			 */
-			static inline void
-			initialize(
-						InvertingInput n_in,
-					{% if id > 1 -%}
-						NonInvertingInput p_in,
-					{% endif -%}
-						Output out = Output::NOT_CONNECTED,
-						Hysteresis hyst = Hysteresis::NO_HYSTERESIS,
-						Mode mode = Mode::HIGH_SPEED,
-						Polarity pol = Polarity::NOT_INVERTED,
-						bool lock_comp = false)
-			{
-				setInvertingInput(n_in);
+			{% if target.family == "f3" -%}
+			Vref1Div4		= 0b000 << 4,
+			Vref1Div2		= 0b001 << 4,
+			Vref3Div4		= 0b010 << 4,
+			Vref			= 0b011 << 4,
+			Dac1Channel1	= 0b100 << 4,
+			GpioA4			= 0b100 << 4,
+			Dac1Channel2	= 0b101 << 4,
+			GpioA5			= 0b101 << 4,
 			{% if id > 1 -%}
-				setNonInvertingInput(p_in);
+			// and more inputs (different for every instance) ...
+			Config0b1001	= (0b1 << 22) | (0b001 << 4),
+			Config0b1010	= (0b1 << 22) | (0b010 << 4),
+			Config0b1011	= (0b1 << 22) | (0b011 << 4),
+			Config0b1100	= (0b1 << 22) | (0b100 << 4),
+			Config0b1101	= (0b1 << 22) | (0b101 << 4),
+			Config0b1110	= (0b1 << 22) | (0b110 << 4),
+			Config0b1111	= (0b1 << 22) | (0b111 << 4),
 			{% endif -%}
-				setOutputSelection(out);
-				setHysteresis(hyst);
-				setMode(mode);
-				setPolarity(pol);
-				setEnabled(true);	// enable comparator
-				if(lock_comp) lock();
-			}
-
-
-
-			/**
-			 * \brief	Enable/Disable the comparator.
-			 */
-			static inline void
-			setEnabled(bool enabled)
-			{
-				if(enabled)
-					COMP{{ id }}->CSR |= COMP{{ id }}_CSR_COMP{{ id }}EN;
-				else
-					COMP{{ id }}->CSR &= ~COMP{{ id }}_CSR_COMP{{ id }}EN;
-			}
-
-			/**
-			 * \brief	Returns whether the comparator is enabled.
-			 */
-			static inline bool
-			isEnabled()
-			{
-				return COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}EN;
-			}
-
-		{% if id == 1 -%}
-			/**
-			 * \brief Open/Close Switch between comp and DAC out I/O.
-			 *
-			 * This bit closes a switch between comp 1 non inverting input (PA0)
-			 * and DAC out pin (PA4)
-			 */
-			static inline void
-			setSwitch1(bool closed)
-			{
-				if(closed)
-					COMP{{ id }}->CSR |= COMP{{ id }}_CSR_COMP{{ id }}SW1;
-				else
-					COMP{{ id }}->CSR &= ~COMP{{ id }}_CSR_COMP{{ id }}SW1;
-			}
-
-			/**
-			 * \brief Returns true if Switch is closed.
-			 *
-			 * This bit closes a switch between comp 1 non inverting input (PA0)
-			 * and DAC out pin (PA4)
-			 */
-			static inline bool
-			isSwitch1Closed()
-			{
-				return COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}SW1;
-			}
-		{% endif -%}
-
-			/**
-			 * \brief	Sets the mode that determins speed/power consumption.
-			 *
-			 * This setting is also called "output mode".
-			 */
-			static inline void
-			setMode(Mode mode)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}MODE)
-					| static_cast<uint32_t>(mode);
-			}
-
-			/**
-			 * \brief	Sets the mode that determins speed/power consumption.
-			 *
-			 * This setting is also called "output mode".
-			 */
-			static inline Mode
-			getMode()
-			{
-				return static_cast<Mode>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}MODE);
-			}
-
-			/**
-			 * \brief	Selects what the inverting input is connected to.
-			 */
-			static inline void
-			setInvertingInput(InvertingInput input)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}INSEL)
-					| static_cast<uint32_t>(input);
-			}
-
-			/**.
-			 * \brief	Returns what is connected to the inverting input.
-			 */
-			static inline InvertingInput
-			getInvertingInput()
-			{
-				return static_cast<InvertingInput>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}INSEL);
-			}
-
-		{% if id > 1 -%}
-			/**
-			 * \brief	Selects what the non-inverting input is connected to.
-			 */
-			static inline void
-			setNonInvertingInput(NonInvertingInput input)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}NONINSEL)
-					| static_cast<uint32_t>(input);
-			}
-
-			/**.
-			 * \brief	Returns what is connected to the non-inverting input.
-			 */
-			static inline NonInvertingInput
-			getNonInvertingInput()
-			{
-				return static_cast<NonInvertingInput>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}NONINSEL);
-			}
-		{% endif -%}
-
-		{% if id == 2 or id == 4 or id == 6 -%}
-			/**
-			 * \brief Enable/Disable window mode for COMP{{ (id-1) }}/{{ id }}.
-			 */
-			static inline void
-			setWindowMode(bool enabled)
-			{
-				if(enabled)
-					COMP{{ id }}->CSR |= COMP{{ id }}_CSR_COMP{{ id }}WNDWEN;
-				else
-					COMP{{ id }}->CSR &= ~COMP{{ id }}_CSR_COMP{{ id }}WNDWEN;
-			}
-
-			/**
-			 * \brief Returns true if win mode for COMP{{ (id-1) }}/{{ id }} on.
-			 */
-			static inline bool
-			isWindowModeEnabled()
-			{
-				return COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}WNDWEN;
-			}
-		{% endif -%}
-
-			/**
-			 * \brief	Selects what the output is connected to.
-			 */
-			static inline void
-			setOutputSelection(Output output)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}OUTSEL)
-					| static_cast<uint32_t>(output);
-			}
-
-			/**.
-			 * \brief	Returns what is connected to the output.
-			 */
-			static inline Output
-			getOutputSelection()
-			{
-				return static_cast<Output>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}OUTSEL);
-			}
-
-			/**
-			 * \brief	Selects output polarity.
-			 */
-			static inline void
-			setPolarity(Polarity pol)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}POL)
-					| static_cast<uint32_t>(pol);
-			}
-
-			/**.
-			 * \brief	Returns output polarity.
-			 */
-			static inline Polarity
-			getPolarity()
-			{
-				return static_cast<Polarity>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}POL);
-			}
-
-			/**
-			 * \brief	Selects the hysteresis.
-			 */
-			static inline void
-			setHysteresis(Hysteresis hyst)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}HYST)
-					| static_cast<uint32_t>(hyst);
-			}
-
-			/**.
-			 * \brief	Returns the hysteresis.
-			 */
-			static inline Hysteresis
-			getHysteresis()
-			{
-				return static_cast<Hysteresis>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}HYST);
-			}
-
-			/**
-			 * \brief	Selects the blanking source.
-			 */
-			static inline void
-			setBlankingSource(BlankingSource blanking)
-			{
-				COMP{{ id }}->CSR |=
-					(COMP{{ id }}->CSR & ~COMP{{ id }}_CSR_COMP{{ id }}BLANKING)
-					| static_cast<uint32_t>(blanking);
-			}
-
-			/**.
-			 * \brief	Returns the blanking source.
-			 */
-			static inline BlankingSource
-			getBlankingSource()
-			{
-				return static_cast<BlankingSource>
-					(COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}BLANKING);
-			}
-
-			/**
-			 * \brief	Returns the current Comparator output.
-			 */
-			static inline bool
-			getOutput()
-			{
-				return COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}OUT;
-			}
-
-			/**
-			 * \brief	Locks the comparator.
-			 *
-			 * Comparator can only be unlocked by a system reset.
-			 */
-			static inline void
-			lock(void)
-			{
-				COMP{{ id }}->CSR |= COMP{{ id }}_CSR_COMP{{ id }}LOCK;
-			}
-
-			/**
-			 * \brief	Returns true if the comparator is locked.
-			 */
-			static inline bool
-			isLocked(void)
-			{
-				return COMP{{ id }}->CSR & COMP{{ id }}_CSR_COMP{{ id }}LOCK;
-			}
+			{% elif target.family == "l4" -%}
+			Vref1Div4		= (0b000 << 4) | (0b11 << 22),
+			Vref1Div2		= (0b001 << 4) | (0b11 << 22),
+			Vref3Div4		= (0b010 << 4) | (0b11 << 22),
+			Vref			= 0b011 << 4,
+			DacChannel1		= 0b100 << 4,
+			DacChannel2		= 0b101 << 4,
+			{% if id == 1 -%}
+			GpioB1			= 0b110 << 4,
+			GpioC4			= (0b111 << 4) | (0b00 << 25),
+			GpioA0			= (0b111 << 4) | (0b01 << 25),
+			{% elif id == 2 -%}
+			GpioB3			= 0b110 << 4,
+			GpioB7			= (0b111 << 4) | (0b00 << 25),
+			GpioA2			= (0b111 << 4) | (0b01 << 25),
+			{% endif -%}
+			GpioA4			= (0b111 << 4) | (0b10 << 25),
+			GpioA5			= (0b111 << 4) | (0b11 << 25),
+			{% endif -%}
 		};
-	}
+	protected:
+		{% if target.family == "f3" -%}
+		static constexpr uint32_t InvertingInputMask = (0b111 << 4) | (0b1 << 22);
+		{% elif target.family == "l4" -%}
+		static constexpr uint32_t InvertingInputMask = (0b111 << 4) | (0b11 << 22) | (0b11 << 25);
+		{% endif -%}
+
+	public:
+		enum class
+		NonInvertingInput
+		{
+			{% if target.family == "f3" -%}
+			// TODO: Gpio names (with data from parsed datasheets
+			BitUnset	= 0b0 << 7,
+			BitSet		= 0b1 << 7,
+			{% elif target.family == "l4" -%}
+			{% if id == 1 -%}
+			GpioC5		= 0b00 << 7,
+			GpioB2		= 0b01 << 7,
+			GpioA1		= 0b10 << 7,
+			{% elif id == 2 -%}
+			GpioB4		= 0b00 << 7,
+			GpioB6		= 0b01 << 7,
+			GpioA3		= 0b10 << 7,
+			{% endif -%}
+			{% endif -%}
+		};
+	protected:
+		{% if target.family == "f3" -%}
+		static constexpr uint32_t NonInvertingInputMask = 0b1 << 7;
+		{% elif target.family == "l4" -%}
+		static constexpr uint32_t NonInvertingInputMask = 0b11 << 7;
+		{% endif -%}
+
+	{% if target.family == "f3" -%}
+	public:
+		enum class
+		Output
+		{
+			// same in every comparator instance:
+			NoSelection		= 0b0000 << 10,
+			Tim1BkIn		= 0b0001 << 10,
+			Tim1BkIn2		= 0b0010 << 10,
+			Tim8BkIn		= 0b0011 << 10,
+			Tim8BkIn2		= 0b0100 << 10,
+			Tim1Or8BkIn2	= 0b0101 << 10,
+			// different for every instance:
+			// TODO: output names (with data from parsed datasheets
+			Config0b0110	= 0b0110 << 10,
+			Config0b0111	= 0b0111 << 10,
+			Config0b1000	= 0b1000 << 10,
+			Config0b1001	= 0b1001 << 10,
+			Config0b1010	= 0b1010 << 10,
+			Config0b1011	= 0b1011 << 10,
+			Config0b1100	= 0b1100 << 10,
+			Config0b1101	= 0b1101 << 10,
+			Config0b1110	= 0b1110 << 10,
+			Config0b1111	= 0b1111 << 10,
+		};
+	protected:
+		static constexpr uint32_t OutputMask = 0b1111 << 10;
+	{% endif -%}
+
+	public:
+		enum class
+		BlankingSource
+		{
+			NoBlanking		= 0b000 << 18,
+			{% if target.family == "f3" -%}
+			Tim1Oc5			= 0b001 << 18,
+			Tim2Oc3			= 0b010 << 18,
+			Tim3Oc3			= 0b011 << 18,
+			{% elif target.family == "l4" -%}
+			{% if id == 1 -%}
+			Tim1Oc5			= 0b001 << 18,
+			Tim2Oc3			= 0b010 << 18,
+			{% elif id == 2 -%}
+			Tim15Oc1		= 0b100 << 18,
+			{% endif -%}
+			{% endif -%}
+		};
+	protected:
+		static constexpr uint32_t BlankingSourceMask = 0b111 << 18;
+
+	public:
+		/**
+		 * Initialize and enable the comparator.
+		 *
+		 * Enables the comperator and sets important values.
+		 *
+		 * Do NOT set lock = true if you want to be able to set other values
+		 * later.
+		 */
+		static inline void
+		initialize(
+					InvertingInput n_in,
+				{% if (target.family == "f3" and id > 1) or target.family == "l4" -%}
+					NonInvertingInput p_in,
+				{% endif -%}
+				{% if target.family == "f3" -%}
+					Output out = Output::NoSelection,
+				{% endif -%}
+					Hysteresis hyst = Hysteresis::NoHysteresis,
+					Mode mode = Mode::HighSpeed,
+					Polarity pol = Polarity::NonInverted,
+					bool lock_comp = false)
+		{
+			setInvertingInput(n_in);
+		{% if (target.family == "f3" and id > 1) or target.family == "l4" -%}
+			setNonInvertingInput(p_in);
+		{% endif -%}
+		{% if target.family == "f3" -%}
+			setOutputSelection(out);
+		{% endif -%}
+			setHysteresis(hyst);
+			setMode(mode);
+			setPolarity(pol);
+			setEnabled(true);	// enable comparator
+			if(lock_comp) {
+				lock();
+			}
+		}
+
+		/**
+		 * \brief	Enable/Disable the comparator.
+		 */
+		static inline void
+		setEnabled(bool enabled)
+		{
+			if(enabled)
+				COMP{{ id }}->CSR |= {{ csr }}EN;
+			else
+				COMP{{ id }}->CSR &= ~{{ csr }}EN;
+		}
+
+		/**
+		 * \brief	Returns whether the comparator is enabled.
+		 */
+		static inline bool
+		isEnabled()
+		{
+			return COMP{{ id }}->CSR & {{ csr }}EN;
+		}
+
+	{% if false -%} // SW1 bit is not available on F303, F328, F358 and F398
+		/**
+		 * \brief Open/Close Switch between comp and DAC out I/O.
+		 *
+		 * This bit closes a switch between comp 1 non inverting input (PA0)
+		 * and DAC out pin (PA4)
+		 */
+		static inline void
+		setSwitch1(bool closed)
+		{
+			if(closed)
+				COMP{{ id }}->CSR |= {{ csr }}SW1;
+			else
+				COMP{{ id }}->CSR &= ~{{ csr }}SW1;
+		}
+
+		/**
+		 * \brief Returns true if Switch is closed.
+		 *
+		 * This bit closes a switch between comp 1 non inverting input (PA0)
+		 * and DAC out pin (PA4)
+		 */
+		static inline bool
+		isSwitch1Closed()
+		{
+			return COMP{{ id }}->CSR & {{ csr }}SW1;
+		}
+	{% endif -%}
+
+		/**
+		 * \brief	Sets the mode that determins speed/power consumption.
+		 *
+		 * This setting is also called "output mode".
+		 */
+		static inline void
+		setMode(Mode mode)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~ModeMask) | static_cast<uint32_t>(mode);
+		}
+
+		/**
+		 * \brief	Sets the mode that determins speed/power consumption.
+		 *
+		 * This setting is also called "output mode".
+		 */
+		static inline Mode
+		getMode()
+		{
+			return static_cast<Mode>(COMP{{ id }}->CSR & ModeMask);
+		}
+
+		/**
+		 * \brief	Selects what the inverting input is connected to.
+		 */
+		static inline void
+		setInvertingInput(InvertingInput input)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~InvertingInputMask) | static_cast<uint32_t>(input);
+		}
+
+		/**.
+		 * \brief	Returns what is connected to the inverting input.
+		 */
+		static inline InvertingInput
+		getInvertingInput()
+		{
+			return static_cast<InvertingInput>(COMP{{ id }}->CSR & InvertingInputMask);
+		}
+
+	{% if (target.family == "f3" and id > 1) or target.family == "l4" -%}
+		/**
+		 * \brief	Selects what the non-inverting input is connected to.
+		 */
+		static inline void
+		setNonInvertingInput(NonInvertingInput input)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~NonInvertingInputMask) | static_cast<uint32_t>(input);
+		}
+
+		/**.
+		 * \brief	Returns what is connected to the non-inverting input.
+		 */
+		static inline NonInvertingInput
+		getNonInvertingInput()
+		{
+			return static_cast<NonInvertingInput>(COMP{{ id }}->CSR & NonInvertingInputMask);
+		}
+	{% endif -%}
+
+	{% if (target.family == "f3" and (id == 2 or id == 4 or id == 6)) or (target.family == "l4" and id == 2) -%}
+		{% if target.family == "f3" -%}
+		{% set windowmode = "WNDWEN" %}
+		{% elif target.family == "l4" -%}
+		{% set windowmode = "WINMODE" %}
+		{% endif -%}
+
+		/**
+		 * \brief Enable/Disable window mode for COMP{{ (id-1) }}/{{ id }}.
+		 */
+		static inline void
+		setWindowMode(bool enabled)
+		{
+			if(enabled)
+				COMP{{ id }}->CSR |= {{ csr }}{{ windowmode }};
+			else
+				COMP{{ id }}->CSR &= ~{{ csr }}{{ windowmode }};
+		}
+
+		/**
+		 * \brief Returns true if win mode for COMP{{ (id-1) }}/{{ id }} on.
+		 */
+		static inline bool
+		isWindowModeEnabled()
+		{
+			return COMP{{ id }}->CSR & {{ csr }}{{ windowmode }};
+		}
+	{% endif -%}
+
+	{% if target.family == "f3" -%}
+		/**
+		 * \brief	Selects what the output is connected to.
+		 */
+		static inline void
+		setOutputSelection(Output output)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~OutputMask) | static_cast<uint32_t>(output);
+		}
+
+		/**.
+		 * \brief	Returns what is connected to the output.
+		 */
+		static inline Output
+		getOutputSelection()
+		{
+			return static_cast<Output>
+				(COMP{{ id }}->CSR & OutputMask);
+		}
+	{% endif -%}
+
+		/**
+		 * \brief	Selects output polarity.
+		 */
+		static inline void
+		setPolarity(Polarity pol)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~PolarityMask) | static_cast<uint32_t>(pol);
+		}
+
+		/**.
+		 * \brief	Returns output polarity.
+		 */
+		static inline Polarity
+		getPolarity()
+		{
+			return static_cast<Polarity>(COMP{{ id }}->CSR & PolarityMask);
+		}
+
+		/**
+		 * \brief	Selects the hysteresis.
+		 */
+		static inline void
+		setHysteresis(Hysteresis hyst)
+		{
+			COMP{{ id }}->CSR = (COMP{{ id }}->CSR & ~HysteresisMask) | static_cast<uint32_t>(hyst);
+		}
+
+		/**.
+		 * \brief	Returns the hysteresis.
+		 */
+		static inline Hysteresis
+		getHysteresis()
+		{
+			return static_cast<Hysteresis> (COMP{{ id }}->CSR & HysteresisMask);
+		}
+
+		/**
+		 * \brief	Selects the blanking source.
+		 */
+		static inline void
+		setBlankingSource(BlankingSource blanking)
+		{
+			COMP{{ id }}->CSR |= (COMP{{ id }}->CSR & ~BlankingSourceMask) | static_cast<uint32_t>(blanking);
+		}
+
+		/**.
+		 * \brief	Returns the blanking source.
+		 */
+		static inline BlankingSource
+		getBlankingSource()
+		{
+			return static_cast<BlankingSource>(COMP{{ id }}->CSR & BlankingSourceMask);
+		}
+
+		/**
+		 * \brief	Returns the current Comparator output.
+		 */
+		static inline bool
+		getOutput()
+		{
+		{% if target.family == "f3" -%}
+			return COMP{{ id }}->CSR & {{ csr }}OUT;
+		{% elif target.family == "l4" -%}
+			return COMP{{ id }}->CSR & {{ csr }}VALUE;
+		{% endif -%}
+		}
+
+		/**
+		 * \brief	Locks the comparator.
+		 *
+		 * Comparator can only be unlocked by a system reset.
+		 */
+		static inline void
+		lock(void)
+		{
+			COMP{{ id }}->CSR |= {{ csr }}LOCK;
+		}
+
+		/**
+		 * \brief	Returns true if the comparator is locked.
+		 */
+		static inline bool
+		isLocked(void)
+		{
+			return COMP{{ id }}->CSR & {{ csr }}LOCK;
+		}
+
+	public:
+		// start inherited documentation
+		template< template<Peripheral _> class... Signals >
+		static void
+		connect()
+		{
+			using Connector = GpioConnector<Peripheral::Comp{{ id }}, Signals...>;
+			Connector::connect();
+		}
+	};
 }
-#else	// defined(STM32F3XX)
-	#  error 	"STM32F3XX not defined. Are you sure the comparator hw " \
-				"feature is enabled on you platform?"
-#endif
 
 #endif	//  MODM_STM32_COMP{{ id }}_HPP

--- a/src/modm/platform/comp/stm32/module.lb
+++ b/src/modm/platform/comp/stm32/module.lb
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+class Instance(Module):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "COMP {} instance".format(self.instance)
+
+    def prepare(self, module, options):
+        module.depends(":platform:comp")
+        return True
+
+    def build(self, env):
+        device = env[":target"]
+        driver = device.get_driver("comp")
+
+        properties = device.properties
+        properties["target"] = device.identifier
+        properties["partname"] = device.partname
+        instance_id = int(self.instance)
+        properties["id"] = instance_id
+        properties["csr"] = "COMP_CSR_" if device.identifier["family"] in ["l4"] else "COMP_CSR_COMPx"
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/comp"
+
+        env.template("comp.hpp.in", "comp_{}.hpp".format(self.instance))
+
+
+def init(module):
+    module.name = "comp"
+    module.parent = "platform"
+
+def prepare(module, options):
+    device = options[":target"]
+
+    if not device.has_driver("comp:stm32*"):
+        return False
+
+    if not device.get_driver("comp")["type"] in ["stm32-v1.3", "stm32-tsmc90_cube"]:
+        return False
+
+    # Only some STM32F3 and STM32L4
+    if device.identifier["family"] == "f3":
+        if not device.identifier["name"] in ["03", "28", "58", "98"]:
+            return False
+    elif device.identifier["family"] == "l4":
+        if not device.identifier["name"] in ["31", "32", "33", "42", "43", "51", "52", "62"]:
+            return False
+    else:
+        return False
+
+    module.depends(":cmsis:device")
+
+    for instance in listify(device.get_driver("comp")["instance"]):
+        module.add_submodule(Instance(int(instance)))
+
+    return True
+
+def build(env):
+    device = env[":target"]
+    driver = device.get_driver("comp")
+
+    properties = device.properties
+    properties["target"] = device.identifier
+    properties["partname"] = device.partname
+    properties["driver"] = driver
+    properties["csr"] = "COMP_CSR_" if device.identifier["family"] in ["l4"] else "COMP_CSR_COMPx"
+
+    env.substitutions = properties
+    env.outbasepath = "modm/src/modm/platform/comp"
+    env.template("base.hpp.in", "base.hpp")

--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -203,7 +203,8 @@ struct Gpio{{ port ~ pin }}::{{ signal.name }}<Peripheral::{{ signal.driver }}>
 	{
 		%% if signal.af | length
 		setAlternateFunction({{ signal.af[0] }});
-		%% elif signal.driver.startswith("Adc") or signal.driver.startswith("Dac")
+		%% elif ( signal.driver.startswith("Adc") or signal.driver.startswith("Dac")
+			or signal.driver.startswith("Comp") )
 		disconnect();
 		setAnalogInput();
 		%% endif

--- a/test/modm/platform/gpio/platform_gpio_test_stm32.cpp.in
+++ b/test/modm/platform/gpio/platform_gpio_test_stm32.cpp.in
@@ -221,7 +221,7 @@ PlatformGpioTest::testConnect()
 		%% if af
 		TEST_ASSERT_TRUE((GPIO{{port}}->MODER & (3ul << {{pin*2}})) == (2ul << {{pin*2}}));
 		TEST_ASSERT_TRUE((GPIO{{port}}->AFR[{{pin//8}}] & (15ul << {{(pin % 8) * 4}})) == ({{af}}ul << {{(pin % 8) * 4}}));
-		%% elif peripheral.startswith("Adc") or peripheral.startswith("Dac")
+		%% elif peripheral.startswith("Adc") or peripheral.startswith("Dac") or peripheral.startswith("Comp")
 		TEST_ASSERT_TRUE((GPIO{{port}}->MODER & (3ul << {{pin*2}})) == (3ul << {{pin*2}}));
 		%% endif
 	%% endfor


### PR DESCRIPTION
Replaces the old `comp/stm32/comp.hpp.in` which neither compiled nor ever worked correctly.

Two examples for Nucleo-L432 and STM32F3-Discovery boards are added.

In the future (with data from PDF datasheets) I plan to improve the input-selection enums and to add support for more STM32 controllers.


#### Todo
- [x] Test in hardware
- [x] Add a `connect<>();` method?