### PR TITLE
Use new lbuild repository features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Check environment
           command: |
@@ -54,7 +54,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples STM32F0 Series
           command: |
@@ -73,7 +73,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples STM32F3 Series
           command: |
@@ -96,7 +96,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples STM32F4 Series
           command: |
@@ -112,7 +112,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples AVR Series
           command: |
@@ -127,7 +127,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Generic Examples
           command: |
@@ -142,7 +142,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples Linux
           command: |
@@ -157,7 +157,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all AVRs
           command: |
@@ -175,7 +175,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F0
           command: |
@@ -193,7 +193,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F1
           command: |
@@ -211,7 +211,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F2
           command: |
@@ -229,7 +229,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F3
           command: |
@@ -247,7 +247,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F4
           command: |
@@ -265,7 +265,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32F7
           command: |
@@ -283,7 +283,7 @@ jobs:
       - SCONSFLAGS: "-j3"
     steps:
       - checkout
-      - run: git submodule sync && git submodule update --init
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Compile HAL for all STM32L4
           command: |

--- a/examples/arduino_uno/basic/analog_read_serial/project.xml
+++ b/examples/arduino_uno/basic/analog_read_serial/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>

--- a/examples/arduino_uno/basic/analog_read_serial/project.xml
+++ b/examples/arduino_uno/basic/analog_read_serial/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/arduino_uno/board.xml</extends>
+  <extends>modm:board:arduino-uno</extends>
   <options>
     <option name=":build:build.path">../../../../build/arduino_uno/basic/analog_read_serial</option>
   </options>

--- a/examples/arduino_uno/basic/blink/project.xml
+++ b/examples/arduino_uno/basic/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/arduino_uno/board.xml</extends>
+  <extends>modm:board:arduino-uno</extends>
   <options>
     <option name=":build:build.path">../../../../build/arduino_uno/basic/blink</option>
   </options>

--- a/examples/arduino_uno/basic/blink/project.xml
+++ b/examples/arduino_uno/basic/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>

--- a/examples/arduino_uno/basic/digital_read_serial/project.xml
+++ b/examples/arduino_uno/basic/digital_read_serial/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/arduino_uno/board.xml</extends>
+  <extends>modm:board:arduino-uno</extends>
   <options>
     <option name=":build:build.path">../../../../build/arduino_uno/basic/digital_read_serial</option>
   </options>

--- a/examples/arduino_uno/basic/digital_read_serial/project.xml
+++ b/examples/arduino_uno/basic/digital_read_serial/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>

--- a/examples/arduino_uno/basic/read_analog_voltage/project.xml
+++ b/examples/arduino_uno/basic/read_analog_voltage/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/arduino_uno/board.xml</extends>
+  <extends>modm:board:arduino-uno</extends>
   <options>
     <option name=":build:build.path">../../../../build/arduino_uno/basic/read_analog_voltage</option>
   </options>

--- a/examples/arduino_uno/basic/read_analog_voltage/project.xml
+++ b/examples/arduino_uno/basic/read_analog_voltage/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>

--- a/examples/avr/1-wire/ds18b20/project.xml
+++ b/examples/avr/1-wire/ds18b20/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/1-wire/ds18b20/project.xml
+++ b/examples/avr/1-wire/ds18b20/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/adc/basic/project.xml
+++ b/examples/avr/adc/basic/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/adc/basic/project.xml
+++ b/examples/avr/adc/basic/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/adc/oversample/project.xml
+++ b/examples/avr/adc/oversample/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/adc/oversample/project.xml
+++ b/examples/avr/adc/oversample/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/app_can2usb/project.xml
+++ b/examples/avr/app_can2usb/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">at90can128</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/app_can2usb/project.xml
+++ b/examples/avr/app_can2usb/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">at90can128</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/assert/project.xml
+++ b/examples/avr/assert/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:al-avreb-can</extends>
   <options>

--- a/examples/avr/assert/project.xml
+++ b/examples/avr/assert/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/al_avreb_can/board.xml</extends>
+  <extends>modm:board:al-avreb-can</extends>
   <options>
     <option name=":build:build.path">../../../build/avr/assert</option>
   </options>

--- a/examples/avr/block_device_mirror/project.xml
+++ b/examples/avr/block_device_mirror/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/block_device_mirror/project.xml
+++ b/examples/avr/block_device_mirror/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/can/mcp2515/project.xml
+++ b/examples/avr/can/mcp2515/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/can/mcp2515/project.xml
+++ b/examples/avr/can/mcp2515/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/can/mcp2515_uart/project.xml
+++ b/examples/avr/can/mcp2515_uart/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/can/mcp2515_uart/project.xml
+++ b/examples/avr/can/mcp2515_uart/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/benchmark/project.xml
+++ b/examples/avr/display/dogm128/benchmark/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/benchmark/project.xml
+++ b/examples/avr/display/dogm128/benchmark/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/caged_ball/project.xml
+++ b/examples/avr/display/dogm128/caged_ball/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/caged_ball/project.xml
+++ b/examples/avr/display/dogm128/caged_ball/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/draw/project.xml
+++ b/examples/avr/display/dogm128/draw/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/draw/project.xml
+++ b/examples/avr/display/dogm128/draw/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/image/project.xml
+++ b/examples/avr/display/dogm128/image/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/image/project.xml
+++ b/examples/avr/display/dogm128/image/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/text/project.xml
+++ b/examples/avr/display/dogm128/text/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/text/project.xml
+++ b/examples/avr/display/dogm128/text/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/touch/project.xml
+++ b/examples/avr/display/dogm128/touch/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm128/touch/project.xml
+++ b/examples/avr/display/dogm128/touch/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm132/project.xml
+++ b/examples/avr/display/dogm132/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm132/project.xml
+++ b/examples/avr/display/dogm132/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/dogm163/project.xml
+++ b/examples/avr/display/dogm163/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/display/dogm163/project.xml
+++ b/examples/avr/display/dogm163/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/display/hd44780/project.xml
+++ b/examples/avr/display/hd44780/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/hd44780/project.xml
+++ b/examples/avr/display/hd44780/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/display/siemens_s65/project.xml
+++ b/examples/avr/display/siemens_s65/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/display/siemens_s65/project.xml
+++ b/examples/avr/display/siemens_s65/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">16000000</option>

--- a/examples/avr/flash/project.xml
+++ b/examples/avr/flash/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega328p</option>
     <option name=":platform:clock:f_cpu">1000000</option>

--- a/examples/avr/flash/project.xml
+++ b/examples/avr/flash/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega328p</option>
     <option name=":platform:clock:f_cpu">1000000</option>

--- a/examples/avr/gpio/basic/project.xml
+++ b/examples/avr/gpio/basic/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">attiny85</option>
     <option name=":platform:clock:f_cpu">8000000</option>

--- a/examples/avr/gpio/basic/project.xml
+++ b/examples/avr/gpio/basic/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">attiny85</option>
     <option name=":platform:clock:f_cpu">8000000</option>

--- a/examples/avr/gpio/blinking/project.xml
+++ b/examples/avr/gpio/blinking/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega328p</option>
     <option name=":platform:clock:f_cpu">1000000</option>

--- a/examples/avr/gpio/blinking/project.xml
+++ b/examples/avr/gpio/blinking/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega328p</option>
     <option name=":platform:clock:f_cpu">1000000</option>

--- a/examples/avr/gpio/button_group/project.xml
+++ b/examples/avr/gpio/button_group/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/gpio/button_group/project.xml
+++ b/examples/avr/gpio/button_group/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/logger/project.xml
+++ b/examples/avr/logger/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/logger/project.xml
+++ b/examples/avr/logger/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/ports/project.xml
+++ b/examples/avr/ports/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:al-avreb-can</extends>
   <options>

--- a/examples/avr/ports/project.xml
+++ b/examples/avr/ports/project.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/al_avreb_can/board.xml</extends>
+  <extends>modm:board:al-avreb-can</extends>
   <options>
     <option name=":build:build.path">../../../build/avr/ports</option>
-    <option name=":build:scons:avrdude.programmer">usbasp-clone</option>
+    <option name=":build:avrdude.programmer">usbasp-clone</option>
   </options>
   <modules>
     <module>:build:scons</module>

--- a/examples/avr/protothread/project.xml
+++ b/examples/avr/protothread/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/protothread/project.xml
+++ b/examples/avr/protothread/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/pwm/pca9685/project.xml
+++ b/examples/avr/pwm/pca9685/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega168p</option>
     <option name=":platform:clock:f_cpu">8000000</option>

--- a/examples/avr/pwm/pca9685/project.xml
+++ b/examples/avr/pwm/pca9685/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega168p</option>
     <option name=":platform:clock:f_cpu">8000000</option>

