### PR TITLE
[example] adapt can example from stm32f3 to f469

### DIFF
--- a/examples/stm32f469_discovery/can/main.cpp
+++ b/examples/stm32f469_discovery/can/main.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2013-2014, Sascha Schade
+ * Copyright (c) 2013-2018, Niklas Hauser
+ * Copyright (c) 2018, Sebastian Birke
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing/timer.hpp>
+#include <modm/debug/logger.hpp>
+
+/**
+ * Example of CAN Hardware on STM32 F469 Discovery Board (with display).
+ *
+ * Connect PB5 / PB13 to a CAN transceiver which is connected to a CAN bus.
+ *
+ * Tested in hardware (F469I-DISCO) on 2018-08-21 by Sebastian Birke.
+ */
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::DEBUG
+
+static void
+displayMessage(const modm::can::Message& message)
+{
+	static uint32_t receiveCounter = 0;
+	receiveCounter++;
+
+	MODM_LOG_INFO<< "id  =" << message.getIdentifier();
+	if (message.isExtended()) {
+		MODM_LOG_INFO<< " extended";
+	}
+	else {
+		MODM_LOG_INFO<< " standard";
+	}
+	if (message.isRemoteTransmitRequest()) {
+		MODM_LOG_INFO<< ", rtr";
+	}
+	MODM_LOG_INFO<< modm::endl;
+
+	MODM_LOG_INFO<< "dlc =" << message.getLength() << modm::endl;
+	if (!message.isRemoteTransmitRequest())
+	{
+		MODM_LOG_INFO << "data=";
+		for (uint32_t i = 0; i < message.getLength(); ++i) {
+			MODM_LOG_INFO<< modm::hex << message.data[i] << modm::ascii << ' ';
+		}
+		MODM_LOG_INFO<< modm::endl;
+	}
+	MODM_LOG_INFO<< "# received=" << receiveCounter << modm::endl;
+}
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput(modm::Gpio::Low);
+
+	Board::LedGreen::set();
+
+	MODM_LOG_INFO << "CAN Test Program" << modm::endl;
+
+	/* Split filter bank, otherwise Can2 won't work */
+	CanFilter::setStartFilterBankForCan2(14);
+
+	MODM_LOG_INFO << "Initializing Can ..." << modm::endl;
+	// Initialize Can
+	Can2::connect<GpioB13::Tx, GpioB5::Rx>(Gpio::InputType::PullUp);
+	Can2::initialize<Board::systemClock, Can2::Bitrate::kBps125>(9);
+
+	MODM_LOG_INFO << "Setting up Filter for Can ..." << modm::endl;
+	// Receive every message
+	CanFilter::setFilter(14, CanFilter::FIFO0,
+			CanFilter::ExtendedIdentifier(0),
+			CanFilter::ExtendedFilterMask(0));
+
+	// Send a message
+	MODM_LOG_INFO << "Sending message on Can ..." << modm::endl;
+	modm::can::Message msg1(1, 1);
+	msg1.setExtended(true);
+	msg1.data[0] = 0x11;
+	Can2::sendMessage(msg1);
+
+	modm::ShortPeriodicTimer pTimer(100);
+
+	while (1)
+	{
+		if (Can2::isMessageAvailable())
+		{
+			MODM_LOG_INFO << "Can2: Message is available..." << modm::endl;
+			modm::can::Message message;
+			Can2::getMessage(message);
+			displayMessage(message);
+			Board::LedGreen::toggle();
+		}
+
+		if (pTimer.execute()) {
+			Board::LedRed::toggle();
+
+			static uint8_t idx = 0;
+			modm::can::Message msg1(1, 1);
+			msg1.setExtended(true);
+			msg1.data[0] = idx;
+			Can2::sendMessage(msg1);
+
+			++idx;
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32f469_discovery/can/project.xml
+++ b/examples/stm32f469_discovery/can/project.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <options>
+    <option name=":build:build.path">../../../build/stm32f469_discovery/can</option>
+  </options>
+  <modules>
+    <module>:debug</module>
+    <module>:platform:can:1</module>
+    <module>:platform:can:2</module>
+    <module>:platform:gpio</module>
+    <module>:platform:uart:3</module>
+    <module>:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -4,6 +4,7 @@
  * Copyright (c) 2013-2014, 2016, Kevin Läufer
  * Copyright (c) 2014, Georgi Grinshpun
  * Copyright (c) 2014, 2016-2018, Niklas Hauser
+ * Copyright (c) 2018, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -42,27 +43,33 @@ static modm::atomic::Queue<modm::can::Message, {{ options["buffer.rx"] }}> rxQue
 
 
 // ----------------------------------------------------------------------------
-// Re-implemented here to save some code space. As all arguments in the calls
-// below are constant the compiler is able to calculate everything at
-// compile time.
-static modm_always_inline void
-nvicEnableInterrupt(IRQn_Type IRQn)
-{
-	NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1UL << ((uint32_t)(IRQn) & 0x1F));
-}
-
-// ----------------------------------------------------------------------------
 void
 modm::platform::Can{{ id }}::initializeWithPrescaler(
 		uint16_t prescaler, uint8_t bs1, uint8_t bs2,
 		uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun)
 {
+%% macro enable_reset(instance)
 	// enable clock
-	RCC->APB1ENR{{ apb_post }}  |=  RCC_APB1ENR{{ apb_post }}_{{ reg }}EN;
+	RCC->APB1ENR{{ apb_post }}  |=  RCC_APB1ENR{{ apb_post }}_{{ instance }}EN;
 
 	// reset controller
-	RCC->APB1RSTR{{ apb_post }} |=  RCC_APB1RSTR{{ apb_post }}_{{ reg }}RST;
-	RCC->APB1RSTR{{ apb_post }} &= ~RCC_APB1RSTR{{ apb_post }}_{{ reg }}RST;
+	RCC->APB1RSTR{{ apb_post }} |=  RCC_APB1RSTR{{ apb_post }}_{{ instance }}RST;
+	RCC->APB1RSTR{{ apb_post }} &= ~RCC_APB1RSTR{{ apb_post }}_{{ instance }}RST;
+%% endmacro
+%% if type == "Slave"
+	// enable and reset master if disabled
+	if (!(RCC->APB1ENR{{ apb_post }} & RCC_APB1ENR{{ apb_post }}_{{ reg_other }}EN)) {
+	{{ enable_reset(reg_other) | lbuild.indent(4) }}
+	}
+%% endif
+%% if type == "Master"
+	// skip enable and reset if device has already been enabled by slave
+	if (!(RCC->APB1ENR{{ apb_post }} & RCC_APB1ENR{{ apb_post }}_{{ reg }}EN)) {
+	{{ enable_reset(reg) | lbuild.indent(4) }}
+	}
+%% else
+	{{ enable_reset(reg) }}
+%% endif
 
 	// CAN Master Reset
 	// FMP bits and CAN_MCR register are initialized to the reset values
@@ -109,18 +116,18 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	NVIC_SetPriority(CEC_CAN_IRQn, interruptPriority);
 
 	// Register Interrupts at the NVIC
-	nvicEnableInterrupt(CEC_CAN_IRQn);
+	NVIC_EnableIRQ(CEC_CAN_IRQn);
 %% else
 	// Set vector priority
 	NVIC_SetPriority({{ reg }}_RX0_IRQn, interruptPriority);
 	NVIC_SetPriority({{ reg }}_RX1_IRQn, interruptPriority);
 
 	// Register Interrupts at the NVIC
-	nvicEnableInterrupt({{ reg }}_RX0_IRQn);
-	nvicEnableInterrupt({{ reg }}_RX1_IRQn);
+	NVIC_EnableIRQ({{ reg }}_RX0_IRQn);
+	NVIC_EnableIRQ({{ reg }}_RX1_IRQn);
 
 	%% if options["buffer.tx"] > 0
-	nvicEnableInterrupt({{ reg }}_TX_IRQn);
+	NVIC_EnableIRQ({{ reg }}_TX_IRQn);
 	NVIC_SetPriority({{ reg }}_TX_IRQn, interruptPriority);
 	%% endif
 %% endif
@@ -144,7 +151,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	while ((({{ reg }}->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) and (deadlockPreventer-- > 0))  {
 		// wait for the normal mode
 	}
-	modm_assert(deadlockPreventer > 0, "can", "init", "timeout", {{ 0 if id == '' else id }});
+	modm_assert(deadlockPreventer > 0, "can", "init", "timeout2", {{ 0 if id == '' else id }});
 }
 
 // ----------------------------------------------------------------------------
@@ -467,7 +474,7 @@ modm::platform::Can{{ id }}::enableStatusChangeInterrupt(
 {
 %% if target["family"] != "f0"
 	NVIC_SetPriority({{ reg }}_SCE_IRQn, interruptPriority);
-	nvicEnableInterrupt({{ reg }}_SCE_IRQn);
+	NVIC_EnableIRQ({{ reg }}_SCE_IRQn);
 %% endif
 
 	{{ reg }}->IER = interruptEnable | ({{ reg }}->IER & 0x000000ff);

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2016-2018, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2018, Christopher Durand
 #
 # This file is part of the modm project.
 #
@@ -10,6 +11,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
+
+from collections import namedtuple
+from enum import Enum
 
 def load_options(module):
     module.add_option(
@@ -25,6 +29,7 @@ def load_options(module):
             minimum=1, maximum=2 ** 16 - 2,
             default=32))
 
+
 # Register mappings per family
 # - F0: CAN
 # - F1: CAN1 or CAN{1,2}
@@ -36,25 +41,58 @@ def load_options(module):
 # - L1: None
 # - L4: CAN1 or CAN{1,2}
 
+CanType = Enum('CanType', 'Single Master Slave')
+CanInfo = namedtuple('CanInfo', 'register type associated_instance')
+
 can_map = {
-    "f0": {0: ""},
-    "f1": {0: "1", 1: "1", 2: "2"},
-    "f2": {1: "1", 2: "2"},
-    "f3": {0: ""},
-    "f4": {1: "1", 2: "2", 3: "3"},
-    "f7": {0: "1", 1: "1", 2: "2", 3: "3"},
+    "f0": {0: CanInfo("", CanType.Single, None)},
+    "f1": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
+    "f2": {
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
+    "f3": {0: CanInfo("", CanType.Single, None)},
+    "f4": {
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1),
+        3: CanInfo("3", CanType.Single, None)
+    },
+    "f7": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1),
+        3: CanInfo("3", CanType.Single, None)
+    },
     "l0": {},
     "l1": {},
-    "l4": {0: "1", 1: "1", 2: "2"},
+    "l4": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
 }
 
-def get_substitutions(instance, target, env):
+def get_substitutions(instance, device, env):
+    target = device.identifier
+    driver = device.get_driver("can")
+    instances = map(lambda i: int(i), driver["instance"]) if "instance" in driver else (0,)
+
     cm = can_map[target["family"]]
+    is_single = (cm[instance].type == CanType.Single) or (cm[instance].associated_instance not in instances)
+    other = cm[instance].associated_instance
+
     subs = {
         "id": "" if instance == 0 else str(instance),
         "apb_post": "1" if target["family"] in ["l4"] else "",
-        "reg": "CAN" + cm[instance]
+        "reg": "CAN" + cm[instance].register,
+        "reg_other": ("CAN" + cm[other].register) if other in cm else None,
+        "type": cm[instance].type.name if not is_single else CanType.Single.name
     }
+
     env.log.debug("Substitutions for {} with instance {}: {}".format(target["family"], instance, str(subs)))
     return subs
 
@@ -78,7 +116,7 @@ class Instance(Module):
         properties["target"] = target = device.identifier
         properties["partname"] = device.partname
         properties["driver"] = driver
-        properties.update(get_substitutions(self.instance, properties["target"], env))
+        properties.update(get_substitutions(self.instance, device, env))
 
         env.substitutions = properties
         env.outbasepath = "modm/src/modm/platform/can"
@@ -130,7 +168,7 @@ def build(env):
     properties["driver"] = driver
 
     if "instance" not in driver:
-        properties.update(get_substitutions(0, properties["target"], env))
+        properties.update(get_substitutions(0, device, env))
 
     env.substitutions = properties
     env.outbasepath = "modm/src/modm/platform/can"


### PR DESCRIPTION
retransmit incoming messages and increase idx
LED color toggling (red activity/green received message)
fix CanFilter bank for Can2
enable can1 to use can2 ...