### PR TITLE
[gpio] Fix GpioSet table order for Python 3.5

### DIFF
--- a/repo.lb
+++ b/repo.lb
@@ -30,6 +30,10 @@ except Exception as e:
           "then build again.")
     exit(1)
 
+if sys.version_info[1] < 6:
+    print("modm will require Python 3.6 in the near future.\n"
+          "Please check if you can upgrade your installation!\n")
+
 def init(repo):
     repo.name = "modm"
 

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -142,7 +142,7 @@ def prepare(module, options):
         return False
 
     bprops["ranges"] = port_ranges(device.get_driver("gpio")["gpio"])
-    bprops["ports"] = {k:i for i, k in enumerate([p["name"] for p in bprops["ranges"]])}
+    bprops["ports"] = OrderedDict([(k, i) for i, k in enumerate([p["name"] for p in bprops["ranges"]])])
 
     module.add_option(
         SetOption(

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -66,6 +66,7 @@ def post_build(env, buildlog):
         "cmake_wrapper",
         "qtcreator",
         "gdb",
+        "build_target",
     ]
     if has_xpcc_generator:
         build_tools += ["xpcc_generator"]
@@ -125,6 +126,9 @@ def post_build(env, buildlog):
     # Copy the scons-build-tools
     env.copy(repopath("ext/dlr/scons-build-tools"), "ext/dlr/scons-build-tools")
     env.copy("site_tools", "scons/site_tools")
+    # Generate the env.BuildTarget tool
+    env.outbasepath = "modm/scons/site_tools"
+    env.template("resources/build_target.py.in", "build_target.py")
 
     # these are the ONLY files that are allowed to NOT be namespaced with modm!
     env.outbasepath = "."

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -12,12 +12,25 @@ from os.path import join, abspath
 
 Import("env")
 profile = ARGUMENTS.get("profile", "release")
+env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
+
+%% if family == "darwin"
+# Using homebrew gcc-8 on macOS
+env["COMPILERSUFFIX"] = "-8"
+%% endif
 
 env.Append(toolpath=[abspath("scons/site_tools"), abspath("ext/dlr/scons-build-tools/site_tools")])
 %% for tool in build_tools | sort
 env.Tool("{{tool}}")
 %% endfor
 env["BASEPATH"] = abspath(".")
+
+%% if options[":::info.git"] != "Disabled"
+env.InfoGit(with_status={{ "True" if "Status" in options[":::info.git"] else "False" }})
+%% endif
+%% if options[":::info.build"]
+env.InfoBuild()
+%% endif
 
 env.Append(CPPPATH=[
 %% for path in metadata.include_path | sort

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -15,26 +15,14 @@ from os.path import join, abspath
 project_name = "{{ options[":build:project.name"] }}"
 build_path = "{{ options[":build:build.path"] }}"
 modm_path = "modm"
-profile = ARGUMENTS.get("profile", "release")
 
 # SCons environment with all tools
 env = Environment(ENV=os.environ)
-env["BUILDPATH"] = join(abspath(build_path), profile)
+env["CONFIG_BUILD_BASE"] = abspath(build_path)
 env["CONFIG_PROJECT_NAME"] = project_name
-%% if family == "darwin"
-# Using homebrew gcc-8 on macOS
-env["COMPILERSUFFIX"] = "-8"
-%% endif
 
 # Building all libraries
 env.SConscript(dirs=[modm_path], exports="env")
-
-%% if options[":::info.git"] != "Disabled"
-env.InfoGit(with_status={{ "True" if "Status" in options[":::info.git"] else "False" }})
-%% endif
-%% if options[":::info.build"]
-env.InfoBuild()
-%% endif
 
 %% if is_unittest
 # Building unit tests
@@ -70,34 +58,4 @@ sources += env.XpccCommunication(
 sources += env.FindSourceFiles(".", ignorePaths=ignored)
 %% endif
 
-# Building application
-program = env.Program(target=project_name+".elf", source=sources)
-
-# SCons functions
-env.Alias("cmakewrapper", env.CMakeWrapper())
-env.Alias("qtcreator", env.QtCreatorProject(sources))
-env.Alias("symbols", env.Symbols(program))
-env.Alias("listing", env.Listing(program))
-env.Alias("bin", env.Bin(program))
-%% if platform in ["hosted"]
-env.Alias("build", program)
-env.Alias("run", env.Run(program))
-env.Alias("all", ["build", "run"])
-%% else
-    %% if platform in ["stm32"]
-env.Alias("size", env.Size(program))
-env.Alias("program", env.OpenOcd(program, commands=["modm_program $SOURCE"]))
-env.Alias("gdb", env.OpenOcdGdb(program))
-    %% elif platform in ["avr"]
-env.Alias("program", env.Avrdude(program))
-    %% endif
-    %#
-env.Alias("build", [program, "listing"])
-    %% if platform in ["stm32"]
-env.Alias("all", ["build", "size"])
-    %% else
-env.Alias("all", ["build"])
-    %% endif
-%% endif
-
-env.Default("all")
+env.BuildTarget(sources)

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def build_target(env, sources):
+	# Building application
+	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+".elf", source=sources)
+
+	# SCons functions
+	env.Alias("cmakewrapper", env.CMakeWrapper())
+	env.Alias("qtcreator", env.QtCreatorProject(sources))
+	env.Alias("symbols", env.Symbols(program))
+	env.Alias("listing", env.Listing(program))
+	env.Alias("bin", env.Bin(program))
+%% if platform in ["hosted"]
+	env.Alias("build", program)
+	env.Alias("run", env.Run(program))
+	env.Alias("all", ["build", "run"])
+%% else
+    %% if platform in ["stm32"]
+	env.Alias("size", env.Size(program))
+	env.Alias("program", env.OpenOcd(program, commands=["modm_program $SOURCE"]))
+	env.Alias("gdb", env.OpenOcdGdb(program))
+    %% elif platform in ["avr"]
+	env.Alias("program", env.Avrdude(program))
+    %% endif
+
+	env.Alias("build", [program, "listing"])
+	%% if platform in ["stm32"]
+	env.Alias("all", ["build", "size"])
+	%% else
+	env.Alias("all", ["build"])
+    %% endif
+%% endif
+
+	env.Default("all")
+
+
+def generate(env, **kw):
+	env.AddMethod(build_target, "BuildTarget")
+
+def exists(env):
+	return True

--- a/tools/build_script_generator/scons/site_tools/info.py
+++ b/tools/build_script_generator/scons/site_tools/info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2014-2015, Kevin Läufer


### PR DESCRIPTION
This would generate the wrong mask tables for Python 3.5 runners, which would mess up any GPIO access.

Adds a warning that Python 3.5 will not be supported in future.

Also moves as much SConstruct code into SConscript and SCons tools. This makes upgrading custom SConstructs easier.

@rleh @chris-durand 