### PR TITLE
Move git/build information into it's own file

### DIFF
--- a/examples/linux/build_info/main.cpp
+++ b/examples/linux/build_info/main.cpp
@@ -12,6 +12,7 @@
 
 #include <modm/platform.hpp>
 #include <modm/debug/logger.hpp>
+#include <info_build.h>
 
 // Set the log level
 #undef	MODM_LOG_LEVEL
@@ -21,10 +22,11 @@ int
 main()
 {
 	// Let's print some information that is provided in the modm_build_info.hpp
-	MODM_LOG_INFO << "Machine:  " << MODM_BUILD_MACHINE  << modm::endl;
-	MODM_LOG_INFO << "User:     " << MODM_BUILD_USER     << modm::endl;
-	MODM_LOG_INFO << "Os:       " << MODM_BUILD_OS       << modm::endl;
-	MODM_LOG_INFO << "Compiler: " << MODM_BUILD_COMPILER << modm::endl;
+	MODM_LOG_INFO << "Project:  " << MODM_BUILD_PROJECT_NAME << modm::endl;
+	MODM_LOG_INFO << "Machine:  " << MODM_BUILD_MACHINE      << modm::endl;
+	MODM_LOG_INFO << "User:     " << MODM_BUILD_USER         << modm::endl;
+	MODM_LOG_INFO << "Os:       " << MODM_BUILD_OS           << modm::endl;
+	MODM_LOG_INFO << "Compiler: " << MODM_BUILD_COMPILER     << modm::endl;
 
 	return 0;
 }

--- a/examples/linux/git/main.cpp
+++ b/examples/linux/git/main.cpp
@@ -12,6 +12,7 @@
 
 #include <modm/platform.hpp>
 #include <modm/debug/logger.hpp>
+#include <info_git.h>
 
 // Set the log level
 #undef	MODM_LOG_LEVEL

--- a/examples/linux/printf/main.cpp
+++ b/examples/linux/printf/main.cpp
@@ -13,6 +13,7 @@
 
 #include <modm/platform.hpp>
 #include <modm/debug/logger.hpp>
+#include <info_build.h>
 
 // Set the log level
 #undef	MODM_LOG_LEVEL

--- a/test/runner/hosted.cpp.in
+++ b/test/runner/hosted.cpp.in
@@ -19,6 +19,9 @@
 #include <modm/debug/logger.hpp>
 #include <modm/platform.hpp>
 
+#include <info_git.h>
+#include <info_build.h>
+
 modm::pc::Terminal outputDevice;
 
 modm::log::StyleWrapper< modm::log::Prefix< char[10] > > loggerDeviceDebug( \

--- a/test/runner/stm32.cpp.in
+++ b/test/runner/stm32.cpp.in
@@ -18,6 +18,9 @@
 #include <unittest/reporter.hpp>
 #include <unittest/controller.hpp>
 
+#include <info_git.h>
+#include <info_build.h>
+
 ${includes}
 
 ${names}

--- a/tools/build_script_generator/gitignore.in
+++ b/tools/build_script_generator/gitignore.in
@@ -1,0 +1,3 @@
+%% for entry in metadata["modm.gitignore"]
+{{ entry }}
+%% endfor

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -72,12 +72,16 @@ def build(env):
 
 def post_build(env, buildlog):
     target = env[":target"]
-    subs = {
+    env.substitutions = {
         "metadata": buildlog.metadata,
     }
+
+    if len(buildlog.metadata.get("modm.gitignore", [])):
+        env.outbasepath = "modm"
+        env.template("gitignore.in", ".gitignore")
+
     # these are the ONLY files that are allowed to NOT be namespaced with modm!
     env.outbasepath = "."
-    env.substitutions = subs
 
     if env.get_option("::include_openocd", False):
         env.template("openocd.cfg.in")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -44,6 +44,11 @@ def build(env):
     env.append_metadata_unique("elf.release", join(build_path, "release", project_name + ".elf"))
     env.append_metadata_unique("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
+    if env[":::info.git"] != "Disabled":
+        env.append_metadata_unique("modm.gitignore", "src/info_git.h")
+    if env[":::info.build"]:
+        env.append_metadata_unique("modm.gitignore", "src/info_build.h")
+
 
 def post_build(env, buildlog):
     is_unittest = env.has_module(":test")

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -30,7 +30,7 @@ env["COMPILERSUFFIX"] = "-8"
 env.SConscript(dirs=[modm_path], exports="env")
 
 %% if options[":::info.git"] != "Disabled"
-env.InfoGit({{ "True" if "Status" in options[":::info.git"] else "False" }})
+env.InfoGit(with_status={{ "True" if "Status" in options[":::info.git"] else "False" }})
 %% endif
 %% if options[":::info.build"]
 env.InfoBuild()

--- a/tools/build_script_generator/scons/site_tools/info.h.in
+++ b/tools/build_script_generator/scons/site_tools/info.h.in
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_INFO_{{ type | upper }}_HPP
+#define MODM_INFO_{{ type | upper }}_HPP
+
+%% for name, value in defines.items()
+#define {{ name | upper }} {{ value }}
+%% endfor
+
+#endif // MODM_INFO_{{ type | upper }}_HPP


### PR DESCRIPTION
This refactors the `info` SCons tool to create a `<info_git.h>` and `<info_build.h>` header file containing the information, instead of passing the information via the command line, to prevent complete rebuilds whenever it changed.

The generated files are .gitignored, so that if you commit the modm/ directory, you don't commit these files. 

Preliminary documentation can be found here: https://modm.io/reference/module/modm-build-scons/#information-tool

cc @rleh @chris-durand @strongly-typed 