### PR TITLE
[driver] Rename AMSYS5915 to AMS5915

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ can easily configure them for you specific needs.
 <td align="center">AD7928</td>
 <td align="center">ADNS9800</td>
 <td align="center">ADS7843</td>
-<td align="center">AMSYS5915</td>
+<td align="center">AMS5915</td>
 <td align="center">SPI-FLASH</td>
 </tr><tr>
 <td align="center">BME280</td>

--- a/examples/stm32f4_discovery/pressure_ams5915/main.cpp
+++ b/examples/stm32f4_discovery/pressure_ams5915/main.cpp
@@ -13,7 +13,7 @@
 #include <modm/board.hpp>
 
 #include <modm/processing.hpp>
-#include <modm/driver/pressure/amsys5915.hpp>
+#include <modm/driver/pressure/ams5915.hpp>
 #include <modm/io/iostream.hpp>
 #include <modm/debug/logger.hpp>
 
@@ -43,8 +43,8 @@ modm::log::Logger modm::log::error(device);
 typedef I2cMaster2 MyI2cMaster;
 // typedef modm::SoftwareI2cMaster<GpioB10, GpioB11> MyI2cMaster;
 
-modm::amsys5915::Data data;
-modm::Amsys5915<MyI2cMaster> pressureSensor(data);
+modm::ams5915::Data data;
+modm::Ams5915<MyI2cMaster> pressureSensor(data);
 
 class ThreadOne : public modm::pt::Protothread
 {

--- a/examples/stm32f4_discovery/pressure_ams5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_ams5915/project.xml
@@ -1,10 +1,10 @@
 <library>
   <extends>modm:board:disco-f407vg</extends>
   <options>
-    <option name="modm:build:build.path">../../../build/stm32f4_discovery/pressure_amsys5915</option>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/pressure_ams5915</option>
   </options>
   <modules>
-    <module>modm:driver:amsys5915</module>
+    <module>modm:driver:ams5915</module>
     <module>modm:io</module>
     <module>modm:debug</module>
     <module>modm:platform:gpio</module>

--- a/src/modm/driver/pressure/ams5915.hpp
+++ b/src/modm/driver/pressure/ams5915.hpp
@@ -11,8 +11,8 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_AMSYS5915_HPP
-#define MODM_AMSYS5915_HPP
+#ifndef MODM_AMS5915_HPP
+#define MODM_AMS5915_HPP
 
 #include <modm/architecture/interface/i2c_device.hpp>
 #include <modm/math/utils/endianness.hpp>
@@ -20,18 +20,18 @@
 namespace modm
 {
 
-// forward declaration for friending with amsys5915::Data
+// forward declaration for friending with ams5915::Data
 template < typename I2cMaster >
-class Amsys5915;
+class Ams5915;
 
-/// @ingroup modm_driver_amsys5915
-struct amsys5915
+/// @ingroup modm_driver_ams5915
+struct ams5915
 {
 	struct modm_packed
 	Data
 	{
 		template < typename I2cMaster >
-		friend class Amsys5915;
+		friend class Ams5915;
 
 	public:
 		uint16_t
@@ -92,17 +92,17 @@ struct amsys5915
 };
 
 /**
- * @ingroup modm_driver_amsys5915
+ * @ingroup modm_driver_ams5915
  * @author	Raphael Lehman, Niklas Hauser
  */
 template < typename I2cMaster >
-class Amsys5915 : public amsys5915, public modm::I2cDevice<I2cMaster, 1, I2cReadTransaction>
+class Ams5915 : public ams5915, public modm::I2cDevice<I2cMaster, 1, I2cReadTransaction>
 {
 public:
 	/**
-	 * @param	data	a amsys5915::Data object
+	 * @param	data	a ams5915::Data object
 	 */
-	Amsys5915(Data &data, uint8_t i2cAddress = 0x28)
+	Ams5915(Data &data, uint8_t i2cAddress = 0x28)
 	:	I2cDevice<I2cMaster,1,I2cReadTransaction>(i2cAddress), data(data)
 	{
 		this->transaction.configureRead(data.data, 4);
@@ -142,4 +142,4 @@ private:
 
 }	// namespace modm
 
-#endif // MODM_AMSYS5915_HPP
+#endif // MODM_AMS5915_HPP

--- a/src/modm/driver/pressure/ams5915.lb
+++ b/src/modm/driver/pressure/ams5915.lb
@@ -13,15 +13,15 @@
 
 def init(module):
     module.parent = "driver"
-    module.name = "amsys5915"
+    module.name = "ams5915"
     module.description = """\
-# AMSYS 5915 Pressure Sensor
+# AMS 5915 Pressure Sensor
 
-Driver for the AMSYS 5915 differential and absolute pressure sensors.
+Driver for the AMS 5915 differential and absolute pressure sensors.
 The device runs a cyclic program, which will store a corrected pressure value with
 12 bit resolution about every 500 μs within the output registers of the internal ASIC.
 
-[Datasheet](http://www.amsys.de/sheets/amsys.de.ams5915.pdf)
+[Datasheet](https://www.analog-micro.com/_pages/sens/ams5915/ams5915_data_sheet.pdf)
 """
 
 def prepare(module, options):
@@ -32,4 +32,4 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/driver/pressure"
-    env.copy("amsys5915.hpp")
+    env.copy("ams5915.hpp")

--- a/tools/scripts/modm_modules.py
+++ b/tools/scripts/modm_modules.py
@@ -62,7 +62,7 @@ modm_modules = [
     (r"modm/driver/motor/drv832x_spi\.hpp", r"modm:driver:drv832x_spi"),
     (r"modm/driver/position/vl53l0\.hpp", r"modm:driver:vl53l0"),
     (r"modm/driver/position/vl6180\.hpp", r"modm:driver:vl6180"),
-    (r"modm/driver/pressure/amsys5915\.hpp", r"modm:driver:amsys5915"),
+    (r"modm/driver/pressure/ams5915\.hpp", r"modm:driver:ams5915"),
     (r"modm/driver/pressure/bme280.*", r"modm:driver:bme280"),
     (r"modm/driver/pressure/bmp085.*", r"modm:driver:bmp085"),
     (r"modm/driver/pressure/hclax\.hpp", r"modm:driver:hclax"),


### PR DESCRIPTION
I got a nice email from Analog Microelectronics requesting that I fix this:

> Sehr geehrter Herr Hauser,
> 
> auf der modm barbone Seite verweisen sie unter https://modm.io/reference/module/modm-driver-amsys5915/ auf einen Drucksensor vom Typ AMSYS5915. Dies ist nicht korrekt. Der korrekte Bezeichnung lautet AMS5915. Der Sensor ist ein Produkt von Analog Microelectronics GmbH.
> 
> Ich möchte Sie bitten, dies zu korrigieren und den link auf das Datenblatt entsprechend anzupassen
> 
> https://www.analog-micro.com/_pages/sens/ams5915/ams5915_data_sheet.pdf
> 
> Mit freundlichem Gruß
> [Prokurist]

Apparently we're really famous among Deutsche Mittelstandsunternehmen… 😂

Also really hilarious, [Analog Microelectronics (An der Fahrt 13) is lead by Dr. Norbert Rauch](https://www.analog-micro.com/de/unternehmen/impressum/), and [Amsys (An der Fahrt 4) is lead by Ursula Rauch](https://www.amsys.de/impressum/). To quote my friend: "Ein wahres Tochterunternehmen!"

cc @rleh @chris-durand @dergraaf @strongly-typed 