### PR TITLE
Share code and data with lbuild queries, fix config aliases

### DIFF
--- a/docs/getting-started.md.in
+++ b/docs/getting-started.md.in
@@ -16,8 +16,23 @@ we still recommend adding modm as a git submodule for reproducibility.
 ### Using a Board Support Package
 
 To build on a BSP, inherit from an existing project configuration using the
-`<extends>` element.
-Our BSPs declare a minimal set of modules as dependencies as well as pre-define several important options for this board.
+`<extends>` element. You can discover the available configuration aliases using
+lbuild:
+
+```
+ $ lbuild --repository ../modm/repo.lb discover
+Parser(lbuild)
+╰── Repository(modm @ ../modm)   modm: a barebone embedded library generator
+    ├── Configuration(modm:arduino-uno)   Arduino UNO
+    ├── Configuration(modm:blue-pill)   Blue Pill
+    ├── Configuration(modm:disco-f469ni)   STM32F469IDISCOVERY
+    ├── Configuration(modm:nucleo-f401re)   NUCLEO-F401RE
+    ├── Configuration(modm:olimexino-stm32)   Olimexino STM32
+    ╰── Configuration(modm:stm32f030_demo)   STM32F030 Demo Board
+```
+
+Our BSPs declare a minimal set of modules as dependencies as well as pre-define
+several important options for this board.
 You can then add all the modules you need and configure them as you want.
 
 ```xml
@@ -29,7 +44,7 @@ You can then add all the modules you need and configure them as you want.
     </repository>
   </repositories>
   <!-- extend this board configuration -->
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <!-- give this project a custom name -->
     <option name="modm:build:project.name">test</option>

--- a/examples/arduino_uno/basic/analog_read_serial/project.xml
+++ b/examples/arduino_uno/basic/analog_read_serial/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:arduino-uno</extends>
+  <extends>modm:arduino-uno</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/arduino_uno/basic/analog_read_serial</option>
   </options>

--- a/examples/arduino_uno/basic/blink/project.xml
+++ b/examples/arduino_uno/basic/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:arduino-uno</extends>
+  <extends>modm:arduino-uno</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/arduino_uno/basic/blink</option>
   </options>

--- a/examples/arduino_uno/basic/digital_read_serial/project.xml
+++ b/examples/arduino_uno/basic/digital_read_serial/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:arduino-uno</extends>
+  <extends>modm:arduino-uno</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/arduino_uno/basic/digital_read_serial</option>
   </options>

--- a/examples/arduino_uno/basic/read_analog_voltage/project.xml
+++ b/examples/arduino_uno/basic/read_analog_voltage/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:arduino-uno</extends>
+  <extends>modm:arduino-uno</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/arduino_uno/basic/read_analog_voltage</option>
   </options>

--- a/examples/avr/assert/project.xml
+++ b/examples/avr/assert/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:al-avreb-can</extends>
+  <extends>modm:al-avreb-can</extends>
   <options>
     <option name="modm:build:build.path">../../../build/avr/assert</option>
   </options>

--- a/examples/avr/ports/project.xml
+++ b/examples/avr/ports/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:al-avreb-can</extends>
+  <extends>modm:al-avreb-can</extends>
   <options>
     <option name="modm:build:build.path">../../../build/avr/ports</option>
     <option name="modm:build:avrdude.programmer">usbasp-clone</option>

--- a/examples/generic/blinky/project.xml
+++ b/examples/generic/blinky/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/generic/blinky</option>
   </options>

--- a/examples/generic/resumable/project.xml
+++ b/examples/generic/resumable/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/generic/resumable</option>
   </options>

--- a/examples/generic/ros/can_bridge/project.xml
+++ b/examples/generic/ros/can_bridge/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/generic/ros/can_bridge</option>
     <option name="modm:platform:uart:2:buffer.tx">512</option>

--- a/examples/generic/ros/environment/project.xml
+++ b/examples/generic/ros/environment/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/generic/ros/environment</option>
     <option name="modm:platform:uart:2:buffer.tx">512</option>

--- a/examples/generic/ros/sub_pub/project.xml
+++ b/examples/generic/ros/sub_pub/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/generic/ros/sub_pub</option>
     <option name="modm:platform:uart:2:buffer.tx">512</option>

--- a/examples/generic/rtc_ds1302/project.xml
+++ b/examples/generic/rtc_ds1302/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/generic/rtc_ds1302</option>
   </options>

--- a/examples/nucleo_f031k6/blink/project.xml
+++ b/examples/nucleo_f031k6/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f031k6</extends>
+  <extends>modm:nucleo-f031k6</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f031k6/blink</option>
   </options>

--- a/examples/nucleo_f042k6/adc/project.xml
+++ b/examples/nucleo_f042k6/adc/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f042k6</extends>
+  <extends>modm:nucleo-f042k6</extends>
   <options>
     <option name=":build:build.path">../../../build/nucleo_f042k6/adc</option>
   </options>

--- a/examples/nucleo_f042k6/blink/project.xml
+++ b/examples/nucleo_f042k6/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f042k6</extends>
+  <extends>modm:nucleo-f042k6</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f042k6/blink</option>
   </options>

--- a/examples/nucleo_f103rb/blink/project.xml
+++ b/examples/nucleo_f103rb/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f103rb</extends>
+  <extends>modm:nucleo-f103rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f103rb/blink</option>
   </options>

--- a/examples/nucleo_f303k8/blink/project.xml
+++ b/examples/nucleo_f303k8/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f303k8</extends>
+  <extends>modm:nucleo-f303k8</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f303k8/blink</option>
   </options>

--- a/examples/nucleo_f401re/blink/project.xml
+++ b/examples/nucleo_f401re/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f401re</extends>
+  <extends>modm:nucleo-f401re</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f401re/blink</option>
   </options>

--- a/examples/nucleo_f401re/distance_vl53l0/project.xml
+++ b/examples/nucleo_f401re/distance_vl53l0/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f401re</extends>
+  <extends>modm:nucleo-f401re</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f401re/distance_vl53l0</option>
   </options>

--- a/examples/nucleo_f411re/blink/project.xml
+++ b/examples/nucleo_f411re/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f411re</extends>
+  <extends>modm:nucleo-f411re</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f411re/blink</option>
   </options>

--- a/examples/nucleo_f429zi/blink/project.xml
+++ b/examples/nucleo_f429zi/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f429zi</extends>
+  <extends>modm:nucleo-f429zi</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f429zi/blink</option>
   </options>

--- a/examples/nucleo_f429zi/pat9125el/project.xml
+++ b/examples/nucleo_f429zi/pat9125el/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f429zi</extends>
+  <extends>modm:nucleo-f429zi</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f429zi/pat9125el</option>
   </options>

--- a/examples/nucleo_f429zi/spi_flash/project.xml
+++ b/examples/nucleo_f429zi/spi_flash/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-f429zi</extends>
+  <extends>modm:nucleo-f429zi</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_f429zi/spi_flash</option>
   </options>

--- a/examples/nucleo_l432kc/blink/project.xml
+++ b/examples/nucleo_l432kc/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/blink</option>
   </options>

--- a/examples/nucleo_l432kc/comp/project.xml
+++ b/examples/nucleo_l432kc/comp/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/comp</option>
   </options>

--- a/examples/nucleo_l432kc/gyroscope/project.xml
+++ b/examples/nucleo_l432kc/gyroscope/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/gyroscope</option>
   </options>

--- a/examples/nucleo_l432kc/pwm/project.xml
+++ b/examples/nucleo_l432kc/pwm/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/pwm</option>
   </options>

--- a/examples/nucleo_l432kc/pwm_advanced/project.xml
+++ b/examples/nucleo_l432kc/pwm_advanced/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/pwm_advanced</option>
   </options>

--- a/examples/nucleo_l432kc/uart_spi/project.xml
+++ b/examples/nucleo_l432kc/uart_spi/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l432kc</extends>
+  <extends>modm:nucleo-l432kc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l432kc/uart_spi</option>
   </options>

--- a/examples/nucleo_l476rg/adc/project.xml
+++ b/examples/nucleo_l476rg/adc/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l476rg/adc</option>
   </options>

--- a/examples/nucleo_l476rg/blink/project.xml
+++ b/examples/nucleo_l476rg/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l476rg/blink</option>
   </options>

--- a/examples/nucleo_l476rg/i2c_test/project.xml
+++ b/examples/nucleo_l476rg/i2c_test/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:nucleo-l476rg</extends>
+  <extends>modm:nucleo-l476rg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_l476rg/i2c_test</option>
   </options>

--- a/examples/olimexino_stm32/blink/project.xml
+++ b/examples/olimexino_stm32/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:olimexino-stm32</extends>
+  <extends>modm:olimexino-stm32</extends>
   <options>
     <option name="modm:build:build.path">../../../build/olimexino_stm32/blink</option>
   </options>

--- a/examples/stm32f030f4p6_demo_board/blink/project.xml
+++ b/examples/stm32f030f4p6_demo_board/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:stm32f030_demo</extends>
+  <extends>modm:stm32f030_demo</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f030f4p6_demo/blink</option>
   </options>

--- a/examples/stm32f072_discovery/blink/project.xml
+++ b/examples/stm32f072_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/blink</option>
   </options>

--- a/examples/stm32f072_discovery/can/project.xml
+++ b/examples/stm32f072_discovery/can/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/can</option>
   </options>

--- a/examples/stm32f072_discovery/hard_fault/project.xml
+++ b/examples/stm32f072_discovery/hard_fault/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/hard_fault</option>
   </options>

--- a/examples/stm32f072_discovery/rotation/project.xml
+++ b/examples/stm32f072_discovery/rotation/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/rotation</option>
   </options>

--- a/examples/stm32f072_discovery/tmp102/project.xml
+++ b/examples/stm32f072_discovery/tmp102/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/tmp102</option>
   </options>

--- a/examples/stm32f072_discovery/uart/project.xml
+++ b/examples/stm32f072_discovery/uart/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/uart</option>
   </options>

--- a/examples/stm32f072_discovery/unaligned_access/project.xml
+++ b/examples/stm32f072_discovery/unaligned_access/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f072rb</extends>
+  <extends>modm:disco-f072rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f072_discovery/unaligned_access</option>
   </options>

--- a/examples/stm32f0_discovery/blink/project.xml
+++ b/examples/stm32f0_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f051r8</extends>
+  <extends>modm:disco-f051r8</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f0_discovery/blink</option>
   </options>

--- a/examples/stm32f0_discovery/logger/project.xml
+++ b/examples/stm32f0_discovery/logger/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f100rb</extends>
+  <extends>modm:disco-f100rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f0_discovery/logger</option>
   </options>

--- a/examples/stm32f103c8t6_black_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_black_pill/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:black-pill</extends>
+  <extends>modm:black-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_black_pill/blink</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/adns_9800</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink.cmake</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/can/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/can/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/can</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/environment/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/environment/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/environment</option>
   </options>

--- a/examples/stm32f103c8t6_blue_pill/logger/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/logger/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:blue-pill</extends>
+  <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/logger</option>
   </options>

--- a/examples/stm32f1_discovery/blink/project.xml
+++ b/examples/stm32f1_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f100rb</extends>
+  <extends>modm:disco-f100rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f1_discovery/blink</option>
   </options>

--- a/examples/stm32f1_discovery/logger/project.xml
+++ b/examples/stm32f1_discovery/logger/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f100rb</extends>
+  <extends>modm:disco-f100rb</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f1_discovery/logger</option>
   </options>

--- a/examples/stm32f3_discovery/accelerometer/project.xml
+++ b/examples/stm32f3_discovery/accelerometer/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/accelerometer</option>
   </options>

--- a/examples/stm32f3_discovery/adc/continous/project.xml
+++ b/examples/stm32f3_discovery/adc/continous/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/continous</option>
   </options>

--- a/examples/stm32f3_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f3_discovery/adc/interrupt/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/interrupt</option>
   </options>

--- a/examples/stm32f3_discovery/adc/simple/project.xml
+++ b/examples/stm32f3_discovery/adc/simple/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/adc/simple</option>
   </options>

--- a/examples/stm32f3_discovery/blink/project.xml
+++ b/examples/stm32f3_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/blink</option>
   </options>

--- a/examples/stm32f3_discovery/can/project.xml
+++ b/examples/stm32f3_discovery/can/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/can</option>
   </options>

--- a/examples/stm32f3_discovery/comp/project.xml
+++ b/examples/stm32f3_discovery/comp/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/comp</option>
   </options>

--- a/examples/stm32f3_discovery/ft245/project.xml
+++ b/examples/stm32f3_discovery/ft245/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/ft245</option>
   </options>

--- a/examples/stm32f3_discovery/gdb/project.xml
+++ b/examples/stm32f3_discovery/gdb/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/gdb</option>
   </options>

--- a/examples/stm32f3_discovery/hard_fault/project.xml
+++ b/examples/stm32f3_discovery/hard_fault/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/hard_fault</option>
     <option name="modm:platform:fault.cortex:led">E3</option>

--- a/examples/stm32f3_discovery/rotation/project.xml
+++ b/examples/stm32f3_discovery/rotation/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f3_discovery/rotation</option>
   </options>

--- a/examples/stm32f3_discovery/timer/basic/project.xml
+++ b/examples/stm32f3_discovery/timer/basic/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/timer/basic</option>
   </options>

--- a/examples/stm32f3_discovery/uart/hal/project.xml
+++ b/examples/stm32f3_discovery/uart/hal/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/uart/hal</option>
   </options>

--- a/examples/stm32f3_discovery/uart/logger/project.xml
+++ b/examples/stm32f3_discovery/uart/logger/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f303vc</extends>
+  <extends>modm:disco-f303vc</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f3_discovery/uart/logger</option>
   </options>

--- a/examples/stm32f429_discovery/blink/project.xml
+++ b/examples/stm32f429_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f429zi</extends>
+  <extends>modm:disco-f429zi</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f429_discovery/blink</option>
   </options>

--- a/examples/stm32f429_discovery/logger/project.xml
+++ b/examples/stm32f429_discovery/logger/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f429zi</extends>
+  <extends>modm:disco-f429zi</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f429_discovery/logger</option>
   </options>

--- a/examples/stm32f469_discovery/assert/project.xml
+++ b/examples/stm32f469_discovery/assert/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/assert</option>
   </options>

--- a/examples/stm32f469_discovery/blink/project.xml
+++ b/examples/stm32f469_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/blink</option>
   </options>

--- a/examples/stm32f469_discovery/can/project.xml
+++ b/examples/stm32f469_discovery/can/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/can</option>
   </options>

--- a/examples/stm32f469_discovery/display/project.xml
+++ b/examples/stm32f469_discovery/display/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/display</option>
   </options>

--- a/examples/stm32f469_discovery/game_of_life/project.xml
+++ b/examples/stm32f469_discovery/game_of_life/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/game_of_life</option>
   </options>

--- a/examples/stm32f469_discovery/ports/project.xml
+++ b/examples/stm32f469_discovery/ports/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/ports</option>
   </options>

--- a/examples/stm32f469_discovery/tlsf-allocator/project.xml
+++ b/examples/stm32f469_discovery/tlsf-allocator/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/tlsf-allocator</option>
   </options>

--- a/examples/stm32f469_discovery/touchscreen/project.xml
+++ b/examples/stm32f469_discovery/touchscreen/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f469ni</extends>
+  <extends>modm:disco-f469ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f469_discovery/touchscreen</option>
   </options>

--- a/examples/stm32f4_discovery/accelerometer/project.xml
+++ b/examples/stm32f4_discovery/accelerometer/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/accelerometer</option>
   </options>

--- a/examples/stm32f4_discovery/adc/interrupt/project.xml
+++ b/examples/stm32f4_discovery/adc/interrupt/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/interrupt</option>
   </options>

--- a/examples/stm32f4_discovery/adc/oversample/project.xml
+++ b/examples/stm32f4_discovery/adc/oversample/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/oversample</option>
   </options>

--- a/examples/stm32f4_discovery/adc/simple/project.xml
+++ b/examples/stm32f4_discovery/adc/simple/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/adc/simple</option>
   </options>

--- a/examples/stm32f4_discovery/app_uart_sniffer/project.xml
+++ b/examples/stm32f4_discovery/app_uart_sniffer/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/app_uart_sniffer</option>
   </options>

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/barometer_bmp085_bmp180</option>
   </options>

--- a/examples/stm32f4_discovery/blink/project.xml
+++ b/examples/stm32f4_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/blink</option>
   </options>

--- a/examples/stm32f4_discovery/can/project.xml
+++ b/examples/stm32f4_discovery/can/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/can</option>
   </options>

--- a/examples/stm32f4_discovery/can2/project.xml
+++ b/examples/stm32f4_discovery/can2/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/can2</option>
   </options>

--- a/examples/stm32f4_discovery/colour_tcs3414/project.xml
+++ b/examples/stm32f4_discovery/colour_tcs3414/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/colour_tcs3414</option>
   </options>

--- a/examples/stm32f4_discovery/display/hd44780/project.xml
+++ b/examples/stm32f4_discovery/display/hd44780/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/hd44780</option>
   </options>

--- a/examples/stm32f4_discovery/display/nokia_5110/project.xml
+++ b/examples/stm32f4_discovery/display/nokia_5110/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/nokia_5110</option>
   </options>

--- a/examples/stm32f4_discovery/display/ssd1306/project.xml
+++ b/examples/stm32f4_discovery/display/ssd1306/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/display/ssd1306</option>
   </options>

--- a/examples/stm32f4_discovery/distance_vl6180/project.xml
+++ b/examples/stm32f4_discovery/distance_vl6180/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/distance_vl6180</option>
   </options>

--- a/examples/stm32f4_discovery/exti/project.xml
+++ b/examples/stm32f4_discovery/exti/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/exti</option>
   </options>

--- a/examples/stm32f4_discovery/fpu/project.xml
+++ b/examples/stm32f4_discovery/fpu/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/fpu</option>
   </options>

--- a/examples/stm32f4_discovery/fsmc/project.xml
+++ b/examples/stm32f4_discovery/fsmc/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/fsmc</option>
   </options>

--- a/examples/stm32f4_discovery/hard_fault/project.xml
+++ b/examples/stm32f4_discovery/hard_fault/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/hard_fault</option>
   </options>

--- a/examples/stm32f4_discovery/led_matrix_display/project.xml
+++ b/examples/stm32f4_discovery/led_matrix_display/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/led_matrix_display</option>
   </options>

--- a/examples/stm32f4_discovery/open407v-d/gui/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/gui/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/open407v-d/gui</option>
     <option name="modm:build:scons:image.source">images</option>

--- a/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
+++ b/examples/stm32f4_discovery/open407v-d/touchscreen/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/open407v-d/touchscreen</option>
   </options>

--- a/examples/stm32f4_discovery/pressure_ams5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_ams5915/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/pressure_ams5915</option>
   </options>

--- a/examples/stm32f4_discovery/protothreads/project.xml
+++ b/examples/stm32f4_discovery/protothreads/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/protothreads</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-basic-comm</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/rx/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/rx</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-data/tx/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../../build/stm32f4_discovery/radio/nrf24-data/tx</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-phy-test/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-phy-test</option>
   </options>

--- a/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
+++ b/examples/stm32f4_discovery/radio/nrf24-scanner/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/radio/nrf24-scanner</option>
   </options>

--- a/examples/stm32f4_discovery/rtos/float_check/project.xml
+++ b/examples/stm32f4_discovery/rtos/float_check/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../../build/stm32f4_discovery/rtos/float_check</option>
   </options>

--- a/examples/stm32f4_discovery/sab2/project.xml
+++ b/examples/stm32f4_discovery/sab2/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/sab2</option>
   </options>

--- a/examples/stm32f4_discovery/spi/project.xml
+++ b/examples/stm32f4_discovery/spi/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/spi</option>
   </options>

--- a/examples/stm32f4_discovery/temperature_ltc2984/project.xml
+++ b/examples/stm32f4_discovery/temperature_ltc2984/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/temperature_ltc2984</option>
   </options>

--- a/examples/stm32f4_discovery/timer/project.xml
+++ b/examples/stm32f4_discovery/timer/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/timer</option>
     <option name="modm:ui:led:gamma">2.2,2.0</option>

--- a/examples/stm32f4_discovery/timer_test/project.xml
+++ b/examples/stm32f4_discovery/timer_test/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/timer_test</option>
   </options>

--- a/examples/stm32f4_discovery/uart/project.xml
+++ b/examples/stm32f4_discovery/uart/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/uart</option>
   </options>

--- a/examples/stm32f4_discovery/uart_spi/project.xml
+++ b/examples/stm32f4_discovery/uart_spi/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/uart_spi</option>
   </options>

--- a/examples/stm32f746g_discovery/adc_ad7928/project.xml
+++ b/examples/stm32f746g_discovery/adc_ad7928/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f746ng</extends>
+  <extends>modm:disco-f746ng</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f746g_discovery/adc_ad7928</option>
   </options>

--- a/examples/stm32f746g_discovery/blink/project.xml
+++ b/examples/stm32f746g_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f746ng</extends>
+  <extends>modm:disco-f746ng</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f746g_discovery/blink</option>
   </options>

--- a/examples/stm32f746g_discovery/tmp102/project.xml
+++ b/examples/stm32f746g_discovery/tmp102/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f746ng</extends>
+  <extends>modm:disco-f746ng</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f746g_discovery/tmp102</option>
   </options>

--- a/examples/stm32f769i_discovery/blink/project.xml
+++ b/examples/stm32f769i_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f769ni</extends>
+  <extends>modm:disco-f769ni</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f769i_discovery/blink</option>
   </options>

--- a/examples/stm32l476_discovery/blink/project.xml
+++ b/examples/stm32l476_discovery/blink/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-l476vg</extends>
+  <extends>modm:disco-l476vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32l476_discovery/blink</option>
   </options>

--- a/examples/zmq/1_stm32/project.xml
+++ b/examples/zmq/1_stm32/project.xml
@@ -1,5 +1,5 @@
 <library>
-  <extends>modm:board:disco-f407vg</extends>
+  <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/zmq/1_stm32</option>
     <option name="modm:communication:xpcc:generator:source">../../xpcc/xml/communication.xml</option>

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -72,19 +72,19 @@ def build(env):
 
 
 # ============================ Option Descriptions ============================
-globals()["descr_unaligned_data"] = """# Allow unaligned data storage
+descr_unaligned_data = """# Allow unaligned data storage
 
 If the core supports it, this options enables storing data in unaligned memory.
 This may reduce data size, but cost some speed.
 """
 
-globals()["descr_matrix_sizes"] = """# Check input/output matrix size
+descr_matrix_sizes = """# Check input/output matrix size
 
 Check the input and output sizes of matrices and return
 `ARM_MATH_SIZE_MISMATCH` on failure.
 """
 
-globals()["descr_round_floats"] = """# Round float inputs
+descr_round_floats = """# Round float inputs
 
 Rounds float inputs properly during all conversions.
 """

--- a/repo.lb
+++ b/repo.lb
@@ -34,7 +34,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.7.0"
+min_lbuild_version = "1.7.1"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))
@@ -169,8 +169,13 @@ def init(repo):
 
     # Add the board configuration files as their module name aliases
     for config in Path(repopath("src/modm/board")).glob("*/board.xml"):
-        name = re.search("<module>(modm:board:.*?)</module>", config.read_text()).group(1).replace("modm:", "")
-        repo.add_configuration(name, config)
+        name = re.search(r"<module>modm:board:(.*?)</module>", config.read_text()).group(1)
+        if (config.parent / "module.md").exists():
+            description = FileReader(str(config.parent / "module.md"))
+        else:
+            description = re.search(r'\.description += +""?"?\\?(.*?)""?"?', (config.parent / "module.lb").read_text(), flags=re.S|re.M)
+            description = description.group(1) if description else None
+        repo.add_configuration(name, config, description)
 
     # Add Jinja2 filters commonly used in this repository
     def windowsify(path):

--- a/repo.lb
+++ b/repo.lb
@@ -34,7 +34,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.6.0"
+min_lbuild_version = "1.7.0"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))

--- a/src/modm/processing/resumable/module.lb
+++ b/src/modm/processing/resumable/module.lb
@@ -36,7 +36,7 @@ def build(env):
 
 
 # ============================ Option Descriptions ============================
-globals()["descr_nesting_depth"] = """# Check nesting call depth
+descr_nesting_depth = """# Check nesting call depth
 
 Nested resumable functions protect against memory corruption by checking if the
 nesting level is within the allocated nesting level depth, on first entry to

--- a/test/config/al-avreb-can.xml
+++ b/test/config/al-avreb-can.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>modm:board:al-avreb-can</extends>
+  <extends>modm:al-avreb-can</extends>
   <options>
     <!-- <option name="modm:build:avrdude.programmer">avrispmkII</option> -->
     <option name="modm:build:avrdude.programmer">usbasp-clone</option>

--- a/test/config/nucleo-f103.xml
+++ b/test/config/nucleo-f103.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>modm:board:nucleo-f103rb</extends>
+  <extends>modm:nucleo-f103rb</extends>
   <modules>
     <!-- Not everything fits -->
     <!-- <module>modm-test:test:architecture</module>

--- a/test/config/nucleo-f401.xml
+++ b/test/config/nucleo-f401.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>modm:board:nucleo-f401re</extends>
+  <extends>modm:nucleo-f401re</extends>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/test/config/nucleo-f411.xml
+++ b/test/config/nucleo-f411.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
-  <extends>modm:board:nucleo-f411re</extends>
+  <extends>modm:nucleo-f411re</extends>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -12,9 +12,6 @@
 
 import os
 from os.path import join
-# import all common code
-with open(localpath("../common.py")) as common:
-    exec(common.read())
 
 def init(module):
     module.parent = "build"
@@ -43,13 +40,13 @@ def build(env):
 def post_build(env, buildlog):
     target = env["modm:target"]
     # get CPU information
-    subs = common_target(target)
+    subs = env.query("::device")
     # Extract all source code files
-    subs["sources"] = sorted(p for sources in common_source_files(env, buildlog).values() for p in sources)
+    subs["sources"] = sorted(p for sources in env.query("::source_files")(buildlog).values() for p in sources)
     # get memory information
-    subs["memories"] = common_memories(target)
+    subs["memories"] = env.query("::memories")
     # get memory information
-    subs["flags"] = common_metadata_flags(buildlog.repo_metadata, "modm")
+    subs["flags"] = env.query("::metadata_flags")(buildlog, "modm")
 
     # Add SCons specific data
     subs.update({

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -81,7 +81,7 @@ def post_build(env, buildlog):
         env.template("resources/Makefile.in", "Makefile")
 
 # ============================ Option Descriptions ============================
-globals()["descr_include_makefile"] = """# Generate a wrapper Makefile
+descr_include_makefile = """# Generate a wrapper Makefile
 
 !!! warning "This overwrites any top-level `Makefile` file!"
 """

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -90,7 +90,7 @@ def post_build(env, buildlog):
 
 
 # ============================ Option Descriptions ============================
-globals()["descr_project_name"] = """# Project Name
+descr_project_name = """# Project Name
 
 The project name defaults to the folder name you're calling lbuild from.
 
@@ -98,7 +98,7 @@ It's used by your build system to name the executable and it may also be passed
 to your application via a string constant or CPP define.
 """
 
-globals()["descr_build_path"] = """# Build Path
+descr_build_path = """# Build Path
 
 The build path is defaulted to `build/{modm:build:project.name}`.
 
@@ -110,7 +110,7 @@ You should use a relative path instead of an absolute one, so that this option
 still works for other developers.
 """
 
-globals()["descr_openocd_cfg"] = """# Path to a custom OpenOCD configuration file
+descr_openocd_cfg = """# Path to a custom OpenOCD configuration file
 
 If you have a custom configuration file for your target, it will get included
 by the generated `modm/openocd.cfg`.

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -55,6 +55,17 @@ def prepare(module, options):
             StringOption(name="openocd.cfg", default="",
                          description=descr_openocd_cfg))
 
+    module.add_query(
+        Query(name="source_files", function=common_source_files))
+    module.add_query(
+        EnvironmentQuery(name="device", factory=common_target))
+    module.add_query(
+        EnvironmentQuery(name="memories", factory=common_memories))
+    module.add_query(
+        Query(name="metadata_flags", function=common_metadata_flags))
+    module.add_query(
+        Query(name="file_flags", function=common_file_flags))
+
     return True
 
 

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -175,23 +175,23 @@ def post_build(env, buildlog):
 
 
 # ============================ Option Descriptions ============================
-globals()["descr_include_sconstruct"] = """# Generate a SConstruct file
+descr_include_sconstruct = """# Generate a SConstruct file
 
 !!! warning "This overwrites any top-level `SConstruct` file!"
 """
 
-globals()["descr_cache_dir"] = """# Path to SConstruct CacheDir
+descr_cache_dir = """# Path to SConstruct CacheDir
 
 If value is `/cache`, the cache is placed into the top-level `build/` folder.
 You can disable CacheDir by setting an empty string.
 """
 
-globals()["descr_image_source"] = """# Path to directory containing .pbm files"""
+descr_image_source = """# Path to directory containing .pbm files"""
 
-globals()["descr_info_git"] = """# Generate git repository state information
+descr_info_git = """# Generate git repository state information
 
 - `Info`: generates information about the last commit.
 - `Info+Status`: like `Info` plus git file status.
 """
 
-globals()["descr_info_build"] = """# Generate build state information"""
+descr_info_build = """# Generate build state information"""

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -10,10 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-from os.path import join, relpath
-# import all common code
-with open(localpath("../common.py")) as common:
-    exec(common.read())
+from os.path import join, relpath, isdir
 
 def init(module):
     module.parent = "build"
@@ -73,12 +70,12 @@ def post_build(env, buildlog):
     is_unittest = env.has_module(":test")
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["image.source"])
-    repositories = [p for p in buildlog.repositories if os.path.isdir(env.outpath(p, basepath="."))]
+    repositories = [p for p in buildlog.repositories if isdir(env.outpath(p, basepath="."))]
     repositories = sorted(repositories, key=lambda name: "0" if name == "modm" else name)
 
     target = env["modm:target"]
-    subs = common_target(target)
-    sources = common_source_files(env, buildlog)
+    subs = env.query("::device")
+    sources = env.query("::source_files")(buildlog)
 
     build_tools = [
         "settings_buildpath",
@@ -111,7 +108,7 @@ def post_build(env, buildlog):
         if "build/" in cache_dir:
             cache_dir = "{}build/cache".format(cache_dir.split("build/")[0])
     # get memory information
-    subs["memories"] = common_memories(target)
+    subs["memories"] = env.query("::memories")
     # Add SCons specific data
     subs.update({
         "metadata": buildlog.metadata,
@@ -134,6 +131,8 @@ def post_build(env, buildlog):
     # Set these substitutions for all templates
     env.substitutions = subs
 
+    common_file_flags = env.query("::file_flags")
+    common_metadata_flags = env.query("::metadata_flags")
     for repo in repositories:
         files = []
         for f in sources[repo]:
@@ -145,7 +144,7 @@ def post_build(env, buildlog):
 
         subs.update({
             "repo": repo,
-            "flags": common_metadata_flags(buildlog.repo_metadata, repo),
+            "flags": common_metadata_flags(buildlog, repo),
             "sources": files,
             "libraries": buildlog.repo_metadata["required_library"][repo],
             "library_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["required_library_path"][repo]],


### PR DESCRIPTION
This uses lbuild queries to share code and data within the build script generators using lbuild queries.
You can discover them with `lbuild discover -n modm:build --developer`.

In addition, repository configuration aliases are now also `lbuild discover`-able, however, due to my own stupidity, I prefixed each name with `board:`, thus putting the board separator `:` in the name, which breaks path resolution in lbuild. This is now being checked in v1.7.1, however, it is now necessary to remove the `:` from the alias' names, thus this is a breaking change. Sorry.

```
 $ lbuild discover
