### PR TITLE
[xpcc] Pass include paths to builders

### DIFF
--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -50,7 +50,8 @@ sources += env.XpccCommunication(
     xmlfile=abspath("{{ generator_source }}"),
     container="{{ generator_container }}",
     path=abspath("{{ generator_path }}"),
-    namespace="{{ generator_namespace }}")
+    namespace="{{ generator_namespace }}",
+    include_paths=["."])
 %% endif
 
 %% if not is_unittest

--- a/tools/xpcc_generator/builder/builder_base.py
+++ b/tools/xpcc_generator/builder/builder_base.py
@@ -89,6 +89,7 @@ class Builder(object):
 				"-I", "--include_path",
 				dest = "includePath",
 				default = None,
+				action = "append",
 				help = "Include Search Path [optional]")
 
 		self.setup(optparser)


### PR DESCRIPTION
Allows passing several include paths to the XPCC generator to make including files also possible with global include paths, not just relative include paths.