### PR TITLE
Enable support for STM32G0 device family

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,10 @@ jobs:
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32f746g_discovery)
       - run:
+          name: Examples STM32G0 Series
+          command: |
+            (cd examples && ../tools/scripts/examples_compile.py nucleo_g071rb)
+      - run:
           name: Examples STM32L4 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc)
@@ -234,6 +238,20 @@ jobs:
           path: test/all/log
           destination: log
 
+  stm32g0-compile-all:
+    docker:
+      - image: modm/modm-build:latest
+    steps:
+      - checkout
+      - run: (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run:
+          name: Compile HAL for all STM32G0
+          command: |
+            (cd test/all && python3 run_all.py stm32g0)
+      - store_artifacts:
+          path: test/all/log
+          destination: log
+
   build-docs:
     docker:
       - image: modm/modm-build:latest
@@ -302,6 +320,10 @@ workflows:
           requires:
             - unittests
             - stm32-examples
+      - stm32g0-compile-all:
+          requires:
+            - unittests
+            - stm32-examples
       - stm32l4-compile-all:
           requires:
             - unittests
@@ -315,5 +337,6 @@ workflows:
             - stm32f3-compile-all
             - stm32f4-compile-all
             - stm32f7-compile-all
+            - stm32g0-compile-all
             - stm32l4-compile-all
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone --recurse-submodules https://github.com/modm-io/modm.git
 
 ## Targets
 
-modm can generate code for <!--avrcount-->76<!--/avrcount--> AVR and <!--stmcount-->886<!--/stmcount-->
+modm can generate code for <!--avrcount-->76<!--/avrcount--> AVR and <!--stmcount-->917<!--/stmcount-->
 STM32 devices, however, there are different levels of support and testing.
 
 <center>
@@ -134,10 +134,11 @@ documentation.
 <td align="center">NUCLEO-F411RE</td>
 </tr><tr>
 <td align="center">NUCLEO-F429ZI</td>
+<td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
-<td align="center">OLIMEXINO-STM32</td>
 </tr><tr>
+<td align="center">OLIMEXINO-STM32</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ make gdb
 
 ## Interesting Examples
 
-We have a lot of examples, <!--examplecount-->168<!--/examplecount--> to be
+We have a lot of examples, <!--examplecount-->169<!--/examplecount--> to be
 exact, but here are some of our favorite examples for our supported development
 boards:
 

--- a/examples/nucleo_g071rb/blink/main.cpp
+++ b/examples/nucleo_g071rb/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	LedD13::setOutput();
+	static uint8_t counter{0};
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delayMilliseconds(Button::read() ? 500 : 1000);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g071rb/blink/project.xml
+++ b/examples/nucleo_g071rb/blink/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-g071rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g071rb/blink</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -60,7 +60,7 @@ def common_rcc_map(env):
     define = None
 
     content = Path(localpath(folder, family_header)).read_text(encoding="utf-8", errors="replace")
-    match = re.findall(r"if defined\((?P<define>STM32[F|L].....)\)", content)
+    match = re.findall(r"if defined\((?P<define>STM32[F|L|G].....)\)", content)
     define = getDefineForDevice(device.identifier, match)
     if define is None or match is None:
         raise ValidateException("No device define found for '{}'!".format(device.partname))

--- a/repo.lb
+++ b/repo.lb
@@ -69,7 +69,10 @@ class DevicesCache(dict):
 
         # roughly filter to supported devices
         supported = ["stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
-                     "stm32l4", "at90", "attiny", "atmega", "hosted"]
+                     "stm32g0",
+                     "stm32l4",
+                     "at90", "attiny", "atmega",
+                     "hosted"]
         device_file_names = [dfn for dfn in device_file_names if any(s in dfn for s in supported)]
 
         # Parse the files and build the :target enumeration

