### PR TITLE
[test] Limit parallel execution for CI

### DIFF
--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -148,7 +148,7 @@ def main():
 
     try:
         #devices = [device for device in devices if device.startswith("atx")]
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.Pool(2) as pool:
             test_runs = pool.map(build_device, [TestRun(x) for x in devices])
 
         succeded = []


### PR DESCRIPTION
The CI runs out of memory (4GB) probably because of excessive parallel compilation.