### PR TITLE
[stm32] Fix setting timer compare value on STM32F1

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -360,21 +360,13 @@ public:
 	static inline void
 	setCompareValue(uint32_t channel, uint16_t value)
 	{
-%% if target["family"] == "f1"
-		*(&TIM{{ id }}->CCR1 + ((channel - 1) * 2)) = value;
-%% else
 		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
-%% endif
 	}
 
 	static inline uint16_t
 	getCompareValue(uint32_t channel)
 	{
-%% if target["family"] == "f1"
-		return *(&TIM{{ id }}->CCR1 + ((channel - 1) * 2));
-%% else
 		return *(&TIM{{ id }}->CCR1 + (channel - 1));
-%% endif
 	}
 
 public:

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -352,21 +352,13 @@ public:
 	static inline void
 	setCompareValue(uint32_t channel, Value value)
 	{
-%% if target["family"] == "f1"
-		*(&TIM{{ id }}->CCR1 + ((channel - 1) * 2)) = value;
-%% else
 		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
-%% endif
 	}
 
 	static inline Value
 	getCompareValue(uint32_t channel)
 	{
-%% if target["family"] == "f1"
-		return *(&TIM{{ id }}->CCR1 + ((channel - 1) * 2));
-%% else
 		return *(&TIM{{ id }}->CCR1 + (channel - 1));
-%% endif
 	}
 
 public:


### PR DESCRIPTION
The address of `TIMx->CCRx` is calculated incorrectly in `setCompareValue()`. A really long time ago ST changed the type of `TIMx->CCRx` from `uint16_t` to `uint32_t` in the F1 headers. Thus, the factor `* 2` is not necessary anymore. 