--- a/src/modm/board/nucleo_g071rb/board.hpp
+++ b/src/modm/board/nucleo_g071rb/board.hpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef MODM_STM32_NUCLEO_G071RB_HPP
+#define MODM_STM32_NUCLEO_G071RB_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_g071rb
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_g071rb
+namespace Board
+{
+using namespace modm::literals;
+
+/// STM32G071RB running at 64MHz generated from the internal 16MHz crystal
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 64_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Aes		= Ahb;
+	static constexpr uint32_t Rng		= Ahb;
+	static constexpr uint32_t Crc		= Ahb;
+	static constexpr uint32_t Flash		= Ahb;
+	static constexpr uint32_t Exti		= Ahb;
+	static constexpr uint32_t Rcc		= Ahb;
+	static constexpr uint32_t Dmamux	= Ahb;
+	static constexpr uint32_t Dma		= Ahb;
+
+	static constexpr uint32_t Dbg		= Apb;
+	static constexpr uint32_t Timer17	= Apb;
+	static constexpr uint32_t Timer16	= Apb;
+	static constexpr uint32_t Timer15	= Apb;
+	static constexpr uint32_t Usart1	= Apb;
+	static constexpr uint32_t Spi1		= Apb;
+	static constexpr uint32_t I2s1		= Apb;
+	static constexpr uint32_t Timer1	= Apb;
+	static constexpr uint32_t Adc		= Apb;
+	static constexpr uint32_t Comp		= Apb;
+	static constexpr uint32_t ItLine	= Apb;
+	static constexpr uint32_t VrefBuf	= Apb;
+	static constexpr uint32_t SysCfg	= Apb;
+	static constexpr uint32_t Tamp		= Apb;
+	static constexpr uint32_t Bkp		= Apb;
+	static constexpr uint32_t Ucpd2		= Apb;
+	static constexpr uint32_t Ucpd1		= Apb;
+	static constexpr uint32_t LpTimer2	= Apb;
+	static constexpr uint32_t LpUart1	= Apb;
+	static constexpr uint32_t LpTimer1	= Apb;
+	static constexpr uint32_t HdmiCec	= Apb;
+	static constexpr uint32_t Dac		= Apb;
+	static constexpr uint32_t Pwr		= Apb;
+	static constexpr uint32_t I2c2		= Apb;
+	static constexpr uint32_t I2c1		= Apb;
+	static constexpr uint32_t Usart4	= Apb;
+	static constexpr uint32_t Usart3	= Apb;
+	static constexpr uint32_t Usart2	= Apb;
+	static constexpr uint32_t Spi2		= Apb;
+	static constexpr uint32_t Iwdg		= Apb;
+	static constexpr uint32_t Wwdg		= Apb;
+	static constexpr uint32_t Rtc		= Apb;
+	static constexpr uint32_t Timer14	= Apb;
+	static constexpr uint32_t Timer7	= Apb;
+	static constexpr uint32_t Timer6	= Apb;
+	static constexpr uint32_t Timer3	= Apb;
+	static constexpr uint32_t Timer2	= Apb;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableInternalClock();	// 16MHz
+		// (internal clock / 1_M) * 8_N / 2_R = 128MHz / 2 = 64MHz
+		Rcc::enablePll(
+			Rcc::PllSource::InternalClock,
+			1,	// Pll_M
+			8,	// Pll_N
+			2	// Pll_R
+		);
+		// set flash latency for 64MHz
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA4;
+using A3 = GpioB1;
+using A4 = GpioB11;
+using A5 = GpioB12;
+
+using D0  = GpioC5;
+using D1  = GpioC4;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB14;
+using D7  = GpioA8;
+using D8  = GpioA9;
+using D9  = GpioC7;
+using D10 = GpioB0;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+
+using Button = GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Button::setInput();
+	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	Button::enableExternalInterrupt();
+//	Button::enableExternalInterruptVector(12);
+}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_G071RB_HPP

