### PR TITLE
Fix cmake builds on windows

### DIFF
--- a/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake.in
+++ b/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake.in
@@ -1,5 +1,3 @@
-INCLUDE(./modm/cmake/report-build-options.cmake)
-
 SET(CMAKE_SYSTEM_NAME Generic)
 SET(CMAKE_SYSTEM_PROCESSOR arm)
 

--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -2,6 +2,9 @@
 # Do not modify!
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+
+INCLUDE(./modm/cmake/configure-{{ platform }}-{{ compiler }}.cmake)
+
 PROJECT({{ project_name }})
 
 IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
@@ -36,7 +39,7 @@ SET(PROJECT_CORE       {{ core     }})
 SET(PROJECT_NAME       {{ project_name }})
 SET(PROJECT_BUILD_PATH {{ build_path }})
 
-INCLUDE(./modm/cmake/configure-{{ platform }}-{{ compiler }}.cmake)
+INCLUDE(./modm/cmake/report-build-options.cmake)
 
 if ( APPLE )
     string ( REPLACE "-Wl,-search_paths_first" "" CMAKE_C_LINK_FLAGS ${CMAKE_C_LINK_FLAGS} )

--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -18,7 +18,7 @@ FILE(GLOB APP_SOURCE_FILES *.c *.cpp *.hpp *.h)
 
 SET(SOURCE_FILES
 %% for file in sources
-    {{ file }}
+    {{ file | modm.windowsify }}
 %% endfor
     ${APP_SOURCE_FILES}
 )
@@ -26,7 +26,7 @@ SET(SOURCE_FILES
 INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}
 %% for path in metadata.include_path
-    {{ path }}
+    {{ path | modm.windowsify }}
 %% endfor
 )
 INCLUDE_DIRECTORIES(SYSTEM include)

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -23,9 +23,6 @@ def common_source_files(env, buildlog):
         _, extension = os.path.splitext(filename)
 
         if extension in [".c", ".cpp", ".cc", ".sx", ".S"]:
-            # Windows path compatibility hack
-            if platform.system() == "Windows":
-                filename = filename.replace('\\', '/')
             files_to_build[repo].append(filename)
 
     for repo in files_to_build:

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -11,6 +11,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+import platform
 from collections import defaultdict
 
 def common_source_files(env, buildlog):
@@ -22,7 +23,10 @@ def common_source_files(env, buildlog):
         _, extension = os.path.splitext(filename)
 
         if extension in [".c", ".cpp", ".cc", ".sx", ".S"]:
-            files_to_build[repo].append(filename.replace('\\','\\\\')) #windows path compatibility hack
+            # Windows path compatibility hack
+            if platform.system() == "Windows":
+                filename = filename.replace('\\', '/')
+            files_to_build[repo].append(filename)
 
     for repo in files_to_build:
         files_to_build[repo].sort()

--- a/tools/build_script_generator/gdbinit.in
+++ b/tools/build_script_generator/gdbinit.in
@@ -2,7 +2,7 @@
 %% if "elf." ~ profile in metadata
 define file_{{profile}}
     file
-    file {{ metadata["elf." ~ profile][0] | windowsify }}
+    file {{ metadata["elf." ~ profile][0] | modm.windowsify }}
 end
 %% endif
 %% endfor

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -29,6 +29,7 @@ def windowsify(path):
 def init(module):
     module.name = "build"
     module.description = FileReader("module.md")
+    module.add_filter("windowsify", windowsify)
 
 
 def prepare(module, options):
@@ -94,8 +95,8 @@ def post_build(env, buildlog):
         env.template("gitignore.in", ".gitignore")
 
     if env[":target"].has_driver("core:cortex-m*"):
-        env.template("openocd.cfg.in", filters={"windowsify": windowsify})
-        env.template("gdbinit.in", filters={"windowsify": windowsify})
+        env.template("openocd.cfg.in")
+        env.template("gdbinit.in")
 
 
 # ============================ Option Descriptions ============================

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -15,7 +15,7 @@ proc modm_program { SOURCE } {
 %% for profile in ["release", "debug"]
 %% if "elf." ~ profile in metadata
 proc program_{{ profile }} {} {
-	modm_program {{ metadata["elf." ~ profile][0]  | windowsify }}
+	modm_program {{ metadata["elf." ~ profile][0]  | modm.windowsify }}
 }
 %% endif
 %% endfor


### PR DESCRIPTION
Sets the compiler before the PROJECT call in cmake ensuring it tests the embedded toolchain and not the system compiler, which might be unavailable, especially on Windows.

Writes paths with forward slashes into CMakeLists.txt, because cmake cannot handle backslashes even on Windows.