--- a/examples/avr/sab/master/project.xml
+++ b/examples/avr/sab/master/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/sab/master/project.xml
+++ b/examples/avr/sab/master/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/sab/slave/project.xml
+++ b/examples/avr/sab/slave/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/sab/slave/project.xml
+++ b/examples/avr/sab/slave/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/timeout/project.xml
+++ b/examples/avr/timeout/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/timeout/project.xml
+++ b/examples/avr/timeout/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/uart/basic/project.xml
+++ b/examples/avr/uart/basic/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644pa</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/uart/basic/project.xml
+++ b/examples/avr/uart/basic/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644pa</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/uart/extended/project.xml
+++ b/examples/avr/uart/extended/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/uart/extended/project.xml
+++ b/examples/avr/uart/extended/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/xpcc/receiver/project.xml
+++ b/examples/avr/xpcc/receiver/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/xpcc/receiver/project.xml
+++ b/examples/avr/xpcc/receiver/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/xpcc/sender/project.xml
+++ b/examples/avr/xpcc/sender/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/avr/xpcc/sender/project.xml
+++ b/examples/avr/xpcc/sender/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">atmega644</option>
     <option name=":platform:clock:f_cpu">14745600</option>

--- a/examples/generic/blinky/project.xml
+++ b/examples/generic/blinky/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/generic/blinky/project.xml
+++ b/examples/generic/blinky/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/generic/blinky</option>
   </options>

--- a/examples/generic/resumable/project.xml
+++ b/examples/generic/resumable/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/generic/resumable/project.xml
+++ b/examples/generic/resumable/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/generic/resumable</option>
   </options>

--- a/examples/generic/ros/environment/project.xml
+++ b/examples/generic/ros/environment/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/generic/ros/environment/project.xml
+++ b/examples/generic/ros/environment/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../../build/generic/ros/environment</option>
     <option name=":platform:uart:2:buffer.tx">512</option>

--- a/examples/generic/ros/sub_pub/project.xml
+++ b/examples/generic/ros/sub_pub/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/generic/ros/sub_pub/project.xml
+++ b/examples/generic/ros/sub_pub/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../../build/generic/ros/sub_pub</option>
     <option name=":platform:uart:2:buffer.tx">512</option>

--- a/examples/generic/rtc_ds1302/project.xml
+++ b/examples/generic/rtc_ds1302/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/generic/rtc_ds1302</option>
   </options>

--- a/examples/generic/rtc_ds1302/project.xml
+++ b/examples/generic/rtc_ds1302/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/lbuild.xml
+++ b/examples/lbuild.xml
@@ -1,0 +1,10 @@
+<library>
+  <!-- This is the default lbuild configuration file for every
+       example in this folder. It only sets the repository path,
+       so that this isn't duplicated in every single example.
+       When you write your own application, you must set this
+       path yourself! -->
+  <repositories>
+  	<repository><path>../repo.lb</path></repository>
+  </repositories>
+</library>

--- a/examples/linux/assert/project.xml
+++ b/examples/linux/assert/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/assert</option>

--- a/examples/linux/assert/project.xml
+++ b/examples/linux/assert/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/assert</option>

--- a/examples/linux/block_device/file/project.xml
+++ b/examples/linux/block_device/file/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/file</option>

--- a/examples/linux/block_device/file/project.xml
+++ b/examples/linux/block_device/file/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/file</option>

--- a/examples/linux/block_device/mirror/project.xml
+++ b/examples/linux/block_device/mirror/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/mirror</option>

--- a/examples/linux/block_device/mirror/project.xml
+++ b/examples/linux/block_device/mirror/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/mirror</option>

--- a/examples/linux/block_device/ram/project.xml
+++ b/examples/linux/block_device/ram/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/ram</option>

--- a/examples/linux/block_device/ram/project.xml
+++ b/examples/linux/block_device/ram/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/block_device/ram</option>

--- a/examples/linux/build_info/project.xml
+++ b/examples/linux/build_info/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/build_info</option>

--- a/examples/linux/build_info/project.xml
+++ b/examples/linux/build_info/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/build_info</option>

--- a/examples/linux/can_debugger/project.xml
+++ b/examples/linux/can_debugger/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/can_debugger</option>

--- a/examples/linux/can_debugger/project.xml
+++ b/examples/linux/can_debugger/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/can_debugger</option>

--- a/examples/linux/git/project.xml
+++ b/examples/linux/git/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/git</option>

--- a/examples/linux/git/project.xml
+++ b/examples/linux/git/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/git</option>

--- a/examples/linux/gui/basic/project.xml
+++ b/examples/linux/gui/basic/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/gui/basic</option>

--- a/examples/linux/gui/basic/project.xml
+++ b/examples/linux/gui/basic/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/gui/basic</option>

--- a/examples/linux/logger/project.xml
+++ b/examples/linux/logger/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/logger</option>

--- a/examples/linux/logger/project.xml
+++ b/examples/linux/logger/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/logger</option>

--- a/examples/linux/printf/project.xml
+++ b/examples/linux/printf/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/printf</option>

--- a/examples/linux/printf/project.xml
+++ b/examples/linux/printf/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/printf</option>

--- a/examples/linux/serial_interface/project.xml
+++ b/examples/linux/serial_interface/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/serial_interface</option>

--- a/examples/linux/serial_interface/project.xml
+++ b/examples/linux/serial_interface/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/serial_interface</option>

--- a/examples/linux/static_serial_interface/project.xml
+++ b/examples/linux/static_serial_interface/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/static_serial_interface</option>

--- a/examples/linux/static_serial_interface/project.xml
+++ b/examples/linux/static_serial_interface/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/static_serial_interface</option>

--- a/examples/linux/threads/project.xml
+++ b/examples/linux/threads/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/threads</option>

--- a/examples/linux/threads/project.xml
+++ b/examples/linux/threads/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/linux/threads</option>

--- a/examples/linux/xpcc/basic/project.xml
+++ b/examples/linux/xpcc/basic/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/xpcc/basic</option>

--- a/examples/linux/xpcc/basic/project.xml
+++ b/examples/linux/xpcc/basic/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../../build/linux/xpcc/basic</option>

--- a/examples/nucleo_f031k6/blink/project.xml
+++ b/examples/nucleo_f031k6/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f031k6/board.xml</extends>
+  <extends>modm:board:nucleo-f031k6</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f031k6/blink</option>
   </options>

--- a/examples/nucleo_f031k6/blink/project.xml
+++ b/examples/nucleo_f031k6/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f031k6</extends>
   <options>

--- a/examples/nucleo_f042k6/blink/project.xml
+++ b/examples/nucleo_f042k6/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f042k6/board.xml</extends>
+  <extends>modm:board:nucleo-f042k6</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f042k6/blink</option>
   </options>

--- a/examples/nucleo_f042k6/blink/project.xml
+++ b/examples/nucleo_f042k6/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f042k6</extends>
   <options>

--- a/examples/nucleo_f103rb/blink/project.xml
+++ b/examples/nucleo_f103rb/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f103rb</extends>
   <options>

--- a/examples/nucleo_f103rb/blink/project.xml
+++ b/examples/nucleo_f103rb/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f103rb/board.xml</extends>
+  <extends>modm:board:nucleo-f103rb</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f103rb/blink</option>
   </options>

--- a/examples/nucleo_f303k8/blink/project.xml
+++ b/examples/nucleo_f303k8/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f303k8</extends>
   <options>

--- a/examples/nucleo_f303k8/blink/project.xml
+++ b/examples/nucleo_f303k8/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f303k8/board.xml</extends>
+  <extends>modm:board:nucleo-f303k8</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f303k8/blink</option>
   </options>

--- a/examples/nucleo_f401re/blink/project.xml
+++ b/examples/nucleo_f401re/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f401re/board.xml</extends>
+  <extends>modm:board:nucleo-f401re</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f401re/blink</option>
   </options>

--- a/examples/nucleo_f401re/blink/project.xml
+++ b/examples/nucleo_f401re/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f401re</extends>
   <options>

--- a/examples/nucleo_f401re/distance_vl53l0/project.xml
+++ b/examples/nucleo_f401re/distance_vl53l0/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f401re</extends>
   <options>

--- a/examples/nucleo_f401re/distance_vl53l0/project.xml
+++ b/examples/nucleo_f401re/distance_vl53l0/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f401re/board.xml</extends>
+  <extends>modm:board:nucleo-f401re</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f401re/distance_vl53l0</option>
   </options>

--- a/examples/nucleo_f411re/blink/project.xml
+++ b/examples/nucleo_f411re/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f411re/board.xml</extends>
+  <extends>modm:board:nucleo-f411re</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f411re/blink</option>
   </options>

