### PR TITLE
Better support for generating modm:build:scons with multiple repos

### DIFF
--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -31,4 +31,4 @@ def build(env):
     if "m0" not in core:
         env.copy("cmsis/CMSIS/Core/Include/mpu_armv7.h", "mpu_armv7.h")
 
-    env.append_metadata_unique("include_path", "modm/ext/cmsis/core")
+    env.add_metadata("include_path", "modm/ext/cmsis/core")

--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -31,4 +31,4 @@ def build(env):
     if "m0" not in core:
         env.copy("cmsis/CMSIS/Core/Include/mpu_armv7.h", "mpu_armv7.h")
 
-    env.append_metadata_unique("include_path", "ext/cmsis/core")
+    env.append_metadata_unique("include_path", "modm/ext/cmsis/core")

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -43,20 +43,20 @@ def prepare(module, options):
 def build(env):
     core = env[":target"].get_driver("core")["type"]
     core = core.replace("cortex-m", "CM").replace("+", "PLUS").replace("f", "").replace("d", "")
-    env.append_metadata_unique("cpp.define", "ARM_MATH_{}".format(core))
+    env.add_metadata("cpp.define", "ARM_MATH_{}".format(core))
 
     if env[":::check_matrix_sizes"]:
-        env.append_metadata_unique("cpp.define", "ARM_MATH_MATRIX_CHECK")
+        env.add_metadata("cpp.define", "ARM_MATH_MATRIX_CHECK")
     else:
-        env.append_metadata_unique("cpp.define.debug", "ARM_MATH_MATRIX_CHECK")
+        env.add_metadata("cpp.define.debug", "ARM_MATH_MATRIX_CHECK")
 
     if env[":::round_float_inputs"]:
-        env.append_metadata_unique("cpp.define", "ARM_MATH_ROUNDING")
+        env.add_metadata("cpp.define", "ARM_MATH_ROUNDING")
 
     if not env.get_option(":::unaligned_data", False):
-        env.append_metadata_unique("cpp.define", "UNALIGNED_SUPPORT_DISABLE")
+        env.add_metadata("cpp.define", "UNALIGNED_SUPPORT_DISABLE")
 
-    env.append_metadata_unique("include_path", "modm/ext/cmsis/dsp")
+    env.add_metadata("include_path", "modm/ext/cmsis/dsp")
 
     env.outbasepath = "modm/ext/cmsis/dsp"
     env.copy("cmsis/CMSIS/DSP/Include", ".")

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -56,7 +56,7 @@ def build(env):
     if not env.get_option(":::unaligned_data", False):
         env.append_metadata_unique("cpp.define", "UNALIGNED_SUPPORT_DISABLE")
 
-    env.append_metadata_unique("include_path", "ext/cmsis/dsp")
+    env.append_metadata_unique("include_path", "modm/ext/cmsis/dsp")
 
     env.outbasepath = "modm/ext/cmsis/dsp"
     env.copy("cmsis/CMSIS/DSP/Include", ".")

--- a/ext/nxp/module.lb
+++ b/ext/nxp/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.append_metadata_unique("include_path", "modm/ext/cmsis_device")
+    env.add_metadata("include_path", "modm/ext/cmsis_device")
 
     device = env[":target"]
 

--- a/ext/nxp/module.lb
+++ b/ext/nxp/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.append_metadata_unique("include_path", "ext/cmsis_device")
+    env.append_metadata_unique("include_path", "modm/ext/cmsis_device")
 
     device = env[":target"]
 

--- a/ext/ros/module.lb
+++ b/ext/ros/module.lb
@@ -17,7 +17,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.append_metadata_unique("include_path", "modm/ext/ros")
+    env.add_metadata("include_path", "modm/ext/ros")
 
     env.outbasepath = "modm/ext"
     env.copy("ros-lib/ros_lib", "ros")

