### PR TITLE
Use fully qualified names in lbuild configuration

### DIFF
--- a/examples/arduino_uno/basic/analog_read_serial/project.xml
+++ b/examples/arduino_uno/basic/analog_read_serial/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>
-    <option name=":build:build.path">../../../../build/arduino_uno/basic/analog_read_serial</option>
+    <option name="modm:build:build.path">../../../../build/arduino_uno/basic/analog_read_serial</option>
   </options>
   <modules>
-    <module>:platform:adc</module>
-    <module>:build:scons</module>
+    <module>modm:platform:adc</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/arduino_uno/basic/blink/project.xml
+++ b/examples/arduino_uno/basic/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>
-    <option name=":build:build.path">../../../../build/arduino_uno/basic/blink</option>
+    <option name="modm:build:build.path">../../../../build/arduino_uno/basic/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/arduino_uno/basic/digital_read_serial/project.xml
+++ b/examples/arduino_uno/basic/digital_read_serial/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>
-    <option name=":build:build.path">../../../../build/arduino_uno/basic/digital_read_serial</option>
+    <option name="modm:build:build.path">../../../../build/arduino_uno/basic/digital_read_serial</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/arduino_uno/basic/read_analog_voltage/project.xml
+++ b/examples/arduino_uno/basic/read_analog_voltage/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:arduino-uno</extends>
   <options>
-    <option name=":build:build.path">../../../../build/arduino_uno/basic/read_analog_voltage</option>
+    <option name="modm:build:build.path">../../../../build/arduino_uno/basic/read_analog_voltage</option>
   </options>
   <modules>
-    <module>:platform:adc</module>
-    <module>:build:scons</module>
+    <module>modm:platform:adc</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/1-wire/ds18b20/project.xml
+++ b/examples/avr/1-wire/ds18b20/project.xml
@@ -1,17 +1,17 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/1-wire/ds18b20</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/1-wire/ds18b20</option>
   </options>
   <modules>
-    <module>:driver:ds18b20</module>
-    <module>:io</module>
-    <module>:platform:1-wire.bitbang</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ds18b20</module>
+    <module>modm:io</module>
+    <module>modm:platform:1-wire.bitbang</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/adc/basic/project.xml
+++ b/examples/avr/adc/basic/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/adc/basic</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/adc/basic</option>
   </options>
   <modules>
-    <module>:io</module>
-    <module>:platform:adc</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:io</module>
+    <module>modm:platform:adc</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/adc/oversample/project.xml
+++ b/examples/avr/adc/oversample/project.xml
@@ -1,18 +1,18 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/adc/oversample</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/adc/oversample</option>
   </options>
   <modules>
-    <module>:driver:adc_sampler</module>
-    <module>:io</module>
-    <module>:platform:adc</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:adc_sampler</module>
+    <module>modm:io</module>
+    <module>modm:platform:adc</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/app_can2usb/project.xml
+++ b/examples/avr/app_can2usb/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">at90can128</option>
-    <option name=":platform:clock:f_cpu">16000000</option>
-    <option name=":build:build.path">../../../build/avr/app_can2usb</option>
+    <option name="modm:target">at90can128</option>
+    <option name="modm:platform:clock:f_cpu">16000000</option>
+    <option name="modm:build:build.path">../../../build/avr/app_can2usb</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:ft245</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:ft245</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/assert/project.xml
+++ b/examples/avr/assert/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:al-avreb-can</extends>
   <options>
-    <option name=":build:build.path">../../../build/avr/assert</option>
+    <option name="modm:build:build.path">../../../build/avr/assert</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/block_device_mirror/project.xml
+++ b/examples/avr/block_device_mirror/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../build/avr/block_device_mirror</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../build/avr/block_device_mirror</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:block.device:heap</module>
-    <module>:driver:block.device:mirror</module>
-    <module>:platform:core</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:block.device:heap</module>
+    <module>modm:driver:block.device:mirror</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/can/mcp2515/project.xml
+++ b/examples/avr/can/mcp2515/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/can/mcp2515</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/can/mcp2515</option>
   </options>
   <modules>
-    <module>:driver:mcp2515</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:build:scons</module>
+    <module>modm:driver:mcp2515</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/can/mcp2515_uart/project.xml
+++ b/examples/avr/can/mcp2515_uart/project.xml
@@ -1,18 +1,18 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/can/mcp2515_uart</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/can/mcp2515_uart</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:driver:mcp2515</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:uart:0</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:driver:mcp2515</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/benchmark/project.xml
+++ b/examples/avr/display/dogm128/benchmark/project.xml
@@ -1,19 +1,19 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/benchmark</option>
-    <option name=":build:scons:image.source">images</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/benchmark</option>
+    <option name="modm:build:scons:image.source">images</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:processing:timer</module>
-    <module>:ui:display</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:processing:timer</module>
+    <module>modm:ui:display</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/caged_ball/project.xml
+++ b/examples/avr/display/dogm128/caged_ball/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/caged_ball</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/caged_ball</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/draw/project.xml
+++ b/examples/avr/display/dogm128/draw/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/draw</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/draw</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/image/project.xml
+++ b/examples/avr/display/dogm128/image/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/image</option>
-    <option name=":build:scons:image.source">images</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/image</option>
+    <option name="modm:build:scons:image.source">images</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/text/project.xml
+++ b/examples/avr/display/dogm128/text/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/text</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/text</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:ui:display</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:ui:display</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm128/touch/project.xml
+++ b/examples/avr/display/dogm128/touch/project.xml
@@ -1,18 +1,18 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../../build/avr/display/dogm128/touch</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/touch</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:io</module>
-    <module>:platform:adc</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:io</module>
+    <module>modm:platform:adc</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm132/project.xml
+++ b/examples/avr/display/dogm132/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/display/dogm132</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/display/dogm132</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:ui:button</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:ui:button</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/dogm163/project.xml
+++ b/examples/avr/display/dogm163/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">16000000</option>
-    <option name=":build:build.path">../../../../build/avr/display/dogm163</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">16000000</option>
+    <option name="modm:build:build.path">../../../../build/avr/display/dogm163</option>
   </options>
   <modules>
-    <module>:driver:ea_dog</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:ui:display</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ea_dog</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:ui:display</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/hd44780/project.xml
+++ b/examples/avr/display/hd44780/project.xml
@@ -1,13 +1,13 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/display/hd44780</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/display/hd44780</option>
   </options>
   <modules>
-    <module>:driver:hd44780</module>
-    <module>:platform:gpio</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:driver:hd44780</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/display/siemens_s65/project.xml
+++ b/examples/avr/display/siemens_s65/project.xml
@@ -1,16 +1,16 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">16000000</option>
-    <option name=":build:build.path">../../../../build/avr/display/siemens_s65</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">16000000</option>
+    <option name="modm:build:build.path">../../../../build/avr/display/siemens_s65</option>
   </options>
   <modules>
-    <module>:driver:siemens_s65</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:ui:button</module>
-    <module>:build:scons</module>
+    <module>modm:driver:siemens_s65</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:ui:button</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/flash/project.xml
+++ b/examples/avr/flash/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">atmega328p</option>
-    <option name=":platform:clock:f_cpu">1000000</option>
-    <option name=":build:build.path">../../../build/avr/flash</option>
+    <option name="modm:target">atmega328p</option>
+    <option name="modm:platform:clock:f_cpu">1000000</option>
+    <option name="modm:build:build.path">../../../build/avr/flash</option>
   </options>
   <modules>