--- a/examples/nucleo_f411re/blink/project.xml
+++ b/examples/nucleo_f411re/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f411re</extends>
   <options>

--- a/examples/nucleo_f429zi/blink/project.xml
+++ b/examples/nucleo_f429zi/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f429zi</extends>
   <options>

--- a/examples/nucleo_f429zi/blink/project.xml
+++ b/examples/nucleo_f429zi/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f429zi/board.xml</extends>
+  <extends>modm:board:nucleo-f429zi</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f429zi/blink</option>
   </options>

--- a/examples/nucleo_f429zi/spi_flash/project.xml
+++ b/examples/nucleo_f429zi/spi_flash/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_f429zi/board.xml</extends>
+  <extends>modm:board:nucleo-f429zi</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f429zi/spi_flash</option>
   </options>

--- a/examples/nucleo_f429zi/spi_flash/project.xml
+++ b/examples/nucleo_f429zi/spi_flash/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-f429zi</extends>
   <options>

--- a/examples/nucleo_l432kc/blink/project.xml
+++ b/examples/nucleo_l432kc/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <extends>modm:board:nucleo-l432kc</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>

--- a/examples/nucleo_l432kc/blink/project.xml
+++ b/examples/nucleo_l432kc/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <extends>modm:board:nucleo-l432kc</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>

--- a/examples/nucleo_l432kc/pwm/project.xml
+++ b/examples/nucleo_l432kc/pwm/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <extends>modm:board:nucleo-l432kc</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>

--- a/examples/nucleo_l432kc/pwm/project.xml
+++ b/examples/nucleo_l432kc/pwm/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l432kc/board.xml</extends>
+  <extends>modm:board:nucleo-l432kc</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>

--- a/examples/nucleo_l476rg/adc/project.xml
+++ b/examples/nucleo_l476rg/adc/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l476rg/adc</option>
   </options>

--- a/examples/nucleo_l476rg/adc/project.xml
+++ b/examples/nucleo_l476rg/adc/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/nucleo_l476rg/blink/project.xml
+++ b/examples/nucleo_l476rg/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/nucleo_l476rg/blink/project.xml
+++ b/examples/nucleo_l476rg/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l476rg/blink</option>
   </options>

--- a/examples/nucleo_l476rg/i2c_test/project.xml
+++ b/examples/nucleo_l476rg/i2c_test/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>

--- a/examples/nucleo_l476rg/i2c_test/project.xml
+++ b/examples/nucleo_l476rg/i2c_test/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/nucleo_l476rg/board.xml</extends>
+  <extends>modm:board:nucleo-l476rg</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_l476rg/i2c_test</option>
   </options>

--- a/examples/olimexino_stm32/blink/project.xml
+++ b/examples/olimexino_stm32/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:olimexino-stm32</extends>
   <options>

--- a/examples/olimexino_stm32/blink/project.xml
+++ b/examples/olimexino_stm32/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/olimexino_stm32/board.xml</extends>
+  <extends>modm:board:olimexino-stm32</extends>
   <options>
     <option name=":build:build.path">../../../build/olimexino_stm32/blink</option>
   </options>

--- a/examples/stm32f030f4p6_demo_board/blink/project.xml
+++ b/examples/stm32f030f4p6_demo_board/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/stm32f030f4p6_demo/board.xml</extends>
+  <extends>modm:board:stm32f030_demo</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f030f4p6_demo/blink</option>
   </options>

--- a/examples/stm32f030f4p6_demo_board/blink/project.xml
+++ b/examples/stm32f030f4p6_demo_board/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:stm32f030_demo</extends>
   <options>

--- a/examples/stm32f072_discovery/blink/project.xml
+++ b/examples/stm32f072_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/blink</option>
   </options>

--- a/examples/stm32f072_discovery/blink/project.xml
+++ b/examples/stm32f072_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f072_discovery/can/project.xml
+++ b/examples/stm32f072_discovery/can/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/can</option>
   </options>

--- a/examples/stm32f072_discovery/can/project.xml
+++ b/examples/stm32f072_discovery/can/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f072_discovery/hard_fault/project.xml
+++ b/examples/stm32f072_discovery/hard_fault/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/hard_fault</option>
   </options>

--- a/examples/stm32f072_discovery/hard_fault/project.xml
+++ b/examples/stm32f072_discovery/hard_fault/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f072_discovery/rotation/project.xml
+++ b/examples/stm32f072_discovery/rotation/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/rotation</option>
   </options>

--- a/examples/stm32f072_discovery/rotation/project.xml
+++ b/examples/stm32f072_discovery/rotation/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f072_discovery/uart/project.xml
+++ b/examples/stm32f072_discovery/uart/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f072_discovery/uart/project.xml
+++ b/examples/stm32f072_discovery/uart/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/uart</option>
   </options>

--- a/examples/stm32f072_discovery/unaligned_access/project.xml
+++ b/examples/stm32f072_discovery/unaligned_access/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f072rb/board.xml</extends>
+  <extends>modm:board:disco-f072rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f072_discovery/unaligned_access</option>
   </options>

--- a/examples/stm32f072_discovery/unaligned_access/project.xml
+++ b/examples/stm32f072_discovery/unaligned_access/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>

--- a/examples/stm32f0_discovery/blink/project.xml
+++ b/examples/stm32f0_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f051r8/board.xml</extends>
+  <extends>modm:board:disco-f051r8</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f0_discovery/blink</option>
   </options>

--- a/examples/stm32f0_discovery/blink/project.xml
+++ b/examples/stm32f0_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f051r8</extends>
   <options>

--- a/examples/stm32f0_discovery/logger/project.xml
+++ b/examples/stm32f0_discovery/logger/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f100rb/board.xml</extends>
+  <extends>modm:board:disco-f100rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f1_discovery/logger</option>
   </options>

--- a/examples/stm32f0_discovery/logger/project.xml
+++ b/examples/stm32f0_discovery/logger/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>

--- a/examples/stm32f103c8t6_black_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_black_pill/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:black-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_black_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_black_pill/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/black_pill/board.xml</extends>
+  <extends>modm:board:black-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_black_pill/blink</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/adns_9800</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/blink.cmake</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/blink</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/can/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/can/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/can/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/can/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/can</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/environment/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/environment/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/environment/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/environment/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/environment</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/logger/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/logger/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>

--- a/examples/stm32f103c8t6_blue_pill/logger/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/logger/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/blue_pill/board.xml</extends>
+  <extends>modm:board:blue-pill</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/logger</option>
   </options>

--- a/examples/stm32f1_discovery/blink/project.xml
+++ b/examples/stm32f1_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f100rb/board.xml</extends>
+  <extends>modm:board:disco-f100rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f1_discovery/blink</option>
   </options>

--- a/examples/stm32f1_discovery/blink/project.xml
+++ b/examples/stm32f1_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>

--- a/examples/stm32f1_discovery/logger/project.xml
+++ b/examples/stm32f1_discovery/logger/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f100rb/board.xml</extends>
+  <extends>modm:board:disco-f100rb</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f1_discovery/logger</option>
   </options>

--- a/examples/stm32f1_discovery/logger/project.xml
+++ b/examples/stm32f1_discovery/logger/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>

--- a/examples/stm32f3_discovery/accelerometer/project.xml
+++ b/examples/stm32f3_discovery/accelerometer/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/accelerometer</option>
   </options>

--- a/examples/stm32f3_discovery/accelerometer/project.xml
+++ b/examples/stm32f3_discovery/accelerometer/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/adc/continous/project.xml
+++ b/examples/stm32f3_discovery/adc/continous/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/continous</option>
   </options>

--- a/examples/stm32f3_discovery/adc/continous/project.xml
+++ b/examples/stm32f3_discovery/adc/continous/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f3_discovery/adc/interrupt/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/interrupt</option>
   </options>

--- a/examples/stm32f3_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f3_discovery/adc/interrupt/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/adc/simple/project.xml
+++ b/examples/stm32f3_discovery/adc/simple/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/simple</option>
   </options>

--- a/examples/stm32f3_discovery/adc/simple/project.xml
+++ b/examples/stm32f3_discovery/adc/simple/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/blink/project.xml
+++ b/examples/stm32f3_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/blink</option>
   </options>

--- a/examples/stm32f3_discovery/blink/project.xml
+++ b/examples/stm32f3_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/can/project.xml
+++ b/examples/stm32f3_discovery/can/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/can/project.xml
+++ b/examples/stm32f3_discovery/can/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/can</option>
   </options>

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/blink</option>
   </options>

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/ft245/project.xml
+++ b/examples/stm32f3_discovery/ft245/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/ft245/project.xml
+++ b/examples/stm32f3_discovery/ft245/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/ft245</option>
   </options>

