### PR TITLE
Move OpenOCD and GDB tools into parent build module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ project.xml.log
 
 # CMake
 CMakeLists.txt
-**/cmake-build-debug/
 
 #Clion
 **/.idea/
@@ -32,4 +31,5 @@ examples/**/modm
 examples/**/SConstruct
 examples/**/Makefile
 examples/**/generated
+examples/**/gdbinit
 examples/**/openocd.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ examples/**/modm
 examples/**/SConstruct
 examples/**/Makefile
 examples/**/generated
+examples/**/openocd.cfg

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -11,6 +11,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+from os.path import join
 # import all common code
 exec(open(localpath("../common.py")).read())
 
@@ -27,7 +28,10 @@ def prepare(module, options):
 
 
 def build(env):
-    pass
+    project_name = env[":build:project.name"]
+    build_path = env[":build:build.path"]
+    env.append_metadata_unique("elf.release", join(build_path, "cmake-build-release", project_name + ".elf"))
+    env.append_metadata_unique("elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
 
 
 def post_build(env, buildlog):
@@ -45,7 +49,6 @@ def post_build(env, buildlog):
     subs.update({
         "project_path": os.getcwd(),
         "metadata": buildlog.metadata,
-        "openocd_config" : buildlog.metadata["openocd.configfile"][0],
         "compiler": "gcc",
         "project_name": env[":build:project.name"],
         "build_path": env[":build:build.path"],

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -2,9 +2,6 @@
 CMAKE_BUILD_TYPE = Debug
 BUILD_DIR = {{ build_path }}
 
-OPENOCD_CONFIG = {{ openocd_config }}
-OPENOCD_INCLUDE = modm/openocd
-
 CMAKE_GENERATOR = Unix Makefiles
 CMAKE_FLAGS = -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DCMAKE_RULE_MESSAGES:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
 
@@ -37,10 +34,10 @@ cleanall:
 	@rm -rf $(BUILD_DIR)/cmake-build-debug
 
 upload-debug: build-debug
-	@openocd -s $(OPENOCD_INCLUDE) -f $(OPENOCD_CONFIG) -c "program $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf verify reset exit"
+	@openocd -f openocd.cfg -c "program_debug"
 
 upload-release: build-release
-	@openocd -s $(OPENOCD_INCLUDE) -f $(OPENOCD_CONFIG) -c "program $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf verify reset exit"
+	@openocd -f openocd.cfg -c "program_release"
 
 gdb: build-debug
 	@arm-none-eabi-gdb --command=$(GDB_INIT)  $(EXECUTABLE_PATH)

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -40,7 +40,11 @@ upload-release: build-release
 	@openocd -f openocd.cfg -c "program_release"
 
 gdb: build-debug
-	@arm-none-eabi-gdb --command=$(GDB_INIT)  $(EXECUTABLE_PATH)
+	@arm-none-eabi-gdb -x gdbinit $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
+	@killall openocd || true
+
+gdb-release: build-release
+	@arm-none-eabi-gdb -x gdbinit $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
 	@killall openocd || true
 
 killopenocd:

--- a/tools/build_script_generator/gdbinit.in
+++ b/tools/build_script_generator/gdbinit.in
@@ -1,0 +1,35 @@
+%% for profile in ["release", "debug"]
+%% if "elf." ~ profile in metadata
+define file_{{profile}}
+    file
+    file {{ metadata["elf." ~ profile][0] }}
+end
+%% endif
+%% endfor
+
+layout split
+focus cmd
+set print pretty
+set print asm-demangle on
+set mem inaccessible-by-default off
+
+# Doesn't work correctly since Ctrl-C will kill openocd
+# See https://github.com/RIOT-OS/RIOT/pull/3619
+# Launch with `openocd -f openocd.cfg & arm-none-eabi-gdb; kill $!` in shell instead
+# target extended-remote | openocd -f openocd.cfg -c "gdb_port pipe"
+
+target extended-remote :3333
+
+define restart
+  mon reset halt
+end
+
+define rerun
+  mon reset halt
+  c
+end
+
+mon init
+mon poll on
+refresh
+c

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -27,6 +27,21 @@ def prepare(module, options):
         StringOption(name="build.path", default="build/"+default_project_name,
                      description="Path to the build folder"))
 
+    if platform in ["avr"]:
+        # we need the clock:f_cpu option!
+        module.depends(":platform:clock")
+        module.add_option(
+            StringOption(name="avrdude.programmer", default="avrispmkII",
+                         description="AvrDude programmer"))
+        module.add_option(
+            StringOption(name="avrdude.port", default="usb",
+                         description="AvrDude programmer port"))
+        module.add_option(
+            NumericOption(name="avrdude.baudrate", default=-1,
+                          description="AvrDude programmer baudrate"))
+        module.add_option(
+            StringOption(name="avrdude.options", default="",
+                         description="AvrDude programmer options"))
     return True
 
 

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -49,10 +49,14 @@ def prepare(module, options):
             BooleanOption(name="include_openocd", default=True,
                           description="Generate a default openocd.cfg file"))
         module.add_option(
+            BooleanOption(name="include_gdbinit", default=True,
+                          description="Generate a default .gdbinit file"))
+        module.add_option(
             StringOption(name="openocd.cfg", default="",
                          description="Path to a custom OpenOCD configuration file"))
 
     return True
+
 
 def build(env):
     env.append_metadata_unique("include_path", "src")
@@ -65,6 +69,7 @@ def build(env):
     # Append common search paths to metadata
     env.append_metadata_unique("openocd.search", "modm/openocd")
 
+
 def post_build(env, buildlog):
     target = env[":target"]
     subs = {
@@ -76,3 +81,6 @@ def post_build(env, buildlog):
 
     if env.get_option("::include_openocd", False):
         env.template("openocd.cfg.in")
+
+    if env.get_option("::include_gdbinit", False):
+        env.template("gdbinit.in")

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -19,6 +19,7 @@ def init(module):
 def prepare(module, options):
     _, default_project_name = os.path.split(os.getcwd())
     default_project_name = default_project_name.replace(".", "_").replace(" ", "_")
+    platform = options[":target"].identifier["platform"]
 
     module.add_option(
         StringOption(name="project.name", default=default_project_name,
@@ -42,8 +43,36 @@ def prepare(module, options):
         module.add_option(
             StringOption(name="avrdude.options", default="",
                          description="AvrDude programmer options"))
-    return True
 
+    if options[":target"].has_driver("core:cortex-m*"):
+        module.add_option(
+            BooleanOption(name="include_openocd", default=True,
+                          description="Generate a default openocd.cfg file"))
+        module.add_option(
+            StringOption(name="openocd.cfg", default="",
+                         description="Path to a custom OpenOCD configuration file"))
+
+    return True
 
 def build(env):
     env.append_metadata_unique("include_path", "src")
+
+    # Append custom openocd config file to metadata
+    openocd_cfg = env.get_option(":build:openocd.cfg", "")
+    if len(openocd_cfg):
+        env.append_metadata_unique("openocd.configfile", openocd_cfg)
+
+    # Append common search paths to metadata
+    env.append_metadata_unique("openocd.search", "modm/openocd")
+
+def post_build(env, buildlog):
+    target = env[":target"]
+    subs = {
+        "metadata": buildlog.metadata,
+    }
+    # these are the ONLY files that are allowed to NOT be namespaced with modm!
+    env.outbasepath = "."
+    env.substitutions = subs
+
+    if env.get_option("::include_openocd", False):
+        env.template("openocd.cfg.in")

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -1,0 +1,22 @@
+%% for path in metadata.get("openocd.search", []) | sort
+add_script_search_dir {{ path }}
+%% endfor
+%% for file in metadata.get("openocd.configfile", []) | sort
+source [find {{ file }}]
+%% endfor
+
+proc modm_program { SOURCE } {
+	program $SOURCE verify
+	reset halt
+	mww 0xE000EDF0 0xA05F0000
+	shutdown
+}
+
+%% for profile in ["release", "debug"]
+%% if "elf." ~ profile in metadata
+proc program_{{ profile }} {} {
+	modm_program {{ metadata["elf." ~ profile][0] }}
+}
+%% endif
+%% endfor
+

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -60,6 +60,7 @@ def post_build(env, buildlog):
         "template",
         "cmake_wrapper",
         "qtcreator",
+        "gdb",
     ]
     if has_xpcc_generator:
         build_tools += ["xpcc_generator"]

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -35,22 +35,7 @@ def prepare(module, options):
         BooleanOption(name="info.build", default=False,
                       description="Generate CPP defines about the build state"))
 
-    if options[":target"].identifier["platform"] == "avr":
-        # we need the clock:f_cpu option!
-        module.depends(":platform:clock")
-        module.add_option(
-            StringOption(name="avrdude.programmer", default="avrispmkII",
-                         description="AvrDude programmer"))
-        module.add_option(
-            StringOption(name="avrdude.port", default="usb",
-                         description="AvrDude programmer port"))
-        module.add_option(
-            NumericOption(name="avrdude.baudrate", default=-1,
-                          description="AvrDude programmer baudrate"))
-        module.add_option(
-            StringOption(name="avrdude.options", default="",
-                         description="AvrDude programmer options"))
-    elif options[":target"].identifier["platform"] == "stm32":
+    if options[":target"].identifier["platform"] == "stm32":
         module.add_option(
             StringOption(name="openocd.cfg", default="",
                          description="Path to the OpenOCD configuration file"))
@@ -112,6 +97,10 @@ def post_build(env, buildlog):
         "generator_container": env.get_option(":communication:xpcc:generator:container", ""),
         "generator_path": env.get_option(":communication:xpcc:generator:path", ""),
         "generator_namespace": env.get_option(":communication:xpcc:generator:namespace", ""),
+        "avrdude_programmer": env.get_option(":build:avrdude.programmer", ""),
+        "avrdude_port": env.get_option(":build:avrdude.port", ""),
+        "avrdude_options": env.get_option(":build:avrdude.options", ""),
+        "avrdude_baudrate": env.get_option(":build:avrdude.baudrate", 0),
     })
     # Set these substitutions for all templates
     env.substitutions = subs

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-import os
+from os.path import join
 # import all common code
 exec(open(localpath("../common.py")).read())
 