--- a/src/modm/board/nucleo_g071rb/board.xml
+++ b/src/modm/board/nucleo_g071rb/board.xml
@@ -1,0 +1,15 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32g071rbt</option>
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-g071rb</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_g071rb/module.lb
+++ b/src/modm/board/nucleo_g071rb/module.lb
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.parent = "board"
+    module.name = "nucleo-g071rb"
+    module.description = """\
+# NUCLEO-G071RB
+
+Nucleo kit for STM32G071RB
+http://www.st.com/en/evaluation-tools/nucleo-g071rb.html
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32g071rbt":
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": True}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+
+    # Waiting on this patch to OpenOCD http://openocd.zylin.com/#/c/4807
+    # env.outbasepath = "modm/openocd/modm/board/"
+    # env.copy(repopath("tools/openocd/modm/st_nucleo_g0.cfg"), "st_nucleo_g0.cfg")
+    # env.collect(":build:openocd.source", "modm/board/st_nucleo_g0.cfg")

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -157,7 +157,7 @@ modm::platform::Rcc::enablePll(PllSource source, uint8_t pllM, uint16_t pllN, ui
 
 	return tmp;
 }
-%% elif target["family"] in ["l4"]
+%% elif target["family"] in ["g0", "l4"]
 // ----------------------------------------------------------------------------
 bool
 modm::platform::Rcc::enablePll(PllSource source,
@@ -182,11 +182,17 @@ modm::platform::Rcc::enablePll(PllSource source,
 	tmp |= (uint32_t(pllN) << RCC_PLLCFGR_PLLN_Pos) & RCC_PLLCFGR_PLLN;
 
 	// PLLR divider for CPU frequency
+%% if target["family"] in ["g0"]
+	tmp |= ((uint32_t(pllR) - 1) << RCC_PLLCFGR_PLLR_Pos) & RCC_PLLCFGR_PLLR;
+	// PLLP divider for P frequency
+	// tmp |= ((uint32_t(pllP) - 1) << RCC_PLLCFGR_PLLP_Pos) & RCC_PLLCFGR_PLLP;
+%% else
 	tmp |= ((uint32_t(pllR / 2) - 1) << RCC_PLLCFGR_PLLR_Pos) & RCC_PLLCFGR_PLLR;
 	// PLLQ (21) divider for USB frequency; (00: PLLQ = 2, 01: PLLQ = 4, etc.)
 	// tmp |= (((uint32_t) (pllQ / 2) - 1) << RCC_PLLCFGR_PLLQ_Pos) & RCC_PLLCFGR_PLLQ;
 	// enable pll USB clock output
 	// tmp |= RCC_PLLCFGR_PLLQEN;
+%% endif
 
 	// enable pll CPU clock output
 	tmp |= RCC_PLLCFGR_PLLREN;

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -40,7 +40,7 @@ public:
 	enum class
 	PllSource : uint32_t
 	{
-%% if target["family"] in ["f2", "f4", "f7", "l4"]
+%% if target["family"] in ["f2", "f4", "f7", "l4", "g0"]
 		/// High speed internal clock (16 MHz)
 		Hsi = RCC_PLLCFGR_PLLSRC_HSI,
 		/// High speed external clock (see HseConfig)
@@ -129,7 +129,7 @@ public:
 		Div512 = RCC_CFGR_HPRE_DIV512
 	};
 
-%% if target["family"] == "f0"
+%% if target["family"] in ["f0", "g0"]
 	enum class
 	ApbPrescaler : uint32_t
 	{
@@ -181,13 +181,15 @@ public:
 		Pll = RCC_CFGR_MCO2_1 | RCC_CFGR_MCO2_0,
 	};
 	%% endif
-%% elif target["family"] in ["l4"]
+%% elif target["family"] in ["l4", "g0"]
 	enum class
 	ClockOutputSource : uint32_t
 	{
 		Disable = 0,
 		SystemClock = (1 << RCC_CFGR_MCOSEL_Pos), // SYSCLK
+%% if target["family"] in ["l4"]
 		MultiSpeedInternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // MSI
+%% endif
 		InternalClock = (3 << RCC_CFGR_MCOSEL_Pos), // HSI16
 		ExternalClock = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
 		ExternalCrystal = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
@@ -269,7 +271,7 @@ public:
 	enableLowSpeedExternalCrystal(uint32_t waitCycles = 2048);
 
 	// plls
-%% if target["family"] in ["f2", "f4", "f7", "l4"]
+%% if target["family"] in ["f2", "f4", "f7", "l4", "g0"]
 	/**
 	 * Enable PLL.
 	 *
@@ -301,7 +303,7 @@ public:
 	 */
 	static bool
 	enablePll(PllSource source, uint8_t pllM, uint16_t pllN,
-%% if target["family"] in ["l4"]
+%% if target["family"] in ["l4", "g0"]
 	          uint8_t pllR,
 %% else
 			  uint8_t pllP,
@@ -354,7 +356,7 @@ public:
 		return true;
 	}
 	%% endif
-%% elif target["family"] in ["l4"]
+%% elif target["family"] in ["l4", "g0"]
 	enum class
 	ClockOutputPrescaler : uint32_t
 	{
@@ -363,6 +365,11 @@ public:
 		Div4 = (2 << RCC_CFGR_MCOPRE_Pos),
 		Div8 = (3 << RCC_CFGR_MCOPRE_Pos),
 		Div16 = (4 << RCC_CFGR_MCOPRE_Pos),
+%% if target["family"] in ["g0"]
+		Div32 = (5 << RCC_CFGR_MCOPRE_Pos),
+		Div64 = (6 << RCC_CFGR_MCOPRE_Pos),
+		Div128 = (7 << RCC_CFGR_MCOPRE_Pos),
+%% endif
 	};
 
 	static inline bool
@@ -388,7 +395,7 @@ public:
 		return true;
 	}
 
-%% if target["family"] == "f0"
+%% if target["family"] in ["f0", "g0"]
 	static inline bool
 	setApbPrescaler(ApbPrescaler prescaler)
 	{

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -65,6 +65,9 @@ Rcc::setFlashLatency()
 %% if target["family"] in ["f2", "f4", "l4"]
 	// enable flash prefetch and data and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
+%% elif target["family"] in ["g0"]
+	// enable flash prefetch and instruction cache
+	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ICEN;
 %% elif target["family"] == "f7"
 	// enable flash prefetch and flash accelerator
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -27,7 +27,9 @@ void
 __modm_initialize_platform(void)
 {
 	// Enable SYSCFG
-%% if target.family == "f1"
+%% if target.family == "g0"
+	RCC->APBENR2 |= RCC_APBENR2_SYSCFGEN;
+%% elif target.family == "f1"
 	RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
 %% else
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;

--- a/src/modm/platform/fault/cortex/hard_fault.sx.in
+++ b/src/modm/platform/fault/cortex/hard_fault.sx.in
@@ -30,7 +30,7 @@
 	.func	HardFault_Handler
 HardFault_Handler:
 
-%% if target.platform == "stm32" and not target.family == "f0"
+%% if "m0" not in core
 	/* When a hard fault occurs, this handler will move the stack pointer around.
  	 * This makes it harder to debug a hard fault with a real debugger, so if one is connected we would
 	 * like to trigger a software breakpoint before moving the stack pointer.

--- a/src/modm/platform/fault/cortex/module.lb
+++ b/src/modm/platform/fault/cortex/module.lb
@@ -23,10 +23,11 @@ Dealing with Fault handlers.
 """
 
 def prepare(module, options):