-    <module>:architecture:accessor</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:accessor</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/gpio/basic/project.xml
+++ b/examples/avr/gpio/basic/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">attiny85</option>
-    <option name=":platform:clock:f_cpu">8000000</option>
-    <option name=":build:build.path">../../../../build/avr/gpio/basic</option>
+    <option name="modm:target">attiny85</option>
+    <option name="modm:platform:clock:f_cpu">8000000</option>
+    <option name="modm:build:build.path">../../../../build/avr/gpio/basic</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/gpio/blinking/project.xml
+++ b/examples/avr/gpio/blinking/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">atmega328p</option>
-    <option name=":platform:clock:f_cpu">1000000</option>
-    <option name=":build:build.path">../../../../build/avr/gpio/blinking</option>
+    <option name="modm:target">atmega328p</option>
+    <option name="modm:platform:clock:f_cpu">1000000</option>
+    <option name="modm:build:build.path">../../../../build/avr/gpio/blinking</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/gpio/button_group/project.xml
+++ b/examples/avr/gpio/button_group/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/gpio/button_group</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/gpio/button_group</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:ui:button</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:ui:button</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/logger/project.xml
+++ b/examples/avr/logger/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../build/avr/logger</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../build/avr/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/ports/project.xml
+++ b/examples/avr/ports/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:al-avreb-can</extends>
   <options>
-    <option name=":build:build.path">../../../build/avr/ports</option>
-    <option name=":build:avrdude.programmer">usbasp-clone</option>
+    <option name="modm:build:build.path">../../../build/avr/ports</option>
+    <option name="modm:build:avrdude.programmer">usbasp-clone</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/protothread/project.xml
+++ b/examples/avr/protothread/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../build/avr/protothread</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../build/avr/protothread</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/pwm/pca9685/project.xml
+++ b/examples/avr/pwm/pca9685/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">atmega168p</option>
-    <option name=":platform:clock:f_cpu">8000000</option>
-    <option name=":build:build.path">../../../../build/avr/pwm/pca9685</option>
+    <option name="modm:target">atmega168p</option>
+    <option name="modm:platform:clock:f_cpu">8000000</option>
+    <option name="modm:build:build.path">../../../../build/avr/pwm/pca9685</option>
   </options>
   <modules>
-    <module>:driver:pca9685</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:i2c</module>
-    <module>:build:scons</module>
+    <module>modm:driver:pca9685</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:i2c</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/sab/master/project.xml
+++ b/examples/avr/sab/master/project.xml
@@ -1,13 +1,13 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/sab/master</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/sab/master</option>
   </options>
   <modules>
-    <module>:communication:sab</module>
-    <module>:platform:core</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:communication:sab</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/sab/slave/project.xml
+++ b/examples/avr/sab/slave/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/sab/slave</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/sab/slave</option>
   </options>
   <modules>
-    <module>:communication:sab</module>
-    <module>:platform:adc</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:communication:sab</module>
+    <module>modm:platform:adc</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/timeout/project.xml
+++ b/examples/avr/timeout/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../build/avr/timeout</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../build/avr/timeout</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/uart/basic/project.xml
+++ b/examples/avr/uart/basic/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">atmega644pa</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/uart/basic</option>
+    <option name="modm:target">atmega644pa</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/uart/basic</option>
   </options>
   <modules>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/uart/extended/project.xml
+++ b/examples/avr/uart/extended/project.xml
@@ -1,15 +1,15 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/uart/extended</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/uart/extended</option>
   </options>
   <modules>
-    <module>:io</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:io</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/xpcc/receiver/project.xml
+++ b/examples/avr/xpcc/receiver/project.xml
@@ -1,20 +1,20 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/xpcc/receiver</option>
-    <option name="::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
-    <option name="::xpcc:generator:container">receiver</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/xpcc/receiver</option>
+    <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
+    <option name="modm::xpcc:generator:container">receiver</option>
   </options>
   <modules>
-    <module>:communication:xpcc:generator</module>
-    <module>:debug</module>
-    <module>:driver:mcp2515</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc:generator</module>
+    <module>modm:debug</module>
+    <module>modm:driver:mcp2515</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/avr/xpcc/sender/project.xml
+++ b/examples/avr/xpcc/sender/project.xml
@@ -1,20 +1,20 @@
 <library>
   <options>
-    <option name=":target">atmega644</option>
-    <option name=":platform:clock:f_cpu">14745600</option>
-    <option name=":build:build.path">../../../../build/avr/xpcc/sender</option>
-    <option name="::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
-    <option name="::xpcc:generator:container">sender</option>
+    <option name="modm:target">atmega644</option>
+    <option name="modm:platform:clock:f_cpu">14745600</option>
+    <option name="modm:build:build.path">../../../../build/avr/xpcc/sender</option>
+    <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
+    <option name="modm::xpcc:generator:container">sender</option>
   </options>
   <modules>
-    <module>:communication:xpcc:generator</module>
-    <module>:debug</module>
-    <module>:driver:mcp2515</module>
-    <module>:platform:clock</module>
-    <module>:platform:core</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:uart:0</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc:generator</module>
+    <module>modm:debug</module>
+    <module>modm:driver:mcp2515</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/generic/blinky/project.xml
+++ b/examples/generic/blinky/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/generic/blinky</option>
+    <option name="modm:build:build.path">../../../build/generic/blinky</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/generic/resumable/project.xml
+++ b/examples/generic/resumable/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/generic/resumable</option>
+    <option name="modm:build:build.path">../../../build/generic/resumable</option>
   </options>
   <modules>
-    <module>:processing:protothread</module>
-    <module>:processing:resumable</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:resumable</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/generic/ros/can_bridge/project.xml
+++ b/examples/generic/ros/can_bridge/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../../build/generic/ros/can_bridge</option>
-    <option name=":platform:uart:2:buffer.tx">512</option>
-    <option name=":platform:uart:2:buffer.rx">512</option>
+    <option name="modm:build:build.path">../../../../build/generic/ros/can_bridge</option>
+    <option name="modm:platform:uart:2:buffer.tx">512</option>
+    <option name="modm:platform:uart:2:buffer.rx">512</option>
   </options>
   <modules>
-    <module>:build:scons</module>
-    <module>:communication:ros</module>
-    <module>:platform:can</module>
-    <module>:platform:uart:2</module>
-    <module>:ros</module>
+    <module>modm:build:scons</module>
+    <module>modm:communication:ros</module>
+    <module>modm:platform:can</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:ros</module>
   </modules>
 </library>

--- a/examples/generic/ros/environment/project.xml
+++ b/examples/generic/ros/environment/project.xml
@@ -1,18 +1,18 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/generic/ros/environment</option>
-    <option name=":platform:uart:2:buffer.tx">512</option>
-    <option name=":platform:uart:2:buffer.rx">512</option>
+    <option name="modm:build:build.path">../../../../build/generic/ros/environment</option>
+    <option name="modm:platform:uart:2:buffer.tx">512</option>
+    <option name="modm:platform:uart:2:buffer.rx">512</option>
   </options>
   <modules>
-    <module>:driver:bme280</module>
-    <module>:driver:ssd1306</module>
-    <module>:ros</module>
-    <module>:communication:ros</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:platform:i2c:1</module>
-    <module>:build:scons</module>
+    <module>modm:driver:bme280</module>
+    <module>modm:driver:ssd1306</module>
+    <module>modm:ros</module>
+    <module>modm:communication:ros</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/generic/ros/sub_pub/project.xml
+++ b/examples/generic/ros/sub_pub/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/generic/ros/sub_pub</option>
-    <option name=":platform:uart:2:buffer.tx">512</option>
-    <option name=":platform:uart:2:buffer.rx">512</option>
+    <option name="modm:build:build.path">../../../../build/generic/ros/sub_pub</option>
+    <option name="modm:platform:uart:2:buffer.tx">512</option>
+    <option name="modm:platform:uart:2:buffer.rx">512</option>
   </options>
   <modules>
