### PR TITLE
[build] Generate SConscripts only for repositories

### DIFF
--- a/repo.lb
+++ b/repo.lb
@@ -33,7 +33,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.5.0"
+min_lbuild_version = "1.5.6"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip install -U lbuild".format(min_lbuild_version))

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -68,10 +68,8 @@ def post_build(env, buildlog):
     is_unittest = env.has_module(":test")
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["image.source"])
-    generated_paths = sorted(set(o.local_filename_out().split("/")[0] for o in buildlog))
-    generated_paths.remove("modm")
-    generated_paths.insert(0, "modm")
-    generated_paths = [p for p in generated_paths if os.path.isdir(env.outpath(p, basepath="."))]
+    repositories = [p for p in buildlog.repositories if os.path.isdir(env.outpath(p, basepath="."))]
+    repositories = sorted(repositories, key=lambda name: "0" if name == "modm" else name)
 
     target = env["modm:target"]
     subs = common_target(target)
@@ -107,7 +105,7 @@ def post_build(env, buildlog):
     # Add SCons specific data
     subs.update({
         "metadata": buildlog.metadata,
-        "generated_paths": generated_paths,
+        "generated_paths": repositories,
         "build_tools": build_tools,
         "is_unittest": is_unittest,
         "has_image_source": has_image_source,
@@ -125,7 +123,7 @@ def post_build(env, buildlog):
     # Set these substitutions for all templates
     env.substitutions = subs
 
-    for repo in generated_paths:
+    for repo in repositories:
         subs.update({
             "repo": repo,
             "flags": common_metadata_flags(buildlog, repo),


### PR DESCRIPTION
A repository may generate more that one folder, but the SConscript may
only be generated once, in the folder named like the repository name.