### PR TITLE
[cmake] Add include_makefile option and fix config file paths

### DIFF
--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -22,9 +22,14 @@ def init(module):
 
 
 def prepare(module, options):
-    if options[":target"].identifier["platform"] == "stm32":
-        return True
-    return False
+    if options[":target"].identifier["platform"] != "stm32":
+        return False
+
+    module.add_option(
+        BooleanOption(name="include_makefile", default=True,
+                      description="Generate a wrapper Makefile"))
+
+    return True
 
 
 def build(env):
@@ -64,8 +69,12 @@ def post_build(env, buildlog):
         flag = flag.format(**subs)
         return flag
 
-    env.append_metadata_unique('include_path', 'src')
+    env.outbasepath = "modm/cmake"
+    env.copy("cmake_scripts/report-build-options.cmake", "report-build-options.cmake")
+    env.template("cmake_scripts/configure-stm32-gcc.cmake.in", "configure-stm32-gcc.cmake", filters={"flag_format": flag_format})
+
+    # these are the ONLY files that are allowed to NOT be namespaced with modm!
+    env.outbasepath = "."
     env.template("resources/CMakeLists.txt.in", "CMakeLists.txt")
-    env.template("resources/Makefile.in", "Makefile")
-    env.copy("cmake_scripts/report-build-options.cmake", "modm/cmake/report-build-options.cmake")
-    env.template("cmake_scripts/configure-stm32-gcc.cmake.in", "modm/cmake/configure-stm32-gcc.cmake", filters={"flag_format": flag_format})
+    if env[":::include_makefile"]:
+        env.template("resources/Makefile.in", "Makefile")

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -34,17 +34,17 @@ cleanall:
 	@rm -rf $(BUILD_DIR)/cmake-build-debug
 
 upload-debug: build-debug
-	@openocd -f openocd.cfg -c "program_debug"
+	@openocd -f modm/openocd.cfg -c "program_debug"
 
 upload-release: build-release
-	@openocd -f openocd.cfg -c "program_release"
+	@openocd -f modm/openocd.cfg -c "program_release"
 
 gdb: build-debug
-	@arm-none-eabi-gdb -x gdbinit $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
+	@arm-none-eabi-gdb -x modm/gdbinit $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
 	@killall openocd || true
 
 gdb-release: build-release
-	@arm-none-eabi-gdb -x gdbinit $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
+	@arm-none-eabi-gdb -x modm/gdbinit $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
 	@killall openocd || true
 
 killopenocd:


### PR DESCRIPTION
Forgot to adapt the CMake paths to `modm/openocd.cfg` and `modm/gdbinit` in #61. Whoops.

Also adds an option to turn off Makefile generation.