-    <module>:communication:ros</module>
-    <module>:driver</module>
-    <module>:platform:i2c:1</module>
-    <module>:processing:timer</module>
-    <module>:ros</module>
-    <module>:build:scons</module>
+    <module>modm:communication:ros</module>
+    <module>modm:driver</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:processing:timer</module>
+    <module>modm:ros</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/generic/rtc_ds1302/project.xml
+++ b/examples/generic/rtc_ds1302/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/generic/rtc_ds1302</option>
+    <option name="modm:build:build.path">../../../build/generic/rtc_ds1302</option>
   </options>
   <modules>
-    <module>:driver:ds1302</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ds1302</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/assert/project.xml
+++ b/examples/linux/assert/project.xml
@@ -1,11 +1,11 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/assert</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/assert</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/block_device/file/project.xml
+++ b/examples/linux/block_device/file/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../../build/linux/block_device/file</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/block_device/file</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:driver:block.device:file</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:driver:block.device:file</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/block_device/mirror/project.xml
+++ b/examples/linux/block_device/mirror/project.xml
@@ -1,13 +1,13 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../../build/linux/block_device/mirror</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/block_device/mirror</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:driver:block.device:file</module>
-    <module>:driver:block.device:mirror</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:driver:block.device:file</module>
+    <module>modm:driver:block.device:mirror</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/block_device/ram/project.xml
+++ b/examples/linux/block_device/ram/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../../build/linux/block_device/ram</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/block_device/ram</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:driver:block.device:heap</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:driver:block.device:heap</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/build_info/project.xml
+++ b/examples/linux/build_info/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/build_info</option>
-    <option name=":build:scons:info.build">True</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/build_info</option>
+    <option name="modm:build:scons:info.build">True</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/can_debugger/project.xml
+++ b/examples/linux/can_debugger/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/can_debugger</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/can_debugger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:canusb</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:canusb</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/git/project.xml
+++ b/examples/linux/git/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/git</option>
-    <option name=":build:scons:info.git">Info+Status</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/git</option>
+    <option name="modm:build:scons:info.git">Info+Status</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/gui/basic/project.xml
+++ b/examples/linux/gui/basic/project.xml
@@ -1,13 +1,13 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../../build/linux/gui/basic</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/gui/basic</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:ui:gui</module>
-    <module>:driver:sdl_display</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:ui:gui</module>
+    <module>modm:driver:sdl_display</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/logger/project.xml
+++ b/examples/linux/logger/project.xml
@@ -1,11 +1,11 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/logger</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/printf/project.xml
+++ b/examples/linux/printf/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/printf</option>
-    <option name=":build:scons:info.build">True</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/printf</option>
+    <option name="modm:build:scons:info.build">True</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/serial_interface/project.xml
+++ b/examples/linux/serial_interface/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/serial_interface</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/serial_interface</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:platform:uart</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/static_serial_interface/project.xml
+++ b/examples/linux/static_serial_interface/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/static_serial_interface</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/static_serial_interface</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:platform:uart</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/threads/project.xml
+++ b/examples/linux/threads/project.xml
@@ -1,12 +1,12 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/linux/threads</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/threads</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:debug</module>
-    <module>:processing:rtos</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:processing:rtos</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/linux/xpcc/basic/project.xml
+++ b/examples/linux/xpcc/basic/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../../build/linux/xpcc/basic</option>
-    <option name=":communication:xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
-    <option name=":communication:xpcc:generator:container">sender receiver</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/xpcc/basic</option>
+    <option name="modm:communication:xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
+    <option name="modm:communication:xpcc:generator:container">sender receiver</option>
   </options>
   <modules>
-    <module>:platform:core</module>
-    <module>:communication:xpcc:generator</module>
-    <module>:debug</module>
-    <module>:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:communication:xpcc:generator</module>
+    <module>modm:debug</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f031k6/blink/project.xml
+++ b/examples/nucleo_f031k6/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f031k6</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f031k6/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f031k6/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f042k6/blink/project.xml
+++ b/examples/nucleo_f042k6/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f042k6</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f042k6/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f042k6/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f103rb/blink/project.xml
+++ b/examples/nucleo_f103rb/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f103rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f103rb/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f103rb/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f303k8/blink/project.xml
+++ b/examples/nucleo_f303k8/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f303k8</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f303k8/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f303k8/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f401re/blink/project.xml
+++ b/examples/nucleo_f401re/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f401re</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f401re/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f401re/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f401re/distance_vl53l0/project.xml
+++ b/examples/nucleo_f401re/distance_vl53l0/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:nucleo-f401re</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f401re/distance_vl53l0</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f401re/distance_vl53l0</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:vl53l0</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:vl53l0</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f411re/blink/project.xml
+++ b/examples/nucleo_f411re/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f411re</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f411re/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f411re/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f429zi/blink/project.xml
+++ b/examples/nucleo_f429zi/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-f429zi</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f429zi/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f429zi/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_f429zi/spi_flash/project.xml
+++ b/examples/nucleo_f429zi/spi_flash/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:nucleo-f429zi</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_f429zi/spi_flash</option>
+    <option name="modm:build:build.path">../../../build/nucleo_f429zi/spi_flash</option>
   </options>
   <modules>
-  	<module>:driver:block.device:spi.flash</module>
-  	<module>:platform:spi:1</module>
-    <module>:build:scons</module>
+    <module>modm:driver:block.device:spi.flash</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/blink/project.xml
+++ b/examples/nucleo_l432kc/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/comp</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/comp</option>
   </options>
   <modules>
     <module>modm:platform:comp:*</module>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/gyroscope/project.xml
+++ b/examples/nucleo_l432kc/gyroscope/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/gyroscope</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/gyroscope</option>
   </options>
   <modules>
-    <module>:driver:l3gd20</module>
-    <module>:math:filter</module>
-    <module>:platform:uart.spi:1</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:driver:l3gd20</module>
+    <module>modm:math:filter</module>
+    <module>modm:platform:uart.spi:1</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/pwm/project.xml
+++ b/examples/nucleo_l432kc/pwm/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/pwm</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/pwm</option>
   </options>
   <modules>
-    <module>:build:scons</module>
-    <module>:platform:timer:1</module>
+    <module>modm:build:scons</module>
+    <module>modm:platform:timer:1</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/pwm_advanced</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/pwm_advanced</option>
   </options>
   <modules>
-    <module>:build:scons</module>
-    <module>:platform:timer:1</module>
+    <module>modm:build:scons</module>
+    <module>modm:platform:timer:1</module>
   </modules>
 </library>

--- a/examples/nucleo_l432kc/uart_spi/project.xml
+++ b/examples/nucleo_l432kc/uart_spi/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:nucleo-l432kc</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l432kc/uart_spi</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l432kc/uart_spi</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart.spi:1</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart.spi:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l476rg/adc/project.xml
+++ b/examples/nucleo_l476rg/adc/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l476rg/adc</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l476rg/adc</option>
   </options>
   <modules>
-    <module>:platform:adc:1</module>
-    <module>:platform:clock</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l476rg/blink/project.xml
+++ b/examples/nucleo_l476rg/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l476rg/blink</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l476rg/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_l476rg/i2c_test/project.xml
+++ b/examples/nucleo_l476rg/i2c_test/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:nucleo-l476rg</extends>
   <options>