--- a/ext/ros/module.lb
+++ b/ext/ros/module.lb
@@ -17,7 +17,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.append_metadata_unique("include_path", "ext/ros")
+    env.append_metadata_unique("include_path", "modm/ext/ros")
 
     env.outbasepath = "modm/ext"
     env.copy("ros-lib/ros_lib", "ros")

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -104,8 +104,8 @@ def validate(env):
     })
 
 def build(env):
-    env.append_metadata_unique("include_path", "modm/ext")
-    env.append_metadata_unique("include_path", "modm/ext/cmsis/device")
+    env.add_metadata("include_path", "modm/ext")
+    env.add_metadata("include_path", "modm/ext/cmsis/device")
 
     env.outbasepath = "modm/ext/cmsis/device"
     env.copy(localpath(bprops["folder"], bprops["device_header"]), bprops["device_header"])

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -104,8 +104,8 @@ def validate(env):
     })
 
 def build(env):
-    env.append_metadata_unique("include_path", "ext")
-    env.append_metadata_unique("include_path", "ext/cmsis/device")
+    env.append_metadata_unique("include_path", "modm/ext")
+    env.append_metadata_unique("include_path", "modm/ext/cmsis/device")
 
     env.outbasepath = "modm/ext/cmsis/device"
     env.copy(localpath(bprops["folder"], bprops["device_header"]), bprops["device_header"])

--- a/repo.lb
+++ b/repo.lb
@@ -178,4 +178,4 @@ def prepare(repo, options):
     repo.add_modules_recursive(".", modulefile="*.lb")
 
 def build(env):
-    env.append_metadata_unique("include_path", "src")
+    env.append_metadata_unique("include_path", "modm/src")

--- a/repo.lb
+++ b/repo.lb
@@ -178,4 +178,4 @@ def prepare(repo, options):
     repo.add_modules_recursive(".", modulefile="*.lb")
 
 def build(env):
-    env.append_metadata_unique("include_path", "modm/src")
+    env.add_metadata("include_path", "modm/src")

--- a/repo.lb
+++ b/repo.lb
@@ -19,11 +19,8 @@ import hashlib
 from pathlib import Path
 from distutils.version import StrictVersion
 
-rootpath = repopath("ext/modm-devices/tools/device")
-sys.path.append(rootpath)
-
+sys.path.append(repopath("ext/modm-devices/tools/device"))
 try:
-    import modm.pkg
     import modm.parser
 except Exception as e:
     print(e, "\n")
@@ -39,7 +36,7 @@ if sys.version_info[1] < 6:
           "Please check if you can upgrade your installation!\n")
 
 import lbuild
-min_lbuild_version = "1.1.0"
+min_lbuild_version = "1.4.0"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip install -U lbuild".format(min_lbuild_version))

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -30,8 +30,8 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.copy('.')
-    env.append_metadata_unique("avrdude.port", "usb");
-    env.append_metadata_unique("avrdude.programmer", "avrispmkII");
-    env.append_metadata_unique("avrdude.efuse", "0xff");
-    env.append_metadata_unique("avrdude.hfuse", "0xd9");
-    env.append_metadata_unique("avrdude.lfuse", "0xfe");
+    env.add_metadata("avrdude.port", "usb");
+    env.add_metadata("avrdude.programmer", "avrispmkII");
+    env.add_metadata("avrdude.efuse", "0xff");
+    env.add_metadata("avrdude.hfuse", "0xd9");
+    env.add_metadata("avrdude.lfuse", "0xfe");