@@ -35,15 +35,14 @@ def prepare(module, options):
         BooleanOption(name="info.build", default=False,
                       description="Generate CPP defines about the build state"))
 
-    if options[":target"].identifier["platform"] == "stm32":
-        module.add_option(
-            StringOption(name="openocd.cfg", default="",
-                         description="Path to the OpenOCD configuration file"))
     return True
 
 
 def build(env):
-    pass
+    project_name = env[":build:project.name"]
+    build_path = env[":build:build.path"]
+    env.append_metadata_unique("elf.release", join(build_path, "release", project_name + ".elf"))
+    env.append_metadata_unique("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
 
 def post_build(env, buildlog):
@@ -85,8 +84,6 @@ def post_build(env, buildlog):
     subs["flags"] = common_compiler_flags("gcc", target, buildlog)
     # Add SCons specific data
     subs.update({
-        "openocd_base_dir": os.path.dirname(env.get_option(":::openocd.cfg", "")),
-        "openocd_file": os.path.basename(env.get_option(":::openocd.cfg", "")),
         "metadata": buildlog.metadata,
         "build_tools": build_tools,
         "is_unittest": is_unittest,

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -73,11 +73,11 @@ env["CONFIG_DEVICE_MEMORY"] = [
 # Programming configuration
 %% if platform in ["avr"]
 env["CONFIG_AVRDUDE_DEVICE"] = "{{ mcu }}"
-env["CONFIG_AVRDUDE_PROGRAMMER"] = "{{ options[":::avrdude.programmer"] }}"
-env["CONFIG_AVRDUDE_PORT"] = "{{ options[":::avrdude.port"] }}"
-env["CONFIG_AVRDUDE_OPTIONS"] = "{{ options[":::avrdude.options"] }}"
-%% if options[":::avrdude.baudrate"] > 0
-env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ options[":::avrdude.baudrate"] }}"
+env["CONFIG_AVRDUDE_PROGRAMMER"] = "{{ avrdude_programmer }}"
+env["CONFIG_AVRDUDE_PORT"] = "{{ avrdude_port }}"
+env["CONFIG_AVRDUDE_OPTIONS"] = "{{ avrdude_options }}"
+%% if avrdude_baudrate > 0
+env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ avrdude_baudrate }}"
 %% endif
 %% endif
 %% if platform in ["stm32"]

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -80,28 +80,6 @@ env["CONFIG_AVRDUDE_OPTIONS"] = "{{ avrdude_options }}"
 env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ avrdude_baudrate }}"
 %% endif
 %% endif