Parser(lbuild)
╰── Repository(modm @ .)   modm: a barebone embedded library generator
    ├── EnumerationOption(target) = REQUIRED in [...]
    ├── Configuration(modm:al-avreb-can)   AL-AVREB_CAN Board
    ├── Configuration(modm:arduino-uno)   Arduino UNO
    ├── Configuration(modm:black-pill)   Black Pill
    ├── Configuration(modm:blue-pill)   Blue Pill
    ├── Configuration(modm:disco-f051r8)   STM32F0DISCOVERY
    ├── Configuration(modm:disco-f072rb)   STM32F072DISCOVERY
    ├── Configuration(modm:disco-f100rb)   STM32VLDISCOVERY
    ├── Configuration(modm:disco-f303vc)   STM32F3DISCOVERY
    ├── Configuration(modm:disco-f407vg)   STM32F4DISCOVERY
    ├── Configuration(modm:disco-f429zi)   STM32F429IDISCOVERY
    ├── Configuration(modm:disco-f469ni)   STM32F469IDISCOVERY
    ├── Configuration(modm:disco-f746ng)   STM32F7DISCOVERY
    ├── Configuration(modm:disco-f769ni)   STM32F769IDISCOVERY
    ├── Configuration(modm:disco-l476vg)   STM32L476DISCOVERY
    ├── Configuration(modm:nucleo-f031k6)   NUCLEO-F031K6
    ├── Configuration(modm:nucleo-f042k6)   NUCLEO-F042K6
    ├── Configuration(modm:nucleo-f103rb)   NUCLEO-F103RB
    ├── Configuration(modm:nucleo-f303k8)   NUCLEO-F303K8
    ├── Configuration(modm:nucleo-f401re)   NUCLEO-F401RE
    ├── Configuration(modm:nucleo-f411re)   NUCLEO-F411RE
    ├── Configuration(modm:nucleo-f429zi)   NUCLEO-F429ZI
    ├── Configuration(modm:nucleo-g071rb)   NUCLEO-F042K6
    ├── Configuration(modm:nucleo-l432kc)   NUCLEO-L432KC
    ├── Configuration(modm:nucleo-l476rg)   NUCLEO-L476RG
    ├── Configuration(modm:olimexino-stm32)   Olimexino STM32
    ╰── Configuration(modm:stm32f030_demo)   STM32F030 Demo Board
```

cc @strongly-typed @rleh @chris-durand 