### PR TITLE
[core] Make default the fastest vector table location

### DIFF
--- a/src/modm/platform/core/cortex/linkerscript/linker.macros
+++ b/src/modm/platform/core/cortex/linkerscript/linker.macros
@@ -52,7 +52,7 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_vector_ram(memory)
-	.vector_ram :  /* Vector table in RAM, only if remapped */
+	.vector_ram (NOLOAD) :  /* Vector table in RAM, only if remapped */
 	{
 		__vector_table_ram_start = .;
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -48,12 +48,16 @@ def prepare(module, options):
             default="newlib",
             dependencies=lambda value: ":tlsf" if value == "tlsf" else None))
     if not options[":target"].has_driver("core:cortex-m0*"):
+        memories = listify(options[":target"].get_driver("core")["memory"])
+        default_location = "rom"
+        if any((m["name"] == "ccm" and "x" in m["access"]) or m["name"] == "dtcm" for m in memories):
+            default_location = "ram"
         module.add_option(
             EnumerationOption(
                 name="vector_table_location",
                 description=FileReader("option/vector_table_location.md"),
-                enumeration=["rom", "ram", "fastest"],
-                default="fastest"))
+                enumeration=["rom", "ram"],
+                default=default_location))
     module.add_option(
         NumericOption(
             name="main_stack_size",
@@ -99,7 +103,7 @@ def build(env):
     properties["partname"] = device.partname
     properties["driver"] = driver
     # Cortex-M0 does not have remappable vector table, so it will remain in Flash
-    properties["vector_table_location"] = env.get_option(":::vector_table_location", "rom")
+    properties["vector_table_location"] = env.get("vector_table_location", "rom")
     properties["core"] = driver["type"]
     properties["process_stack_size"] = 0
     if env.get_option(":platform:fault.cortex:led", None):
@@ -141,16 +145,12 @@ def build(env):
     for memory in memories:
         if memory["name"] == "ccm":
             if "x" in memory["access"]:
-                if properties["vector_table_location"] == "fastest":
-                    properties["vector_table_location"] = "ram"
                 # Executable CCM (Instruction Core-Coupled Memory)
                 linkerscript = "iccm"
             else:
                 # Non-executable CCM (Data Core-Coupled Memory)
                 linkerscript = "dccm"
         elif memory["name"] == "dtcm":
-            if properties["vector_table_location"] == "fastest":
-                properties["vector_table_location"] = "ram"
             # Executable ITCM and DTCM (Tightly-Coupled Memory)
             linkerscript = "idtcm"
 


### PR DESCRIPTION
There's no need for the "fastest" option, since this can simply be made the default.
This now also allows other modules to know the real vector table location.

Also fixes #79 by marking the `.vector_ram` section as `(NOLOAD)`.

cc @strongly-typed @rleh @chris-durand 