--- a/examples/stm32f3_discovery/gdb/project.xml
+++ b/examples/stm32f3_discovery/gdb/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/gdb</option>
   </options>

--- a/examples/stm32f3_discovery/gdb/project.xml
+++ b/examples/stm32f3_discovery/gdb/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/hard_fault/project.xml
+++ b/examples/stm32f3_discovery/hard_fault/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/hard_fault/project.xml
+++ b/examples/stm32f3_discovery/hard_fault/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/hard_fault</option>
     <option name=":platform:fault.cortex:led">E3</option>

--- a/examples/stm32f3_discovery/rotation/project.xml
+++ b/examples/stm32f3_discovery/rotation/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/rotation/project.xml
+++ b/examples/stm32f3_discovery/rotation/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f3_discovery/rotation</option>
   </options>

--- a/examples/stm32f3_discovery/timer/basic/project.xml
+++ b/examples/stm32f3_discovery/timer/basic/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/timer/basic</option>
   </options>

--- a/examples/stm32f3_discovery/timer/basic/project.xml
+++ b/examples/stm32f3_discovery/timer/basic/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/uart/hal/project.xml
+++ b/examples/stm32f3_discovery/uart/hal/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/uart/hal</option>
   </options>

--- a/examples/stm32f3_discovery/uart/hal/project.xml
+++ b/examples/stm32f3_discovery/uart/hal/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f3_discovery/uart/logger/project.xml
+++ b/examples/stm32f3_discovery/uart/logger/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f303vc/board.xml</extends>
+  <extends>modm:board:disco-f303vc</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f3_discovery/uart/logger</option>
   </options>

--- a/examples/stm32f3_discovery/uart/logger/project.xml
+++ b/examples/stm32f3_discovery/uart/logger/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>

--- a/examples/stm32f429_discovery/blink/project.xml
+++ b/examples/stm32f429_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f429zi/board.xml</extends>
+  <extends>modm:board:disco-f429zi</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f429_discovery/blink</option>
   </options>

--- a/examples/stm32f429_discovery/blink/project.xml
+++ b/examples/stm32f429_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f429zi</extends>
   <options>

--- a/examples/stm32f429_discovery/logger/project.xml
+++ b/examples/stm32f429_discovery/logger/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f429zi/board.xml</extends>
+  <extends>modm:board:disco-f429zi</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f429_discovery/logger</option>
   </options>

--- a/examples/stm32f429_discovery/logger/project.xml
+++ b/examples/stm32f429_discovery/logger/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f429zi</extends>
   <options>

--- a/examples/stm32f469_discovery/assert/project.xml
+++ b/examples/stm32f469_discovery/assert/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/assert/project.xml
+++ b/examples/stm32f469_discovery/assert/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/assert</option>
   </options>

--- a/examples/stm32f469_discovery/blink/project.xml
+++ b/examples/stm32f469_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/blink</option>
   </options>

--- a/examples/stm32f469_discovery/blink/project.xml
+++ b/examples/stm32f469_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/can/project.xml
+++ b/examples/stm32f469_discovery/can/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/can</option>
   </options>

--- a/examples/stm32f469_discovery/can/project.xml
+++ b/examples/stm32f469_discovery/can/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/display/project.xml
+++ b/examples/stm32f469_discovery/display/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/display</option>
   </options>

--- a/examples/stm32f469_discovery/display/project.xml
+++ b/examples/stm32f469_discovery/display/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/game_of_life/project.xml
+++ b/examples/stm32f469_discovery/game_of_life/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/game_of_life</option>
   </options>

--- a/examples/stm32f469_discovery/game_of_life/project.xml
+++ b/examples/stm32f469_discovery/game_of_life/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/ports/project.xml
+++ b/examples/stm32f469_discovery/ports/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/ports/project.xml
+++ b/examples/stm32f469_discovery/ports/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/ports</option>
   </options>

--- a/examples/stm32f469_discovery/tlsf-allocator/project.xml
+++ b/examples/stm32f469_discovery/tlsf-allocator/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/tlsf-allocator</option>
   </options>

--- a/examples/stm32f469_discovery/tlsf-allocator/project.xml
+++ b/examples/stm32f469_discovery/tlsf-allocator/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f469_discovery/touchscreen/project.xml
+++ b/examples/stm32f469_discovery/touchscreen/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f469ni/board.xml</extends>
+  <extends>modm:board:disco-f469ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f469_discovery/touchscreen</option>
   </options>

--- a/examples/stm32f469_discovery/touchscreen/project.xml
+++ b/examples/stm32f469_discovery/touchscreen/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>

--- a/examples/stm32f4_discovery/accelerometer/project.xml
+++ b/examples/stm32f4_discovery/accelerometer/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/accelerometer</option>
   </options>

--- a/examples/stm32f4_discovery/accelerometer/project.xml
+++ b/examples/stm32f4_discovery/accelerometer/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f4_discovery/adc/interrupt/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/interrupt</option>
   </options>

--- a/examples/stm32f4_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f4_discovery/adc/interrupt/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/adc/oversample/project.xml
+++ b/examples/stm32f4_discovery/adc/oversample/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/oversample</option>
   </options>

--- a/examples/stm32f4_discovery/adc/oversample/project.xml
+++ b/examples/stm32f4_discovery/adc/oversample/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/adc/simple/project.xml
+++ b/examples/stm32f4_discovery/adc/simple/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/simple</option>
   </options>

--- a/examples/stm32f4_discovery/adc/simple/project.xml
+++ b/examples/stm32f4_discovery/adc/simple/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/app_uart_sniffer/project.xml
+++ b/examples/stm32f4_discovery/app_uart_sniffer/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/app_uart_sniffer</option>
   </options>

--- a/examples/stm32f4_discovery/app_uart_sniffer/project.xml
+++ b/examples/stm32f4_discovery/app_uart_sniffer/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/barometer_bmp085_bmp180</option>
   </options>

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/blink/project.xml
+++ b/examples/stm32f4_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/blink</option>
   </options>

--- a/examples/stm32f4_discovery/blink/project.xml
+++ b/examples/stm32f4_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/can/project.xml
+++ b/examples/stm32f4_discovery/can/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/can/project.xml
+++ b/examples/stm32f4_discovery/can/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/can</option>
   </options>

--- a/examples/stm32f4_discovery/can2/project.xml
+++ b/examples/stm32f4_discovery/can2/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/can2</option>
   </options>

--- a/examples/stm32f4_discovery/can2/project.xml
+++ b/examples/stm32f4_discovery/can2/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/colour_tcs3414/project.xml
+++ b/examples/stm32f4_discovery/colour_tcs3414/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/colour_tcs3414</option>
   </options>

--- a/examples/stm32f4_discovery/colour_tcs3414/project.xml
+++ b/examples/stm32f4_discovery/colour_tcs3414/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/display/hd44780/project.xml
+++ b/examples/stm32f4_discovery/display/hd44780/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/display/hd44780</option>
   </options>

--- a/examples/stm32f4_discovery/display/hd44780/project.xml
+++ b/examples/stm32f4_discovery/display/hd44780/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/display/nokia_5110/project.xml
+++ b/examples/stm32f4_discovery/display/nokia_5110/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/display/nokia_5110</option>
   </options>

--- a/examples/stm32f4_discovery/display/nokia_5110/project.xml
+++ b/examples/stm32f4_discovery/display/nokia_5110/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/display/ssd1306/project.xml
+++ b/examples/stm32f4_discovery/display/ssd1306/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/display/ssd1306</option>
   </options>

--- a/examples/stm32f4_discovery/display/ssd1306/project.xml
+++ b/examples/stm32f4_discovery/display/ssd1306/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/distance_vl6180/project.xml
+++ b/examples/stm32f4_discovery/distance_vl6180/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/distance_vl6180</option>
   </options>

--- a/examples/stm32f4_discovery/distance_vl6180/project.xml
+++ b/examples/stm32f4_discovery/distance_vl6180/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/exti/project.xml
+++ b/examples/stm32f4_discovery/exti/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/exti</option>
   </options>

--- a/examples/stm32f4_discovery/exti/project.xml
+++ b/examples/stm32f4_discovery/exti/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/fpu/project.xml
+++ b/examples/stm32f4_discovery/fpu/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/fpu</option>
   </options>

--- a/examples/stm32f4_discovery/fpu/project.xml
+++ b/examples/stm32f4_discovery/fpu/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/fsmc/project.xml
+++ b/examples/stm32f4_discovery/fsmc/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/fsmc</option>
   </options>

--- a/examples/stm32f4_discovery/fsmc/project.xml
+++ b/examples/stm32f4_discovery/fsmc/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/hard_fault/project.xml
+++ b/examples/stm32f4_discovery/hard_fault/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/hard_fault/project.xml
+++ b/examples/stm32f4_discovery/hard_fault/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/hard_fault</option>
   </options>

