### PR TITLE
[stm32] Fix Can2 initialization

### DIFF
--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -4,6 +4,7 @@
  * Copyright (c) 2013-2014, 2016, Kevin Läufer
  * Copyright (c) 2014, Georgi Grinshpun
  * Copyright (c) 2014, 2016-2018, Niklas Hauser
+ * Copyright (c) 2018, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -42,27 +43,33 @@ static modm::atomic::Queue<modm::can::Message, {{ options["buffer.rx"] }}> rxQue
 
 
 // ----------------------------------------------------------------------------
-// Re-implemented here to save some code space. As all arguments in the calls
-// below are constant the compiler is able to calculate everything at
-// compile time.
-static modm_always_inline void
-nvicEnableInterrupt(IRQn_Type IRQn)
-{
-	NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1UL << ((uint32_t)(IRQn) & 0x1F));
-}
-
-// ----------------------------------------------------------------------------
 void
 modm::platform::Can{{ id }}::initializeWithPrescaler(
 		uint16_t prescaler, uint8_t bs1, uint8_t bs2,
 		uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun)
 {
+%% macro enable_reset(instance)
 	// enable clock
-	RCC->APB1ENR{{ apb_post }}  |=  RCC_APB1ENR{{ apb_post }}_{{ reg }}EN;
+	RCC->APB1ENR{{ apb_post }}  |=  RCC_APB1ENR{{ apb_post }}_{{ instance }}EN;
 
 	// reset controller
-	RCC->APB1RSTR{{ apb_post }} |=  RCC_APB1RSTR{{ apb_post }}_{{ reg }}RST;
-	RCC->APB1RSTR{{ apb_post }} &= ~RCC_APB1RSTR{{ apb_post }}_{{ reg }}RST;
+	RCC->APB1RSTR{{ apb_post }} |=  RCC_APB1RSTR{{ apb_post }}_{{ instance }}RST;
+	RCC->APB1RSTR{{ apb_post }} &= ~RCC_APB1RSTR{{ apb_post }}_{{ instance }}RST;
+%% endmacro
+%% if type == "Slave"
+	// enable and reset master if disabled
+	if (!(RCC->APB1ENR{{ apb_post }} & RCC_APB1ENR{{ apb_post }}_{{ reg_other }}EN)) {
+	{{ enable_reset(reg_other) | lbuild.indent(4) }}
+	}
+%% endif
+%% if type == "Master"
+	// skip enable and reset if device has already been enabled by slave
+	if (!(RCC->APB1ENR{{ apb_post }} & RCC_APB1ENR{{ apb_post }}_{{ reg }}EN)) {
+	{{ enable_reset(reg) | lbuild.indent(4) }}
+	}
+%% else
+	{{ enable_reset(reg) }}
+%% endif
 
 	// CAN Master Reset
 	// FMP bits and CAN_MCR register are initialized to the reset values
@@ -109,18 +116,18 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	NVIC_SetPriority(CEC_CAN_IRQn, interruptPriority);
 
 	// Register Interrupts at the NVIC
-	nvicEnableInterrupt(CEC_CAN_IRQn);
+	NVIC_EnableIRQ(CEC_CAN_IRQn);
 %% else
 	// Set vector priority
 	NVIC_SetPriority({{ reg }}_RX0_IRQn, interruptPriority);
 	NVIC_SetPriority({{ reg }}_RX1_IRQn, interruptPriority);
 
 	// Register Interrupts at the NVIC
-	nvicEnableInterrupt({{ reg }}_RX0_IRQn);
-	nvicEnableInterrupt({{ reg }}_RX1_IRQn);
+	NVIC_EnableIRQ({{ reg }}_RX0_IRQn);
+	NVIC_EnableIRQ({{ reg }}_RX1_IRQn);
 
 	%% if options["buffer.tx"] > 0
-	nvicEnableInterrupt({{ reg }}_TX_IRQn);
+	NVIC_EnableIRQ({{ reg }}_TX_IRQn);
 	NVIC_SetPriority({{ reg }}_TX_IRQn, interruptPriority);
 	%% endif
 %% endif
@@ -144,7 +151,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	while ((({{ reg }}->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) and (deadlockPreventer-- > 0))  {
 		// wait for the normal mode
 	}
-	modm_assert(deadlockPreventer > 0, "can", "init", "timeout", {{ 0 if id == '' else id }});
+	modm_assert(deadlockPreventer > 0, "can", "init", "timeout2", {{ 0 if id == '' else id }});
 }
 
 // ----------------------------------------------------------------------------
@@ -467,7 +474,7 @@ modm::platform::Can{{ id }}::enableStatusChangeInterrupt(
 {
 %% if target["family"] != "f0"
 	NVIC_SetPriority({{ reg }}_SCE_IRQn, interruptPriority);
-	nvicEnableInterrupt({{ reg }}_SCE_IRQn);
+	NVIC_EnableIRQ({{ reg }}_SCE_IRQn);
 %% endif
 
 	{{ reg }}->IER = interruptEnable | ({{ reg }}->IER & 0x000000ff);

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2016-2018, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2018, Christopher Durand
 #
 # This file is part of the modm project.
 #
@@ -10,6 +11,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
+
+from collections import namedtuple
+from enum import Enum
 
 def load_options(module):
     module.add_option(
@@ -25,6 +29,7 @@ def load_options(module):
             minimum=1, maximum=2 ** 16 - 2,
             default=32))
 
+
 # Register mappings per family
 # - F0: CAN
 # - F1: CAN1 or CAN{1,2}
@@ -36,25 +41,58 @@ def load_options(module):
 # - L1: None
 # - L4: CAN1 or CAN{1,2}
 
+CanType = Enum('CanType', 'Single Master Slave')
+CanInfo = namedtuple('CanInfo', 'register type associated_instance')
+
 can_map = {
-    "f0": {0: ""},
-    "f1": {0: "1", 1: "1", 2: "2"},
-    "f2": {1: "1", 2: "2"},
-    "f3": {0: ""},
-    "f4": {1: "1", 2: "2", 3: "3"},
-    "f7": {0: "1", 1: "1", 2: "2", 3: "3"},
+    "f0": {0: CanInfo("", CanType.Single, None)},
+    "f1": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
+    "f2": {
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
+    "f3": {0: CanInfo("", CanType.Single, None)},
+    "f4": {
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1),
+        3: CanInfo("3", CanType.Single, None)
+    },
+    "f7": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1),
+        3: CanInfo("3", CanType.Single, None)
+    },
     "l0": {},
     "l1": {},
-    "l4": {0: "1", 1: "1", 2: "2"},
+    "l4": {
+        0: CanInfo("1", CanType.Single, None),
+        1: CanInfo("1", CanType.Master, 2),
+        2: CanInfo("2", CanType.Slave , 1)
+    },
 }
 
