### PR TITLE
Add support for qch generation

### DIFF
--- a/tools/doc_generator/doxyfile.cfg.in
+++ b/tools/doc_generator/doxyfile.cfg.in
@@ -15,6 +15,11 @@ QUIET                  = {{ "YES" if xml else "NO" }}
 WARN_LOGFILE           = doxygen_warnings.txt
 
 GENERATE_HTML          = YES
+{% if qch %}
+GENERATE_QHP           = YES
+QHP_NAMESPACE          = org.modm
+QHG_LOCATION           = /usr/bin/qhelpgenerator
+{% endif %}
 GENERATE_LATEX         = NO
 GENERATE_MAN           = NO
 GENERATE_RTF           = NO

--- a/tools/doc_generator/module.lb
+++ b/tools/doc_generator/module.lb
@@ -145,11 +145,14 @@ def prepare(module, options):
     module.add_option(BooleanOption(name="generate_module_docs",
                                     description="Generate the module docs (alpha)",
                                     default=False))
+    module.add_option(BooleanOption(name="generate_module_docs_as_qch",
+                                    description="Generate the module docs as qch (Qt Help format) (alpha)",
+                                    default=False))
     return True
 
 def build(env):
     env.outbasepath = "modm/docs"
-    env.substitutions = {"xml": env["generate_module_docs"]}
+    env.substitutions = {"xml": env["generate_module_docs"], "qch": env["generate_module_docs_as_qch"]}
     env.template("doxyfile.cfg.in")
     env.copy(repopath("README.md"), "README.md")
 


### PR DESCRIPTION
This adds support to internally-used doxygen to create qch files, which, in turn, enables to use generated docs in QtCreator natively.
See example:
![documentation usage example](https://i.imgur.com/PQ17G1E.png)
In this example I've just tapped `F1` while having cursor on line with:
```cpp
Adc::setReference(Adc::Reference::InternalVcc);
```