### PR TITLE
[test] Prevent CI running out of memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -51,7 +51,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -70,7 +70,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -93,7 +93,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -109,7 +109,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -124,7 +124,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -139,7 +139,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -154,7 +154,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -172,7 +172,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -190,7 +190,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -208,7 +208,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -226,7 +226,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -244,7 +244,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -262,7 +262,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
@@ -280,7 +280,7 @@ jobs:
     environment:
       - LANG: "en_US.UTF-8"
       - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j3"
+      - SCONSFLAGS: "-j4"
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             python2 tools/xpcc_generator/builder/system_layout.py examples/xpcc/xml/communication.xml -o /tmp
             python3 tools/xpcc_generator/builder/system_layout.py examples/xpcc/xml/communication.xml -o /tmp
 
-  stm32f0-f1-examples:
+  stm32-examples:
     docker:
       - image: modm/modm-build:latest
     environment:
@@ -63,17 +63,6 @@ jobs:
           name: Examples STM32F1 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32f1_discovery nucleo_f103rb olimexino_stm32 stm32f103c8t6_blue_pill stm32f103c8t6_black_pill)
-
-  stm32f3-l4-f7-examples:
-    docker:
-      - image: modm/modm-build:latest
-    environment:
-      - LANG: "en_US.UTF-8"
-      - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j4"
-    steps:
-      - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
           name: Examples STM32F3 Series
           command: |
@@ -118,7 +107,7 @@ jobs:
           command: |
             (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno)
 
-  generic-examples:
+  linux-generic-examples:
     docker:
       - image: modm/modm-build:latest
     environment:
@@ -128,25 +117,14 @@ jobs:
     steps:
       - checkout
       - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run:
+          name: Linux Examples
+          command: |
+            (cd examples && ../tools/scripts/examples_compile.py linux zmq)
       - run:
           name: Generic Examples
           command: |
             (cd examples && ../tools/scripts/examples_compile.py generic)
-
-  linux-examples:
-    docker:
-      - image: modm/modm-build:latest
-    environment:
-      - LANG: "en_US.UTF-8"
-      - SCONS_LIB_DIR: "/usr/local/lib/python3.6/dist-packages/scons-3.0.1"
-      - SCONSFLAGS: "-j4"
-    steps:
-      - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
-      - run:
-          name: Examples Linux
-          command: |
-            (cd examples && ../tools/scripts/examples_compile.py linux zmq)
 
   avr-compile-all:
     docker:
@@ -297,12 +275,10 @@ workflows:
   build:
     jobs:
       - stm32f4-examples
-      - linux-examples
+      - linux-generic-examples
       - unittests
-      - stm32f3-l4-f7-examples
       - avr-examples
-      - stm32f0-f1-examples
-      - generic-examples
+      - stm32-examples
 
       - avr-compile-all:
           requires:
@@ -311,18 +287,18 @@ workflows:
       - stm32f0-compile-all:
           requires:
             - unittests
-            - stm32f0-f1-examples
+            - stm32-examples
       - stm32f1-compile-all:
           requires:
             - unittests
-            - stm32f0-f1-examples
+            - stm32-examples
       - stm32f2-compile-all:
           requires:
             - unittests
       - stm32f3-compile-all:
           requires:
             - unittests
-            - stm32f3-l4-f7-examples
+            - stm32-examples
       - stm32f4-compile-all:
           requires:
             - unittests
@@ -330,8 +306,8 @@ workflows:
       - stm32f7-compile-all:
           requires:
             - unittests
-            - stm32f3-l4-f7-examples
+            - stm32-examples
       - stm32l4-compile-all:
           requires:
             - unittests
-            - stm32f3-l4-f7-examples
+            - stm32-examples

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,7 +1,7 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
+    <option name=":build:build.path">../../../build/nucleo_l432kc/comp</option>
   </options>
   <modules>
     <module>modm:platform:comp:*</module>

--- a/examples/nucleo_l432kc/pwm/project.xml
+++ b/examples/nucleo_l432kc/pwm/project.xml
@@ -1,7 +1,7 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
+    <option name=":build:build.path">../../../build/nucleo_l432kc/pwm</option>
   </options>
   <modules>
     <module>:build:scons</module>

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,7 +1,7 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
+    <option name=":build:build.path">../../../build/nucleo_l432kc/pwm_advanced</option>
   </options>
   <modules>
     <module>:build:scons</module>

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,7 +1,7 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/blink</option>
+    <option name=":build:build.path">../../../build/stm32f3_discovery/comp</option>
   </options>
   <modules>
     <module>:debug</module>

