### PR TITLE
[ui] Fix build of KeyFrameAnimation

### DIFF
--- a/src/modm/ui/animation/key_frame_impl.hpp
+++ b/src/modm/ui/animation/key_frame_impl.hpp
@@ -199,7 +199,7 @@ template< typename T, class... Args >
 modm::ui::KeyFrameAnimationMode
 modm::ui::KeyFrameAnimationBase<T, Args...>::getMode() const
 {
-	return mode;
+	return static_cast<KeyFrameAnimationMode>(mode);
 }
 
 template< typename T, class... Args >


### PR DESCRIPTION
key_frame.hpp and thus the F4 Discovery timer example does not build with a recent GCC because in KeyFrameAnimationBase::getMode() it is attempted to return a uint8_t. The required return type is KeyFrameAnimationMode. A static_cast is added to fix this.