### PR TITLE
Add SCons CacheDir to top-level build directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_unittests & wait
+      - restore_cache:
+          keys:
+            - scons-cache-unittests-{{ checksum "cache_checksum_unittests" }}
       - run:
           name: Check environment
           command: |
@@ -58,6 +61,10 @@ jobs:
           name: Check for Unique Build Paths
           command: |
             python3 tools/scripts/examples_check.py examples
+      - save_cache:
+          key: scons-cache-unittests-{{ checksum "cache_checksum_unittests" }}
+          paths:
+            - "build/cache"
 
   stm32-examples:
     docker:
@@ -68,7 +75,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 examples > cache_checksum_examples & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32-examples-{{ checksum "cache_checksum_examples" }}
       - run:
           name: Examples STM32F0 Series
           command: |
@@ -89,6 +99,10 @@ jobs:
           name: Examples STM32L4 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc)
+      - save_cache:
+          key: scons-cache-stm32-examples-{{ checksum "cache_checksum_examples" }}
+          paths:
+            - "build/cache"
 
   stm32f4-examples:
     docker:
@@ -99,12 +113,19 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 examples > cache_checksum_examples & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f4-examples-{{ checksum "cache_checksum_examples" }}
       - run:
           name: Examples STM32F4 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32f4_discovery)
             (cd examples && ../tools/scripts/examples_compile.py stm32f429_discovery stm32f469_discovery nucleo_f401re nucleo_f411re nucleo_f429zi)
+      - save_cache:
+          key: scons-cache-stm32f4-examples-{{ checksum "cache_checksum_examples" }}
+          paths:
+            - "build/cache"
 
   avr-examples:
     docker:
@@ -115,11 +136,18 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 examples > cache_checksum_examples & wait
+      - restore_cache:
+          keys:
+            - scons-cache-avr-examples-{{ checksum "cache_checksum_examples" }}
       - run:
           name: Examples AVR Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno)
+      - save_cache:
+          key: scons-cache-avr-examples-{{ checksum "cache_checksum_examples" }}
+          paths:
+            - "build/cache"
 
   linux-generic-examples:
     docker:
@@ -130,7 +158,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 examples > cache_checksum_examples & wait
+      - restore_cache:
+          keys:
+            - scons-cache-linux-generic-examples-{{ checksum "cache_checksum_examples" }}
       - run:
           name: Linux Examples
           command: |
@@ -139,6 +170,10 @@ jobs:
           name: Generic Examples
           command: |
             (cd examples && ../tools/scripts/examples_compile.py generic)
+      - save_cache:
+          key: scons-cache-linux-generic-examples-{{ checksum "cache_checksum_examples" }}
+          paths:
+            - "build/cache"
 
   avr-compile-all:
     docker:
@@ -149,7 +184,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-avr-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all AVRs
           command: |
@@ -157,6 +195,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-avr-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f0-compile-all:
     docker:
@@ -167,7 +209,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f0-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F0
           command: |
@@ -175,6 +220,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f0-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f1-compile-all:
     docker:
@@ -185,7 +234,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f1-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F1
           command: |
@@ -193,6 +245,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f1-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f2-compile-all:
     docker:
@@ -203,7 +259,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f2-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F2
           command: |
@@ -211,6 +270,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f2-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f3-compile-all:
     docker:
@@ -221,7 +284,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f3-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F3
           command: |
@@ -229,6 +295,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f3-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f4-compile-all:
     docker:
@@ -239,7 +309,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f4-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F4
           command: |
@@ -247,6 +320,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f4-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32f7-compile-all:
     docker:
@@ -257,7 +334,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32f7-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32F7
           command: |
@@ -265,6 +345,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32f7-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   stm32l4-compile-all:
     docker:
@@ -275,7 +359,10 @@ jobs:
       - SCONSFLAGS: "-j4"
     steps:
       - checkout
-      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & ls -aR1 test > cache_checksum_test & wait
+      - restore_cache:
+          keys:
+            - scons-cache-stm32l4-all-{{ checksum "cache_checksum_test" }}
       - run:
           name: Compile HAL for all STM32L4
           command: |
@@ -283,6 +370,10 @@ jobs:
       - store_artifacts:
           path: test/all/log
           destination: log
+      - save_cache:
+          key: scons-cache-stm32l4-all-{{ checksum "cache_checksum_test" }}
+          paths:
+            - "build/cache"
 
   build-docs:
     docker:
@@ -309,7 +400,6 @@ jobs:
             (cd docs && mkdocs build)
             if [ "$CIRCLE_BRANCH" = "develop" ]; then
               cd docs/modm.io
-
               git config user.email "rca@circleci.com"
               git config user.name "CircleCI Deployment Bot"
               git add -A

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -32,7 +32,7 @@ class CommandException(Exception):
 def run_command(cmdline):
     try:
         cmdline = " ".join(cmdline)
-        p = subprocess.run(cmdline, shell=True, stdout=subprocess.PIPE, universal_newlines = True)
+        p = subprocess.run(cmdline, shell=True, stdout=subprocess.PIPE, universal_newlines=True)
         return (p.stdout, p.returncode)
     except KeyboardInterrupt:
         raise multiprocessing.ProcessError()
