### PR TITLE
Use the vector table to deduct IRQ names

### DIFF
--- a/repo.lb
+++ b/repo.lb
@@ -15,6 +15,7 @@ import re
 import sys
 import glob
 import hashlib
+import platform
 
 from pathlib import Path
 from distutils.version import StrictVersion
@@ -171,6 +172,16 @@ def init(repo):
         name = re.search("<module>(modm:board:.*?)</module>", config.read_text()).group(1).replace("modm:", "")
         repo.add_configuration(name, config)
 
+    # Add Jinja2 filters commonly used in this repository
+    def windowsify(path):
+        if 'Windows' in platform.platform():
+            path = path.replace('/','\\').replace("\\", "\\\\")
+        return path
+    repo.add_filter("windowsify", windowsify)
+    repo.add_filter("ord", lambda letter: ord(letter[0].lower()) - ord("a"))
+    repo.add_filter("chr", lambda num: chr(num + ord("A")))
+
+    # Compute the available data from modm-devices
     devices = DevicesCache()
     try:
         devices.build()

--- a/src/modm/platform/gpio/stm32/base.hpp.in
+++ b/src/modm/platform/gpio/stm32/base.hpp.in
@@ -103,7 +103,7 @@ struct Gpio
 	Port
 	{
 %% for port in ports
-		{{ port | upper }} = {{ port | letterToNum }},
+		{{ port | upper }} = {{ port | modm.ord }},
 %% endfor
 	};
 

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -25,12 +25,6 @@ def port_ranges(gpios):
     ports.sort(key=lambda p: p["name"])
     return ports
 
-def letter_to_num(letter):
-    return ord(letter[0].lower()) - ord("a")
-
-def num_to_letter(num):
-    return chr(num + ord("A"))
-
 def translate(s):
     name = ""
     for part in s.split("_"):
@@ -275,7 +269,7 @@ def build(env):
     env.template("set.hpp.in")
     if "f1" in driver["type"]:
         env.template("connector_specialized.hpp.in", filters={"formatPeripheral": get_driver, "printSignalMap": print_remap_group_table})
-    env.template("base.hpp.in", filters={"letterToNum": letter_to_num})
+    env.template("base.hpp.in")
     env.template("unused.hpp.in")
     if len(env["enable_ports"]):
         env.template("enable.cpp.in")

--- a/src/modm/platform/id/stm32/id.hpp
+++ b/src/modm/platform/id/stm32/id.hpp
@@ -14,6 +14,7 @@
 #define MODM_PLATFORM_ID_HPP
 
 #include <stdint.h>
+#include "../device.hpp"
 
 namespace modm
 {
@@ -32,7 +33,7 @@ static inline uint32_t
 getUniqueId(uint8_t offset)
 {
 	if (offset > 2) return 0;
-	return *(((uint32_t *) {{ address }}) + offset);
+	return *(((uint32_t *) UID_BASE) + offset);
 }
 
 }

--- a/src/modm/platform/id/stm32/module.lb
+++ b/src/modm/platform/id/stm32/module.lb
@@ -16,24 +16,8 @@ def init(module):
     module.description = "Unique ID"
 
 def prepare(module, options):
-    if options[":target"].identifier["family"] not in ["f1", "f2", "f3", "f4", "f7"]:
-        return False
-    return True
+    return options[":target"].identifier.platform == "stm32"
 
 def build(env):
-    device = env[":target"]
-
-    properties = device.properties
-    properties["target"] = target = device.identifier
-
-    if target["family"] in ["f2", "f3", "f4"]:
-        properties["address"] = "0x1FFF7A10"
-    elif target["family"] == "f7":
-        properties["address"] = "0x1FF0F420"
-    elif target["family"] == "f1":
-        properties["address"] = "0x1FFFF7E8"
-
-    env.substitutions = properties
     env.outbasepath = "modm/src/modm/platform/id"
-
-    env.template("id.hpp.in")
+    env.copy("id.hpp")

--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -234,106 +234,21 @@ uint32_t modeOutputPorts)
 }
 
 // ----------------------------------------------------------------------------