--- a/examples/stm32f746g_discovery/adc_ad7928/project.xml
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.xml
@@ -1,7 +1,7 @@
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f746g_discovery/blink</option>
+    <option name=":build:build.path">../../../build/stm32f746g_discovery/adc_ad7928</option>
   </options>
   <modules>
     <module>:driver:ad7928</module>

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -23,7 +23,7 @@ import multiprocessing
 
 LOGGER = logging.getLogger("run")
 LBUILD_COMMAND = ["lbuild"]
-
+cpus = 4 if os.getenv("CIRCLECI") else os.cpu_count()
 
 class CommandException(Exception):
     pass
@@ -148,7 +148,7 @@ def main():
 
     try:
         #devices = [device for device in devices if device.startswith("atx")]
-        with multiprocessing.Pool() as pool:
+        with multiprocessing.Pool(cpus) as pool:
             test_runs = pool.map(build_device, [TestRun(x) for x in devices])
 
         succeded = []

--- a/tools/scripts/examples_compile.py
+++ b/tools/scripts/examples_compile.py
@@ -11,28 +11,60 @@ import os
 import sys
 import re
 import subprocess
+import multiprocessing
 from pathlib import Path
 
 def run(where, command):
-	global results
 	result = subprocess.run(command, shell=True, cwd=where, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	results += result.returncode
-	if result.returncode: print(result.stdout.decode("utf-8"));
-	print(result.stderr.decode("utf-8"))
-	return result.returncode
+	output = ""
+	if result.returncode:
+		output += result.stdout.decode("utf-8").strip(" \n")
+	output += result.stderr.decode("utf-8").strip(" \n")
+	return (result.returncode, output)
 
+def generate(project):
+	path = project.parent
+	output = ["=" * 90, "Generating: {}".format(path)]
+	rc, ro = run(path, "lbuild build")
+	print("\n".join(output + [ro]))
+	return None if rc else project
+
+def build(project):
+	path = project.parent
+	project_cfg = project.read_text()
+	commands = []
+	if ":build:scons" in project_cfg:
+		commands.append("scons build")
+	if ":build:cmake" in project_cfg:
+		commands.append("make")
+
+	rcs = 0
+	for command in commands:
+		output = ["=" * 90, "Building: {} with {}".format(path, "SCons" if "scons" in command else "CMake")]
+		rc, ro = run(path, command)
+		rcs += rc
+		print("\n".join(output + [ro]))
+
+	return None if rcs else project
+
+
+cpus = 4 if os.getenv("CIRCLECI") else os.cpu_count()
+print("Using {}x parallelism".format(cpus))
+# Create build folder to prevent process race
+(Path(__file__).parents[3] / "build").mkdir(exist_ok=True)
+# Find all project files
 projects = [p for path in sys.argv[1:] for p in Path(path).glob("**/project.xml")]
-results = 0
+# first generate all projects
+with multiprocessing.Pool(cpus) as pool:
+    projects = pool.map(generate, projects)
+results = projects.count(None)
 
-for project in projects:
-	print("============================================================================================")
-	print("Building: {}".format(project.parent))
-	result = run(project.parent, "lbuild build")
-	if result: continue;
-	if ":build:scons" in project.read_text():
-		run(project.parent, "scons build")
-	elif ":build:cmake" in project.read_text():
-		run(project.parent, "make")
+# Filter projects for successful generation
+projects = [p for p in projects if p is not None]
+# Then build the successfully generated ones
+with multiprocessing.Pool(cpus) as pool:
+    projects = pool.map(build, projects)
+results += projects.count(None)
 
 exit(results)
 


### PR DESCRIPTION
Multiprocessing Pool seems to have chosen an incorrect value like 8 cores, which lead to excessive memory thrashing and running out of memory alltogether.
4 cores/parallelism seems to be the sweetspot, so that is chosen. In addition, the examples are now generated and built with multiprocessing too, so that lbuild isn't the bottleneck anymore.

This change makes example compilation about 2 times faster (from about 5-6mins total to about 2-3mins), and compiling all targets more stable but  remains similar in time.