@@ -46,20 +46,14 @@ def run_lbuild(command):
     return output
 
 def run_scons(tempdir):
-    cmdline = ["scons", "-C", tempdir]
+    cmdline = ["scons", "-C", tempdir, "--random", "--cache-show"]
     return run_command(cmdline)
 
 def build_code(tempdir):
-    count = 0
-    while count < 20:
-        output, retval = run_scons(tempdir)
-        if retval != 0:
-            if "Cannot allocate memory" in output:
-                # CircleCI is running out of memory
-                count += 1
-                continue
-            raise CommandException(output)
-        return output
+    output, retval = run_scons(tempdir)
+    if retval != 0:
+        raise CommandException(output)
+    return output
 
 
 class TestRunResult(enum.Enum):
@@ -69,11 +63,12 @@ class TestRunResult(enum.Enum):
 
 
 class TestRun:
-    def __init__(self, device):
+    def __init__(self, device, cache_dir=None):
         self.device = device
         self.output = ""
         self.result = TestRunResult.FAIL_BUILD
         self.time = None
+        self.cache_dir = cache_dir
 
     def run(self):
         start_time = time.time()
@@ -85,6 +80,9 @@ class TestRun:
             elif self.device.startswith("stm32"):
                 lbuild_command = ["-c", "stm32.xml"]
                 shutil.copyfile("stm32.cpp", os.path.join(tempdir, "main.cpp"))
+
+            if self.cache_dir:
+                lbuild_command.append("-D:::cache_dir={}".format(self.cache_dir))
 
             lbuild_command.extend(["-D:target={}".format(self.device),
                                    "-p", str(tempdir),
@@ -145,11 +143,14 @@ def main():
     devices = [d for d in devices if d not in ignored_devices]
 
     os.makedirs("log", exist_ok=True)
+    cache_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../build/cache"))
+    if "no-cache" in sys.argv:
+        cache_dir = None
 
     try:
         #devices = [device for device in devices if device.startswith("atx")]
         with multiprocessing.Pool(cpus) as pool:
-            test_runs = pool.map(build_device, [TestRun(x) for x in devices])
+            test_runs = pool.map(build_device, [TestRun(x, cache_dir) for x in devices])
 
         succeded = []
         failed = []

--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -8,6 +8,7 @@
     <option name="modm:build:scons:include_sconstruct">True</option>
     <option name="modm:build:scons:info.build">True</option>
     <option name="modm:build:scons:info.git">Info+Status</option>
+    <option name="modm:build:scons:cache_dir">../../cache</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -26,6 +26,9 @@ def prepare(module, options):
         BooleanOption(name="include_sconstruct", default=True,
                       description=descr_include_sconstruct))
     module.add_option(
+        StringOption(name="cache_dir", default="/cache",
+                     description=descr_cache_dir))
+    module.add_option(
         StringOption(name="image.source", default="",
                      description=descr_image_source))
     module.add_option(
@@ -35,6 +38,7 @@ def prepare(module, options):
     module.add_option(
         BooleanOption(name="info.build", default=False,
                       description=descr_info_build))
+
 
     return True
 
@@ -101,6 +105,11 @@ def post_build(env, buildlog):
     else:
         build_tools += ["utils_buildsize", "compiler_hosted_gcc"]
 
+    cache_dir = env["cache_dir"]
+    if cache_dir == "/cache":
+        cache_dir = env[":build:build.path"] + "/cache"
+        if "build/" in cache_dir:
+            cache_dir = "{}build/cache".format(cache_dir.split("build/")[0])
     # get memory information
     subs["memories"] = common_memories(target)
     # Add SCons specific data
@@ -111,6 +120,7 @@ def post_build(env, buildlog):
         "is_unittest": is_unittest,
         "has_image_source": has_image_source,
         "image_source": env["image.source"],
+        "cache_dir": cache_dir,
         "has_xpcc_generator": has_xpcc_generator,
         "generator_source": env.get_option(":communication:xpcc:generator:source", ""),
         "generator_container": env.get_option(":communication:xpcc:generator:container", ""),
@@ -168,6 +178,12 @@ def post_build(env, buildlog):
 globals()["descr_include_sconstruct"] = """# Generate a SConstruct file
 
 !!! warning "This overwrites any top-level `SConstruct` file!"
+"""
+
+globals()["descr_cache_dir"] = """# Path to SConstruct CacheDir
+
+If value is `/cache`, the cache is placed into the top-level `build/` folder.
+You can disable CacheDir by setting an empty string.
 """
 
 globals()["descr_image_source"] = """# Path to directory containing .pbm files"""

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -15,6 +15,9 @@ from os.path import join, abspath
 project_name = "{{ options[":build:project.name"] }}"
 build_path = "{{ options[":build:build.path"] }}"
 generated_paths = {{ generated_paths }}
+%% if cache_dir | length
+CacheDir("{{ cache_dir }}")
+%% endif
 
 # SCons environment with all tools
 env = Environment(ENV=os.environ)


### PR DESCRIPTION
This adds a simple `CacheDir("build/")` call to the SConstruct, which should enable faster builds locally and on the CI.