### PR TITLE
Various compilation fixes for GCC 8

### DIFF
--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -113,7 +113,7 @@ bool
 modm::platform::Adc{{ id }}::setChannel(const Channel channel,
 									 const SampleTime sampleTime)
 {
-	if (uint32_t(channel) >= 18) return false;
+	if (uint32_t(channel) > 18) return false;
 	// clear number of conversions in the sequence
 	// and set number of conversions to 1
 	ADC{{ id }}->SQR1 = 0;

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -189,7 +189,7 @@ public:
 	 * @pre The ADC clock must be started and the ADC switched on with
 	 * 		initialize()
 	 */
-	static inline void
+	static inline bool
 	setChannel(const Channel channel,
 			   const SampleTime sampleTime=static_cast<SampleTime>(0b000));
 

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -97,10 +97,14 @@ modm::stm32::Adc::setDataAlignmentAndResolution(const DataAlignment align,
                   (ADC1->CFGR1 & ~(ADC_CFGR1_ALIGN | ADC_CFGR1_RES));
 }
 
-void
+bool
 modm::stm32::Adc::setChannel(const Channel channel,
                              const SampleTime sampleTime)
 {
+    if(static_cast<uint32_t>(channel) > 18) {
+        return false;
+    }
+
     ADC1->CHSELR |= 1 << static_cast<uint32_t>(channel);
     ADC1->SMPR   = static_cast<uint32_t>(sampleTime);
 
@@ -109,6 +113,8 @@ modm::stm32::Adc::setChannel(const Channel channel,
     } else if (channel == Channel::Temperature) {
         ADC1_COMMON->CCR |= ADC_CCR_TSEN;
     }
+
+    return true;
 }
 
 void

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -297,7 +297,7 @@ public:
 	 * @pre The ADC clock must be started and the ADC switched on with
 	 * 		initialize()
 	 */
-	static inline void
+	static inline bool
 	setChannel(const Channel channel,
 			const SampleTime sampleTime=static_cast<SampleTime>(0b000));
 

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -137,10 +137,14 @@ modm::platform::Adc{{ id }}::setLeftAdjustResult(const bool enable)
 	}
 }
 
-void
+bool
 modm::platform::Adc{{ id }}::setChannel(	const Channel channel,
 										const SampleTime sampleTime)
 {
+	if(static_cast<uint8_t>(channel) > 18) {
+		return false;
+	}
+
 	uint32_t tmpreg;
 	// SQR1[10:6] contain SQ1[4:0]
 	ADC{{ id }}->SQR1 = (static_cast<uint8_t>(channel) & 0b11111) << 6;
@@ -159,6 +163,7 @@ modm::platform::Adc{{ id }}::setChannel(	const Channel channel,
 						((static_cast<uint8_t>(channel)-10) * 3);
 		ADC{{ id }}->SMPR2 = tmpreg;
 	}
+	return true;
 }
 
 void

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -50,4 +50,7 @@ def build(env):
         "boost_thread" if env[":target"].identifier["family"] == "linux" else
         "boost_thread-mt")
 
+    if env[":target"].identifier["family"] == "linux":
+        env.append_metadata_unique("required_library", "pthread")
+
     env.copy(".", ignore=env.ignore_patterns(*ignore))

--- a/src/modm/ui/animation/key_frame_impl.hpp
+++ b/src/modm/ui/animation/key_frame_impl.hpp
@@ -199,7 +199,7 @@ template< typename T, class... Args >
 modm::ui::KeyFrameAnimationMode
 modm::ui::KeyFrameAnimationBase<T, Args...>::getMode() const
 {
-	return mode;
+	return static_cast<KeyFrameAnimationMode>(mode);
 }
 
 template< typename T, class... Args >

--- a/tools/devices/hosted/windows.xml
+++ b/tools/devices/hosted/windows.xml
@@ -6,6 +6,7 @@
 
     <attribute-core value="x86"/>
 
+    <driver name="core" type="hosted"/>
     <driver name="graphics" type="hosted"/>
     <driver name="gpio" type="hosted"/>
     <driver name="uart" type="hosted"/>


### PR DESCRIPTION
Using gcc 8.2.0 the F3/L4 ADC examples fail to build with 
> modm/src/modm/platform/adc/adc_1.hpp: In static member function 'static bool modm::platform::Adc1::setPinChannel(modm::platform::Adc1::SampleTime)':
modm/src/modm/platform/adc/adc_1.hpp:260:51: error: void value not ignored as it ought to be
   return setChannel(Channel(Gpio::pin), sampleTime);

setPinChannel expects setChannel to return bool instead of void like in the F4/F7 implementation. A range check on the channel parameter is added to the F3/L4 and F0 ADC implementations.

How can that build in our CI :astonished: ?

An off-by-1 error in the F4/F7 ADC is also fixed. The maximum channel index 18 is currently rejected as invalid. 