-    if not options[":target"].has_driver("core:cortex-m*"):
+    device = options[":target"]
+    if not device.has_driver("core:cortex-m*"):
         return False
 
-    if options[":target"].identifier["platform"] not in ["stm32"]:
+    if device.identifier["platform"] not in ["stm32"]:
         return False
 
     module.depends(
@@ -35,7 +36,7 @@ def prepare(module, options):
         ":platform:gpio",
         ":cmsis:device")
 
-    pins = [p["port"].upper() + p["pin"] for p in options[":target"].get_driver("gpio")["gpio"]]
+    pins = [p["port"].upper() + p["pin"] for p in device.get_driver("gpio")["gpio"]]
     module.add_option(
         EnumerationOption(
             name="led",

--- a/src/modm/platform/gpio/stm32/base.hpp.in
+++ b/src/modm/platform/gpio/stm32/base.hpp.in
@@ -54,7 +54,21 @@ struct Gpio
 	enum class
 	OutputSpeed
 	{
-%% if target["family"] in ["f2", "f4", "f7", "l4"]
+%% if target["family"] in ["f1"]
+		Low    = 0x2,
+		Medium = 0x1,
+		High   = 0x3,
+		MHz2   = Low,
+		MHz10  = Medium,
+		MHz50  = High,
+%% elif target["family"] in ["f0", "f3"]
+		Low    = 0,
+		Medium = 0x1,
+		High   = 0x3,
+		MHz2   = Low,
+		MHz10  = Medium,
+		MHz50  = High,
+%% else
 		Low      = 0,
 		Medium   = 0x1,
 		High     = 0x2,
@@ -63,20 +77,6 @@ struct Gpio
 		MHz25    = Medium,
 		MHz50    = High,
 		MHz100   = VeryHigh,
-%% elif target["family"] in ["f0", "f3"]
-		Low    = 0,
-		Medium = 0x1,
-		High   = 0x3,
-		MHz2   = Low,
-		MHz10  = Medium,
-		MHz50  = High,
-%% elif target["family"] in ["f1"]
-		Low    = 0x2,
-		Medium = 0x1,
-		High   = 0x3,
-		MHz2   = Low,
-		MHz10  = Medium,
-		MHz50  = High,
 %% endif
 	};
 

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -25,6 +25,8 @@ modm_gpio_enable(void)
 %%	set prefix = "IOP"
 %% elif target["family"] in ["l4"]
 %%  set clock_tree = 'AHB2'
+%% elif target["family"] in ["g0"]
+%%  set clock_tree = 'IOP'
 %% endif
 
 %% if target["family"] in ["f2", "f4", "f7"]

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -238,14 +238,12 @@ def validate(env):
         all_peripherals.extend([get_driver(r) for r in driver["remap"]])
     bprops["all_peripherals"] = sorted(list(set(all_peripherals)))
     bprops["all_signals"] = sorted(list(set(s["name"] for s in all_signals.values())))
-    bprops["pf"] = "1" if device.identifier["family"] in ["l4"] else ""
+    bprops["pf"] = "1" if device.identifier["family"] in ["l4", "g0"] else ""
 
     # Check the max number of ADC instances
     max_adc_instance = max(map(int, device.get_driver("adc").get("instance", [1])))
     if (max_adc_instance > (3 if device.identifier["family"] == "f1" else 4)):
         raise ValidateException("Too many ADC instances: '{}'".format(max_adc_instance))
-
-    return True
 
 def build(env):
     device = env[":target"]

--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -117,7 +117,11 @@ public:
 		constexpr uint8_t bit_pos = (pin & 0b0011) << 2;
 		constexpr uint16_t syscfg_mask = (0b1111) << bit_pos;
 		constexpr uint16_t syscfg_value = (port_nr & (0b1111)) << bit_pos;
+%% if target.family in ["g0"]
+		EXTI->EXTICR[index] = (EXTI->EXTICR[index] & ~syscfg_mask) | syscfg_value;
+%% else
 		SYSCFG->EXTICR[index] = (SYSCFG->EXTICR[index] & ~syscfg_mask) | syscfg_value;
+%% endif
 		EXTI->IMR{{pf}} |= mask;
 	}
 	inline static void disableExternalInterrupt() { EXTI->IMR{{pf}} &= ~mask; }
@@ -145,8 +149,15 @@ public:
 			break;
 		}
 	}