-    <option name=":build:build.path">../../../build/nucleo_l476rg/i2c_test</option>
+    <option name="modm:build:build.path">../../../build/nucleo_l476rg/i2c_test</option>
   </options>
   <modules>
-    <module>:architecture:i2c.device</module>
-    <module>:platform:i2c:1</module>
-    <module>:processing:protothread</module>
-    <module>:processing:resumable</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:i2c.device</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:resumable</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/olimexino_stm32/blink/project.xml
+++ b/examples/olimexino_stm32/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:olimexino-stm32</extends>
   <options>
-    <option name=":build:build.path">../../../build/olimexino_stm32/blink</option>
+    <option name="modm:build:build.path">../../../build/olimexino_stm32/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f030f4p6_demo_board/blink/project.xml
+++ b/examples/stm32f030f4p6_demo_board/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:stm32f030_demo</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f030f4p6_demo/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f030f4p6_demo/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/blink/project.xml
+++ b/examples/stm32f072_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/can/project.xml
+++ b/examples/stm32f072_discovery/can/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/can</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/can</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/hard_fault/project.xml
+++ b/examples/stm32f072_discovery/hard_fault/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/hard_fault</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/hard_fault</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/rotation/project.xml
+++ b/examples/stm32f072_discovery/rotation/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/rotation</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/rotation</option>
   </options>
   <modules>
-    <module>:math:filter</module>
-    <module>:platform:gpio</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:math:filter</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/tmp102/project.xml
+++ b/examples/stm32f072_discovery/tmp102/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/tmp102</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/tmp102</option>
   </options>
   <modules>
-    <module>:driver:tmp102</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:platform:uart:1</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:driver:tmp102</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/uart/project.xml
+++ b/examples/stm32f072_discovery/uart/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/uart</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/uart</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f072_discovery/unaligned_access/project.xml
+++ b/examples/stm32f072_discovery/unaligned_access/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f072rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f072_discovery/unaligned_access</option>
+    <option name="modm:build:build.path">../../../build/stm32f072_discovery/unaligned_access</option>
   </options>
   <modules>
-    <module>:architecture:unaligned</module>
-    <module>:container</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:unaligned</module>
+    <module>modm:container</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f0_discovery/blink/project.xml
+++ b/examples/stm32f0_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f051r8</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f0_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f0_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f0_discovery/logger/project.xml
+++ b/examples/stm32f0_discovery/logger/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f1_discovery/logger</option>
+    <option name="modm:build:build.path">../../../build/stm32f1_discovery/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_black_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_black_pill/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:black-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_black_pill/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_black_pill/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/adns_9800</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/adns_9800</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:adns9800</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:1</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:adns9800</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/blink.cmake</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink.cmake</option>
   </options>
   <modules>
-    <module>:build:cmake</module>
+    <module>modm:build:cmake</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/can/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/can/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/can</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/can</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/environment/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/environment/project.xml
@@ -1,18 +1,18 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/environment</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/environment</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:bme280</module>
-    <module>:driver:bmp085</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:platform:i2c:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:bme280</module>
+    <module>modm:driver:bmp085</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f103c8t6_blue_pill/logger/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/logger/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:blue-pill</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f103c8t6_blue_pill/logger</option>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f1_discovery/blink/project.xml
+++ b/examples/stm32f1_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f1_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f1_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f1_discovery/logger/project.xml
+++ b/examples/stm32f1_discovery/logger/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f100rb</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f1_discovery/logger</option>
+    <option name="modm:build:build.path">../../../build/stm32f1_discovery/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/accelerometer/project.xml
+++ b/examples/stm32f3_discovery/accelerometer/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/accelerometer</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/accelerometer</option>
   </options>
   <modules>
-    <module>:math:filter</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:math:filter</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/adc/continous/project.xml
+++ b/examples/stm32f3_discovery/adc/continous/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/continous</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/continous</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:adc:1</module>
-    <module>:platform:adc:2</module>
-    <module>:platform:adc:3</module>
-    <module>:platform:adc:4</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:platform:adc:2</module>
+    <module>modm:platform:adc:3</module>
+    <module>modm:platform:adc:4</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f3_discovery/adc/interrupt/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/interrupt</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/interrupt</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:adc:4</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:4</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/adc/simple/project.xml
+++ b/examples/stm32f3_discovery/adc/simple/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/adc/simple</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/simple</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:adc:4</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:4</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/blink/project.xml
+++ b/examples/stm32f3_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/can/project.xml
+++ b/examples/stm32f3_discovery/can/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/can</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/can</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/comp</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/comp</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:uart:2</module>
+    <module>modm:debug</module>
+    <module>modm:platform:uart:2</module>
     <module>modm:platform:comp:*</module>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/ft245/project.xml
+++ b/examples/stm32f3_discovery/ft245/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/ft245</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/ft245</option>
   </options>
   <modules>
-    <module>:driver:ft245</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ft245</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/gdb/project.xml
+++ b/examples/stm32f3_discovery/gdb/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/gdb</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/gdb</option>
   </options>
   <modules>
-    <module>:platform:can</module>
-    <module>:build:scons</module>
+    <module>modm:platform:can</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/hard_fault/project.xml
+++ b/examples/stm32f3_discovery/hard_fault/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/hard_fault</option>
-    <option name=":platform:fault.cortex:led">E3</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/hard_fault</option>
+    <option name="modm:platform:fault.cortex:led">E3</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:fault.cortex</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:fault.cortex</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/rotation/project.xml
+++ b/examples/stm32f3_discovery/rotation/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f3_discovery/rotation</option>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/rotation</option>
   </options>
   <modules>
-    <module>:math:filter</module>
-    <module>:platform:gpio</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:math:filter</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/timer/basic/project.xml
+++ b/examples/stm32f3_discovery/timer/basic/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/timer/basic</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/timer/basic</option>
   </options>
   <modules>
-    <module>:platform:timer:1</module>
-    <module>:build:scons</module>
+    <module>modm:platform:timer:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/uart/hal/project.xml
+++ b/examples/stm32f3_discovery/uart/hal/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/uart/hal</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/uart/hal</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f3_discovery/uart/logger/project.xml
+++ b/examples/stm32f3_discovery/uart/logger/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f303vc</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f3_discovery/uart/logger</option>
+    <option name="modm:build:build.path">../../../../build/stm32f3_discovery/uart/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f429_discovery/blink/project.xml
+++ b/examples/stm32f429_discovery/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f429zi</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f429_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f429_discovery/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f429_discovery/logger/project.xml
+++ b/examples/stm32f429_discovery/logger/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f429zi</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f429_discovery/logger</option>
+    <option name="modm:build:build.path">../../../build/stm32f429_discovery/logger</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/assert/project.xml
+++ b/examples/stm32f469_discovery/assert/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/assert</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/assert</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/blink/project.xml
+++ b/examples/stm32f469_discovery/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/can/project.xml
+++ b/examples/stm32f469_discovery/can/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/can</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/can</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can:1</module>
-    <module>:platform:can:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:3</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can:1</module>
+    <module>modm:platform:can:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:3</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/display/project.xml
+++ b/examples/stm32f469_discovery/display/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/display</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/display</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/game_of_life/project.xml
+++ b/examples/stm32f469_discovery/game_of_life/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/game_of_life</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/game_of_life</option>
   </options>
   <modules>
