### PR TITLE
Use relative, configurable paths for openocd.cfg and gdbinit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ examples/**/modm
 examples/**/SConstruct
 examples/**/Makefile
 examples/**/generated
-examples/**/gdbinit
-examples/**/openocd.cfg

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -46,12 +46,6 @@ def prepare(module, options):
 
     if options[":target"].has_driver("core:cortex-m*"):
         module.add_option(
-            BooleanOption(name="include_openocd", default=True,
-                          description="Generate a default openocd.cfg file"))
-        module.add_option(
-            BooleanOption(name="include_gdbinit", default=True,
-                          description="Generate a default .gdbinit file"))
-        module.add_option(
             StringOption(name="openocd.cfg", default="",
                          description="Path to a custom OpenOCD configuration file"))
 
@@ -75,16 +69,11 @@ def post_build(env, buildlog):
     env.substitutions = {
         "metadata": buildlog.metadata,
     }
+    env.outbasepath = "modm"
 
     if len(buildlog.metadata.get("modm.gitignore", [])):
-        env.outbasepath = "modm"
         env.template("gitignore.in", ".gitignore")
 
-    # these are the ONLY files that are allowed to NOT be namespaced with modm!
-    env.outbasepath = "."
-
-    if env.get_option("::include_openocd", False):
+    if env[":target"].has_driver("core:cortex-m*"):
         env.template("openocd.cfg.in")
-
-    if env.get_option("::include_gdbinit", False):
         env.template("gdbinit.in")

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -79,6 +79,9 @@ env["CONFIG_AVRDUDE_OPTIONS"] = "{{ avrdude_options }}"
 %% if avrdude_baudrate > 0
 env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ avrdude_baudrate }}"
 %% endif
+%% elif platform in ["stm32"]
+env.Append(MODM_OPENOCD_CONFIGFILES=["$BASEPATH/openocd.cfg"])
+env.SetDefault(MODM_GDBINIT=["$BASEPATH/gdbinit"])
 %% endif
 
 # XPCC generator tool path

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -42,7 +42,7 @@ headers = env.FindHeaderFiles(join(modm_path, "test"))
 sources = env.UnittestRunner(target="main.cpp", source=headers, template="modm/test/runner.cpp.in")
 %% else
 env.Append(CPPPATH=".")
-ignored = ["modm", "cmake-build-*", "build"]
+ignored = [modm_path, "cmake-*", build_path]
 sources = []
 %% endif
 
@@ -86,8 +86,8 @@ env.Alias("all", ["build", "run"])
 %% else
     %% if platform in ["stm32"]
 env.Alias("size", env.Size(program))
-env.Alias("program", env.OpenOcd(program, commands=["program_{}".format(profile)]))
-env.Alias("gdb", env.OpenocdGdb(program))
+env.Alias("program", env.OpenOcd(program, commands=["modm_program $SOURCE"]))
+env.Alias("gdb", env.OpenOcdGdb(program))
     %% elif platform in ["avr"]
 env.Alias("program", env.Avrdude(program))
     %% endif

--- a/tools/build_script_generator/scons/site_tools/gdb.py
+++ b/tools/build_script_generator/scons/site_tools/gdb.py
@@ -18,10 +18,15 @@ import signal
 def run_openocd_gdb(target, source, env):
 	# We have to start openocd in its own session ID, so that Ctrl-C in GDB
 	# does not kill OpenOCD. See https://github.com/RIOT-OS/RIOT/pull/3619.
-	openocd = subprocess.Popen("openocd -f openocd.cfg -c \"log_output /dev/null\"", cwd=os.getcwd(), shell=True,
-	                           preexec_fn=os.setsid)
+	config = env.get("MODM_OPENOCD_CONFIGFILES", [])
+	config = " ".join(map("-f \"{}\"".format, map(env.subst, config)))
+	openocd = subprocess.Popen("openocd {} -c \"log_output /dev/null\"".format(config),
+	                           cwd=os.getcwd(), shell=True, preexec_fn=os.setsid)
 	# This call is blocking
-	subprocess.call("arm-none-eabi-gdb -x gdbinit {}".format(source[0]), cwd=os.getcwd(), shell=True)
+	config = env.get("MODM_GDBINIT", [])
+	config = " ".join(map("-x \"{}\"".format, map(env.subst, config)))
+	subprocess.call("arm-none-eabi-gdb {} {}".format(config, source[0]),
+	                cwd=os.getcwd(), shell=True)
 	# Then kill just the background OpenOCD process
 	os.killpg(os.getpgid(openocd.pid), signal.SIGTERM)
 	return 0
@@ -34,11 +39,11 @@ def gdb_arm_none_eabi_debug(env, source, alias="gdb_arm_none_eabi_debug"):
 def generate(env, **kw):
 	# build messages
 	if not ARGUMENTS.get("verbose"):
-		env["OPENOCDGDBSTR"] = "%s.------GDB----- %s$SOURCE\n" \
+		env["OPENOCDGDBSTR"] = "%s.------GDB----> %s$SOURCE\n" \
 	                           "%s'----OpenOCD--> %s$CONFIG_DEVICE_NAME%s" % \
 	                           ("\033[;0;32m", "\033[;0;33m", "\033[;0;32m", "\033[;1;33m", "\033[;0;0m")
 
-	env.AddMethod(gdb_arm_none_eabi_debug, "OpenocdGdb")
+	env.AddMethod(gdb_arm_none_eabi_debug, "OpenOcdGdb")
 
 def exists(env):
 	return env.Detect("openocd") and env.Detect("arm-none-eabi-gdb")

--- a/tools/build_script_generator/scons/site_tools/program_openocd.py
+++ b/tools/build_script_generator/scons/site_tools/program_openocd.py
@@ -29,7 +29,7 @@ def openocd_run(env, source, commands=[], alias="openocd_run"):
 	search = env.get("MODM_OPENOCD_SEARCHDIRS", [])
 	config = env.get("MODM_OPENOCD_CONFIGFILES", [])
 
-	openocdcmd = "$OPENOCD -f openocd.cfg {} {} {}".format(
+	openocdcmd = "$OPENOCD {} {} {}".format(
 		" ".join(map("-s \"{}\"".format, search)),
 		" ".join(map("-f \"{}\"".format, config)),
 		" ".join(map("-c \"{}\"".format, commands))


### PR DESCRIPTION
The initial idea was to define an `openocd.cfg` and `.gdbinit` file in the user directory, so that you'd only have to type `openocd`, which would then automatically load the `openocd.cfg`, same with `arm-none-eabi-gdb`.

However, this doesn't work when passing anything else to openocd, and GDB on some distros doesn't  automatically load `.gdbinit` files outside the home dir for security reasons.
So, both are called explicitly with `-f openocd.cfg` and `-x gdbinit`.

There are two problems with this:

1. This path is hardcoded, which required the files to be in `./`. Sometimes we need to place the generated `modm/` in subfolders.
2. They unnecessarily overwrite the user's files in `./`.

This PR moves the `openocd.cfg` and `gdbinit` files into the generated `modm/` folder, and makes their path relative to the SConscript using the `MODM_OPENOCD_CONFIGFILES` and `MODM_GDBINIT` environment variables, so that only the path to the `modm/SConscript` needs to be known.

For programming, openocd now calls `modm_program $SOURCE`, instead of `program_{profile}`, since for most of the RCA projects with custom SConstructs do not set the `modm:build:build.path` variable, and therefore the `modm:build` module generates wrong paths (ie. the default `build/{profile}/{project.name}.elf`). This change makes `scons program` work also in that scenario.

@rleh @chris-durand 