### PR TITLE
[tools] Fix Python scripts running on Windows

### DIFF
--- a/tools/scripts/examples_check.py
+++ b/tools/scripts/examples_check.py
@@ -37,11 +37,12 @@ def check_unique_paths(projects):
 	return result
 
 
-# Find all project files
-projects = [p for path in sys.argv[1:] for p in Path(path).glob("**/project.xml")]
+if __name__ == "__main__":
+	# Find all project files
+	projects = [p for path in sys.argv[1:] for p in Path(path).glob("**/project.xml")]
 
-result = check_unique_paths(projects)
+	result = check_unique_paths(projects)
 
-exit(result)
+	exit(result)
 
 


### PR DESCRIPTION
Protects the entry point of the program as Windows does not have
process forking. Fixes #164.

cc @operativeF