--- a/examples/stm32f4_discovery/led_matrix_display/project.xml
+++ b/examples/stm32f4_discovery/led_matrix_display/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/led_matrix_display</option>
   </options>

--- a/examples/stm32f4_discovery/led_matrix_display/project.xml
+++ b/examples/stm32f4_discovery/led_matrix_display/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/open407v-d/gui/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/gui/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/open407v-d/gui</option>
     <option name=":build:scons:image.source">images</option>

--- a/examples/stm32f4_discovery/open407v-d/gui/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/gui/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/open407v-d/touchscreen</option>
   </options>

--- a/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/pressure_amsys5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_amsys5915/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/pressure_amsys5915</option>
   </options>

--- a/examples/stm32f4_discovery/pressure_amsys5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_amsys5915/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/protothreads/project.xml
+++ b/examples/stm32f4_discovery/protothreads/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/protothreads</option>
   </options>

--- a/examples/stm32f4_discovery/protothreads/project.xml
+++ b/examples/stm32f4_discovery/protothreads/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-basic-comm</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/rx</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/tx</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-phy-test</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-scanner</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/rtos/float_check/project.xml
+++ b/examples/stm32f4_discovery/rtos/float_check/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../../build/stm32f4_discovery/rtos/float_check</option>
   </options>

--- a/examples/stm32f4_discovery/rtos/float_check/project.xml
+++ b/examples/stm32f4_discovery/rtos/float_check/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/sab2/project.xml
+++ b/examples/stm32f4_discovery/sab2/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/sab2</option>
   </options>

--- a/examples/stm32f4_discovery/sab2/project.xml
+++ b/examples/stm32f4_discovery/sab2/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/spi/project.xml
+++ b/examples/stm32f4_discovery/spi/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/spi/project.xml
+++ b/examples/stm32f4_discovery/spi/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/spi</option>
   </options>

--- a/examples/stm32f4_discovery/temperature_ltc2984/project.xml
+++ b/examples/stm32f4_discovery/temperature_ltc2984/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/temperature_ltc2984</option>
   </options>

--- a/examples/stm32f4_discovery/temperature_ltc2984/project.xml
+++ b/examples/stm32f4_discovery/temperature_ltc2984/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/timer/project.xml
+++ b/examples/stm32f4_discovery/timer/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/timer</option>
     <option name=":ui:led:gamma">2.2,2.0</option>

--- a/examples/stm32f4_discovery/timer/project.xml
+++ b/examples/stm32f4_discovery/timer/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/timer_test/project.xml
+++ b/examples/stm32f4_discovery/timer_test/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/timer_test</option>
   </options>

--- a/examples/stm32f4_discovery/timer_test/project.xml
+++ b/examples/stm32f4_discovery/timer_test/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/uart/project.xml
+++ b/examples/stm32f4_discovery/uart/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f4_discovery/uart/project.xml
+++ b/examples/stm32f4_discovery/uart/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/uart</option>
   </options>

--- a/examples/stm32f4_discovery/uart_spi/project.xml
+++ b/examples/stm32f4_discovery/uart_spi/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f4_discovery/uart_spi</option>
   </options>

--- a/examples/stm32f4_discovery/uart_spi/project.xml
+++ b/examples/stm32f4_discovery/uart_spi/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/stm32f746g_discovery/adc_ad7928/project.xml
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>

--- a/examples/stm32f746g_discovery/adc_ad7928/project.xml
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f746ng/board.xml</extends>
+  <extends>modm:board:disco-f746ng</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f746g_discovery/blink</option>
   </options>

--- a/examples/stm32f746g_discovery/blink/project.xml
+++ b/examples/stm32f746g_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>

--- a/examples/stm32f746g_discovery/blink/project.xml
+++ b/examples/stm32f746g_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f746ng/board.xml</extends>
+  <extends>modm:board:disco-f746ng</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f746g_discovery/blink</option>
   </options>

--- a/examples/stm32f769i_discovery/blink/project.xml
+++ b/examples/stm32f769i_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f769ni</extends>
   <options>

--- a/examples/stm32f769i_discovery/blink/project.xml
+++ b/examples/stm32f769i_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f769ni/board.xml</extends>
+  <extends>modm:board:disco-f769ni</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32f769i_discovery/blink</option>
   </options>

--- a/examples/stm32l476_discovery/blink/project.xml
+++ b/examples/stm32l476_discovery/blink/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-l476vg</extends>
   <options>

--- a/examples/stm32l476_discovery/blink/project.xml
+++ b/examples/stm32l476_discovery/blink/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_l476vg/board.xml</extends>
+  <extends>modm:board:disco-l476vg</extends>
   <options>
     <option name=":build:build.path">../../../build/stm32l476_discovery/blink</option>
   </options>

--- a/examples/windows/build_info/project.xml
+++ b/examples/windows/build_info/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-windows</option>
     <option name=":build:build.path">../../../build/windows/build_info</option>

--- a/examples/windows/build_info/project.xml
+++ b/examples/windows/build_info/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-windows</option>
     <option name=":build:build.path">../../../build/windows/build_info</option>

--- a/examples/zmq/1_stm32/project.xml
+++ b/examples/zmq/1_stm32/project.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>../../../src/modm/board/disco_f407vg/board.xml</extends>
+  <extends>modm:board:disco-f407vg</extends>
   <options>
     <option name=":build:build.path">../../../build/zmq/1_stm32</option>
     <option name=":communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>

--- a/examples/zmq/1_stm32/project.xml
+++ b/examples/zmq/1_stm32/project.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>

--- a/examples/zmq/2_zmq_gateway/project.xml
+++ b/examples/zmq/2_zmq_gateway/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/2_zmq_gateway</option>

--- a/examples/zmq/2_zmq_gateway/project.xml
+++ b/examples/zmq/2_zmq_gateway/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/2_zmq_gateway</option>

--- a/examples/zmq/3_zmq_app/project.xml
+++ b/examples/zmq/3_zmq_app/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/3_zmq_app</option>

--- a/examples/zmq/3_zmq_app/project.xml
+++ b/examples/zmq/3_zmq_app/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/3_zmq_app</option>

--- a/examples/zmq/4_zmq_backtoback/project.xml
+++ b/examples/zmq/4_zmq_backtoback/project.xml
@@ -1,12 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
-  <repositories>
-    <repository>
-      <path>../../../repo.lb</path>
-    </repository>
-  </repositories>
-
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/4_zmq_backtoback</option>

--- a/examples/zmq/4_zmq_backtoback/project.xml
+++ b/examples/zmq/4_zmq_backtoback/project.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <options>
     <option name=":target">hosted-linux</option>
     <option name=":build:build.path">../../../build/zmq/4_zmq_backtoback</option>

--- a/ext/fatfs/module.lb
+++ b/ext/fatfs/module.lb
@@ -19,4 +19,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/ext/fatfs"
-    env.copy(".", ignore=env.ignore_files("*.lb", "*.in"))
+    env.copy(".", ignore=env.ignore_files("*.in"))

--- a/ext/freertos/module.lb
+++ b/ext/freertos/module.lb
@@ -31,5 +31,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/ext/freertos"
-    env.copy(".", ignore=env.ignore_files("*.lb", "*.in"))
+    env.copy(".", ignore=env.ignore_files("*.in"))
     env.template("portable/FreeRTOSConfig.h.in", "portable/FreeRTOSConfig.h")

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -55,7 +55,7 @@ def prepare(module, options):
     return True
 
 bprops = {}
-def pre_build(env):
+def validate(env):
     device = env[":target"]
 
     core = device.get_driver("core")["type"]
@@ -73,7 +73,7 @@ def pre_build(env):
         if match:
             define = getDefineForDevice(device.identifier, match)
     if define is None:
-        raise PreBuildException("No device define found for '{}'!".format(device.partname))
+        raise ValidateException("No device define found for '{}'!".format(device.partname))
 
     device_header = define.lower() + ".h"
     peripherals = []

--- a/repo.lb
+++ b/repo.lb
@@ -156,6 +156,7 @@ def init(repo):
     repo.description = FileReader("README.md")
     repo.format_description = modm_format_description
     repo.format_short_description = modm_format_short_description
+    repo.add_ignore_patterns("*/*.lb", "*/board.xml")
 
     devices = DevicesCache()
     try:
@@ -170,4 +171,4 @@ def init(repo):
                           enumeration=devices))
 
 def prepare(repo, options):
-    repo.find_modules_recursive(".", modulefile="*.lb", ignore="repo.lb")
+    repo.add_modules_recursive(".", modulefile="*.lb")

--- a/repo.lb
+++ b/repo.lb
@@ -158,6 +158,11 @@ def init(repo):
     repo.format_short_description = modm_format_short_description
     repo.add_ignore_patterns("*/*.lb", "*/board.xml")
 