-// Re-implemented here to save some code space. As all arguments in the calls
-// below are constant the compiler is able to calculate everything at
-// compile time.
-static modm_always_inline void
-nvicEnableInterrupt(IRQn_Type IRQn)
-{
-	NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));
-}
-
-static modm_always_inline void
-nvicDisableInterrupt(IRQn_Type IRQn)
-{
-	NVIC_DisableIRQ(IRQn);
-}
-%% if target["family"] in ["f2", "f4", "f7"]
-	%% if id == 1
-#	define TIM1_BRK_IRQn		TIM1_BRK_TIM9_IRQn
-%% if not partname.startswith("stm32f410")
-#	define TIM1_UP_IRQn			TIM1_UP_TIM10_IRQn
-%% endif
-#	define TIM1_TRG_COM_IRQn	TIM1_TRG_COM_TIM11_IRQn
-	%% elif id == 8
-#	define TIM8_BRK_IRQn		TIM8_BRK_TIM12_IRQn
-#	define TIM8_UP_IRQn			TIM8_UP_TIM13_IRQn
-#	define TIM8_TRG_COM_IRQn	TIM8_TRG_COM_TIM14_IRQn
-	%% endif
-%% elif target["family"] in ["l4"]
-	%% if id == 1
-#	define TIM1_BRK_IRQn		TIM1_BRK_TIM15_IRQn
-#	define TIM1_UP_IRQn			TIM1_UP_TIM16_IRQn
-	%% elif id == 8
-#	define TIM8_BRK_IRQn		TIM8_BRK_IRQn
-#	define TIM8_UP_IRQn			TIM8_UP_IRQn
-#	define TIM8_TRG_COM_IRQn	TIM8_TRG_COM_IRQn
-	%% endif
-%% elif target["family"] == "f3"
-	%% if id == 1
-#	define TIM1_BRK_IRQn		TIM1_BRK_TIM15_IRQn
-#	define TIM1_UP_IRQn			TIM1_UP_TIM16_IRQn
-#	define TIM1_TRG_COM_IRQn	TIM1_TRG_COM_TIM17_IRQn
-	%% endif
-%% endif
-
-// ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::enableInterruptVector(Interrupt interrupt, bool enable, uint32_t priority)
 {
-	if (enable)
+%% for vector, flags in vectors.items()
+	if(interrupt & ({% for flag in flags %}Interrupt::{{ flag }}{% if not loop.last %} | {% endif %}{% endfor %}))
 	{
-%% if target["family"] == "f0"
-		if(interrupt & (Interrupt::Update | Interrupt::Break | Interrupt::COM | Interrupt::Trigger)) {
-			NVIC_SetPriority(TIM{{ id }}_BRK_UP_TRG_COM_IRQn, priority);
-			nvicEnableInterrupt(TIM{{ id }}_BRK_UP_TRG_COM_IRQn);
+		if (enable)
+		{
+			NVIC_SetPriority({{ vector }}_IRQn, priority);
+			NVIC_EnableIRQ({{ vector }}_IRQn);
 		}
-%% else
-		if (interrupt & Interrupt::Update) {
-			NVIC_SetPriority(TIM{{ id }}_UP_IRQn, priority);
-			nvicEnableInterrupt(TIM{{ id }}_UP_IRQn);
-		}
-
-		if (interrupt & Interrupt::Break) {
-			NVIC_SetPriority(TIM{{ id }}_BRK_IRQn, priority);
-			nvicEnableInterrupt(TIM{{ id }}_BRK_IRQn);
-		}
-
-		if (interrupt & (Interrupt::COM | Interrupt::Trigger)) {
-			NVIC_SetPriority(TIM{{ id }}_TRG_COM_IRQn, priority);
-			nvicEnableInterrupt(TIM{{ id }}_TRG_COM_IRQn);
-		}
-%% endif
-		if (interrupt &
-				(Interrupt::CaptureCompare1 | Interrupt::CaptureCompare2 |
-				 Interrupt::CaptureCompare3 | Interrupt::CaptureCompare4)) {
-			NVIC_SetPriority(TIM{{ id }}_CC_IRQn, priority);
-			nvicEnableInterrupt(TIM{{ id }}_CC_IRQn);
+		else
+		{
+			NVIC_DisableIRQ({{ vector }}_IRQn);
 		}
 	}
-	else
-	{
-%% if target["family"] == "f0"
-		if(interrupt & (Interrupt::Update | Interrupt::Break | Interrupt::COM | Interrupt::Trigger)) {
-			nvicDisableInterrupt(TIM{{ id }}_BRK_UP_TRG_COM_IRQn);
-		}
-%% else
-		if (interrupt & Interrupt::Update) {
-			nvicDisableInterrupt(TIM{{ id }}_UP_IRQn);
-		}
-
-		if (interrupt & Interrupt::Break) {
-			nvicDisableInterrupt(TIM{{ id }}_BRK_IRQn);
-		}
-
-		if (interrupt & (Interrupt::COM | Interrupt::Trigger)) {
-			nvicDisableInterrupt(TIM{{ id }}_TRG_COM_IRQn);
-		}
-%% endif
-		if (interrupt &
-				(Interrupt::CaptureCompare1 | Interrupt::CaptureCompare2 |
-				 Interrupt::CaptureCompare3 | Interrupt::CaptureCompare4)) {
-			nvicDisableInterrupt(TIM{{ id }}_CC_IRQn);
-		}
-	}
+%% endfor
 }

--- a/src/modm/platform/timer/stm32/basic.cpp.in
+++ b/src/modm/platform/timer/stm32/basic.cpp.in
@@ -44,25 +44,18 @@ modm::platform::Timer{{ id }}::setMode(Mode mode)
 	TIM{{ id }}->CR2 = 0;
 }
 
-%% if (id == 6) and (target["family"] in ["f2", "f3", "f4", "f7", "l4"]) and not partname.startswith("stm32f412")
-%%   set interrupt_vector = "TIM6_DAC_IRQn"
-%% elif (id == 7) and (target["family"] == "f3" and ((target["name"] in ["28", "34"]) or (target["name"] in ["03"] and target["size"] in ["8"])))
-%%   set interrupt_vector = "TIM7_DAC2_IRQn"
-%% elif (id == 18) and (target["family"] == "f3" and target["name"] in ["73", "78"])
-%%   set interrupt_vector = "TIM18_DAC2_IRQn"
-%% else
-%%   set interrupt_vector = "TIM" ~ id ~ "_IRQn"
-%% endif
 void
 modm::platform::Timer{{ id }}::enableInterruptVector(bool enable, uint32_t priority)
 {
-	if (enable) {
-		// Set vector priority
-		NVIC_SetPriority({{ interrupt_vector }}, priority);
-		// register IRQ at the NVIC
-		NVIC_EnableIRQ({{ interrupt_vector }});
+%% for vector in vectors
+	if (enable)
+	{
+		NVIC_SetPriority({{ vector }}_IRQn, priority);
+		NVIC_EnableIRQ({{ vector }}_IRQn);
 	}
-	else {
-		NVIC_DisableIRQ({{ interrupt_vector }});
+	else
+	{
+		NVIC_DisableIRQ({{ vector }}_IRQn);
 	}
+%% endfor
 }

--- a/src/modm/platform/timer/stm32/general_purpose.cpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.cpp.in
@@ -34,34 +34,6 @@
 %%   endif
 %% endif
 
-%% if (target["family"] == "f3" and target["name"] in ["73", "78"]) or target["family"] == "f0"
-%%   set irq_name = id
-%% else
-%%   if id == 9
-%%     set irq_name = "1_BRK_TIM9"
-%%   elif id == 10
-%%     set irq_name = "1_UP_TIM10"
-%%   elif id == 11
-%%     set irq_name = "1_TRG_COM_TIM11"
-%%   elif id == 12
-%%     set irq_name = "8_BRK_TIM12"
-%%   elif id == 13
-%%     set irq_name = "8_UP_TIM13"
-%%   elif id == 14 and not target["family"] == "f0"
-%%     set irq_name = "8_TRG_COM_TIM14"
-%%   elif id == 15
-%%     set irq_name = "1_BRK_TIM15"
-%%   elif id == 16
-%%     set irq_name = "1_UP_TIM16"
-%%   elif id == 17
-%%     set irq_name = "1_TRG_COM_TIM17"
-%%   elif id == 20
-%%     set irq_name = "20_UP"
-%%   else
-%%     set irq_name = id
-%%   endif
-%% endif
-
 #include "timer_{{ id }}.hpp"
 
 // ----------------------------------------------------------------------------
@@ -214,14 +186,15 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 void
 modm::platform::Timer{{ id }}::enableInterruptVector(bool enable, uint32_t priority)
 {
-	if (enable) {
-		// Set priority for the interrupt vector
-		NVIC_SetPriority(TIM{{ irq_name }}_IRQn, priority);
-
-		// register IRQ at the NVIC
-		NVIC_EnableIRQ(TIM{{ irq_name }}_IRQn);
+%% for vector in vectors
+	if (enable)
+	{
+		NVIC_SetPriority({{ vector }}_IRQn, priority);
+		NVIC_EnableIRQ({{ vector }}_IRQn);
 	}
-	else {
-		NVIC_DisableIRQ(TIM{{ irq_name }}_IRQn);
+	else
+	{
+		NVIC_DisableIRQ({{ vector }}_IRQn);
 	}
+%% endfor
 }

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -10,14 +10,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-def get_properties(env):
-    device = env[":target"]
-    driver = device.get_driver("tim")
-    properties = device.properties
-    properties["target"] = device.identifier
-    properties["partname"] = device.partname
-    properties["driver"] = driver
-    return properties
+from collections import defaultdict
+props = {}
 
 def get_connectors(instance):
     if instance in [1, 8]:
@@ -38,6 +32,12 @@ class Instance(Module):
     def __init__(self, driver, instance):
         self.driver = driver
         self.instance = int(instance)
+        self.vectors = None
+        self.type = "general_purpose"
+        if self.instance in [1, 8, 20]:
+            self.type = "advanced"
+        elif self.instance in [6, 7, 18]:
+            self.type = "basic"
 
     def init(self, module):
         module.name = str(self.instance)
@@ -47,24 +47,40 @@ class Instance(Module):
         module.depends(":platform:timer")
         return True
 
+    def validate(self, env):
+        vecmap = {
+            "_UP": ["Update"],
+            "_TRG": ["Trigger"],
+            "_BRK": ["Break"],
+            "_COM": ["COM"],
+            "_CC": ["CaptureCompare1", "CaptureCompare2",
+                     "CaptureCompare3", "CaptureCompare4"],
+        }
+        self.vectors = {irq:[] for irq in props["timer_vectors"][self.instance]}
+        for irq in self.vectors.keys():
+            for part, flags in vecmap.items():
+                if part in irq:
+                    self.vectors[irq].extend(flags)
+
+        if len(self.vectors) == 0:
+            raise ValidateException("No interrupts found for Timer{}! Possible IRQs are {}"
+                                    .format(self.instance, props["timer_vectors"]))
+        if self.type != "advanced":
+            if len(self.vectors) != 1:
+                raise ValidateException("Timer{} is only allowed to have one IRQ! Found {}"
+                                    .format(self.instance, self.vectors))
+
     def build(self, env):
-        properties = get_properties(env)
-        properties["id"] = int(self.instance)
+        global props
+        props["id"] = self.instance
+        props["connectors"] = get_connectors(self.instance)
+        props["apb_post"] = "1" if props["target"].family in ["l4"] else ""
+        props["vectors"] = self.vectors
 
-        properties["connectors"] = get_connectors(self.instance)
-        properties["apb_post"] = "1" if properties["target"]["family"] in ["l4"] else ""
-
-        env.substitutions = properties
+        env.substitutions = props
         env.outbasepath = "modm/src/modm/platform/timer"
-
-        source_timer = "general_purpose"
-        if self.instance in [1, 8]:
-            source_timer = "advanced"
-        elif self.instance in [6, 7, 18]:
-            source_timer = "basic"
-
-        env.template(source_timer + ".hpp.in", "timer_{}.hpp".format(self.instance))
-        env.template(source_timer + ".cpp.in", "timer_{}.cpp".format(self.instance))
+        env.template("{}.hpp.in".format(self.type), "timer_{}.hpp".format(self.instance))
+        env.template("{}.cpp.in".format(self.type), "timer_{}.cpp".format(self.instance))
 
 
 def init(module):
@@ -82,14 +98,31 @@ def prepare(module, options):
         ":cmsis:device",
         ":platform:gpio")
 
-    for driver in device.get_all_drivers("tim"):
+    timers = device.get_all_drivers("tim")
+    instances = []
+    for driver in timers:
         for instance in driver["instance"]:
             module.add_submodule(Instance(driver, instance))
+            instances.append(int(instance))
+
+    global props
+    device = options[":target"]
+    props["target"] = device.identifier
+
+    props["timer_vectors"] = tim_vectors = defaultdict(list)
+    vectors = [v["name"] for v in device.get_driver("core")["vector"] if "TIM" in v["name"]]
+    for instance in instances:
+        timstr = "TIM{}".format(instance)
+        for vector in vectors:
+            if (vector == timstr or ("_"+timstr+"_") in vector or
+                vector.startswith(timstr+"_") or vector.endswith("_"+timstr)):
+                tim_vectors[instance].append(vector)
 
     return True
 
 def build(env):
-    env.substitutions = get_properties(env)
+    global props
+    env.substitutions = props
     env.outbasepath = "modm/src/modm/platform/timer"
 
     env.template("basic_base.hpp.in")

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -11,17 +11,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-shared_irqs = None
-instances = []
-
-def get_shared_irqs(env):
-    global shared_irqs
-    if shared_irqs is None:
-        shared_irqs = [v["name"] for v in env[":target"].get_driver("core")["vector"]]
-        shared_irqs = [v[5:] for v in shared_irqs if v.startswith("USART") and "_" in v]
-        shared_irqs = [int(s) for s in shared_irqs[0].split("_")] if len(shared_irqs) else []
-        shared_irqs = range(shared_irqs[0], shared_irqs[1] + 1) if len(shared_irqs) else []
-    return shared_irqs
+props = {}
 
 class Instance(Module):
     def __init__(self, driver, instance):
@@ -56,23 +46,21 @@ class Instance(Module):
         return True
 
     def build(self, env):
-        device = env[":target"]
-        properties = device.properties
-        properties["target"] = device.identifier
-        properties["id"] = self.instance
-        properties["driver"] = self.driver
-        properties["features"] = self.driver["feature"] if "feature" in self.driver else []
+        device = env[":target"].identifier
+        global props
+        props["id"] = self.instance
+        props["driver"] = self.driver
+        props["features"] = self.driver["feature"] if "feature" in self.driver else []
 
-        if properties["target"]["family"] == "f0":
-            properties["apb"] = "2" if self.instance in [1, 6, 7, 8] else "1"
+        if device.family == "f0":
+            props["apb"] = "2" if self.instance in [1, 6, 7, 8] else "1"
         else:
-            properties["apb"] = "2" if self.instance in [1, 6, 9, 10] else "1"
-        properties["apb_post"] = "1" if properties["target"]["family"] in ["l4"] and self.instance != 1 else ""
+            props["apb"] = "2" if self.instance in [1, 6, 9, 10] else "1"
+        props["apb_post"] = "1" if device.family in ["l4"] and self.instance != 1 else ""
 
-        properties["uart_name"] = self.driver["name"].capitalize()
-        properties["shared_irqs"] = get_shared_irqs(env)
+        props["uart_name"] = self.driver["name"].capitalize()
 
-        env.substitutions = properties
+        env.substitutions = props
         env.outbasepath = "modm/src/modm/platform/uart"
 
         env.template("uart_hal.hpp.in", "uart_hal_{}.hpp".format(self.instance))
@@ -80,8 +68,7 @@ class Instance(Module):
         env.template("uart.hpp.in", "uart_{}.hpp".format(self.instance))
         env.template("uart.cpp.in", "uart_{}.cpp".format(self.instance))
 
-        global instances
-        instances.append(self.instance)
+        props["instances"].append(self.instance)
 
 
 def init(module):
@@ -102,27 +89,37 @@ def prepare(module, options):
         ":cmsis:device",
         ":platform:gpio")
 
-    for driver in (device.get_all_drivers("uart") + device.get_all_drivers("usart")):
+    global props
+    drivers = (device.get_all_drivers("uart") + device.get_all_drivers("usart"))
+    props["extended_driver"] = ("extended" in drivers[0]["type"])
+    props["over8_sampling"] = ("feature" in drivers[0]) and ("over8" in drivers[0]["feature"])
+    props["tcbgt"] = ("feature" in drivers[0]) and ("tcbgt" in drivers[0]["feature"])
+    props["instances"] = []
+
+    for driver in drivers:
         for instance in driver["instance"]:
             module.add_submodule(Instance(driver, instance))
+
+    shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
+    shared_irqs = [v for v in shared_irqs if v.startswith("USART") and "_" in v]
+    if len(shared_irqs):
+        props["shared_irq"] = name = shared_irqs[0]
+        parts = name[5:].split("_")
+        props["shared_irq_ids"] = range(int(parts[0]), int(parts[1]) + 1)
+    else:
+        props["shared_irq_ids"] = []
+
+    props["target"] = device.identifier
 
     return True
 
 def build(env):
     device = env[":target"]
-    properties = device.properties
-    properties["target"] = device.identifier
 
-    drivers = (device.get_all_drivers("usart") + device.get_all_drivers("uart"))
-    properties["extended_driver"] = ("extended" in drivers[0]["type"])
-    properties["over8_sampling"] = ("feature" in drivers[0]) and ("over8" in drivers[0]["feature"])
-    properties["tcbgt"] = ("feature" in drivers[0]) and ("tcbgt" in drivers[0]["feature"])
-    properties["shared_irqs"] = get_shared_irqs(env)
-    properties["instances"] = instances
-
-    env.substitutions = properties
+    global props
+    env.substitutions = props
     env.outbasepath = "modm/src/modm/platform/uart"
     env.template("uart_base.hpp.in")
     env.template("uart_baudrate.hpp.in")
-    if any(i in properties["shared_irqs"] for i in instances):
+    if any(i in props["shared_irq_ids"] for i in props["instances"]):
         env.template("uart_shared.cpp.in")

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -196,7 +196,7 @@ modm::platform::{{ name }}::discardReceiveBuffer()
 
 %% if options["buffered"]
 %% set hal = "modm::platform::" ~ hal
-%% if id in shared_irqs
+%% if id in shared_irq_ids
 void
 modm::platform::{{ name }}::irq()
 %% else

--- a/src/modm/platform/uart/stm32/uart.hpp.in
+++ b/src/modm/platform/uart/stm32/uart.hpp.in
@@ -131,7 +131,7 @@ public:
 	static std::size_t
 	discardReceiveBuffer();
 
-%% if id in shared_irqs
+%% if id in shared_irq_ids
 	static void
 	irq();
 %% endif

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -287,8 +287,8 @@ modm::platform::{{ name }}::isTransmitRegisterEmpty()
 void
 modm::platform::{{ name }}::enableInterruptVector(bool enable, uint32_t priority)
 {
-%% if id in shared_irqs
-	%% set irq = "USART" ~ shared_irqs[0] ~ "_" ~ shared_irqs[-1]
+%% if id in shared_irq_ids
+	%% set irq = shared_irq
 %% else
 	%% set irq = peripheral
 %% endif

--- a/src/modm/platform/uart/stm32/uart_shared.cpp.in
+++ b/src/modm/platform/uart/stm32/uart_shared.cpp.in
@@ -10,13 +10,13 @@
 // ----------------------------------------------------------------------------
 
 #include "../device.hpp"
-%% for id in instances if id in shared_irqs
+%% for id in instances if id in shared_irq_ids
 #include "uart_{{ id }}.hpp"
 %% endfor
 
-MODM_ISR({{ "USART" ~ shared_irqs[0] ~ "_" ~ shared_irqs[-1] }})
+MODM_ISR({{ shared_irq }})
 {
-%% for id in instances if id in shared_irqs
+%% for id in instances if id in shared_irq_ids
     modm::platform::Usart{{ id }}::irq();
 %% endfor
 }

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -144,10 +144,13 @@ def main():
     devices = [d for d in devices if d not in ignored_devices]
 
     os.makedirs("log", exist_ok=True)
-    cache_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../build/cache"))
-    Path(cache_dir).mkdir(exist_ok=True, parents=True)
+
     if "no-cache" in sys.argv:
         cache_dir = None
+    else:
+        cache_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../build/cache"))
+        Path(cache_dir).mkdir(exist_ok=True, parents=True)
+        (Path(cache_dir) / "config").write_text('{"prefix_len": 2}')
 
     try:
         #devices = [device for device in devices if device.startswith("atx")]

--- a/tools/build_script_generator/gdbinit.in
+++ b/tools/build_script_generator/gdbinit.in
@@ -2,7 +2,7 @@
 %% if "elf." ~ profile in metadata
 define file_{{profile}}
     file
-    file {{ metadata["elf." ~ profile][0] | windowsify }}
+    file {{ metadata["elf." ~ profile][0] | modm.windowsify }}
 end
 %% endif
 %% endfor

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -11,20 +11,10 @@
 # -----------------------------------------------------------------------------
 
 import os
-import platform
 
 # import all common code
 with open(localpath("common.py")) as common:
     exec(common.read())
-
-#filter to windowsify paths separators
-def windowsify(path):
-	if 'Windows' in platform.platform():
-	    path = path.replace('/','\\')
-	    path = path.replace("\\", "\\\\")
-	    return path
-	else:
-	    return path
 
 
 def init(module):
@@ -95,8 +85,8 @@ def post_build(env, buildlog):
         env.template("gitignore.in", ".gitignore")
 
     if env[":target"].has_driver("core:cortex-m*"):
-        env.template("openocd.cfg.in", filters={"windowsify": windowsify})
-        env.template("gdbinit.in", filters={"windowsify": windowsify})
+        env.template("openocd.cfg.in")
+        env.template("gdbinit.in")
 
 
 # ============================ Option Descriptions ============================

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -15,7 +15,7 @@ proc modm_program { SOURCE } {
 %% for profile in ["release", "debug"]
 %% if "elf." ~ profile in metadata
 proc program_{{ profile }} {} {
-	modm_program {{ metadata["elf." ~ profile][0]  | windowsify }}
+	modm_program {{ metadata["elf." ~ profile][0]  | modm.windowsify }}
 }
 %% endif
 %% endfor

--- a/tools/scripts/examples_compile.py
+++ b/tools/scripts/examples_compile.py
@@ -61,6 +61,7 @@ def compile_examples(paths):
 	print("Using {}x parallelism".format(cpus))
 	# Create build folder to prevent process race
 	cache_dir.mkdir(exist_ok=True, parents=True)
+	(cache_dir / "config").write_text('{"prefix_len": 2}')
 	# Find all project files
 	projects = [p for path in paths for p in Path(path).glob("**/project.xml")]
 	# first generate all projects


### PR DESCRIPTION
- For Timer and USART the IRQ names are deduced by looking at the vector table names.
- The `:platform:id` module is simplified by using the `UID_BASE` definition from the CMSIS header files instead of hardcoded values.
- Some Jinja2 filters are made available repository wide.
- A file creation race is fixed for SConc CacheDir config.
