### PR TITLE
Implement separate compile flags per module/file

### DIFF
--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -11,6 +11,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
+from collections import defaultdict
+
 def init(module):
     module.parent = "cmsis"
     module.name = "dsp"
@@ -41,26 +43,32 @@ def prepare(module, options):
     return True
 
 def build(env):
+    metadata = defaultdict(list)
+    metadata["flags.cflags"].append("-fno-strict-aliasing")
+
     core = env[":target"].get_driver("core")["type"]
+    if "f" in core:
+        metadata["flags.cppdefines"].append("__FPU_PRESENT=1")
+
     core = core.replace("cortex-m", "CM").replace("+", "PLUS").replace("f", "").replace("d", "")
     env.add_metadata("flags.cppdefines", "ARM_MATH_{}".format(core))
 
     if env["check_matrix_sizes"]:
-        env.add_metadata("flags.cppdefines", "ARM_MATH_MATRIX_CHECK")
+        metadata["flags.cppdefines"].append("ARM_MATH_MATRIX_CHECK")
     else:
-        env.add_metadata("flags.cppdefines.debug", "ARM_MATH_MATRIX_CHECK")
+        metadata["flags.cppdefines.debug"].append("ARM_MATH_MATRIX_CHECK")
 
     if env["round_float_inputs"]:
-        env.add_metadata("flags.cppdefines", "ARM_MATH_ROUNDING")
+        metadata["flags.cppdefines"].append("ARM_MATH_ROUNDING")
 
     if not env.get("unaligned_data", False):
-        env.add_metadata("flags.cppdefines", "UNALIGNED_SUPPORT_DISABLE")
+        metadata["flags.cppdefines"].append("UNALIGNED_SUPPORT_DISABLE")
 
     env.add_metadata("include_path", "modm/ext/cmsis/dsp")
 
     env.outbasepath = "modm/ext/cmsis/dsp"
     env.copy("cmsis/CMSIS/DSP/Include", ".")
-    env.copy("cmsis/CMSIS/DSP/Source", ".")
+    env.copy("cmsis/CMSIS/DSP/Source", ".", metadata=metadata)
 
 
 # ============================ Option Descriptions ============================

--- a/repo.lb
+++ b/repo.lb
@@ -33,7 +33,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.5.0"
+min_lbuild_version = "1.6.0"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip install -U lbuild".format(min_lbuild_version))

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -48,7 +48,7 @@ def post_build(env, buildlog):
     # get memory information
     subs["memories"] = common_memories(target)
     # get memory information
-    subs["flags"] = common_metadata_flags(buildlog)
+    subs["flags"] = common_metadata_flags(buildlog.repo_metadata, "modm")
 
     # Add SCons specific data
     subs.update({

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -54,14 +54,23 @@ def common_memories(target):
         ])
     return memories
 
-def common_metadata_flags(buildlog, repo=None):
+def common_metadata_flags(metadata, repo=None):
     flags = defaultdict(lambda: defaultdict(list))
-    metadata = buildlog.metadata if repo is None else buildlog.repo_metadata
     for key, values in metadata.items():
         if key.startswith("flags."):
             key = key.split(".")[1:]
             if repo: values = values[repo];
-            flags[key[0].upper()]["" if len(key) < 2 else key[1]] = list(values)
+            flags[key[0].upper()]["" if len(key) < 2 else key[1]].extend(list(values))
+    return flags
+
+def common_file_flags(buildlog, filename):
+    flags = defaultdict(lambda: defaultdict(list))
+    for key, data in buildlog.operation_metadata.items():
+        if key.startswith("flags."):
+            key = key.split(".")[1:]
+            for mfilename, values in data.items():
+                if mfilename == filename:
+                    flags[key[0].upper()]["" if len(key) < 2 else key[1]].extend(list(values))
     return flags
 
 def common_compiler_flags(compiler, target):

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -68,10 +68,8 @@ def post_build(env, buildlog):
     is_unittest = env.has_module(":test")
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["image.source"])
-    generated_paths = sorted(set(o.local_filename_out().split("/")[0] for o in buildlog))
-    generated_paths.remove("modm")
-    generated_paths.insert(0, "modm")
-    generated_paths = [p for p in generated_paths if os.path.isdir(env.outpath(p, basepath="."))]
+    repositories = [p for p in buildlog.repositories if os.path.isdir(env.outpath(p, basepath="."))]
+    repositories = sorted(repositories, key=lambda name: "0" if name == "modm" else name)
 
     target = env["modm:target"]
     subs = common_target(target)