+    # Add the board configuration files as their module name aliases
+    for config in Path(repopath("src/modm/board")).glob("*/board.xml"):
+        name = re.search("<module>(modm:board:.*?)</module>", config.read_text())[1].replace("modm:", "")
+        repo.add_configuration(name, config)
+
     devices = DevicesCache()
     try:
         devices.build()

--- a/repo.lb
+++ b/repo.lb
@@ -12,6 +12,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+import re
 import sys
 import glob
 import hashlib
@@ -133,9 +134,28 @@ class DevicesCache(dict):
         return value
 
 
+from lbuild.format import ansi_escape as c
+def modm_format_description(node, description):
+    # Remove the HTML comments we use for describing doc tests
+    description = re.sub(r"\n?<!--.*?-->", "", description, flags=re.S)
+    # Indent code content
+    for block in re.finditer(r"\n```.*?(\n.*?)\n```", description, flags=re.M|re.S):
+        description = description.replace(block.group(0), block.group(1).replace("\n", "\n    "))
+    # format any markdown headers bold
+    description = re.sub(r"^(#+.*)", r"{}\g<1>{}".format(str(c("bold")), str(c("no_bold"))), description, flags=re.M)
+    return node.format_description(node, description)
+
+def modm_format_short_description(node, description):
+    # All docs use Markdown, so they might start with a `# Header`
+    description = re.sub(r"\n?<!--.*?-->", "", description, flags=re.S)
+    return node.format_short_description(node, description.replace("#", ""))
+
 # =============================================================================
 def init(repo):
     repo.name = "modm"
+    repo.description = FileReader("README.md")
+    repo.format_description = modm_format_description
+    repo.format_short_description = modm_format_short_description
 
     devices = DevicesCache()
     try:

--- a/repo.lb
+++ b/repo.lb
@@ -39,9 +39,10 @@ if sys.version_info[1] < 6:
           "Please check if you can upgrade your installation!\n")
 
 import lbuild
-min_lbuild_version = "0.3.6"
-if StrictVersion(lbuild.__version__) < StrictVersion(min_lbuild_version):
-    print("modm requires at least lbuild v{}, please upgrade lbuild!".format(min_lbuild_version))
+min_lbuild_version = "1.1.0"
+if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
+    print("modm requires at least lbuild v{}, please upgrade!\n"
+          "    pip install -U lbuild".format(min_lbuild_version))
     exit(1)
 
 

--- a/repo.lb
+++ b/repo.lb
@@ -177,3 +177,6 @@ def init(repo):
 
 def prepare(repo, options):
     repo.add_modules_recursive(".", modulefile="*.lb")
+
+def build(env):
+    env.append_metadata_unique("include_path", "src")

--- a/src/modm/board/al_avreb_can/board.xml
+++ b/src/modm/board/al_avreb_can/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -29,7 +29,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/board"
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("avrdude.port", "usb");
     env.append_metadata_unique("avrdude.programmer", "avrispmkII");
     env.append_metadata_unique("avrdude.efuse", "0xff");

--- a/src/modm/board/arduino_uno/board.xml
+++ b/src/modm/board/arduino_uno/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/arduino_uno/module.lb
+++ b/src/modm/board/arduino_uno/module.lb
@@ -31,6 +31,6 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/board"
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("avrdude.programmer", "arduino");
     env.append_metadata_unique("avrdude.baudrate", "115200");

--- a/src/modm/board/black_pill/board.xml
+++ b/src/modm/board/black_pill/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -30,7 +30,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")

--- a/src/modm/board/blue_pill/board.xml
+++ b/src/modm/board/blue_pill/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -30,7 +30,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")

--- a/src/modm/board/disco_f051r8/board.xml
+++ b/src/modm/board/disco_f051r8/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f051r8/module.lb
+++ b/src/modm/board/disco_f051r8/module.lb
@@ -31,5 +31,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f072rb/board.xml
+++ b/src/modm/board/disco_f072rb/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f072rb/module.lb
+++ b/src/modm/board/disco_f072rb/module.lb
@@ -32,5 +32,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f100rb/board.xml
+++ b/src/modm/board/disco_f100rb/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f100rb/module.lb
+++ b/src/modm/board/disco_f100rb/module.lb
@@ -30,5 +30,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32vldiscovery.cfg");

--- a/src/modm/board/disco_f303vc/board.xml
+++ b/src/modm/board/disco_f303vc/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f303vc/module.lb
+++ b/src/modm/board/disco_f303vc/module.lb
@@ -33,5 +33,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f3discovery.cfg");

--- a/src/modm/board/disco_f407vg/board.xml
+++ b/src/modm/board/disco_f407vg/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f407vg/module.lb
+++ b/src/modm/board/disco_f407vg/module.lb
@@ -33,5 +33,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f4discovery.cfg");

--- a/src/modm/board/disco_f429zi/board.xml
+++ b/src/modm/board/disco_f429zi/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f429zi/module.lb
+++ b/src/modm/board/disco_f429zi/module.lb
@@ -32,5 +32,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f429discovery.cfg");

--- a/src/modm/board/disco_f469ni/board.xml
+++ b/src/modm/board/disco_f469ni/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -37,5 +37,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f469discovery.cfg");

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -29,7 +29,6 @@ def prepare(module, options):
         ":platform:gpio",
         ":platform:i2c:1",
         ":platform:uart:3",
-        ":tlsf",
         ":ui:display")
     return True
 

--- a/src/modm/board/disco_f746ng/board.xml
+++ b/src/modm/board/disco_f746ng/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -32,5 +32,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_f769ni/board.xml
+++ b/src/modm/board/disco_f769ni/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_f769ni/module.lb
+++ b/src/modm/board/disco_f769ni/module.lb
@@ -32,5 +32,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_l476vg/board.xml
+++ b/src/modm/board/disco_l476vg/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/disco_l476vg/module.lb
+++ b/src/modm/board/disco_l476vg/module.lb
@@ -26,5 +26,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_f031k6/board.xml
+++ b/src/modm/board/nucleo_f031k6/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f031k6/module.lb
+++ b/src/modm/board/nucleo_f031k6/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f042k6/board.xml
+++ b/src/modm/board/nucleo_f042k6/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -28,6 +28,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f103rb/board.xml
+++ b/src/modm/board/nucleo_f103rb/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f103rb/module.lb
+++ b/src/modm/board/nucleo_f103rb/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/nucleo_f303k8/board.xml
+++ b/src/modm/board/nucleo_f303k8/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f303k8/module.lb
+++ b/src/modm/board/nucleo_f303k8/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f3.cfg");

--- a/src/modm/board/nucleo_f401re/board.xml
+++ b/src/modm/board/nucleo_f401re/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f401re/module.lb
+++ b/src/modm/board/nucleo_f401re/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f411re/board.xml
+++ b/src/modm/board/nucleo_f411re/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f411re/module.lb
+++ b/src/modm/board/nucleo_f411re/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f429zi/board.xml
+++ b/src/modm/board/nucleo_f429zi/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_f429zi/module.lb
+++ b/src/modm/board/nucleo_f429zi/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_l432kc/board.xml
+++ b/src/modm/board/nucleo_l432kc/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_l432kc/module.lb
+++ b/src/modm/board/nucleo_l432kc/module.lb
@@ -27,5 +27,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_l476rg/board.xml
+++ b/src/modm/board/nucleo_l476rg/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/nucleo_l476rg/module.lb
+++ b/src/modm/board/nucleo_l476rg/module.lb
@@ -27,6 +27,6 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
     env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/olimexino_stm32/board.xml
+++ b/src/modm/board/olimexino_stm32/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/olimexino_stm32/module.lb
+++ b/src/modm/board/olimexino_stm32/module.lb
@@ -27,5 +27,5 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
     env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/stm32f030f4p6_demo/board.xml
+++ b/src/modm/board/stm32f030f4p6_demo/board.xml
@@ -1,6 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../../../repo.lb</path>

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -29,7 +29,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/board"
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f030_demo_board.cfg"), "stm32f030_demo_board.cfg")

--- a/src/modm/communication/ros/module.lb
+++ b/src/modm/communication/ros/module.lb
@@ -23,5 +23,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/communication/ros"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../ros.hpp")

--- a/src/modm/communication/sab/module.lb
+++ b/src/modm/communication/sab/module.lb
@@ -23,5 +23,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/communication/sab"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../sab.hpp")

--- a/src/modm/communication/sab2/module.lb
+++ b/src/modm/communication/sab2/module.lb
@@ -24,5 +24,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/communication/sab2"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../sab2.hpp")

