### PR TITLE
Fix Adc::setPinChannel<Gpio>() function

### DIFF
--- a/examples/nucleo_l476rg/adc/main.cpp
+++ b/examples/nucleo_l476rg/adc/main.cpp
@@ -34,7 +34,7 @@ main()
 					Adc1::Prescaler::Disabled,
 					Adc1::CalibrationMode::SingleEndedInputsMode, true);
 	Adc1::connect<GpioInputA0::In5>();
-	Adc1::setChannel(Adc1::Channel::Channel5, Adc1::SampleTime::Cycles182);
+	Adc1::setPinChannel<GpioInputA0>(Adc1::SampleTime::Cycles182);
 
 	int loop(0);
 	while (true)

--- a/examples/stm32f3_discovery/adc/continous/main.cpp
+++ b/examples/stm32f3_discovery/adc/continous/main.cpp
@@ -69,28 +69,28 @@ main()
 					Adc1::CalibrationMode::SingleEndedInputsMode, true);
 	Adc1::setFreeRunningMode(true);
 	Adc1::connect<Adc1In::In6>();
-	Adc1::setChannel(Adc1::Channel::Channel6, Adc1::SampleTime::Cycles2);
+	Adc1::setPinChannel<Adc1In>(Adc1::SampleTime::Cycles2);
 	Adc1::startConversion();
 
 	Adc2::initialize(Adc2::ClockMode::Asynchronous, Adc2::Prescaler::Div128,
 					Adc2::CalibrationMode::SingleEndedInputsMode, true);
 	Adc2::setFreeRunningMode(true);
 	Adc2::connect<Adc2In::In8>();
-	Adc2::setChannel(Adc2::Channel::Channel8, Adc2::SampleTime::Cycles2);
+	Adc2::setPinChannel<Adc2In>(Adc2::SampleTime::Cycles2);
 	Adc2::startConversion();
 
 	Adc3::initialize(Adc3::ClockMode::Asynchronous, Adc3::Prescaler::Div128,
 					Adc3::CalibrationMode::SingleEndedInputsMode, true);
 	Adc3::setFreeRunningMode(true);
 	Adc3::connect<Adc3In::In5>();
-	Adc3::setChannel(Adc3::Channel::Channel5, Adc3::SampleTime::Cycles2);
+	Adc3::setPinChannel<Adc3In>(Adc3::SampleTime::Cycles2);
 	Adc3::startConversion();
 
 	Adc4::initialize(Adc4::ClockMode::Asynchronous, Adc4::Prescaler::Div128,
 					Adc4::CalibrationMode::SingleEndedInputsMode, true);
 	Adc4::setFreeRunningMode(true);
 	Adc4::connect<Adc4In::In3>();
-	Adc4::setChannel(Adc4::Channel::Channel3, Adc4::SampleTime::Cycles2);
+	Adc4::setPinChannel<Adc4In>(Adc4::SampleTime::Cycles2);
 	Adc4::startConversion();
 
 	while (1)

--- a/examples/stm32f3_discovery/adc/interrupt/main.cpp
+++ b/examples/stm32f3_discovery/adc/interrupt/main.cpp
@@ -54,7 +54,7 @@ main()
 	Adc4::enableInterrupt(Adc4::Interrupt::EndOfRegularConversion);
 
 	Adc4::connect<AdcIn0::In3>();
