### PR TITLE
[fix] Send normal and extended CAN frames

### DIFF
--- a/examples/generic/ros/can_bridge/main.cpp
+++ b/examples/generic/ros/can_bridge/main.cpp
@@ -25,8 +25,8 @@ messageRosToModm(const can_msgs::Frame& source, modm::can::Message& destination)
 
 	destination.setIdentifier(source.id);
 	destination.setLength(source.dlc);
-	if (source.is_extended) { destination.setExtended(true); }
-	if (source.is_rtr)      { destination.setRemoteTransmitRequest(true);	}
+	destination.setExtended(source.is_extended);
+	destination.setRemoteTransmitRequest(source.is_rtr);
 	memcpy(destination.data, source.data, source.dlc);
 
 	return true;


### PR DESCRIPTION
C'tor of CAN message by default creates extended messages so the logic
was flawed. Now setting the type explicitly for every frame.