-def get_substitutions(instance, target, env):
+def get_substitutions(instance, device, env):
+    target = device.identifier
+    driver = device.get_driver("can")
+    instances = map(lambda i: int(i), driver["instance"]) if "instance" in driver else (0,)
+
     cm = can_map[target["family"]]
+    is_single = (cm[instance].type == CanType.Single) or (cm[instance].associated_instance not in instances)
+    other = cm[instance].associated_instance
+
     subs = {
         "id": "" if instance == 0 else str(instance),
         "apb_post": "1" if target["family"] in ["l4"] else "",
-        "reg": "CAN" + cm[instance]
+        "reg": "CAN" + cm[instance].register,
+        "reg_other": ("CAN" + cm[other].register) if other in cm else None,
+        "type": cm[instance].type.name if not is_single else CanType.Single.name
     }
+
     env.log.debug("Substitutions for {} with instance {}: {}".format(target["family"], instance, str(subs)))
     return subs
 
@@ -78,7 +116,7 @@ class Instance(Module):
         properties["target"] = target = device.identifier
         properties["partname"] = device.partname
         properties["driver"] = driver
-        properties.update(get_substitutions(self.instance, properties["target"], env))
+        properties.update(get_substitutions(self.instance, device, env))
 
         env.substitutions = properties
         env.outbasepath = "modm/src/modm/platform/can"
@@ -130,7 +168,7 @@ def build(env):
     properties["driver"] = driver
 
     if "instance" not in driver:
-        properties.update(get_substitutions(0, properties["target"], env))
+        properties.update(get_substitutions(0, device, env))
 
     env.substitutions = properties
     env.outbasepath = "modm/src/modm/platform/can"


### PR DESCRIPTION
This should fix #71. Enabling Can2 now enables and resets Can1 unless it is already enabled. 
`Can1::initialize()` will skip resetting the peripheral if is has already been enabled by Can2. This should avoid the crash mentioned in [#70](https://github.com/modm-io/modm/pull/70/files/f3c4f3a2d80ad77a85b3cdea08913dc9fae74b9a#diff-15118828abc159bfcf938c1e1c1357e3R77) and allow to initialize the Can instances in an arbitrary order.

Unfortunately, I don't have access to any Can hardware at this moment to actually test it.

@se-bi, could you please check if it works for your F469 example?
