### PR TITLE
 [build] [scons] Add command-line arguments to manipulate CCFLAGS, CFLAGS, etc.

### DIFF
--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -154,4 +154,20 @@ env.Append(LINKFLAGS="$ARCHFLAGS")
 %% endif
 
 
+for flags in ["CCFLAGS", "CFLAGS", "CXXFLAGS", "ASFLAGS", "ARCHFLAGS", "LINKFLAGS"]:
+	flags_str = ARGUMENTS.get(flags)
+	if flags_str is not None:
+		flags_list = flags_str.split(",")
+		for flag in flags_list:
+			if len(flag) > 1 and flag[0] == "~":
+				try:
+					env[flags].remove(flag[1:])
+				except ValueError:
+					print("'" + flag[1:] + "' does not exist in " + flags +
+						" and therefore can not be removed.")
+					print("Info: " + flags + ": " + ", ".join(env[flags]))
+					exit(1)
+			else:
+				env[flags].append(flag)
+
 Return("library")


### PR DESCRIPTION
Scons arguments _CCFLAGS_, _CFLAGS_, _CXXFLAGS_, _ASFLAGS__, _ARCHFLAGS_, _LINKFLAGS_ are added.
Each argument takes a colon-separated list of compiler/link/... flags to be added or removed (if the flag is prefixed with `~`).

E.g. the user can decrease the maximal inline function size using the command line:
```
scons CCFLAGS=~-finline-limit=10000,-finline-limit=100
```

I do not like to modify the `SConstruct` file because it might be overwritten by lbuild.