-    <module>:architecture:memory</module>
-    <module>:processing:timer</module>
-    <module>:processing:resumable</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:memory</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:resumable</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/ports/project.xml
+++ b/examples/stm32f469_discovery/ports/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/ports</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/ports</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/tlsf-allocator/project.xml
+++ b/examples/stm32f469_discovery/tlsf-allocator/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/tlsf-allocator</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/tlsf-allocator</option>
   </options>
   <modules>
-    <module>:architecture:memory</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:memory</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f469_discovery/touchscreen/project.xml
+++ b/examples/stm32f469_discovery/touchscreen/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f469ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f469_discovery/touchscreen</option>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/touchscreen</option>
   </options>
   <modules>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/accelerometer/project.xml
+++ b/examples/stm32f4_discovery/accelerometer/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/accelerometer</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/accelerometer</option>
   </options>
   <modules>
-    <module>:driver:lis302dl</module>
-    <module>:math:filter</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c</module>
-    <module>:platform:i2c.bitbang</module>
-    <module>:processing:timer</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:driver:lis302dl</module>
+    <module>modm:math:filter</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f4_discovery/adc/interrupt/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/interrupt</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/interrupt</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:adc:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/adc/oversample/project.xml
+++ b/examples/stm32f4_discovery/adc/oversample/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/oversample</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/oversample</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:adc_sampler</module>
-    <module>:platform:adc:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:adc_sampler</module>
+    <module>modm:platform:adc:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/adc/simple/project.xml
+++ b/examples/stm32f4_discovery/adc/simple/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/adc/simple</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/simple</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:adc:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/app_uart_sniffer/project.xml
+++ b/examples/stm32f4_discovery/app_uart_sniffer/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/app_uart_sniffer</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/app_uart_sniffer</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:1</module>
-    <module>:platform:uart:2</module>
-    <module>:platform:uart:3</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:platform:uart:3</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/barometer_bmp085_bmp180</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/barometer_bmp085_bmp180</option>
   </options>
   <modules>
-    <module>:driver:bmp085</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:bmp085</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/blink/project.xml
+++ b/examples/stm32f4_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/can/project.xml
+++ b/examples/stm32f4_discovery/can/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/can</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/can</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can:1</module>
-    <module>:platform:can:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can:1</module>
+    <module>modm:platform:can:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/can2/project.xml
+++ b/examples/stm32f4_discovery/can2/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/can2</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/can2</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:can:1</module>
-    <module>:platform:can:2</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:can:1</module>
+    <module>modm:platform:can:2</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/colour_tcs3414/project.xml
+++ b/examples/stm32f4_discovery/colour_tcs3414/project.xml
@@ -1,17 +1,17 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/colour_tcs3414</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/colour_tcs3414</option>
   </options>
   <modules>
-    <module>:driver:tcs3414</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c.bitbang</module>
-    <module>:platform:i2c:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:tcs3414</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/display/hd44780/project.xml
+++ b/examples/stm32f4_discovery/display/hd44780/project.xml
@@ -1,18 +1,18 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/display/hd44780</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/hd44780</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:pca8574</module>
-    <module>:driver:hd44780</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c.bitbang</module>
-    <module>:platform:i2c:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:pca8574</module>
+    <module>modm:driver:hd44780</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/display/nokia_5110/project.xml
+++ b/examples/stm32f4_discovery/display/nokia_5110/project.xml
@@ -1,17 +1,17 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/display/nokia_5110</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/nokia_5110</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nokia5110</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nokia5110</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/display/ssd1306/project.xml
+++ b/examples/stm32f4_discovery/display/ssd1306/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/display/ssd1306</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/ssd1306</option>
   </options>
   <modules>
-    <module>:driver:ssd1306</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ssd1306</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/distance_vl6180/project.xml
+++ b/examples/stm32f4_discovery/distance_vl6180/project.xml
@@ -1,17 +1,17 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/distance_vl6180</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/distance_vl6180</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:vl6180</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c.bitbang</module>
-    <module>:platform:i2c:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:vl6180</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/exti/project.xml
+++ b/examples/stm32f4_discovery/exti/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/exti</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/exti</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/fpu/project.xml
+++ b/examples/stm32f4_discovery/fpu/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/fpu</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/fpu</option>
   </options>
   <modules>
-    <module>:math:geometry</module>
-    <module>:build:scons</module>
+    <module>modm:math:geometry</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/fsmc/project.xml
+++ b/examples/stm32f4_discovery/fsmc/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/fsmc</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/fsmc</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:fsmc</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:fsmc</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/hard_fault/project.xml
+++ b/examples/stm32f4_discovery/hard_fault/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/hard_fault</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/hard_fault</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/led_matrix_display/project.xml
+++ b/examples/stm32f4_discovery/led_matrix_display/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/led_matrix_display</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/led_matrix_display</option>
   </options>
   <modules>
-    <module>:driver:max7219</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:max7219</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/open407v-d/gui/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/gui/project.xml
@@ -1,21 +1,21 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/open407v-d/gui</option>
-    <option name=":build:scons:image.source">images</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/open407v-d/gui</option>
+    <option name="modm:build:scons:image.source">images</option>
   </options>
   <modules>
-    <module>:container</module>
-    <module>:debug</module>
-    <module>:driver:ads7843</module>
-    <module>:driver:parallel_tft_display</module>
-    <module>:driver:memory_bus</module>
-    <module>:platform:fsmc</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:ui:display</module>
-    <module>:ui:gui</module>
-    <module>:utils</module>
-    <module>:build:scons</module>
+    <module>modm:container</module>
+    <module>modm:debug</module>
+    <module>modm:driver:ads7843</module>
+    <module>modm:driver:parallel_tft_display</module>
+    <module>modm:driver:memory_bus</module>
+    <module>modm:platform:fsmc</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:ui:display</module>
+    <module>modm:ui:gui</module>
+    <module>modm:utils</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
@@ -1,17 +1,17 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/open407v-d/touchscreen</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/open407v-d/touchscreen</option>
   </options>
   <modules>
-    <module>:driver</module>
-    <module>:driver:ads7843</module>
-    <module>:driver:parallel_tft_display</module>
-    <module>:driver:memory_bus</module>
-    <module>:platform:fsmc</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:ui:display</module>
-    <module>:build:scons</module>
+    <module>modm:driver</module>
+    <module>modm:driver:ads7843</module>
+    <module>modm:driver:parallel_tft_display</module>
+    <module>modm:driver:memory_bus</module>
+    <module>modm:platform:fsmc</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:ui:display</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/pressure_amsys5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_amsys5915/project.xml
@@ -1,18 +1,18 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/pressure_amsys5915</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/pressure_amsys5915</option>
   </options>
   <modules>
-    <module>:driver:amsys5915</module>
-    <module>:io</module>
-    <module>:debug</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c.bitbang</module>
-    <module>:platform:i2c:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:amsys5915</module>
+    <module>modm:io</module>
+    <module>modm:debug</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/protothreads/project.xml
+++ b/examples/stm32f4_discovery/protothreads/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/protothreads</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/protothreads</option>
   </options>
   <modules>
