### PR TITLE
Make examples share the scons cache in CI

### DIFF
--- a/tools/scripts/examples_cleanup.sh
+++ b/tools/scripts/examples_cleanup.sh
@@ -16,3 +16,4 @@ find ${@:1} -name gdbinit -delete
 
 find ${@:1} -type d -name modm -exec rm -rf "{}" \;
 find ${@:1} -type d -name generated -exec rm -rf "{}" \;
+find ${@:1} -type d -name build -exec rm -rf "{}" \;


### PR DESCRIPTION
Also reverts caching the SCons CacheDir in the CI, since it doesn't save us any time.