-%% if platform in ["stm32"]
-env.SetDefault(CONFIG_OPENOCD_SEARCHDIRS = [
-%% if "openocd.configfile" in metadata
-    abspath("openocd")
-%% endif
-])
-env.SetDefault(CONFIG_OPENOCD_CONFIGFILES = [
-%% if "openocd.configfile" in metadata
-    %% for configfile in metadata["openocd.configfile"]
-    "{{ configfile }}",
-    %% endfor
-%% endif
-])
-env.SetDefault(CONFIG_OPENOCD_COMMANDS = [
-    "init",
-    "reset halt",
-    "flash write_image erase $SOURCE",
-    "reset halt",
-    "mww 0xE000EDF0 0xA05F0000",
-    "shutdown"
-])
-%% endif
 
 # XPCC generator tool path
 env["XPCC_SYSTEM_DESIGN"] = join(abspath("."), "tools", "xpcc_generator")

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -73,12 +73,6 @@ sources += env.FindSourceFiles(".", ignorePaths=ignored)
 # Building application
 program = env.Program(target=project_name+".elf", source=sources)
 
-%% if openocd_file != ""
-# Using a custom OpenOCD script
-env.Append(CONFIG_OPENOCD_SEARCHDIRS=[abspath("{{openocd_base_dir}}")])
-env.Append(CONFIG_OPENOCD_CONFIGFILES=["{{openocd_file}}"])
-%% endif
-
 # SCons functions
 env.Alias("cmakewrapper", env.CMakeWrapper())
 env.Alias("qtcreator", env.QtCreatorProject(sources))
