### PR TITLE
Added support for Nucleo F042K6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Examples STM32F0 Series
           command: |
-            (cd examples && ../tools/scripts/examples_compile.py stm32f0_discovery stm32f072_discovery nucleo_f031k6 stm32f030f4p6_demo_board)
+            (cd examples && ../tools/scripts/examples_compile.py stm32f0_discovery stm32f072_discovery nucleo_f031k6 nucleo_f042k6 stm32f030f4p6_demo_board)
       - run:
           name: Examples STM32F1 Series
           command: |

--- a/examples/nucleo_f042k6/blink/main.cpp
+++ b/examples/nucleo_f042k6/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (1)
+	{
+		LedD13::toggle();
+		modm::delayMilliseconds(Button::read() ? 100 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f042k6/blink/project.xml
+++ b/examples/nucleo_f042k6/blink/project.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>../../../src/modm/board/nucleo_f042k6/board.xml</extends>
+  <options>
+    <option name=":build.scons:build.path">../../../build/nucleo_f042k6/blink</option>
+  </options>
+  <modules>
+    <module>:build.scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f042k6/board.hpp
+++ b/src/modm/board/nucleo_f042k6/board.hpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-2018, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ * Copyright (c) 2017, Sascha Schade
+ * Copyright (c) 2018, Carl Treudler
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//
+// NUCLEO-F042K6
+// Nucleo kit for STM32F042K6
+// http://www.st.com/en/evaluation-tools/nucleo-f042k6.html
+//
+
+#ifndef MODM_STM32_NUCLEO_F042K6_HPP
+#define MODM_STM32_NUCLEO_F042K6_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+
+namespace Board
+{
+
+/// STM32F042K6 running at 48MHz generated from the internal 8MHz crystal
+// Dummy clock for devices
+struct systemClock {
+	static constexpr uint32_t Frequency = MHz48;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb;
+
+	static constexpr uint32_t Spi1   = Apb;
+
+	static constexpr uint32_t Usart1 = Apb;
+	static constexpr uint32_t Usart2 = Apb;
+
+	static constexpr uint32_t I2c1   = Apb;
+
+	static constexpr uint32_t Timer1  = Apb;
+	static constexpr uint32_t Timer2  = Apb;
+	static constexpr uint32_t Timer3  = Apb;
+	static constexpr uint32_t Timer14 = Apb;
+	static constexpr uint32_t Timer16 = Apb;
+	static constexpr uint32_t Timer17 = Apb;
+
+	static bool inline
+	enable()
+	{
+		ClockControl::enableInternalClock();	// 8MHz
+		// (internal clock / 2) * 12 = 48MHz
+		ClockControl::enablePll(ClockControl::PllSource::InternalClock, ClockControl::UsbPrescaler::Div1, 12, 2, 1);
+		// set flash latency for 48MHz
+		ClockControl::setFlashLatency(Frequency);
+		// switch system clock to PLL output
+		ClockControl::enableSystemClock(ClockControl::SystemClockSource::Pll);
+		ClockControl::setAhbPrescaler(ClockControl::AhbPrescaler::Div1);
+		ClockControl::setApbPrescaler(ClockControl::ApbPrescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		modm::clock::fcpu     = Frequency;
+		modm::clock::fcpu_kHz = Frequency / 1000;
+		modm::clock::fcpu_MHz = Frequency / 1000000;
+		modm::clock::ns_per_loop = ::round(4000.f / (Frequency / 1000000));
+
+		return true;
+	}
+};
+
+// Arduino Nano Footprint
+#include "nucleo32_arduino.hpp"
+
+using Button = GpioUnused;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+	using Rx = GpioInputA15;
+	using Tx = GpioOutputA2;
+
+	using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	systemClock::enable();
+	modm::cortex::SysTickTimer::initialize<systemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<systemClock, 115200>();
+}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_F042K6_HPP

--- a/src/modm/board/nucleo_f042k6/board.xml
+++ b/src/modm/board/nucleo_f042k6/board.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
+         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+    <cache>.lbuild_cache</cache>
+  </repositories>
+
+  <options>
+    <option name=":target">stm32f042k6t</option>
+    <option name=":platform:uart:2:buffer.tx">256</option>
+    <option name=":platform:core:main_stack_size">992</option>
+    <option name=":platform:core:allocator">block</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f042k6</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2018, Carl Treudler
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.parent = "board"
+    module.name = "nucleo-f042k6"
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32f042k6t":
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": True}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
+    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f0.cfg");


### PR DESCRIPTION
It is based on the BSP for Nucelo F031.
Testing is mostly incomplete. I only tested: USART1 & USART2 as loggers, LED blinking.
Basically, I fiddled the clock generation to make the USARTs work, and fixed things along the way.