### PR TITLE
Spi: remove incorrect assertions

### DIFF
--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
@@ -75,10 +75,6 @@ public:
 		using Sck = typename Connector::template GetSignal<Gpio::Signal::{{sck}}>;
 		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Mosi>;
 		using Miso = typename Connector::template GetSignal<Gpio::Signal::Miso>;
-		static_assert(Connector::template IsValid<Sck> and Connector::template IsValid<Mosi> and
-					  ((not Connector::template IsValid<Miso> and sizeof...(Signals) == 2) or
-					   (    Connector::template IsValid<Miso> and sizeof...(Signals) == 3)),
-					  "UartSpiMaster{{id}}::connect() requires one Sck and one Mosi and optionally one Miso signal!");
 
 		// Connector::disconnect();
 		Sck::setOutput(Gpio::OutputType::PushPull);

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
@@ -79,10 +79,6 @@ public:
 		using Sck = typename Connector::template GetSignal<Gpio::Signal::Sck>;
 		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Mosi>;
 		using Miso = typename Connector::template GetSignal<Gpio::Signal::Miso>;
-		static_assert(Connector::template IsValid<Sck> and Connector::template IsValid<Mosi> and
-					  ((not Connector::template IsValid<Miso> and sizeof...(Signals) == 2) or
-					   (    Connector::template IsValid<Miso> and sizeof...(Signals) == 3)),
-					  "UartSpiMaster{{id}}::connect() requires one Sck and one Mosi and optionally one Miso signal!");
 
 		// Connector::disconnect();
 		Sck::setOutput(Gpio::OutputType::PushPull);

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -70,10 +70,6 @@ public:
 		using Sck = typename Connector::template GetSignal<Gpio::Signal::Sck>;
 		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Mosi>;
 		using Miso = typename Connector::template GetSignal<Gpio::Signal::Miso>;
-		static_assert(Connector::template IsValid<Sck> and Connector::template IsValid<Mosi> and
-					  ((not Connector::template IsValid<Miso> and sizeof...(Signals) == 2) or
-					   (    Connector::template IsValid<Miso> and sizeof...(Signals) == 3)),
-					  "SpiMaster{{id}}::connect() requires one Sck and one Mosi and optionally one Miso signal!");
 
 		// Connector::disconnect();
 		Sck::setOutput(Gpio::OutputType::PushPull);

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
@@ -60,10 +60,6 @@ public:
 		using Sck = typename Connector::template GetSignal<Gpio::Signal::Ck>;
 		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Tx>;
 		using Miso = typename Connector::template GetSignal<Gpio::Signal::Rx>;
-		static_assert(Connector::template IsValid<Sck> and Connector::template IsValid<Mosi> and
-					  ((not Connector::template IsValid<Miso> and sizeof...(Signals) == 2) or
-					   (    Connector::template IsValid<Miso> and sizeof...(Signals) == 3)),
-					  "UartSpiMaster{{id}}::connect() requires one Ck and one Tx and optionally one Rx signal!");
 
 		// Connector::disconnect();
 		Sck::setOutput(Gpio::OutputType::PushPull);


### PR DESCRIPTION
These assumptions are incorrect, here are some use-cases for not connecting *all* SPI signals:
* only MO, no SCK: WS2812 accelerated bit-bang
* MI and SCK: read-in 74HC165
* MO and SCK: write-out 74HC595
* Some SPI-slaves have Open-Drain pins -> optional PullUp