-    <module>:driver:tmp102</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:i2c:1</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:driver:tmp102</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-basic-comm</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-basic-comm</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nrf24</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:1</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nrf24</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/rx</option>
+    <option name="modm:build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/rx</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nrf24</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nrf24</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/tx</option>
+    <option name="modm:build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/tx</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nrf24</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nrf24</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-phy-test</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-phy-test</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nrf24</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nrf24</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-scanner</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-scanner</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:driver:nrf24</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:driver:nrf24</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/rtos/float_check/project.xml
+++ b/examples/stm32f4_discovery/rtos/float_check/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../../build/stm32f4_discovery/rtos/float_check</option>
+    <option name="modm:build:build.path">../../../../build/stm32f4_discovery/rtos/float_check</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:processing:rtos</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:processing:rtos</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/sab2/project.xml
+++ b/examples/stm32f4_discovery/sab2/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/sab2</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/sab2</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:communication:sab2</module>
-    <module>:platform:uart:1</module>
-    <module>:platform:uart:4</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:communication:sab2</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:platform:uart:4</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/spi/project.xml
+++ b/examples/stm32f4_discovery/spi/project.xml
@@ -1,12 +1,12 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/spi</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/spi</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:spi.bitbang</module>
-    <module>:platform:spi:2</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi.bitbang</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/temperature_ltc2984/project.xml
+++ b/examples/stm32f4_discovery/temperature_ltc2984/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/temperature_ltc2984</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/temperature_ltc2984</option>
   </options>
   <modules>
-    <module>:driver:ltc2984</module>
-    <module>:io</module>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:platform:spi:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ltc2984</module>
+    <module>modm:io</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/timer/project.xml
+++ b/examples/stm32f4_discovery/timer/project.xml
@@ -1,15 +1,15 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/timer</option>
-    <option name=":ui:led:gamma">2.2,2.0</option>
-    <option name=":ui:led:bit">14,8,16</option>
-    <option name=":ui:led:range">10,100,256</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/timer</option>
+    <option name="modm:ui:led:gamma">2.2,2.0</option>
+    <option name="modm:ui:led:bit">14,8,16</option>
+    <option name="modm:ui:led:range">10,100,256</option>
   </options>
   <modules>
-    <module>:platform:timer:4</module>
-    <module>:ui:led</module>
-    <module>:ui:animation</module>
-    <module>:build:scons</module>
+    <module>modm:platform:timer:4</module>
+    <module>modm:ui:led</module>
+    <module>modm:ui:animation</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/timer_test/project.xml
+++ b/examples/stm32f4_discovery/timer_test/project.xml
@@ -1,24 +1,24 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/timer_test</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/timer_test</option>
   </options>
   <modules>
-    <module>:architecture:interrupt</module>
-    <module>:platform:timer:1</module>
-    <module>:platform:timer:2</module>
-    <module>:platform:timer:3</module>
-    <module>:platform:timer:4</module>
-    <module>:platform:timer:5</module>
-    <module>:platform:timer:6</module>
-    <module>:platform:timer:7</module>
-    <module>:platform:timer:8</module>
-    <module>:platform:timer:9</module>
-    <module>:platform:timer:10</module>
-    <module>:platform:timer:11</module>
-    <module>:platform:timer:12</module>
-    <module>:platform:timer:13</module>
-    <module>:platform:timer:14</module>
-    <module>:build:scons</module>
+    <module>modm:architecture:interrupt</module>
+    <module>modm:platform:timer:1</module>
+    <module>modm:platform:timer:2</module>
+    <module>modm:platform:timer:3</module>
+    <module>modm:platform:timer:4</module>
+    <module>modm:platform:timer:5</module>
+    <module>modm:platform:timer:6</module>
+    <module>modm:platform:timer:7</module>
+    <module>modm:platform:timer:8</module>
+    <module>modm:platform:timer:9</module>
+    <module>modm:platform:timer:10</module>
+    <module>modm:platform:timer:11</module>
+    <module>modm:platform:timer:12</module>
+    <module>modm:platform:timer:13</module>
+    <module>modm:platform:timer:14</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/uart/project.xml
+++ b/examples/stm32f4_discovery/uart/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/uart</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/uart</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart:2</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f4_discovery/uart_spi/project.xml
+++ b/examples/stm32f4_discovery/uart_spi/project.xml
@@ -1,11 +1,11 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f4_discovery/uart_spi</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/uart_spi</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:platform:uart.spi:2</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart.spi:2</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f746g_discovery/adc_ad7928/project.xml
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.xml
@@ -1,14 +1,14 @@
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f746g_discovery/adc_ad7928</option>
+    <option name="modm:build:build.path">../../../build/stm32f746g_discovery/adc_ad7928</option>
   </options>
   <modules>
-    <module>:driver:ad7928</module>
-    <module>:platform:gpio</module>
-    <module>:platform:spi:2</module>
-    <module>:processing:protothread</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ad7928</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f746g_discovery/blink/project.xml
+++ b/examples/stm32f746g_discovery/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f746g_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f746g_discovery/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f746g_discovery/tmp102/project.xml
+++ b/examples/stm32f746g_discovery/tmp102/project.xml
@@ -1,13 +1,13 @@
 <library>
   <extends>modm:board:disco-f746ng</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f746g_discovery/tmp102</option>
+    <option name="modm:build:build.path">../../../build/stm32f746g_discovery/tmp102</option>
   </options>
   <modules>
-    <module>:driver:tmp102</module>
-    <module>:io</module>
-    <module>:platform:i2c:1</module>
-    <module>:processing:protothread</module>
-    <module>:build:scons</module>
+    <module>modm:driver:tmp102</module>
+    <module>modm:io</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32f769i_discovery/blink/project.xml
+++ b/examples/stm32f769i_discovery/blink/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f769ni</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32f769i_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32f769i_discovery/blink</option>
   </options>
   <modules>
-    <module>:platform:gpio</module>
-    <module>:build:scons</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/stm32l476_discovery/blink/project.xml
+++ b/examples/stm32l476_discovery/blink/project.xml
@@ -1,9 +1,9 @@
 <library>
   <extends>modm:board:disco-l476vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/stm32l476_discovery/blink</option>
+    <option name="modm:build:build.path">../../../build/stm32l476_discovery/blink</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/windows/build_info/project.xml
+++ b/examples/windows/build_info/project.xml
@@ -1,11 +1,11 @@
 <library>
   <options>
-    <option name=":target">hosted-windows</option>
-    <option name=":build:build.path">../../../build/windows/build_info</option>
+    <option name="modm:target">hosted-windows</option>
+    <option name="modm:build:build.path">../../../build/windows/build_info</option>
   </options>
   <modules>
-    <module>:debug</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/zmq/1_stm32/project.xml
+++ b/examples/zmq/1_stm32/project.xml
@@ -1,16 +1,16 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name=":build:build.path">../../../build/zmq/1_stm32</option>
-    <option name=":communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>
-    <option name=":communication:xpcc:generator:container">odometry</option>
+    <option name="modm:build:build.path">../../../build/zmq/1_stm32</option>
+    <option name="modm:communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>
+    <option name="modm:communication:xpcc:generator:container">odometry</option>
   </options>
   <modules>
-    <module>:communication:xpcc:generator</module>
-    <module>:platform:can:1</module>
-    <module>:platform:gpio</module>
-    <module>:platform:timer:1</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc:generator</module>
+    <module>modm:platform:can:1</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:timer:1</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/zmq/2_zmq_gateway/project.xml
+++ b/examples/zmq/2_zmq_gateway/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/zmq/2_zmq_gateway</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/zmq/2_zmq_gateway</option>
   </options>
   <modules>
-    <module>:communication:xpcc</module>
-    <module>:debug</module>
-    <module>:platform:canusb</module>
-    <module>:platform:core</module>
-    <module>:platform:uart</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc</module>
+    <module>modm:debug</module>
+    <module>modm:platform:canusb</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:uart</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/zmq/3_zmq_app/project.xml
+++ b/examples/zmq/3_zmq_app/project.xml
@@ -1,14 +1,14 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/zmq/3_zmq_app</option>
-    <option name=":communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>
-    <option name=":communication:xpcc:generator:container">gui</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/zmq/3_zmq_app</option>
+    <option name="modm:communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>
+    <option name="modm:communication:xpcc:generator:container">gui</option>
   </options>
   <modules>