--- a/src/modm/communication/xpcc/module.lb
+++ b/src/modm/communication/xpcc/module.lb
@@ -43,7 +43,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/communication/xpcc"
 
-    ignore = ["*.lb", "*.in", "*backend/tipc*"]
+    ignore = ["*.in", "*backend/tipc*"]
 
     if env[":target"].identifier["platform"] in ["avr"]:
         ignore.append("*postman/dynamic*")

--- a/src/modm/container/module.lb
+++ b/src/modm/container/module.lb
@@ -26,7 +26,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/container"
-    env.copy(".", ignore=env.ignore_files("*.lb", "container.hpp"))
+    env.copy(".", ignore=env.ignore_files("container.hpp"))
 
     env.outbasepath = "modm/src/modm"
     env.copy("container.hpp")

--- a/src/modm/debug/module.lb
+++ b/src/modm/debug/module.lb
@@ -32,7 +32,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/debug"
 
-    ignore_patterns = ["*.lb", "debug.hpp"]
+    ignore_patterns = ["debug.hpp"]
     target = env[":target"].identifier
     if target["platform"] != "hosted":
         ignore_patterns.append("*logger/hosted/*")

--- a/src/modm/driver/bus/memory_bus.lb
+++ b/src/modm/driver/bus/memory_bus.lb
@@ -22,4 +22,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/driver/bus"
-    env.copy(".", ignore=env.ignore_files("*.lb"))
+    env.copy(".")

--- a/src/modm/driver/radio/nrf24/nrf24.lb
+++ b/src/modm/driver/radio/nrf24/nrf24.lb
@@ -27,4 +27,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/driver/radio/nrf24"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")

--- a/src/modm/io/module.lb
+++ b/src/modm/io/module.lb
@@ -23,7 +23,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/io"
-    env.copy(".", ignore=env.ignore_files("*.lb", "io.hpp"))
+    env.copy(".", ignore=env.ignore_files("io.hpp"))
     env.outbasepath = "modm/src/modm"
     env.copy("io.hpp")
 

--- a/src/modm/math/filter/module.lb
+++ b/src/modm/math/filter/module.lb
@@ -23,5 +23,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/math/filter"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../filter.hpp")

--- a/src/modm/math/geometry/module.lb
+++ b/src/modm/math/geometry/module.lb
@@ -25,5 +25,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/math/geometry"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../geometry.hpp")

--- a/src/modm/math/interpolation/module.lb
+++ b/src/modm/math/interpolation/module.lb
@@ -23,5 +23,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/math/interpolation"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../interpolation.hpp")

--- a/src/modm/math/saturated/module.lb
+++ b/src/modm/math/saturated/module.lb
@@ -20,4 +20,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/math/saturated"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")

--- a/src/modm/math/utils/module.lb
+++ b/src/modm/math/utils/module.lb
@@ -21,7 +21,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/math/utils"
 
-    ignore = ["*.lb", "*operator_*"]
+    ignore = ["*operator_*"]
     if "avr" in env[":target"].identifier["platform"]:
         ignore.append("*pc*")
         env.copy("operator_avr_impl.hpp", "operator_impl.hpp")

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -25,7 +25,7 @@ class Instance(Module):
         module.depends(":platform:adc")
         return True
 
-    def pre_build(self, env):
+    def validate(self, env):
         instances.append(self.instance)
 
     def build(self, env):

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -44,7 +44,8 @@ def prepare(module, options):
             name="allocator",
             description=FileReader("option/allocator.md"),
             enumeration=["newlib", "block", "tlsf"],
-            default="newlib"))
+            default="newlib",
+            dependencies=lambda value: ":tlsf" if value == "tlsf" else None))
     if not options[":target"].has_driver("core:cortex-m0*"):
         module.add_option(
             EnumerationOption(
@@ -175,8 +176,6 @@ def build(env):
         env.template("heap_newlib.c.in")
     if env[":::allocator"] == "tlsf":
         env.template("heap_tlsf.c.in")
-        if not env.has_module(":tlsf"):
-            env.log.error("When using `:::allocator == tlsf`, you must also include the `:tlsf` module!")
     if env[":::allocator"] == "block":
         env.template("heap_block_allocator.cpp.in")
 

--- a/src/modm/platform/gpio/at90_tiny_mega/module.lb
+++ b/src/modm/platform/gpio/at90_tiny_mega/module.lb
@@ -58,7 +58,7 @@ def prepare(module, options):
     return True
 
 bprops = {}
-def pre_build(env):
+def validate(env):
     device = env[":target"]
     driver = device.get_driver("gpio")
 
@@ -75,8 +75,8 @@ def pre_build(env):
         exints = list(filter(lambda p: p["driver"] == "exint", signals))
         pcint = list(filter(lambda p: p["name"].startswith("pcint"), exints))
         extint = list(filter(lambda p: not p["name"].startswith("pcint"), exints))
-        if len(pcint) > 1: raise PreBuildException("More than one Pin Change interrupt on pin '{}'!".format(key.upper()));
-        if len(extint) > 1: raise PreBuildException("More than one External interrupt on pin '{}'!".format(key.upper()));
+        if len(pcint) > 1: raise ValidateException("More than one Pin Change interrupt on pin '{}'!".format(key.upper()));
+        if len(extint) > 1: raise ValidateException("More than one External interrupt on pin '{}'!".format(key.upper()));
         bprops[key] = {
             "gpio": gpio,
             "pcint": int(pcint[0]["name"].replace("pcint", "")) if len(pcint) else -1,
@@ -85,12 +85,12 @@ def pre_build(env):
         }
 
     if not len(all_signals):
-        raise PreBuildException("The device file for '{}' does not contain any signals!".format(device.partname))
+        raise ValidateException("The device file for '{}' does not contain any signals!".format(device.partname))
 
     # check if any signal names start with a digit
     faults = [(af["driver"], af["name"]) for af in all_signals.values() if af["name"].isdigit()]
     if len(faults):
-        raise PreBuildException("These signal names are starting with a digit!\n{}".format(
+        raise ValidateException("These signal names are starting with a digit!\n{}".format(
                 ", ".join(["{}::{}".format(d, n) for (d, n) in faults])))
 
     all_peripherals = [s["driver"] for s in all_signals.values()]

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -158,7 +158,7 @@ def prepare(module, options):
         ":platform:gpio.common")
     return True
 
-def pre_build(env):
+def validate(env):
     device = env[":target"]
     driver = device.get_driver("gpio")
     # Not an issue anymore, but kept here for future issues
@@ -199,10 +199,10 @@ def pre_build(env):
     extimap = {}
     for vec in [v["name"][4:] for v in device.get_driver("core")["vector"] if "EXTI" in v["name"]]:
         if vec not in all_exti:
-            raise PreBuildException("Unknown EXTI vector: '{}'".format(vec))
+            raise ValidateException("Unknown EXTI vector: '{}'".format(vec))
         for num in all_exti[vec]:
             if str(num) in extimap:
-                raise PreBuildException("Pin '{}' already in EXTI map!".format(str(num)))
+                raise ValidateException("Pin '{}' already in EXTI map!".format(str(num)))
             extimap[str(num)] = vec
 
     all_signals = {}

--- a/src/modm/platform/spi/lpc/module.lb
+++ b/src/modm/platform/spi/lpc/module.lb
@@ -34,4 +34,4 @@ def build(env):
     env.substitutions = properties
     env.outbasepath = "modm/src/modm/platform/spi"
 
-    env.copy(".", ignore=env.ignore_files("*.lb"))
+    env.copy(".")

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -41,7 +41,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/platform/uart"
 
     # FIXME: Ignore serial_interface, serial_port for windows
-    ignore = ["*.lb"]
+    ignore = []
     if env[":target"].identifier["family"] == "windows":
         ignore.extend(["*/serial_interface*", "*/serial_port*"])
 

--- a/src/modm/processing/protothread/module.lb
+++ b/src/modm/processing/protothread/module.lb
@@ -21,5 +21,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/protothread"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../protothread.hpp")

--- a/src/modm/processing/resumable/module.lb
+++ b/src/modm/processing/resumable/module.lb
@@ -21,5 +21,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/resumable"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../resumable.hpp")

--- a/src/modm/processing/scheduler/module.lb
+++ b/src/modm/processing/scheduler/module.lb
@@ -23,4 +23,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/scheduler"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")

--- a/src/modm/processing/timer/module.lb
+++ b/src/modm/processing/timer/module.lb
@@ -24,5 +24,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/timer"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../timer.hpp")

--- a/src/modm/ui/animation/module.lb
+++ b/src/modm/ui/animation/module.lb
@@ -20,5 +20,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/animation"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../animation.hpp")

