### PR TITLE
Improve linkerscript and add `-fwrapv` flag

### DIFF
--- a/src/modm/platform/core/cortex/linkerscript/linker.macros
+++ b/src/modm/platform/core/cortex/linkerscript/linker.macros
@@ -322,44 +322,20 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_debug()
-	/* Stabs debugging sections.  */
-	.stab          0 : { *(.stab) }
-	.stabstr       0 : { *(.stabstr) }
-	.stab.excl     0 : { *(.stab.excl) }
-	.stab.exclstr  0 : { *(.stab.exclstr) }
-	.stab.index    0 : { *(.stab.index) }
-	.stab.indexstr 0 : { *(.stab.indexstr) }
-	.comment       0 : { *(.comment) }
-
-	/* DWARF debug sections.
-	 Symbols in the DWARF debugging sections are relative to the beginning
-	 of the section so we begin them at 0.  */
-
-	/* DWARF 1 */
-	.debug          0 : { *(.debug) }
-	.line           0 : { *(.line) }
-	/* GNU DWARF 1 extensions */
-	.debug_srcinfo  0 : { *(.debug_srcinfo) }
-	.debug_sfnames  0 : { *(.debug_sfnames) }
-	/* DWARF 1.1 and DWARF 2 */
-	.debug_aranges  0 : { *(.debug_aranges) }
-	.debug_pubnames 0 : { *(.debug_pubnames) }
-	/* DWARF 2 */
-	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	/* DWARF debug sections */
 	.debug_abbrev   0 : { *(.debug_abbrev) }
-	.debug_line     0 : { *(.debug_line) }
+	.debug_aranges  0 : { *(.debug_aranges) }
 	.debug_frame    0 : { *(.debug_frame) }
-	.debug_str      0 : { *(.debug_str) }
+	.debug_info     0 : { *(.debug_info) }
+	.debug_line     0 : { *(.debug_line) }
 	.debug_loc      0 : { *(.debug_loc) }
 	.debug_macinfo  0 : { *(.debug_macinfo) }
-	/* SGI/MIPS DWARF 2 extensions */
-	.debug_weaknames 0 : { *(.debug_weaknames) }
-	.debug_funcnames 0 : { *(.debug_funcnames) }
-	.debug_typenames 0 : { *(.debug_typenames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	.debug_str      0 : { *(.debug_str) }
 
-	.note.gnu.arm.ident 0 : { KEEP(*(.note.gnu.arm.ident)) }
+	.comment 0 : { *(.comment) }
 	.ARM.attributes 0 : { KEEP(*(.ARM.attributes)) }
 	/DISCARD/ : { *(.note.GNU-stack)  }
 %% endmacro

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -81,6 +81,7 @@ def common_compiler_flags(compiler, target, buildlog):
         "-ffunction-sections",
         "-fshort-wchar",
         "-funsigned-char",
+        "-fwrapv",
         # "-fmerge-all-constants",
 
         "-g3",


### PR DESCRIPTION
This refactors the debug linkerscript sections for DWARF-4 format.

Additionally, the `-fwrapv` flag is added to make signed integers overflow as expected and not leave it undefined for the questionable benefit of some compiler engineers to help doctor their benchmarks with.

> This option instructs the compiler to assume that signed arithmetic overflow of addition, subtraction and multiplication wraps around using twos-complement representation. This flag enables some optimizations and disables others. 