-    <module>:communication:xpcc:generator</module>
-    <module>:debug</module>
-    <module>:platform:core</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc:generator</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/zmq/4_zmq_backtoback/project.xml
+++ b/examples/zmq/4_zmq_backtoback/project.xml
@@ -1,13 +1,13 @@
 <library>
   <options>
-    <option name=":target">hosted-linux</option>
-    <option name=":build:build.path">../../../build/zmq/4_zmq_backtoback</option>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/zmq/4_zmq_backtoback</option>
   </options>
   <modules>
-    <module>:communication:xpcc</module>
-    <module>:debug</module>
-    <module>:platform:core</module>
-    <module>:processing:timer</module>
-    <module>:build:scons</module>
+    <module>modm:communication:xpcc</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/src/modm/board/al_avreb_can/board.xml
+++ b/src/modm/board/al_avreb_can/board.xml
@@ -6,8 +6,8 @@
   </repositories>
 
   <options>
-    <option name=":target">at90can128</option>
-    <option name=":platform:clock:f_cpu">16000000</option>
+    <option name="modm:target">at90can128</option>
+    <option name="modm:platform:clock:f_cpu">16000000</option>
   </options>
   <modules>
     <module>modm:board:al-avreb-can</module>

--- a/src/modm/board/arduino_uno/board.xml
+++ b/src/modm/board/arduino_uno/board.xml
@@ -6,8 +6,8 @@
   </repositories>
 
   <options>
-    <option name=":target">atmega328p</option>
-    <option name=":platform:clock:f_cpu">16000000</option>
+    <option name="modm:target">atmega328p</option>
+    <option name="modm:platform:clock:f_cpu">16000000</option>
   </options>
   <modules>
     <module>modm:board:arduino-uno</module>

--- a/src/modm/board/black_pill/board.xml
+++ b/src/modm/board/black_pill/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f103c8t</option>
+    <option name="modm:target">stm32f103c8t</option>
   </options>
   <modules>
     <module>modm:board:black-pill</module>

--- a/src/modm/board/blue_pill/board.xml
+++ b/src/modm/board/blue_pill/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f103c8t</option>
+    <option name="modm:target">stm32f103c8t</option>
   </options>
   <modules>
     <module>modm:board:blue-pill</module>

--- a/src/modm/board/disco_f051r8/board.xml
+++ b/src/modm/board/disco_f051r8/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f051r8t</option>
+    <option name="modm:target">stm32f051r8t</option>
   </options>
   <modules>
     <module>modm:board:disco-f051r8</module>

--- a/src/modm/board/disco_f072rb/board.xml
+++ b/src/modm/board/disco_f072rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f072rbt</option>
+    <option name="modm:target">stm32f072rbt</option>
   </options>
   <modules>
     <module>modm:board:disco-f072rb</module>

--- a/src/modm/board/disco_f100rb/board.xml
+++ b/src/modm/board/disco_f100rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f100rbt</option>
+    <option name="modm:target">stm32f100rbt</option>
   </options>
   <modules>
     <module>modm:board:disco-f100rb</module>

--- a/src/modm/board/disco_f303vc/board.xml
+++ b/src/modm/board/disco_f303vc/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f303vct</option>
+    <option name="modm:target">stm32f303vct</option>
   </options>
   <modules>
     <module>modm:board:disco-f303vc</module>

--- a/src/modm/board/disco_f407vg/board.xml
+++ b/src/modm/board/disco_f407vg/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f407vgt</option>
+    <option name="modm:target">stm32f407vgt</option>
   </options>
   <modules>
     <module>modm:board:disco-f407vg</module>

--- a/src/modm/board/disco_f429zi/board.xml
+++ b/src/modm/board/disco_f429zi/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f429zit</option>
+    <option name="modm:target">stm32f429zit</option>
   </options>
   <modules>
     <module>modm:board:disco-f429zi</module>

--- a/src/modm/board/disco_f469ni/board.xml
+++ b/src/modm/board/disco_f469ni/board.xml
@@ -6,16 +6,16 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f469nih</option>
+    <option name="modm:target">stm32f469nih</option>
 
-    <option name=":platform:uart:3:buffer.tx">2048</option>
-    <option name=":platform:core:allocator">tlsf</option>
-    <option name=":tlsf:minimum_pool_size">16777216</option>
+    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:core:allocator">tlsf</option>
+    <option name="modm:tlsf:minimum_pool_size">16777216</option>
 
-    <option name=":platform:core:linkerscript.memory">
+    <option name="modm:platform:core:linkerscript.memory">
         SDRAM (rwx) : ORIGIN = 0xC0000000, LENGTH = 16M
     </option>
-    <option name=":platform:core:linkerscript.sections">
+    <option name="modm:platform:core:linkerscript.sections">
         .sdramdata :
         {
             __sdramdata_load = LOADADDR (.sdramdata);   /* address in FLASH */
@@ -34,12 +34,12 @@
             __heap_extern_end = .;
         } >SDRAM
     </option>
-    <option name=":platform:core:linkerscript.table_extern.copy">
+    <option name="modm:platform:core:linkerscript.table_extern.copy">
         LONG (__sdramdata_load)
         LONG (__sdramdata_start)
         LONG (__sdramdata_end)
     </option>
-    <option name=":platform:core:linkerscript.table_extern.heap">
+    <option name="modm:platform:core:linkerscript.table_extern.heap">
         LONG (0x801f)
         LONG (__heap_extern_start)
         LONG (__heap_extern_end)

--- a/src/modm/board/disco_f746ng/board.xml
+++ b/src/modm/board/disco_f746ng/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f746ngh</option>
+    <option name="modm:target">stm32f746ngh</option>
 
-    <option name=":platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:disco-f746ng</module>

--- a/src/modm/board/disco_f769ni/board.xml
+++ b/src/modm/board/disco_f769ni/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f769nih</option>
+    <option name="modm:target">stm32f769nih</option>
 
-    <option name=":platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:disco-f769ni</module>

--- a/src/modm/board/disco_l476vg/board.xml
+++ b/src/modm/board/disco_l476vg/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32l476vgt</option>
+    <option name="modm:target">stm32l476vgt</option>
   </options>
   <modules>
     <module>modm:board:disco-l476vg</module>

--- a/src/modm/board/nucleo_f031k6/board.xml
+++ b/src/modm/board/nucleo_f031k6/board.xml
@@ -6,11 +6,11 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f031k6t</option>
+    <option name="modm:target">stm32f031k6t</option>
 
-    <option name=":platform:uart:1:buffer.tx">256</option>
-    <option name=":platform:core:main_stack_size">992</option>
-    <option name=":platform:core:allocator">block</option>
+    <option name="modm:platform:uart:1:buffer.tx">256</option>
+    <option name="modm:platform:core:main_stack_size">992</option>
+    <option name="modm:platform:core:allocator">block</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f031k6</module>

--- a/src/modm/board/nucleo_f042k6/board.xml
+++ b/src/modm/board/nucleo_f042k6/board.xml
@@ -6,10 +6,10 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f042k6t</option>
-    <option name=":platform:uart:2:buffer.tx">256</option>
-    <option name=":platform:core:main_stack_size">992</option>
-    <option name=":platform:core:allocator">block</option>
+    <option name="modm:target">stm32f042k6t</option>
+    <option name="modm:platform:uart:2:buffer.tx">256</option>
+    <option name="modm:platform:core:main_stack_size">992</option>
+    <option name="modm:platform:core:allocator">block</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f042k6</module>