--- a/src/modm/ui/display/module.lb
+++ b/src/modm/ui/display/module.lb
@@ -24,5 +24,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/display"
-    env.copy(".", ignore=env.ignore_patterns("*.lb", "*.font", "*.pbm"))
+    env.copy(".", ignore=env.ignore_patterns("*.font", "*.pbm"))
     env.copy("../display.hpp")

--- a/src/modm/ui/gui/module.lb
+++ b/src/modm/ui/gui/module.lb
@@ -26,5 +26,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/gui"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../gui.hpp")

--- a/src/modm/ui/led/module.lb
+++ b/src/modm/ui/led/module.lb
@@ -47,7 +47,7 @@ def prepare(module, options):
 
 tables = []
 
-def pre_build(env):
+def validate(env):
     option_table = itertools.product(
         sorted(env[":::gamma"]), sorted(env[":::bit"]), sorted(env[":::range"]))
 

--- a/src/modm/ui/menu/module.lb
+++ b/src/modm/ui/menu/module.lb
@@ -24,5 +24,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/menu"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")
     env.copy("../menu.hpp")

--- a/src/modm/ui/time/module.lb
+++ b/src/modm/ui/time/module.lb
@@ -20,4 +20,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/time"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")

--- a/src/modm/utils/module.lb
+++ b/src/modm/utils/module.lb
@@ -20,7 +20,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/utils"
-    env.copy(".", ignore=env.ignore_files("*.lb", "utils.hpp"))
+    env.copy(".", ignore=env.ignore_files("utils.hpp"))
 
     env.outbasepath = "modm/src/modm"
     env.copy("utils.hpp")

--- a/src/stdc++/module.lb
+++ b/src/stdc++/module.lb
@@ -28,4 +28,4 @@ def build(env):
     env.append_metadata_unique("include_path", "src/stdc++")
 
     env.outbasepath = "modm/src/stdc++"
-    env.copy(".", ignore=env.ignore_files("*.lb"))
+    env.copy(".")

--- a/src/unittest/module.lb
+++ b/src/unittest/module.lb
@@ -25,4 +25,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/unittest"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")

--- a/test/al-avreb-can.xml
+++ b/test/al-avreb-can.xml
@@ -3,8 +3,8 @@
          xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
   <extends>../src/modm/board/al_avreb_can/board.xml</extends>
   <options>
-    <!-- <option name=":build:scons:avrdude.programmer">avrispmkII</option> -->
-    <option name=":build:scons:avrdude.programmer">usbasp-clone</option>
+    <!-- <option name=":build:avrdude.programmer">avrispmkII</option> -->
+    <option name=":build:avrdude.programmer">usbasp-clone</option>
     <option name=":build:scons:include_sconstruct">True</option>
     <option name=":build:scons:info.build">True</option>
     <!-- <option name=":build:scons:info.git">Info+Status</option> -->

--- a/test/al-avreb-can.xml
+++ b/test/al-avreb-can.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <extends>../src/modm/board/al_avreb_can/board.xml</extends>
   <options>
     <!-- <option name=":build:avrdude.programmer">avrispmkII</option> -->

--- a/test/all/avr.xml
+++ b/test/all/avr.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../repo.lb</path>

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -31,9 +31,9 @@ class CommandException(Exception):
 
 def run_command(cmdline):
     try:
-        p = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        output, _ = p.communicate()
-        return (output.decode("utf-8"), p.returncode)
+        cmdline = " ".join(cmdline)
+        p = subprocess.run(cmdline, shell=True, stdout=subprocess.PIPE, universal_newlines = True)
+        return (p.stdout, p.returncode)
     except KeyboardInterrupt:
         raise multiprocessing.ProcessError()
 
@@ -128,8 +128,8 @@ def main():
             devices = failed_file.read().strip().split("\n")
     else:
         try:
-            stdout = run_lbuild(["-c", "avr.xml", "discover-option-values", "--option=:target"])
-            devices = stdout.strip().split("\n")
+            stdout = run_lbuild(["-c", "avr.xml", "discover", "--values", "--name :target"])
+            devices = stdout.strip().splitlines()
             # filter for only the devices specified
             for arg in sys.argv[1:]:
                 devices = [d for d in devices if d.startswith(arg)]

--- a/test/all/stm32.xml
+++ b/test/all/stm32.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../../repo.lb</path>

--- a/test/hosted.xml
+++ b/test/hosted.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <repositories>
     <repository>
       <path>../repo.lb</path>

--- a/test/modm/architecture/module.lb
+++ b/test/modm/architecture/module.lb
@@ -30,7 +30,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/test/modm/architecture"
 
-    ignore_patterns = ["*.lb", "*.cfg", "*.xml"]
+    ignore_patterns = []
     target = env[":target"].identifier
     if target["platform"] == "hosted":
         # Test does not work on hosted

--- a/test/modm/communication/module.lb
+++ b/test/modm/communication/module.lb
@@ -23,4 +23,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/communication"
-    env.copy('.', ignore=env.ignore_patterns("*.lb", "*.cfg", "*.xml"))
+    env.copy('.')

--- a/test/modm/container/module.lb
+++ b/test/modm/container/module.lb
@@ -23,4 +23,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/container"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/test/modm/driver/module.lb
+++ b/test/modm/driver/module.lb
@@ -35,7 +35,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/driver"
-    patterns = ["*.lb"]
+    patterns = []
     if env[":target"].identifier["platform"] == "avr":
         patterns += ["*pressure*"]
     env.copy('.', ignore=env.ignore_patterns(*patterns))

--- a/test/modm/io/module.lb
+++ b/test/modm/io/module.lb
@@ -23,4 +23,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/io"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/test/modm/math/module.lb
+++ b/test/modm/math/module.lb
@@ -29,4 +29,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/math"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/test/modm/processing/module.lb
+++ b/test/modm/processing/module.lb
@@ -31,4 +31,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/processing"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/test/modm/ui/module.lb
+++ b/test/modm/ui/module.lb
@@ -25,4 +25,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/modm/ui"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/test/nucleo-f103.xml
+++ b/test/nucleo-f103.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <extends>../src/modm/board/nucleo_f103rb/board.xml</extends>
   <options>
     <option name=":build:scons:include_sconstruct">True</option>

--- a/test/nucleo-f401.xml
+++ b/test/nucleo-f401.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <extends>../src/modm/board/nucleo_f401re/board.xml</extends>
   <options>
     <option name=":build:scons:include_sconstruct">True</option>

--- a/test/nucleo-f411.xml
+++ b/test/nucleo-f411.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<library xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance"
-         xsd:noNamespaceSchemaLocation="https://github.com/dergraaf/library-builder/lbuild/resources/configuration.xsd">
+<library>
   <extends>../src/modm/board/nucleo_f411re/board.xml</extends>
   <options>
     <option name=":build:scons:include_sconstruct">True</option>

--- a/test/stdc++/module.lb
+++ b/test/stdc++/module.lb
@@ -27,4 +27,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/test/stdc++"
-    env.copy('.', ignore=env.ignore_patterns("*.lb"))
+    env.copy('.')

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -16,17 +16,13 @@ from collections import defaultdict
 def common_source_files(env, buildlog):
     files_to_build = []
 
-    prev = env.outbasepath
-    env.outbasepath = "."
-    outpath = env.outpath("modm")
     for operations in buildlog:
-        filename = os.path.relpath(operations.filename_out, outpath)
+        filename = operations.local_filename_out("modm/")
         _, extension = os.path.splitext(filename)
 
         if extension in [".c", ".cpp", ".cc", ".sx", ".S"]:
-            files_to_build.append(os.path.normpath(filename).replace('\\','\\\\')) #windows path compatibility hack
+            files_to_build.append(filename.replace('\\','\\\\')) #windows path compatibility hack
 
-    env.outbasepath = prev
     return sorted(files_to_build)
 
 def common_target(target):

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -64,8 +64,6 @@ def prepare(module, options):
 
 
 def build(env):
-    env.append_metadata_unique("include_path", "src")
-
     # Append custom openocd config file to metadata
     openocd_cfg = env.get_option(":build:openocd.cfg", "")
     if len(openocd_cfg):

--- a/tools/xpcc_generator/module.lb
+++ b/tools/xpcc_generator/module.lb
@@ -32,4 +32,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/tools/xpcc_generator"
-    env.copy(".", ignore=env.ignore_patterns("*.lb"))
+    env.copy(".")


### PR DESCRIPTION
This adds several lbuild features introduced in https://github.com/modm-io/lbuild v1.x:

- repo formatters for modm descriptions: removing HTML comments and some markdown formatting.
- repo ignore patterns: `*.lb` and `*/board.xml` cut down on a lot of duplicate code.
- repo configuration aliases: used for extending board configurations.
- lbuild base config loaded from filesystem.
- option dependencies

cc @dergraaf @rleh @chris-durand 