-	Adc4::setChannel(Adc4::Channel::Channel3, Adc4::SampleTime::Cycles182);
+	Adc4::setPinChannel<AdcIn0>(Adc4::SampleTime::Cycles182);
 
 	while (1)
 	{

--- a/examples/stm32f3_discovery/adc/simple/main.cpp
+++ b/examples/stm32f3_discovery/adc/simple/main.cpp
@@ -38,7 +38,7 @@ main()
 	Adc4::initialize(Adc4::ClockMode::Asynchronous, Adc4::Prescaler::Div256,
 					Adc4::CalibrationMode::SingleEndedInputsMode, true);
 	Adc4::connect<AdcIn0::In3>();
-	Adc4::setChannel(Adc4::Channel::Channel3, Adc4::SampleTime::Cycles182);
+	Adc4::setPinChannel<AdcIn0>(Adc4::SampleTime::Cycles182);
 
 	while (1)
 	{

--- a/examples/stm32f4_discovery/adc/interrupt/main.cpp
+++ b/examples/stm32f4_discovery/adc/interrupt/main.cpp
@@ -51,7 +51,7 @@ main()
 	// initialize Adc2
 	Adc2::initialize<Board::systemClock>();
 	Adc2::connect<AdcIn::In7>();
-	Adc2::setChannel(Adc2::Channel::Channel7);
+	Adc2::setPinChannel<AdcIn>();
 
 	Adc2::enableInterruptVector(5);
 	Adc2::enableInterrupt(Adc2::Interrupt::EndOfRegularConversion);

--- a/examples/stm32f4_discovery/adc/oversample/main.cpp
+++ b/examples/stm32f4_discovery/adc/oversample/main.cpp
@@ -28,9 +28,9 @@ modm::log::Logger modm::log::info(loggerDevice);
 
 // the three sensors are mapped: x = ch1, y = ch2, z = ch0
 Adc2::Channel sensorMapping[3] = {
-		Adc2::Channel::Channel7,
-		Adc2::Channel::Channel4,
-		Adc2::Channel::Channel2
+	Adc2::getPinChannel<AdcIn0>(),
+	Adc2::getPinChannel<AdcIn1>(),
+	Adc2::getPinChannel<AdcIn2>(),
 };
 // the results are up to 16 bit wide
 uint32_t sensorData[3];

--- a/examples/stm32f4_discovery/adc/simple/main.cpp
+++ b/examples/stm32f4_discovery/adc/simple/main.cpp
@@ -34,10 +34,10 @@ main()
 	Usart2::connect<GpioOutputA2::Tx>();
 	Usart2::initialize<Board::systemClock, 115200>();
 
-	// initialize Adc4
+	// initialize Adc2
 	Adc2::connect<AdcIn::In7>();
 	Adc2::initialize<Board::systemClock>();
-	Adc2::setChannel(Adc2::Channel::Channel7);
+	Adc2::setPinChannel<AdcIn>();
 
 	while (1)
 	{

--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -252,12 +252,21 @@ public:
 	setChannel(const Channel channel,
 			   const SampleTime sampleTime = static_cast<SampleTime>(0b000));
 
-	/// Helper function for setting the channel from a Pin
+	/// Setting the channel for a Pin
 	template< class Gpio >
 	static inline bool
 	setPinChannel(SampleTime sampleTime = static_cast<SampleTime>(0b000))
 	{
-		return setChannel(Channel(Gpio::pin), sampleTime);
+		return setChannel(getPinChannel<Gpio>(), sampleTime);
+	}
+	/// Get the channel for a Pin
+	template< class Gpio >
+	static inline constexpr Channel
+	getPinChannel()
+	{
+		constexpr int8_t channel{Gpio::template AdcChannel<Peripheral::Adc{{ id }}>};
+		static_assert(channel >= 0, "Adc{{id}} does not have a channel for this pin!");
+		return Channel(channel);
 	}
 
 	static inline Channel

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -193,12 +193,21 @@ public:
    	static inline void
    	clearChannel(const Channel channel);
 
-	/// Helper function for setting the channel from a Pin
+	/// Setting the channel for a Pin
 	template< class Gpio >
 	static inline bool
 	setPinChannel(SampleTime sampleTime = static_cast<SampleTime>(0b000))
 	{
-		return setChannel(Channel(Gpio::pin), sampleTime);
+		return setChannel(getPinChannel<Gpio>(), sampleTime);
+	}
+	/// Get the channel for a Pin
+	template< class Gpio >
+	static inline constexpr Channel
+	getPinChannel()
+	{
+		constexpr int8_t channel{Gpio::template AdcChannel<Peripheral::Adc{{ id }}>};
+		static_assert(channel >= 0, "Adc{{id}} does not have a channel for this pin!");
+		return Channel(channel);
 	}
 
 	/**

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -301,12 +301,21 @@ public:
 	setChannel(const Channel channel,
 			const SampleTime sampleTime=static_cast<SampleTime>(0b000));
 
-	/// Helper function for setting the channel from a Pin
+	/// Setting the channel for a Pin
 	template< class Gpio >
 	static inline bool
 	setPinChannel(SampleTime sampleTime = static_cast<SampleTime>(0b000))
 	{
-		return setChannel(Channel(Gpio::pin), sampleTime);
+		return setChannel(getPinChannel<Gpio>(), sampleTime);
+	}
+	/// Get the channel for a Pin
+	template< class Gpio >
+	static inline constexpr Channel
+	getPinChannel()
+	{
+		constexpr int8_t channel{Gpio::template AdcChannel<Peripheral::Adc{{ id }}>};
+		static_assert(channel >= 0, "Adc{{id}} does not have a channel for this pin!");
+		return Channel(channel);
 	}
 
 	/**

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -245,6 +245,11 @@ def validate(env):
     bprops["all_signals"] = sorted(list(set(s["name"] for s in all_signals.values())))
     bprops["pf"] = "1" if device.identifier["family"] in ["l4"] else ""
 
+    # Check the max number of ADC instances
+    max_adc_instance = max(map(int, device.get_driver("adc").get("instance", [1])))
+    if (max_adc_instance > (3 if device.identifier["family"] == "f1" else 4)):
+        raise ValidateException("Too many ADC instances: '{}'".format(max_adc_instance))
+
     return True
 
 def build(env):

--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -39,6 +39,8 @@ class Gpio{{ port ~ pin }} : public Gpio, public ::modm::GpioIO
 	template<class... Gpios>
 	friend class GpioSet;
 	using PinSet = GpioSet<Gpio{{ port ~ pin }}>;
+	friend class Adc1; friend class Adc2;
+	friend class Adc3; friend class Adc4;
 public:
 	using Output = Gpio{{ port ~ pin }};
 	using Input = Gpio{{ port ~ pin }};
@@ -169,7 +171,7 @@ public:
 #ifdef __DOXYGEN__
 	/// @{
 	/// Connect to any software peripheral
-	struct BitBang;
+	using BitBang = GpioSignal;
 	%% for name, group in signals.items()
 	/// Connect to {% for sig in group %}{{ sig.driver }}{{ "" if loop.last else " or "}}{% endfor %}
 	using {{ name }} = GpioSignal;
@@ -194,6 +196,9 @@ public:
 	};
 	%% endfor
 	/// @endcond
+private:
+	template< Peripheral peripheral >
+	static constexpr int8_t AdcChannel = -1;
 };
 
 /// @cond
@@ -225,8 +230,16 @@ struct Gpio{{ port ~ pin }}::{{ signal.name }}<Peripheral::{{ signal.driver }}>
 		%% endif
 	}
 };
+		%% if signal.driver.startswith("Adc") and signal.name.startswith("In")
+template<>
+constexpr int8_t
+Gpio{{ port ~ pin }}::AdcChannel<Peripheral::{{ signal.driver }}> = {{ signal.name.replace("In", "") }};
+		%% endif
 	%% endfor
+
 %% endfor
+
+
 /// @endcond
 
 } // namespace platform

--- a/src/modm/platform/gpio/stm32/pin_f1.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin_f1.hpp.in
@@ -41,6 +41,7 @@ struct Gpio{{ port ~ pin }} : public Gpio, ::modm::GpioIO
 	template<class... Gpios>
 	friend class GpioSet;
 	using PinSet = GpioSet<Gpio{{ port ~ pin }}>;
+	friend class Adc1; friend class Adc2; friend class Adc3;
 public:
 	using Output = Gpio{{ port ~ pin }};
 	using Input = Gpio{{ port ~ pin }};
@@ -180,6 +181,9 @@ public:
 	};
 	%% endfor
 	/// @endcond
+private:
+	template< Peripheral peripheral >
+	static constexpr int8_t AdcChannel = -1;
 };
 
 /// @cond
@@ -215,7 +219,13 @@ struct Gpio{{ port ~ pin }}::{{ signal.name }}<Peripheral::{{ signal.driver }}>
 			%% endif
 	}
 };
+		%% if signal.driver.startswith("Adc") and signal.name.startswith("In")
+template<>
+constexpr int8_t
+Gpio{{ port ~ pin }}::AdcChannel<Peripheral::{{ signal.driver }}> = {{ signal.name.replace("In", "") }};
+		%% endif
 	%% endfor
+
 %% endfor
 /// @endcond
 
@@ -223,4 +233,4 @@ struct Gpio{{ port ~ pin }}::{{ signal.name }}<Peripheral::{{ signal.driver }}>
 
 } // namespace modm
 
-#endif // MODM_STM32_GPIO_PIN_HPP
+#endif // MODM_STM32_GPIO_{{ port ~ pin }}_HPP


### PR DESCRIPTION
The mapping isn't 1-1 for all ADC instances and this fixes it by generating an explicit mapping for each GPIO and ADC instance and using that instead.

You can use `Adc::Channel Adc::getPinChannel<Gpio>()` as well to get the numeric value for other purposes.

@Zweistein885 @se-bi @rleh @chris-durand 