### PR TITLE
RTOS: Added missing queue constructor

### DIFF
--- a/src/modm/processing/rtos/freertos/queue.hpp
+++ b/src/modm/processing/rtos/freertos/queue.hpp
@@ -98,7 +98,9 @@ namespace modm
 		class Queue : private QueueBase
 		{
 		public:
-			Queue(unsigned portBASE_TYPE length);
+			inline Queue(unsigned portBASE_TYPE length):
+			    QueueBase(length,sizeof(T))
+			{};
 
 			using QueueBase::getSize;
 


### PR DESCRIPTION
The typesafe wrapper of the queue in the RTOS component is missing a constructor.

This fix will call the constructor of the underlying QueueBase class with the provided length parameter and the size of the templated type 