--- a/src/modm/board/arduino_uno/module.lb
+++ b/src/modm/board/arduino_uno/module.lb
@@ -32,5 +32,5 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.copy('.')
-    env.append_metadata_unique("avrdude.programmer", "arduino");
-    env.append_metadata_unique("avrdude.baudrate", "115200");
+    env.add_metadata("avrdude.programmer", "arduino");
+    env.add_metadata("avrdude.baudrate", "115200");

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -34,4 +34,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.append_metadata_unique("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");
+    env.add_metadata("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -34,4 +34,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.append_metadata_unique("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");
+    env.add_metadata("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");

--- a/src/modm/board/disco_f051r8/module.lb
+++ b/src/modm/board/disco_f051r8/module.lb
@@ -32,4 +32,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f0discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f072rb/module.lb
+++ b/src/modm/board/disco_f072rb/module.lb
@@ -33,4 +33,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f0discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f100rb/module.lb
+++ b/src/modm/board/disco_f100rb/module.lb
@@ -31,4 +31,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32vldiscovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32vldiscovery.cfg");

--- a/src/modm/board/disco_f303vc/module.lb
+++ b/src/modm/board/disco_f303vc/module.lb
@@ -34,4 +34,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f3discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f3discovery.cfg");

--- a/src/modm/board/disco_f407vg/module.lb
+++ b/src/modm/board/disco_f407vg/module.lb
@@ -34,4 +34,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f4discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f4discovery.cfg");

--- a/src/modm/board/disco_f429zi/module.lb
+++ b/src/modm/board/disco_f429zi/module.lb
@@ -33,4 +33,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f429discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f429discovery.cfg");

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -38,4 +38,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f469discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f469discovery.cfg");

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -33,4 +33,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f7discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_f769ni/module.lb
+++ b/src/modm/board/disco_f769ni/module.lb
@@ -33,4 +33,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32f7discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_l476vg/module.lb
+++ b/src/modm/board/disco_l476vg/module.lb
@@ -27,4 +27,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_f031k6/module.lb
+++ b/src/modm/board/nucleo_f031k6/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f0.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -30,4 +30,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f0.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f103rb/module.lb
+++ b/src/modm/board/nucleo_f103rb/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f103rb.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/nucleo_f303k8/module.lb
+++ b/src/modm/board/nucleo_f303k8/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f3.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f3.cfg");

--- a/src/modm/board/nucleo_f401re/module.lb
+++ b/src/modm/board/nucleo_f401re/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f411re/module.lb
+++ b/src/modm/board/nucleo_f411re/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f429zi/module.lb
+++ b/src/modm/board/nucleo_f429zi/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_l432kc/module.lb
+++ b/src/modm/board/nucleo_l432kc/module.lb
@@ -28,4 +28,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_l476rg/module.lb
+++ b/src/modm/board/nucleo_l476rg/module.lb
@@ -29,4 +29,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.append_metadata_unique("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");

--- a/src/modm/board/olimexino_stm32/module.lb
+++ b/src/modm/board/olimexino_stm32/module.lb
@@ -28,4 +28,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.append_metadata_unique("openocd.configfile", "board/st_nucleo_f103rb.cfg");
+    env.add_metadata("openocd.configfile", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -33,4 +33,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f030_demo_board.cfg"), "stm32f030_demo_board.cfg")
-    env.append_metadata_unique("openocd.configfile", "modm/board/stm32f030_demo_board.cfg");
+    env.add_metadata("openocd.configfile", "modm/board/stm32f030_demo_board.cfg");

--- a/src/modm/communication/xpcc/module.lb
+++ b/src/modm/communication/xpcc/module.lb
@@ -49,11 +49,11 @@ def build(env):
         ignore.append("*postman/dynamic*")
 
     if env[":target"].identifier["platform"] in ["hosted"]:
-        env.append_metadata_unique("required_library", "zmqpp")
-        env.append_metadata_unique("required_library", "zmq")
+        env.add_metadata("required_library", "zmqpp")
+        env.add_metadata("required_library", "zmq")
 
         if env[":target"].identifier["family"] in ["linux"]:
-            env.append_metadata("required_library", "pthread")
+            env.add_metadata("required_library", "pthread")
     else:
         ignore.append("*backend/zeromq*")
 

--- a/src/modm/driver/display/sdl_display.lb
+++ b/src/modm/driver/display/sdl_display.lb
@@ -23,9 +23,9 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.append_metadata_unique("required_pkg", "gtkmm-2.4")
-    env.append_metadata_unique("required_pkg", "cairomm-1.0")
-    env.append_metadata_unique("required_pkg", "sdl")
+    env.add_metadata("required_pkg", "gtkmm-2.4")
+    env.add_metadata("required_pkg", "cairomm-1.0")
+    env.add_metadata("required_pkg", "sdl")
 
     env.outbasepath = "modm/src/modm/driver/display"
     env.copy("sdl_display.hpp")

--- a/src/modm/platform/can/canusb/module.lb
+++ b/src/modm/platform/can/canusb/module.lb
@@ -42,7 +42,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/platform/can"
 
     if env[":target"].partname == "hosted-linux":
-        env.append_metadata("required_library", "pthread")
+        env.add_metadata("required_library", "pthread")
 
     env.copy("canusb.hpp")
     env.copy("canusb_impl.hpp")

--- a/src/modm/platform/clock/avr/module.lb
+++ b/src/modm/platform/clock/avr/module.lb
@@ -34,7 +34,7 @@ def prepare(module, options):
 def build(env):
     device = env[":target"]
     driver = device.get_driver("clock")
-    env.append_metadata_unique("cpp.define", "F_CPU={}".format(env[":::f_cpu"]))
+    env.add_metadata("cpp.define", "F_CPU={}".format(env["f_cpu"]))
 
     properties = device.properties
     properties["target"] = target = device.identifier

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -45,12 +45,12 @@ def build(env):
     if env[":target"].identifier["family"] == "windows":
         ignore.extend(["*/serial_interface*", "*/serial_port*"])
 
-    env.append_metadata_unique("required_library", "boost_system")
-    env.append_metadata_unique("required_library",
+    env.add_metadata("required_library", "boost_system")
+    env.add_metadata("required_library",
         "boost_thread" if env[":target"].identifier["family"] == "linux" else
         "boost_thread-mt")
 
     if env[":target"].identifier["family"] == "linux":
-        env.append_metadata_unique("required_library", "pthread")
+        env.add_metadata("required_library", "pthread")
 
     env.copy(".", ignore=env.ignore_patterns(*ignore))

--- a/src/modm/processing/rtos/module.lb
+++ b/src/modm/processing/rtos/module.lb
@@ -31,7 +31,7 @@ def build(env):
     elif env[":target"].identifier["platform"] in ["hosted"]:
         env.copy("stdlib", "rtos")
         if env[":target"].identifier["family"] in ["linux"]:
-            env.append_metadata("required_library", "pthread")
+            env.add_metadata("required_library", "pthread")
     else:
         raise BuildException("No RTOS implementation matches your requirements!")
     env.copy("../rtos.hpp", "rtos.hpp")

--- a/src/stdc++/module.lb
+++ b/src/stdc++/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
 
 
 def build(env):
-    env.append_metadata_unique("include_path", "src/stdc++")
+    env.append_metadata_unique("include_path", "modm/src/stdc++")
 
     env.outbasepath = "modm/src/stdc++"
     env.copy(".")

--- a/src/stdc++/module.lb
+++ b/src/stdc++/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
 
 
 def build(env):
-    env.append_metadata_unique("include_path", "modm/src/stdc++")
+    env.add_metadata("include_path", "modm/src/stdc++")
 
     env.outbasepath = "modm/src/stdc++"
     env.copy(".")

--- a/test/module.lb
+++ b/test/module.lb
@@ -23,7 +23,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/test"
 
-    env.append_metadata_unique("include_path", "test")
+    env.append_metadata_unique("include_path", "modm/test")
 
     platform = env[":target"].identifier["platform"]
     if platform in ["hosted"]:

--- a/test/module.lb
+++ b/test/module.lb
@@ -23,7 +23,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/test"
 
-    env.append_metadata_unique("include_path", "modm/test")
+    env.add_metadata("include_path", "modm/test")
 
     platform = env[":target"].identifier["platform"]
     if platform in ["hosted"]:

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -44,7 +44,7 @@ def post_build(env, buildlog):
     # get CPU information
     subs = common_target(target)
     # Extract all source code files
-    subs["sources"] = common_source_files(env, buildlog)
+    subs["sources"] = sorted(p for sources in common_source_files(env, buildlog).values() for p in sources)
     # get memory information
     subs["memories"] = common_memories(target)
     # get memory information

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -35,8 +35,8 @@ def prepare(module, options):
 def build(env):
     project_name = env[":build:project.name"]
     build_path = env[":build:build.path"]
-    env.append_metadata_unique("elf.release", join(build_path, "cmake-build-release", project_name + ".elf"))
-    env.append_metadata_unique("elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
+    env.add_metadata("elf.release", join(build_path, "cmake-build-release", project_name + ".elf"))
+    env.add_metadata("elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
 
 
 def post_build(env, buildlog):

--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -15,7 +15,7 @@ FILE(GLOB APP_SOURCE_FILES *.c *.cpp *.hpp *.h)
 
 SET(SOURCE_FILES
 %% for file in sources
-    modm/{{ file }}
+    {{ file }}
 %% endfor
     ${APP_SOURCE_FILES}
 )
@@ -23,7 +23,7 @@ SET(SOURCE_FILES
 INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}
 %% for path in metadata.include_path
-    modm/{{ path }}
+    {{ path }}
 %% endfor
 )
 INCLUDE_DIRECTORIES(SYSTEM include)

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -14,16 +14,19 @@ import os
 from collections import defaultdict
 
 def common_source_files(env, buildlog):
-    files_to_build = []
+    files_to_build = defaultdict(list)
 
-    for operations in buildlog:
-        filename = operations.local_filename_out("modm/")
+    for operation in buildlog:
+        repo = operation.module_name.split(":")[0]
+        filename = operation.local_filename_out()
         _, extension = os.path.splitext(filename)
 
         if extension in [".c", ".cpp", ".cc", ".sx", ".S"]:
-            files_to_build.append(filename.replace('\\','\\\\')) #windows path compatibility hack
+            files_to_build[repo].append(filename.replace('\\','\\\\')) #windows path compatibility hack
 
-    return sorted(files_to_build)
+    for repo in files_to_build:
+        files_to_build[repo].sort()
+    return files_to_build
 
 def common_target(target):
     core = target.get_driver("core")["type"]

--- a/tools/build_script_generator/gitignore.in
+++ b/tools/build_script_generator/gitignore.in
@@ -1,3 +1,3 @@
-%% for entry in metadata["modm.gitignore"]
+%% for entry in gitignore
 {{ entry }}
 %% endfor

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -68,10 +68,10 @@ def build(env):
     # Append custom openocd config file to metadata
     openocd_cfg = env.get_option(":build:openocd.cfg", "")
     if len(openocd_cfg):
-        env.append_metadata_unique("openocd.configfile", openocd_cfg)
+        env.add_metadata("openocd.configfile", openocd_cfg)
 
     # Append common search paths to metadata
-    env.append_metadata_unique("openocd.search", "modm/openocd")
+    env.add_metadata("openocd.search", "modm/openocd")
 
 
 

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -79,10 +79,12 @@ def post_build(env, buildlog):
     target = env[":target"]
     env.substitutions = {
         "metadata": buildlog.metadata,
+        "gitignore": [env.reloutpath(i, "modm") for i in buildlog.repo_metadata["gitignore"]["modm"]],
     }
     env.outbasepath = "modm"
 
-    if len(buildlog.metadata.get("modm.gitignore", [])):
+    # Currently a modm only feature
+    if len(env.substitutions["gitignore"]):
         env.template("gitignore.in", ".gitignore")
 
     if env[":target"].has_driver("core:cortex-m*"):

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-from os.path import join
+from os.path import join, relpath
 # import all common code
 exec(open(localpath("../common.py")).read())
 
@@ -44,19 +44,23 @@ def build(env):
     env.add_metadata("elf.release", join(build_path, "release", project_name + ".elf"))
     env.add_metadata("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
-    if env[":::info.git"] != "Disabled":
-        env.add_metadata("modm.gitignore", "src/info_git.h")
-    if env[":::info.build"]:
-        env.add_metadata("modm.gitignore", "src/info_build.h")
+    if env["info.git"] != "Disabled":
+        env.add_metadata("gitignore", "modm/src/info_git.h")
+    if env["info.build"]:
+        env.add_metadata("gitignore", "modm/src/info_build.h")
 
 
 def post_build(env, buildlog):
     is_unittest = env.has_module(":test")
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
-    has_image_source = len(env[":::image.source"])
+    has_image_source = len(env["image.source"])
+    generated_paths = sorted(set(o.local_filename_out().split("/")[0] for o in buildlog))
+    generated_paths.remove("modm")
+    generated_paths.insert(0, "modm")
 
     target = env["modm:target"]
     subs = common_target(target)
+    sources = common_source_files(env, buildlog)
 
     build_tools = [
         "settings_buildpath",
@@ -72,7 +76,7 @@ def post_build(env, buildlog):
         build_tools += ["xpcc_generator"]
     if has_image_source:
         build_tools += ["bitmap"]
-    if env[":::info.git"] != "Disabled" or env[":::info.build"]:
+    if env["info.git"] != "Disabled" or env["info.build"]:
         build_tools += ["info"]
     if is_unittest:
         build_tools += ["unittest"]
@@ -83,8 +87,6 @@ def post_build(env, buildlog):
     else:
         build_tools += ["utils_buildsize", "compiler_hosted_gcc"]
 
-    # Extract all source code files
-    subs["sources"] = common_source_files(env, buildlog)
     # get memory information
     subs["memories"] = common_memories(target)
     # get memory information
@@ -92,10 +94,11 @@ def post_build(env, buildlog):
     # Add SCons specific data
     subs.update({
         "metadata": buildlog.metadata,
+        "generated_paths": generated_paths,
         "build_tools": build_tools,
         "is_unittest": is_unittest,
         "has_image_source": has_image_source,
-        "image_source": env[":::image.source"],
+        "image_source": env["image.source"],
         "has_xpcc_generator": has_xpcc_generator,
         "generator_source": env.get_option(":communication:xpcc:generator:source", ""),
         "generator_container": env.get_option(":communication:xpcc:generator:container", ""),
@@ -120,9 +123,19 @@ def post_build(env, buildlog):
             flag = "{}.format({})".format(flag, ", ".join(vals))
         return flag
 
-    # Generate library SConscript
+    for repo in generated_paths:
+        subs.update({
+            "repo": repo,
+            "sources": [env.reloutpath(s, repo) for s in sources[repo]],
+            "libraries": buildlog.repo_metadata["required_library"][repo],
+            "library_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["required_library_path"][repo]],
+            "include_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["include_path"][repo]],
+        })
+        # Generate library SConscript
+        env.outbasepath = repo
+        env.template("resources/SConscript.in", "SConscript", filters={"flag_format": flag_format})
+
     env.outbasepath = "modm"
-    env.template("resources/SConscript.in", "SConscript", filters={"flag_format": flag_format})
     # Copy the scons-build-tools
     env.copy(repopath("ext/dlr/scons-build-tools"), "ext/dlr/scons-build-tools")
     env.copy("site_tools", "scons/site_tools")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -41,13 +41,13 @@ def prepare(module, options):
 def build(env):
     project_name = env[":build:project.name"]
     build_path = env[":build:build.path"]
-    env.append_metadata_unique("elf.release", join(build_path, "release", project_name + ".elf"))
-    env.append_metadata_unique("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
+    env.add_metadata("elf.release", join(build_path, "release", project_name + ".elf"))
+    env.add_metadata("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
     if env[":::info.git"] != "Disabled":
-        env.append_metadata_unique("modm.gitignore", "src/info_git.h")
+        env.add_metadata("modm.gitignore", "src/info_git.h")
     if env[":::info.build"]:
-        env.append_metadata_unique("modm.gitignore", "src/info_build.h")
+        env.add_metadata("modm.gitignore", "src/info_build.h")
 
 
 def post_build(env, buildlog):

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -11,6 +11,7 @@
 from os.path import join, abspath
 
 Import("env")
+%% if repo == "modm"
 profile = ARGUMENTS.get("profile", "release")
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
 
@@ -25,15 +26,17 @@ env.Tool("{{tool}}")
 %% endfor
 env["BASEPATH"] = abspath(".")
 
-%% if options[":::info.git"] != "Disabled"
-env.InfoGit(with_status={{ "True" if "Status" in options[":::info.git"] else "False" }})
+%% if options["info.git"] != "Disabled"
+env.InfoGit(with_status={{ "True" if "Status" in options["info.git"] else "False" }})
 %% endif
-%% if options[":::info.build"]
+%% if options["info.build"]
 env.InfoBuild()
 %% endif
+%% endif
+
 
 env.Append(CPPPATH=[
-%% for path in metadata.include_path | sort
+%% for path in include_paths | sort
     abspath("{{ path }}"),
 %% endfor
 ])
@@ -44,8 +47,26 @@ files = [
 %% endfor
 ]
 
-library = env.StaticLibrary(target="modm", source=files)
+library = env.StaticLibrary(target="{{ repo }}", source=files)
 
+env.AppendUnique(LIBS=[
+    library,
+%% for library in libraries | sort
+    "{{ library }}",
+%% endfor
+])
+env.AppendUnique(LIBPATH=[
+    abspath(str(library[0].get_dir())),
+%% for library in library_paths | sort
+    abspath("{{ library }}"),
+%% endfor
+])
+%% if "required_pkg" in metadata
+env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
+%% endif
+
+
+%% if repo == "modm"
 %% if platform not in ["hosted"]
 # We need to link libmodm.a with --whole-archive, so that all weak symbols are visible to the linker.
 # Functions placed in a linker section list (like modm_section(".hardware_init")) are typically not
@@ -60,17 +81,6 @@ env["_LIBFLAGS"] = "-Wl,--whole-archive " + env["_LIBFLAGS"] + " -Wl,--no-whole-
 # whole_archive = env.Command(join(env.Dir("#").path, "-Wl,--whole-archive"), [], "")
 # no_whole_archive = env.Command(join(env.Dir("#").path, "-Wl,--no-whole-archive"), [], "")
 # library = whole_archive + library + no_whole_archive
-%% endif
-
-env.Append(LIBS=[
-    library,
-%% for library in metadata.required_library | sort
-    "{{ library }}",
-%% endfor
-])
-env.AppendUnique(LIBPATH=[abspath(str(library[0].get_dir()))])
-%% if "required_pkg" in metadata
-env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
 %% endif
 
 # Device configuration
@@ -132,5 +142,7 @@ if profile == "{{ profile }}":
 env.Append(CCFLAGS="$ARCHFLAGS")
 env.Append(ASFLAGS="$ARCHFLAGS")
 env.Append(LINKFLAGS="$ARCHFLAGS")
+%% endif
+
 
 Return("library")

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -14,7 +14,7 @@ from os.path import join, abspath
 # User Configurable Options
 project_name = "{{ options[":build:project.name"] }}"
 build_path = "{{ options[":build:build.path"] }}"
-modm_path = "modm"
+generated_paths = {{ generated_paths }}
 
 # SCons environment with all tools
 env = Environment(ENV=os.environ)
@@ -22,15 +22,15 @@ env["CONFIG_BUILD_BASE"] = abspath(build_path)
 env["CONFIG_PROJECT_NAME"] = project_name
 
 # Building all libraries
-env.SConscript(dirs=[modm_path], exports="env")
+env.SConscript(dirs=generated_paths, exports="env")
 
 %% if is_unittest
 # Building unit tests
-headers = env.FindHeaderFiles(join(modm_path, "test"))
+headers = env.FindHeaderFiles("modm/test")
 sources = env.UnittestRunner(target="main.cpp", source=headers, template="modm/test/runner.cpp.in")
 %% else
 env.Append(CPPPATH=".")
-ignored = [modm_path, "cmake-*", build_path]
+ignored = ["cmake-*", ".lbuild_cache", build_path] + generated_paths
 sources = []
 %% endif
 


### PR DESCRIPTION
Refactors to be able to better support generating build scripts for multiple repositories via `modm:build:scons`.