--- a/src/modm/board/nucleo_f103rb/board.xml
+++ b/src/modm/board/nucleo_f103rb/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f103rbt</option>
+    <option name="modm:target">stm32f103rbt</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f103rb</module>

--- a/src/modm/board/nucleo_f303k8/board.xml
+++ b/src/modm/board/nucleo_f303k8/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f303k8t</option>
+    <option name="modm:target">stm32f303k8t</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f303k8</module>

--- a/src/modm/board/nucleo_f401re/board.xml
+++ b/src/modm/board/nucleo_f401re/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f401ret</option>
+    <option name="modm:target">stm32f401ret</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f401re</module>

--- a/src/modm/board/nucleo_f411re/board.xml
+++ b/src/modm/board/nucleo_f411re/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f411ret</option>
+    <option name="modm:target">stm32f411ret</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f411re</module>

--- a/src/modm/board/nucleo_f429zi/board.xml
+++ b/src/modm/board/nucleo_f429zi/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f429zit</option>
+    <option name="modm:target">stm32f429zit</option>
 
-    <option name=":platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f429zi</module>

--- a/src/modm/board/nucleo_l432kc/board.xml
+++ b/src/modm/board/nucleo_l432kc/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32l432kcu</option>
+    <option name="modm:target">stm32l432kcu</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l432kc</module>

--- a/src/modm/board/nucleo_l476rg/board.xml
+++ b/src/modm/board/nucleo_l476rg/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32l476rgt</option>
+    <option name="modm:target">stm32l476rgt</option>
 
-    <option name=":platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l476rg</module>

--- a/src/modm/board/olimexino_stm32/board.xml
+++ b/src/modm/board/olimexino_stm32/board.xml
@@ -6,9 +6,9 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f103rbt</option>
+    <option name="modm:target">stm32f103rbt</option>
 
-    <option name=":platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>
   <modules>
     <module>modm:board:olimexino-stm32</module>

--- a/src/modm/board/stm32f030f4p6_demo/board.xml
+++ b/src/modm/board/stm32f030f4p6_demo/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name=":target">stm32f030f4p</option>
+    <option name="modm:target">stm32f030f4p</option>
   </options>
   <modules>
     <module>modm:board:stm32f030_demo</module>

--- a/test/all/avr.xml
+++ b/test/all/avr.xml
@@ -7,10 +7,10 @@
   </repositories>
 
   <options>
-    <option name=":platform:clock:f_cpu">8000000</option>
+    <option name="modm:platform:clock:f_cpu">8000000</option>
   </options>
   <modules>
-    <module>:platform:**</module>
-    <module>:build:scons</module>
+    <module>modm:platform:**</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/test/all/stm32.xml
+++ b/test/all/stm32.xml
@@ -9,7 +9,7 @@
   <options>
   </options>
   <modules>
-    <module>:platform:**</module>
-    <module>:build:scons</module>
+    <module>modm:platform:**</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/test/config/al-avreb-can.xml
+++ b/test/config/al-avreb-can.xml
@@ -2,25 +2,25 @@
 <library>
   <extends>modm:board:al-avreb-can</extends>
   <options>
-    <!-- <option name=":build:avrdude.programmer">avrispmkII</option> -->
-    <option name=":build:avrdude.programmer">usbasp-clone</option>
-    <option name=":build:scons:info.git">Disabled</option>
+    <!-- <option name="modm:build:avrdude.programmer">avrispmkII</option> -->
+    <option name="modm:build:avrdude.programmer">usbasp-clone</option>
+    <option name="modm:build:scons:info.git">Disabled</option>
   </options>
 
   <modules>
     <!-- AT90CAN128 only has 128kB of Flash -->
-    <module>:test:architecture</module>
-    <module>:test:communication</module>
-    <module>:test:container</module>
-    <module>:test:driver</module>
-    <module>:test:stdc++</module>
-    <module>:test:utils</module>
+    <module>modm-test:test:architecture</module>
+    <module>modm-test:test:communication</module>
+    <module>modm-test:test:container</module>
+    <module>modm-test:test:driver</module>
+    <module>modm-test:test:stdc++</module>
+    <module>modm-test:test:utils</module>
 
-    <!-- <module>:test:io</module>
-    <module>:test:platform:**</module>
-    <module>:test:processing</module>
-    <module>:test:ui</module>  -->
+    <!-- <module>modm-test:test:io</module>
+    <module>modm-test:test:platform:**</module>
+    <module>modm-test:test:processing</module>
+    <module>modm-test:test:ui</module>  -->
 
-    <!-- <module>:test:math</module> -->
+    <!-- <module>modm-test:test:math</module> -->
   </modules>
 </library>

--- a/test/config/hosted.xml
+++ b/test/config/hosted.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <modules>
-    <module>:platform:core</module>
-    <module>:test:**</module>
+    <module>modm:platform:core</module>
+    <module>modm-test:test:**</module>
   </modules>
 </library>

--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -5,11 +5,11 @@
     <repository><path>../repo.lb</path></repository>
   </repositories>
   <options>
-    <option name=":build:scons:include_sconstruct">True</option>
-    <option name=":build:scons:info.build">True</option>
-    <option name=":build:scons:info.git">Info+Status</option>
+    <option name="modm:build:scons:include_sconstruct">True</option>
+    <option name="modm:build:scons:info.build">True</option>
+    <option name="modm:build:scons:info.git">Info+Status</option>
   </options>
   <modules>
-    <module>:build:scons</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/test/config/nucleo-f103.xml
+++ b/test/config/nucleo-f103.xml
@@ -3,16 +3,16 @@
   <extends>modm:board:nucleo-f103rb</extends>
   <modules>
     <!-- Not everything fits -->
-    <!-- <module>:test:architecture</module>
-    <module>:test:communication</module>
-    <module>:test:container</module>
-    <module>:test:driver</module> -->
+    <!-- <module>modm-test:test:architecture</module>
+    <module>modm-test:test:communication</module>
+    <module>modm-test:test:container</module>
+    <module>modm-test:test:driver</module> -->
 
-    <module>:test:io</module>
-    <module>:test:platform:**</module>
-    <module>:test:processing</module>
-    <module>:test:ui</module>
-    <module>:test:math</module>
-    <module>:test:utils</module>
+    <module>modm-test:test:io</module>
+    <module>modm-test:test:platform:**</module>
+    <module>modm-test:test:processing</module>
+    <module>modm-test:test:ui</module>
+    <module>modm-test:test:math</module>
+    <module>modm-test:test:utils</module>
   </modules>
 </library>

--- a/test/config/nucleo-f401.xml
+++ b/test/config/nucleo-f401.xml
@@ -2,6 +2,6 @@
 <library>
   <extends>modm:board:nucleo-f401re</extends>
   <modules>
-    <module>:test:**</module>
+    <module>modm-test:test:**</module>
   </modules>
 </library>

--- a/test/config/nucleo-f411.xml
+++ b/test/config/nucleo-f411.xml
@@ -2,6 +2,6 @@
 <library>
   <extends>modm:board:nucleo-f411re</extends>
   <modules>
-    <module>:test:**</module>
+    <module>modm-test:test:**</module>
   </modules>
 </library>


### PR DESCRIPTION
Use fully qualified names for modules and options. This is critical for the board files and the integration with other lbuild based libraries.

E.g. if the board file defines a value for ":target" and another library (other than modm) also defines a "target" option, then lbuild will fail. Using fully qualified names in the configuration files avoids this problem.