### PR TITLE
Fixed issue #156 regarding incorrect datatype in delay declarations

### DIFF
--- a/src/modm/platform/clock/cortex/delay.hpp
+++ b/src/modm/platform/clock/cortex/delay.hpp
@@ -20,9 +20,9 @@
 #include <stdint.h>
 #include <modm/architecture/utils.hpp>
 
-extern "C" void _delay_ns(uint32_t ns);
-extern "C" void _delay_us(uint32_t us);
-extern "C" void _delay_ms(uint32_t ms);
+extern "C" void _delay_ns(uint16_t ns);
+extern "C" void _delay_us(uint16_t us);
+extern "C" void _delay_ms(uint16_t ms);
 
 namespace modm
 {


### PR DESCRIPTION
Simple change to fix #156 and ensure declaration is correctly referencing uint16_t rather than uint32_t. 