+%% if target.family in ["g0"]
+	inline static bool getExternalInterruptFlag()
+	{ return (EXTI->FPR1 & mask) | (EXTI->RPR1 & mask); }
+	inline static void acknowledgeExternalInterruptFlag()
+	{ EXTI->FPR1 |= mask; EXTI->RPR1 |= mask; }
+%% else
 	inline static bool getExternalInterruptFlag() { return (EXTI->PR{{pf}} & mask); }
 	inline static void acknowledgeExternalInterruptFlag() { EXTI->PR{{pf}} |= mask; }
+%% endif
 	// GpioIO
 	// start documentation inherited
 	inline static Direction getDirection() {

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -322,6 +322,9 @@ modm::platform::{{ name }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
 {
 %% if "extended" in driver["type"]
 	// Not all flags can be cleared by writing to this reg
+#ifdef USART_ICR_NECF
+#define USART_ICR_NCF USART_ICR_NECF
+#endif
 	%% if target["family"] == "f0" and target["name"] in ["30", "70"]
 	const uint32_t mask = USART_ICR_PECF  | USART_ICR_FECF   |
 		USART_ICR_NCF   | USART_ICR_ORECF | USART_ICR_IDLECF |


### PR DESCRIPTION
Progress:

- [x] RCC
- [x] UART
- [x] GPIO
- [x] CMSIS-Device
- ~~OpenOCD~~ Used STLink via copying .bin file onto programmer.
- [x] Tested in Hardware

Unfortunately, OpenOCD doesn't yet have support for the G0 Flash driver, you need to compile this patch to enable it manually: http://openocd.zylin.com/#/c/4807/