@@ -92,7 +86,7 @@ env.Alias("all", ["build", "run"])
 %% else
     %% if platform in ["stm32"]
 env.Alias("size", env.Size(program))
-env.Alias("program", env.OpenOcd(program))
+env.Alias("program", env.OpenOcd(program, commands=["program_{}".format(profile)]))
     %% elif platform in ["avr"]
 env.Alias("program", env.Avrdude(program))
     %% endif

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -87,6 +87,7 @@ env.Alias("all", ["build", "run"])
     %% if platform in ["stm32"]
 env.Alias("size", env.Size(program))
 env.Alias("program", env.OpenOcd(program, commands=["program_{}".format(profile)]))
+env.Alias("gdb", env.OpenocdGdb(program))
     %% elif platform in ["avr"]
 env.Alias("program", env.Avrdude(program))
     %% endif

--- a/tools/build_script_generator/scons/site_tools/gdb.py
+++ b/tools/build_script_generator/scons/site_tools/gdb.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2009, Martin Rosekeit
-# Copyright (c) 2009-2012, Fabian Greif
-# Copyright (c) 2012, Georgi Grinshpun
-# Copyright (c) 2012, Sascha Schade
-# Copyright (c) 2012, 2016-2017, Niklas Hauser
-# Copyright (c) 2016, Daniel Krebs
-# Copyright (c) 2017, Michael Thies
+# Copyright (c) 2018, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -16,28 +10,35 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-import platform
+import os
 from SCons.Script import *
