### PR TITLE
Fixes Hd44780 initialization issue #159

### DIFF
--- a/src/modm/driver/display/hd44780_base_impl.hpp
+++ b/src/modm/driver/display/hd44780_base_impl.hpp
@@ -40,6 +40,7 @@ modm::Hd44780Base<DATA, RW, RS, E>::initialize(LineMode lineMode)
 	if (DATA::width == 4) {
 		while(isBusy())
 			;
+		RW::set(RW_Write);
 		Bus<DATA, E, DATA::width>::writeHighNibble(Set4BitBus);
 	}
 


### PR DESCRIPTION
Hd44780_base 's `initialize`call wouldn't work because `isBusy()` would call `RW::set(RW_Read)` and the following `Bus<DATA, E, DATA::width>::writeHighNibble(Set4BitBus)` call would require `RW` set to `RW_Write`.