@@ -107,7 +105,7 @@ def post_build(env, buildlog):
     # Add SCons specific data
     subs.update({
         "metadata": buildlog.metadata,
-        "generated_paths": generated_paths,
+        "generated_paths": repositories,
         "build_tools": build_tools,
         "is_unittest": is_unittest,
         "has_image_source": has_image_source,
@@ -125,11 +123,19 @@ def post_build(env, buildlog):
     # Set these substitutions for all templates
     env.substitutions = subs
 
-    for repo in generated_paths:
+    for repo in repositories:
+        files = []
+        for f in sources[repo]:
+            flags = common_file_flags(buildlog, f)
+            for key, profiles in flags.items():
+                if "" not in profiles: profiles[""] = []
+                profiles[""].insert(0, "${}".format(key))
+            files.append( (env.reloutpath(f, repo), flags) )
+
         subs.update({
             "repo": repo,
-            "flags": common_metadata_flags(buildlog, repo),
-            "sources": [env.reloutpath(s, repo) for s in sources[repo]],
+            "flags": common_metadata_flags(buildlog.repo_metadata, repo),
+            "sources": files,
             "libraries": buildlog.repo_metadata["required_library"][repo],
             "library_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["required_library_path"][repo]],
             "include_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["include_path"][repo]],

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -34,43 +34,6 @@ env.InfoBuild()
 %% endif
 %% endif
 
-
-env.AppendUnique(CPPPATH=[
-%% if family == "darwin"
-	"/usr/local/include",
-%% endif
-%% for path in include_paths | sort
-    abspath("{{ path }}"),
-%% endfor
-])
-
-files = [
-%% for file in sources
-    env.File("{{ file }}"),
-%% endfor
-]
-
-library = env.StaticLibrary(target="{{ repo }}", source=files)
-
-env.AppendUnique(LIBS=[
-    library,
-%% for library in libraries | sort
-    "{{ library }}",
-%% endfor
-])
-env.AppendUnique(LIBPATH=[
-%% if family == "darwin"
-	"/usr/local/lib",
-%% endif
-    abspath(str(library[0].get_dir())),
-%% for library in library_paths | sort
-    abspath("{{ library }}"),
-%% endfor
-])
-%% if "required_pkg" in metadata
-env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
-%% endif
-
 %% macro generate_flags_for_profile(name, profile, append=False)
 env{% if append %}.Append({{name}}{% else %}["{{name}}"]{% endif %} = [
 %% for flag in flags[name][profile] | sort
@@ -101,6 +64,11 @@ if profile == "{{ profile }}":
 {{ generate_flags("ARCHFLAGS", repo != "modm") }}
 
 %% if repo == "modm"
+# ARCHFLAGS must be known for compiling *and* linking
+env.Append(CCFLAGS="$ARCHFLAGS")
+env.Append(ASFLAGS="$ARCHFLAGS")
+env.Append(LINKFLAGS="$ARCHFLAGS")
+
 %% if family != "darwin"
 env["_LIBFLAGS"] = "-Wl,--start-group " + env["_LIBFLAGS"] + " -Wl,--end-group"
 %% endif
@@ -146,12 +114,54 @@ env.SetDefault(MODM_GDBINIT=["$BASEPATH/gdbinit"])
 
 # XPCC generator tool path
 env["XPCC_SYSTEM_DESIGN"] = join(abspath("."), "tools", "xpcc_generator")
-
-# ARCHFLAGS must be known for compiling *and* linking
-env.Append(CCFLAGS="$ARCHFLAGS")
-env.Append(ASFLAGS="$ARCHFLAGS")
-env.Append(LINKFLAGS="$ARCHFLAGS")
 %% endif
 
+
+env.AppendUnique(CPPPATH=[
+%% if family == "darwin"
+	"/usr/local/include",
+%% endif
+%% for path in include_paths | sort
+    abspath("{{ path }}"),
+%% endfor
+])
+
+files = [
+%% for file, flags in sources if not flags | length
+    env.File("{{ file }}"),
+%% endfor
+]
+%% for file, flags in sources
+    %% if flags | length
+flags = { {%- for key, profiles in flags.items() if "" in profiles %}"{{key}}": {{profiles[""]}}, {% endfor -%} }
+    %% for key, profiles in flags.items()
+        %% for profile, flags in profiles.items() if "" != profile
+if profile == "{{profile}}": flags["{{key}}"].extend({{flags}});
+        %% endfor
+    %% endfor
+files.append(env.Object("{{ file }}", **flags))
+    %% endif
+%% endfor
+
+library = env.StaticLibrary(target="{{ repo }}", source=files)
+
+env.AppendUnique(LIBS=[
+    library,
+%% for library in libraries | sort
+    "{{ library }}",
+%% endfor
+])
+env.AppendUnique(LIBPATH=[
+%% if family == "darwin"
+	"/usr/local/lib",
+%% endif
+    abspath(str(library[0].get_dir())),
+%% for library in library_paths | sort
+    abspath("{{ library }}"),
+%% endfor
+])
+%% if "required_pkg" in metadata
+env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
+%% endif
 
 Return("library")


### PR DESCRIPTION
This implements adding separate compile flags for specific files by attaching metadata to lbuild operations. This allows to compile CMSIS-DSP with its own flags (specifically `__FPU_PRESENT=1` is required), without using these settings globally (which triggers a warning since `<stm32xx.h>` device headers usually define this macro).

Implemented for:
- [x] SCons
- [ ] CMake

See #125 for discussion.
Depends on https://github.com/modm-io/lbuild/pull/16.
cc @dergraaf @rleh @se-bi @chris-durand