+import subprocess
+import signal
 
-# -----------------------------------------------------------------------------
-# Start the gnu debugger
-# -----------------------------------------------------------------------------
+def run_openocd_gdb(target, source, env):
+	# We have to start openocd in its own session ID, so that Ctrl-C in GDB
+	# does not kill OpenOCD. See https://github.com/RIOT-OS/RIOT/pull/3619.
+	openocd = subprocess.Popen("openocd -f openocd.cfg -c \"log_output /dev/null\"", cwd=os.getcwd(), shell=True,
+	                           preexec_fn=os.setsid)
+	# This call is blocking
+	subprocess.call("arm-none-eabi-gdb -x gdbinit {}".format(source[0]), cwd=os.getcwd(), shell=True)
+	# Then kill just the background OpenOCD process
+	os.killpg(os.getpgid(openocd.pid), signal.SIGTERM)
+	return 0
 
-def gdb_debug(env, source, alias='gdb_debug'):
-	actionString = '$GDB $SOURCE -ex "target extended-remote :$GDB_PORT"'
-	action = Action(actionString, cmdstr="$GDB_COMSTR")
+def gdb_arm_none_eabi_debug(env, source, alias="gdb_arm_none_eabi_debug"):
+	action = Action(run_openocd_gdb, cmdstr="$OPENOCDGDBSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
 	# build messages
-	if not ARGUMENTS.get('verbose'):
-		env['GDB_COMSTR'] = "GDB: debugging $SOURCE"
+	if not ARGUMENTS.get("verbose"):
+		env["OPENOCDGDBSTR"] = "%s.------GDB----- %s$SOURCE\n" \
+	                           "%s'----OpenOCD--> %s$CONFIG_DEVICE_NAME%s" % \
+	                           ("\033[;0;32m", "\033[;0;33m", "\033[;0;32m", "\033[;1;33m", "\033[;0;0m")
 
-	env['GDB'] = "arm-none-eabi-gdb -tui"
-	env['GDB_PORT'] = '3333'
-
-	env.AddMethod(gdb_debug, 'GdbDebug')
+	env.AddMethod(gdb_arm_none_eabi_debug, "OpenocdGdb")
 
 def exists(env):
-	return env.Detect('gdb')
+	return env.Detect("openocd") and env.Detect("arm-none-eabi-gdb")

--- a/tools/scripts/examples_cleanup.sh
+++ b/tools/scripts/examples_cleanup.sh
@@ -9,8 +9,10 @@
 
 find ${@:1} -name project.xml.log -delete
 find ${@:1} -name SConstruct -delete
-find ${@:1} -name SConscript -delete
 find ${@:1} -name Makefile -delete
+find ${@:1} -name CMakeLists.txt -delete
+find ${@:1} -name openocd.cfg -delete
+find ${@:1} -name gdbinit -delete
 
 find ${@:1} -type d -name modm -exec rm -rf "{}" \;
-find ${@:1} -type d -name cmake -exec rm -r "{}" \;
+find ${@:1} -type d -name generated -exec rm -rf "{}" \;


### PR DESCRIPTION
This adds the generation of a `openocd.cfg` and `.gdbinit` file to the `modm:build` module in order to move the magic commands from the (build system dependent) command line to an independent file format.

To upload via command line is now simply a matter of `openocd -c "program_{profile}"`, and starting the debugger in TUI mode is simply: `arm-none-eabi-gdb`.
By default the debug executable is loaded for GDB, however, with `file_release`, the release version can be reloaded.

You can combine both like this: `openocd & arm-none-eabi-gdb; kill $!`, this will start openocd in the background, start GDB and then kill it after GDB terminates.

- [x] Add automatic openocd start/stop to SCons
- [ ] Add automatic openocd start/stop to CMake
- ~~Add support for remote programming/debugging for RCA~~ doing this later, when I understood the use-cases for this.

cc @rleh @chris-durand @dergraaf @strongly-typed 