### PR TITLE
Add clock source for timers

### DIFF
--- a/src/modm/board/black_pill/board.hpp
+++ b/src/modm/board/black_pill/board.hpp
@@ -49,6 +49,13 @@ struct systemClock {
 	static constexpr uint32_t I2c1   = Apb1;
 	static constexpr uint32_t I2c2   = Apb1;
 
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+
 	static bool inline
 	enable()
 	{

--- a/src/modm/board/blue_pill/board.hpp
+++ b/src/modm/board/blue_pill/board.hpp
@@ -50,6 +50,13 @@ struct systemClock {
 	static constexpr uint32_t I2c1   = Apb1;
 	static constexpr uint32_t I2c2   = Apb1;
 
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+
 	static bool inline
 	enable()
 	{


### PR DESCRIPTION
The blue and black pill board files are missing the clock sources for timers.