### PR TITLE
Use type-safe lbuild collectors for build system generators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
             avr-g++ --version
             which arm-none-eabi-g++
             arm-none-eabi-g++ --version
+            which lbuild
+            lbuild --version
       - run:
           name: Hosted Unittests
           command: |

--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -31,4 +31,4 @@ def build(env):
     if "m0" not in core:
         env.copy("cmsis/CMSIS/Core/Include/mpu_armv7.h", "mpu_armv7.h")
 
-    env.add_metadata("include_path", "modm/ext/cmsis/core")
+    env.collect(":build:path.include", "modm/ext/cmsis/core")

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -44,31 +44,35 @@ def prepare(module, options):
 
 def build(env):
     metadata = defaultdict(list)
-    metadata["flags.cflags"].append("-fno-strict-aliasing")
+    metadata[":build:cflags"].append("-fno-strict-aliasing")
 
     core = env[":target"].get_driver("core")["type"]
     if "f" in core:
-        metadata["flags.cppdefines"].append("__FPU_PRESENT=1")
+        metadata[":build:cppdefines"].append("__FPU_PRESENT=1")
 
     core = core.replace("cortex-m", "CM").replace("+", "PLUS").replace("f", "").replace("d", "")
-    env.add_metadata("flags.cppdefines", "ARM_MATH_{}".format(core))
+    env.collect(":build:cppdefines", "ARM_MATH_{}".format(core))
 
     if env["check_matrix_sizes"]:
-        metadata["flags.cppdefines"].append("ARM_MATH_MATRIX_CHECK")
+        metadata[":build:cppdefines"].append("ARM_MATH_MATRIX_CHECK")
     else:
-        metadata["flags.cppdefines.debug"].append("ARM_MATH_MATRIX_CHECK")
+        metadata[":build:cppdefines.debug"].append("ARM_MATH_MATRIX_CHECK")
 
     if env["round_float_inputs"]:
-        metadata["flags.cppdefines"].append("ARM_MATH_ROUNDING")
+        metadata[":build:cppdefines"].append("ARM_MATH_ROUNDING")
 
     if not env.get("unaligned_data", False):
-        metadata["flags.cppdefines"].append("UNALIGNED_SUPPORT_DISABLE")
+        metadata[":build:cppdefines"].append("UNALIGNED_SUPPORT_DISABLE")
 
-    env.add_metadata("include_path", "modm/ext/cmsis/dsp")
+    env.collect(":build:path.include", "modm/ext/cmsis/dsp")
 
     env.outbasepath = "modm/ext/cmsis/dsp"
     env.copy("cmsis/CMSIS/DSP/Include", ".")
-    env.copy("cmsis/CMSIS/DSP/Source", ".", metadata=metadata)
+    operations = env.copy("cmsis/CMSIS/DSP/Source", ".")
+
+    # For all sources add these compile flags
+    for key, values in metadata.items():
+        env.collect(key, *values, operations=operations)
 
 
 # ============================ Option Descriptions ============================

--- a/ext/gcc/module.lb
+++ b/ext/gcc/module.lb
@@ -24,8 +24,7 @@ See https://github.com/modm-io/avr-libstdcpp.
 
 
 def prepare(module, options):
-    target = options[":target"].identifier
-    if target["platform"] != "avr":
+    if options[":target"].identifier.platform != "avr":
         return False
 
     module.add_option(
@@ -38,7 +37,7 @@ def prepare(module, options):
 
 
 def build(env):
-    env.add_metadata("include_path", "modm/ext/gcc/libstdc++/include")
+    env.collect(":build:path.include", "modm/ext/gcc/libstdc++/include")
 
     env.outbasepath = "modm/ext/gcc"
     env.copy(".", ignore=env.ignore_files("*.lb", "*.md", "*.in", "examples"))

--- a/ext/nxp/module.lb
+++ b/ext/nxp/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.add_metadata("include_path", "modm/ext/cmsis_device")
+    env.collect(":build:path.include", "modm/ext/cmsis_device")
 
     device = env[":target"]
 

--- a/ext/ros/module.lb
+++ b/ext/ros/module.lb
@@ -23,7 +23,7 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.add_metadata("include_path", "modm/ext/ros")
+    env.collect(":build:path.include", "modm/ext/ros")
 
     env.outbasepath = "modm/ext"
     env.copy("ros-lib/ros_lib", "ros")

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -104,8 +104,8 @@ def validate(env):
     })
 
 def build(env):
-    env.add_metadata("include_path", "modm/ext")
-    env.add_metadata("include_path", "modm/ext/cmsis/device")
+    env.collect(":build:path.include", "modm/ext")
+    env.collect(":build:path.include", "modm/ext/cmsis/device")
 
     env.outbasepath = "modm/ext/cmsis/device"
     env.copy(localpath(bprops["folder"], bprops["device_header"]), bprops["device_header"])

--- a/repo.lb
+++ b/repo.lb
@@ -34,7 +34,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.7.1"
+min_lbuild_version = "1.8.0"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))
@@ -205,4 +205,4 @@ def prepare(repo, options):
     repo.add_modules_recursive("tools", modulefile="*.lb")
 
 def build(env):
-    env.add_metadata("include_path", "modm/src")
+    env.collect(":build:path.include", "modm/src")

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -371,7 +371,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/architecture"
 
-    headers = env.get_generated_local_files(filterfunc=lambda path: re.match(r"interface/.*\.hpp", path))
+    headers = env.generated_local_files(filterfunc=lambda path: re.match(r"interface/.*\.hpp", path))
     env.template("interface.hpp.in", substitutions={"headers": sorted(headers)})
 
     env.copy("utils.hpp")

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -36,8 +36,8 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.copy('.')
-    env.add_metadata("avrdude.port", "usb");
-    env.add_metadata("avrdude.programmer", "avrispmkII");
-    env.add_metadata("avrdude.efuse", "0xff");
-    env.add_metadata("avrdude.hfuse", "0xd9");
-    env.add_metadata("avrdude.lfuse", "0xfe");
+    env.collect(":build:default.avrdude.port", "usb");
+    env.collect(":build:default.avrdude.programmer", "avrispmkII");
+    # env.collect(":build:default.avrdude.efuse", "0xff");
+    # env.collect(":build:default.avrdude.hfuse", "0xd9");
+    # env.collect(":build:default.avrdude.lfuse", "0xfe");

--- a/src/modm/board/arduino_uno/module.lb
+++ b/src/modm/board/arduino_uno/module.lb
@@ -33,5 +33,5 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.copy('.')
-    env.add_metadata("avrdude.programmer", "arduino");
-    env.add_metadata("avrdude.baudrate", "115200");
+    env.collect(":build:default.avrdude.programmer", "arduino");
+    env.collect(":build:default.avrdude.baudrate", "115200");

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -44,4 +44,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.add_metadata("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg");

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -44,4 +44,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.add_metadata("openocd.configfile", "modm/board/stm32f103_blue_pill.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg");

--- a/src/modm/board/disco_f051r8/module.lb
+++ b/src/modm/board/disco_f051r8/module.lb
@@ -38,4 +38,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f0discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f072rb/module.lb
+++ b/src/modm/board/disco_f072rb/module.lb
@@ -39,4 +39,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f0discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f0discovery.cfg");

--- a/src/modm/board/disco_f100rb/module.lb
+++ b/src/modm/board/disco_f100rb/module.lb
@@ -37,4 +37,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32vldiscovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32vldiscovery.cfg");

--- a/src/modm/board/disco_f303vc/module.lb
+++ b/src/modm/board/disco_f303vc/module.lb
@@ -40,4 +40,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f3discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f3discovery.cfg");

--- a/src/modm/board/disco_f407vg/module.lb
+++ b/src/modm/board/disco_f407vg/module.lb
@@ -40,4 +40,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f4discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f4discovery.cfg");

--- a/src/modm/board/disco_f429zi/module.lb
+++ b/src/modm/board/disco_f429zi/module.lb
@@ -39,4 +39,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f429discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f429discovery.cfg");

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -39,4 +39,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f469discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f469discovery.cfg");

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -39,4 +39,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f7discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_f769ni/module.lb
+++ b/src/modm/board/disco_f769ni/module.lb
@@ -39,4 +39,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32f7discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32f7discovery.cfg");

--- a/src/modm/board/disco_l476vg/module.lb
+++ b/src/modm/board/disco_l476vg/module.lb
@@ -33,4 +33,4 @@ def build(env):
     env.substitutions = {"board_has_logger": False}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_f031k6/module.lb
+++ b/src/modm/board/nucleo_f031k6/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f0.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -36,4 +36,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f0.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f0.cfg");

--- a/src/modm/board/nucleo_f103rb/module.lb
+++ b/src/modm/board/nucleo_f103rb/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f103rb.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/nucleo_f303k8/module.lb
+++ b/src/modm/board/nucleo_f303k8/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo32_arduino.hpp", "nucleo32_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f3.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f3.cfg");

--- a/src/modm/board/nucleo_f401re/module.lb
+++ b/src/modm/board/nucleo_f401re/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f411re/module.lb
+++ b/src/modm/board/nucleo_f411re/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f429zi/module.lb
+++ b/src/modm/board/nucleo_f429zi/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f4.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_l432kc/module.lb
+++ b/src/modm/board/nucleo_l432kc/module.lb
@@ -34,4 +34,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32l4discovery.cfg");

--- a/src/modm/board/nucleo_l476rg/module.lb
+++ b/src/modm/board/nucleo_l476rg/module.lb
@@ -35,4 +35,4 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
-    env.add_metadata("openocd.configfile", "board/stm32l4discovery.cfg");
+    env.collect(":build:openocd.source", "board/stm32l4discovery.cfg");

--- a/src/modm/board/olimexino_stm32/module.lb
+++ b/src/modm/board/olimexino_stm32/module.lb
@@ -34,4 +34,4 @@ def build(env):
     env.substitutions = {"board_has_logger": True}
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
-    env.add_metadata("openocd.configfile", "board/st_nucleo_f103rb.cfg");
+    env.collect(":build:openocd.source", "board/st_nucleo_f103rb.cfg");

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -44,4 +44,4 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f030_demo_board.cfg"), "stm32f030_demo_board.cfg")
-    env.add_metadata("openocd.configfile", "modm/board/stm32f030_demo_board.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f030_demo_board.cfg");

--- a/src/modm/communication/xpcc/module.lb
+++ b/src/modm/communication/xpcc/module.lb
@@ -50,11 +50,11 @@ def build(env):
         ignore.append("*postman/dynamic*")
 
     if env[":target"].identifier["platform"] in ["hosted"]:
-        env.add_metadata("required_library", "zmqpp")
-        env.add_metadata("required_library", "zmq")
+        env.collect(":build:library", "zmqpp")
+        env.collect(":build:library", "zmq")
 
         if env[":target"].identifier["family"] in ["linux"]:
-            env.add_metadata("required_library", "pthread")
+            env.collect(":build:library", "pthread")
     else:
         ignore.append("*backend/zeromq*")
 

--- a/src/modm/communication/xpcc/module.lb
+++ b/src/modm/communication/xpcc/module.lb
@@ -58,6 +58,6 @@ def build(env):
     else:
         ignore.append("*backend/zeromq*")
 
-    env.copy(".", ignore=env.ignore_patterns(*ignore))
+    env.copy(".", ignore=env.ignore_paths(*ignore))
     env.copy("../xpcc.hpp")
     env.template("dispatcher.hpp.in")

--- a/src/modm/debug/module.lb
+++ b/src/modm/debug/module.lb
@@ -38,7 +38,7 @@ def build(env):
     if target["platform"] != "hosted":
         ignore_patterns.append("*logger/hosted/*")
 
-    env.copy(".", ignore=env.ignore_patterns(*ignore_patterns))
+    env.copy(".", ignore=env.ignore_paths(*ignore_patterns))
 
     env.outbasepath = "modm/src/modm"
     env.copy("debug.hpp")

--- a/src/modm/driver/display/sdl_display.lb
+++ b/src/modm/driver/display/sdl_display.lb
@@ -24,9 +24,9 @@ def prepare(module, options):
     return True
 
 def build(env):
-    env.add_metadata("required_pkg", "gtkmm-2.4")
-    env.add_metadata("required_pkg", "cairomm-1.0")
-    env.add_metadata("required_pkg", "sdl")
+    env.collect(":build:pkg-config", "gtkmm-2.4")
+    env.collect(":build:pkg-config", "cairomm-1.0")
+    env.collect(":build:pkg-config", "sdl")
 
     env.outbasepath = "modm/src/modm/driver/display"
     env.copy("sdl_display.hpp")

--- a/src/modm/math/math.lb
+++ b/src/modm/math/math.lb
@@ -23,5 +23,5 @@ def build(env):
     env.copy("tolerance.hpp")
 
     env.outbasepath = "modm/src/modm"
-    headers = env.get_generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
+    headers = env.generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
     env.template("math.hpp.in", substitutions={"headers": sorted(headers)})

--- a/src/modm/math/utils/module.lb
+++ b/src/modm/math/utils/module.lb
@@ -30,5 +30,5 @@ def build(env):
         ignore.append("*avr*")
         env.copy("operator_impl.hpp")
 
-    env.copy('.', ignore=env.ignore_patterns(*ignore))
+    env.copy('.', ignore=env.ignore_paths(*ignore))
     env.copy("../utils.hpp")

--- a/src/modm/platform/can/canusb/module.lb
+++ b/src/modm/platform/can/canusb/module.lb
@@ -42,7 +42,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/platform/can"
 
     if env[":target"].partname == "hosted-linux":
-        env.add_metadata("required_library", "pthread")
+        env.collect(":build:library", "pthread")
 
     env.copy("canusb.hpp")
     env.copy("canusb_impl.hpp")

--- a/src/modm/platform/clock/avr/module.lb
+++ b/src/modm/platform/clock/avr/module.lb
@@ -35,7 +35,7 @@ def prepare(module, options):
 def build(env):
     device = env[":target"]
     driver = device.get_driver("clock")
-    env.add_metadata("flags.cppdefines", "F_CPU={}".format(env["f_cpu"]))
+    env.collect(":build:cppdefines", "F_CPU={}".format(env["f_cpu"]))
 
     properties = device.properties
     properties["target"] = target = device.identifier

--- a/src/modm/platform/clock/cortex/module.lb
+++ b/src/modm/platform/clock/cortex/module.lb
@@ -37,7 +37,7 @@ def build(env):
     properties["target"] = target = device.identifier
     properties["driver"] = driver
     properties["core"] = driver["type"]
-    properties["systick_frequency"] = int(env.get_option(":freertos:frequency", 1000))
+    properties["systick_frequency"] = int(env.get(":freertos:frequency", 1000))
     if (properties["systick_frequency"] % 1000 != 0):
         raise BuildException("SysTick frequency must be a multiple of 1000Hz!")
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -105,7 +105,7 @@ def build(env):
     properties["vector_table_location"] = env.get("vector_table_location", "rom")
     properties["core"] = driver["type"]
     properties["process_stack_size"] = 0
-    if env.get_option(":platform:fault.cortex:led", None):
+    if env.get(":platform:fault.cortex:led", None):
         properties["process_stack_size"] = 32
 
     # Add ARM Cortex-M exceptions

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -139,12 +139,12 @@ def prepare(module, options):
     bprops["ranges"] = port_ranges(device.get_driver("gpio")["gpio"])
     bprops["ports"] = OrderedDict([(k, i) for i, k in enumerate([p["name"] for p in bprops["ranges"]])])
 
-    module.add_option(
-        SetOption(
+    module.add_set_option(
+        EnumerationOption(
             name="enable_ports",
             description="Enable clock for these GPIO ports during startup",
-            enumeration=list(bprops["ports"].keys()),
-            default=list(bprops["ports"].keys())))
+            enumeration=list(bprops["ports"].keys())),
+        default=list(bprops["ports"].keys()))
 
     module.depends(
         ":architecture:gpio",

--- a/src/modm/platform/module.lb
+++ b/src/modm/platform/module.lb
@@ -26,5 +26,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm"
-    headers = env.get_generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
+    headers = env.generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
     env.template("platform.hpp.in", substitutions={"headers": sorted(headers)})

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -45,12 +45,12 @@ def build(env):
     if env[":target"].identifier["family"] == "windows":
         ignore.extend(["*/serial_interface*", "*/serial_port*"])
 
-    env.add_metadata("required_library", "boost_system")
-    env.add_metadata("required_library",
+    env.collect(":build:library", "boost_system")
+    env.collect(":build:library",
         "boost_thread" if env[":target"].identifier["family"] == "linux" else
         "boost_thread-mt")
 
     if env[":target"].identifier["family"] == "linux":
-        env.add_metadata("required_library", "pthread")
+        env.collect(":build:library", "pthread")
 
     env.copy(".", ignore=env.ignore_patterns(*ignore))

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -53,4 +53,4 @@ def build(env):
     if env[":target"].identifier["family"] == "linux":
         env.collect(":build:library", "pthread")
 
-    env.copy(".", ignore=env.ignore_patterns(*ignore))
+    env.copy(".", ignore=env.ignore_paths(*ignore))

--- a/src/modm/processing/module.lb
+++ b/src/modm/processing/module.lb
@@ -28,5 +28,5 @@ def build(env):
     env.copy("task.hpp")
 
     env.outbasepath = "modm/src/modm"
-    headers = env.get_generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
+    headers = env.generated_local_files(filterfunc=lambda path: ".h" in path and not "_impl.h" in path)
     env.template("processing.hpp.in", substitutions={"headers": sorted(headers)})

--- a/src/modm/processing/resumable/module.lb
+++ b/src/modm/processing/resumable/module.lb
@@ -30,7 +30,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/resumable"
-    env.copy(".", ignore=env.ignore_patterns("*.md", "*.in"))
+    env.copy(".", ignore=env.ignore_files("*.md", "*.in"))
     env.copy("../resumable.hpp")
     env.template("nested_resumable.hpp.in")
 

--- a/src/modm/processing/rtos/module.lb
+++ b/src/modm/processing/rtos/module.lb
@@ -37,7 +37,7 @@ def build(env):
     elif env[":target"].identifier["platform"] in ["hosted"]:
         env.copy("stdlib", "rtos")
         if env[":target"].identifier["family"] in ["linux"]:
-            env.add_metadata("required_library", "pthread")
+            env.collect(":build:library", "pthread")
     else:
         raise BuildException("No RTOS implementation matches your requirements!")
     env.copy("../rtos.hpp", "rtos.hpp")

--- a/src/modm/ui/display/module.lb
+++ b/src/modm/ui/display/module.lb
@@ -50,5 +50,5 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/ui/display"
-    env.copy(".", ignore=env.ignore_patterns("*.font", "*.pbm"))
+    env.copy(".", ignore=env.ignore_files("*.font", "*.pbm"))
     env.copy("../display.hpp")

--- a/src/modm/ui/led/module.lb
+++ b/src/modm/ui/led/module.lb
@@ -19,24 +19,27 @@ def init(module):
 
 def prepare(module, options):
 
-    module.add_option(
-        SetOption(
+    module.add_set_option(
+        NumericOption(
             name="gamma",
             description="Gamma correction of values",
-            enumeration=[1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5],
-            default=2.2))
-    module.add_option(
-        SetOption(
+            minimum=1.0,
+            maximum=3.0),
+        default=2.2)
+    module.add_set_option(
+        NumericOption(
             name="bit",
             description="Resolution of target values",
-            enumeration=[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-            default=[7, 8, 10, 12, 16]))
-    module.add_option(
-        SetOption(
+            minimum=2,
+            maximum=16),
+        default=[7, 8, 12, 16])
+    module.add_set_option(
+        NumericOption(
             name="range",
             description="Range of input values",
-            enumeration=[10, 16, 20, 32, 50, 64, 100, 128, 200, 256, 500, 512, 1000, 1024],
-            default=256))
+            minimum=2,
+            maximum=1024),
+        default=256)
 
     module.depends(
         ":architecture:accessor",

--- a/test/module.lb
+++ b/test/module.lb
@@ -24,7 +24,7 @@ def prepare(module, options):
 def build(env):
     env.outbasepath = "modm-test/src"
 
-    env.add_metadata("include_path", "modm-test/src")
+    env.collect(":build:path.include", "modm-test/src")
 
     platform = env[":target"].identifier["platform"]
     if platform in ["hosted"]:

--- a/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake.in
+++ b/tools/build_script_generator/cmake/cmake_scripts/configure-stm32-gcc.cmake.in
@@ -47,7 +47,7 @@ CONFIGURE_FILE(modm/link/${LINKER_SCRIPT_NAME} ${LINKER_SCRIPT})
 
 # Toolchain configuration
 %% macro generate_flags_for_profile(name, profile, suffix="")
-SET({{name}}{{ "_" ~ (suffix | upper) if suffix | length else "" }} "\
+SET({{ name | upper }}{{ "_" ~ (suffix | upper) if suffix | length else "" }} "\
 %% for flag in flags[name][profile] | sort
     {{ flag | flag_format }} \
 %% endfor
@@ -63,12 +63,12 @@ SET({{name}}{{ "_" ~ (suffix | upper) if suffix | length else "" }} "\
 %% endfor
 %% endmacro
 
-{{ generate_flags("CCFLAGS") }}
-{{ generate_flags("CFLAGS") }}
-{{ generate_flags("CXXFLAGS") }}
-{{ generate_flags("ASFLAGS") }}
-{{ generate_flags("ARCHFLAGS") }}
-{{ generate_flags("LINKFLAGS") }}
+{{ generate_flags("ccflags") }}
+{{ generate_flags("cflags") }}
+{{ generate_flags("cxxflags") }}
+{{ generate_flags("asflags") }}
+{{ generate_flags("archflags") }}
+{{ generate_flags("linkflags") }}
 
 # Set flags for CMake
 SET(CMAKE_C_FLAGS "${ARCHFLAGS} ${CCFLAGS} ${CFLAGS}" CACHE INTERNAL "c compiler flags")

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -38,12 +38,12 @@ def build(env):
     env.collect("::elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
 
 
-def post_build(env, buildlog):
+def post_build(env):
     target = env["modm:target"]
     # get CPU information
     subs = env.query("::device")
     # Extract all source code files
-    subs["sources"] = sorted(p for sources in env.query("::source_files")(buildlog).values() for p in sources)
+    subs["sources"] = sorted(p for sources in env.query("::source_files").values() for p in sources)
     # get memory information
     subs["memories"] = env.query("::memories")
     # get generic build flags information

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2018, Sergiy Yevtushenko
+# Copyright (c) 2018-2019, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -33,8 +34,8 @@ def prepare(module, options):
 def build(env):
     project_name = env[":build:project.name"]
     build_path = env[":build:build.path"]
-    env.add_metadata("elf.release", join(build_path, "cmake-build-release", project_name + ".elf"))
-    env.add_metadata("elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
+    env.collect("::elf.release", join(build_path, "cmake-build-release", project_name + ".elf"))
+    env.collect("::elf.debug",   join(build_path, "cmake-build-debug",   project_name + ".elf"))
 
 
 def post_build(env, buildlog):
@@ -45,16 +46,16 @@ def post_build(env, buildlog):
     subs["sources"] = sorted(p for sources in env.query("::source_files")(buildlog).values() for p in sources)
     # get memory information
     subs["memories"] = env.query("::memories")
-    # get memory information
-    subs["flags"] = env.query("::metadata_flags")(buildlog, "modm")
+    # get generic build flags information
+    subs["flags"] = env.query("::collect_flags")(env)[None]
 
     # Add SCons specific data
     subs.update({
         "project_path": os.getcwd(),
-        "metadata": buildlog.metadata,
         "compiler": "gcc",
         "project_name": env[":build:project.name"],
         "build_path": env[":build:build.path"],
+        "include_paths": env.collector_values(":build:path.include"),
     })
     # Set these substitutions for all templates
     env.substitutions = subs

--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -14,7 +14,7 @@ SET_SOURCE_FILES_PROPERTIES(${APP_STARTUP} PROPERTIES LANGUAGE CXX)
 FILE(GLOB APP_SOURCE_FILES *.c *.cpp *.hpp *.h)
 
 SET(SOURCE_FILES
-%% for file in sources
+%% for file in sources | sort
     {{ file }}
 %% endfor
     ${APP_SOURCE_FILES}
@@ -22,7 +22,7 @@ SET(SOURCE_FILES
 
 INCLUDE_DIRECTORIES(
     ${CMAKE_CURRENT_SOURCE_DIR}
-%% for path in metadata.include_path
+%% for path in include_paths | sort
     {{ path }}
 %% endfor
 )
@@ -46,12 +46,12 @@ endif ()
 ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} ${SOURCE_FILES})
 SET_TARGET_PROPERTIES(${CMAKE_PROJECT_NAME} PROPERTIES SUFFIX ".elf")
 
-%% for define in flags["CPPDEFINES"][""]
+%% for define in flags["cppdefines"][""]
 TARGET_COMPILE_DEFINITIONS(${CMAKE_PROJECT_NAME} PUBLIC "{{ define }}")
 %% endfor
-%% if flags["CPPDEFINES"]["debug"] | length
+%% if flags["cppdefines"]["debug"] | length
 IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
-%% for define in flags["CPPDEFINES"]["debug"]
+%% for define in flags["cppdefines"]["debug"]
 	TARGET_COMPILE_DEFINITIONS(${CMAKE_PROJECT_NAME} PUBLIC "{{ define }}")
 %% endfor
 ENDIF()

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -35,7 +35,7 @@ common_build_flag_names = [
             for profile in ([""] + ["."+p for p in common_build_profiles])
 ]
 
-def common_source_files(buildlog):
+def common_source_files(env):
     """
     Builds a list of files that need to be compiled per repository.
 
@@ -44,13 +44,9 @@ def common_source_files(buildlog):
     """
     files_to_build = defaultdict(list)
 
-    for operation in buildlog:
-        repo = operation.module_name.split(":")[0]
-        filename = operation.local_filename_out()
-        _, extension = os.path.splitext(filename)
-
-        if extension in [".c", ".cpp", ".cc", ".sx", ".S"]:
-            files_to_build[repo].append(filename.replace('\\','\\\\')) #windows path compatibility hack
+    for operation in env.buildlog:
+        if os.path.splitext(operation.filename)[-1] in [".c", ".cpp", ".cc", ".sx", ".S"]:
+            files_to_build[operation.repository].append(operation.filename)
 
     for repo in files_to_build:
         files_to_build[repo].sort()

--- a/tools/build_script_generator/gdbinit.in
+++ b/tools/build_script_generator/gdbinit.in
@@ -1,10 +1,8 @@
-%% for profile in ["release", "debug"]
-%% if "elf." ~ profile in metadata
+%% for profile, path in elf_files.items()
 define file_{{profile}}
     file
-    file {{ metadata["elf." ~ profile][0] | modm.windowsify }}
+    file {{ path | modm.windowsify }}
 end
-%% endif
 %% endfor
 
 layout split

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -26,7 +26,9 @@ def prepare(module, options):
     _, default_project_name = os.path.split(os.getcwd())
     default_project_name = default_project_name.replace(".", "_").replace(" ", "_")
     platform = options[":target"].identifier["platform"]
+    is_cortex_m = options[":target"].has_driver("core:cortex-m*")
 
+    # Options
     module.add_option(
         StringOption(name="project.name", default=default_project_name,
                      description=descr_project_name))
@@ -50,11 +52,12 @@ def prepare(module, options):
             StringOption(name="avrdude.options", default="",
                          description="AvrDude programmer options"))
 
-    if options[":target"].has_driver("core:cortex-m*"):
+    elif is_cortex_m:
         module.add_option(
             StringOption(name="openocd.cfg", default="",
                          description=descr_openocd_cfg))
 
+    # Queries
     module.add_query(
         Query(name="source_files", function=common_source_files))
     module.add_query(
@@ -62,9 +65,60 @@ def prepare(module, options):
     module.add_query(
         EnvironmentQuery(name="memories", factory=common_memories))
     module.add_query(
-        Query(name="metadata_flags", function=common_metadata_flags))
-    module.add_query(
-        Query(name="file_flags", function=common_file_flags))
+        Query(name="collect_flags", function=common_collect_flags_for_scope))
+
+    # Collections
+    module.add_collector(
+        PathCollector(name="path.include",
+                      description="Search path for header files"))
+    module.add_collector(
+        PathCollector(name="path.library",
+                      description="Search path for static libraries"))
+    module.add_collector(
+        StringCollector(name="library",
+                        description="Libraries to link against"))
+    module.add_collector(
+        StringCollector(name="pkg-config",
+                        description="Packages to configure against"))
+
+    module.add_collector(
+        PathCollector(name="elf.release",
+                      description="Path to the compiled .elf file for the release profile"))
+    module.add_collector(
+        PathCollector(name="elf.debug",
+                      description="Path to the compiled .elf file for the debug profile"))
+    module.add_collector(
+        PathCollector(name="gitignore",
+                      description="Generated files that need to be ignored by Git"))
+
+    if is_cortex_m:
+        module.add_collector(
+            PathCollector(name="openocd.source",
+                          description="Additional OpenOCD source files."))
+        module.add_collector(
+            PathCollector(name="path.openocd",
+                          description="Search path for OpenOCD configuration files"))
+
+    elif platform in ["avr"]:
+        module.add_collector(
+            StringCollector(name="default.avrdude.programmer",
+                            description="Default AvrDude programmer"))
+        module.add_collector(
+            NumericCollector(name="default.avrdude.baudrate", minimum=0,
+                             description="Default AvrDude baudrate"))
+        module.add_collector(
+            StringCollector(name="default.avrdude.port",
+                            description="Default AvrDude port"))
+
+    # Compile flag collectors
+    def flag_validate(flag):
+        if not flag.startswith("-"):
+            raise ValueError("Flag '{}' must start with '-'!".format(flag))
+        return flag
+    for name in common_build_flag_names:
+        module.add_collector(
+            StringCollector(name=name, description=None,
+                            validate=flag_validate if "flags" in name else None))
 
     return True
 
@@ -73,29 +127,37 @@ def build(env):
     # Append custom openocd config file to metadata
     openocd_cfg = env.get_option(":build:openocd.cfg", "")
     if len(openocd_cfg):
-        env.add_metadata("openocd.configfile", openocd_cfg)
+        env.collect(":build:openocd.source", openocd_cfg)
 
     # Append common search paths to metadata
-    env.add_metadata("openocd.search", "modm/openocd")
+    if env.has_collector(":build:path.openocd"):
+        env.collect(":build:path.openocd", "modm/openocd")
 
     # Add compiler flags to metadata
     for flag, values in common_compiler_flags("gcc", env[":target"]).items():
-        env.add_metadata(flag, *values)
+        env.collect(flag, *values)
 
 
 def post_build(env, buildlog):
     target = env[":target"]
+    gitignore = [env.reloutpath(ignore, "modm") for ignore in
+                 env.collector_values("gitignore", filterfunc=lambda s: s.repository == "modm")]
+    elf_files = {
+        "release": env.collector_values("elf.release")[0],
+        "debug": env.collector_values("elf.debug")[0],
+    }
+
     env.substitutions = {
-        "metadata": buildlog.metadata,
-        "gitignore": [env.reloutpath(i, "modm") for i in buildlog.repo_metadata["gitignore"]["modm"]],
+        "gitignore": gitignore,
+        "elf_files": elf_files,
     }
     env.outbasepath = "modm"
 
     # Currently a modm only feature
-    if len(env.substitutions["gitignore"]):
+    if len(gitignore):
         env.template("gitignore.in", ".gitignore")
 
-    if env[":target"].has_driver("core:cortex-m*"):
+    if target.has_driver("core:cortex-m*"):
         env.template("openocd.cfg.in")
         env.template("gdbinit.in")
 

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -33,8 +33,8 @@ def prepare(module, options):
         StringOption(name="project.name", default=default_project_name,
                      description=descr_project_name))
     module.add_option(
-        StringOption(name="build.path", default="build/"+default_project_name,
-                     description=descr_build_path))
+        PathOption(name="build.path", default="build/"+default_project_name,
+                   description=descr_build_path))
 
     if platform in ["avr"]:
         # we need the clock:f_cpu option!
@@ -54,8 +54,8 @@ def prepare(module, options):
 
     elif is_cortex_m:
         module.add_option(
-            StringOption(name="openocd.cfg", default="",
-                         description=descr_openocd_cfg))
+            PathOption(name="openocd.cfg", default="", empty_ok=True,
+                       description=descr_openocd_cfg))
 
     # Queries
     module.add_query(

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -59,7 +59,7 @@ def prepare(module, options):
 
     # Queries
     module.add_query(
-        Query(name="source_files", function=common_source_files))
+        EnvironmentQuery(name="source_files", factory=common_source_files))
     module.add_query(
         EnvironmentQuery(name="device", factory=common_target))
     module.add_query(
@@ -125,7 +125,7 @@ def prepare(module, options):
 
 def build(env):
     # Append custom openocd config file to metadata
-    openocd_cfg = env.get_option(":build:openocd.cfg", "")
+    openocd_cfg = env.get(":build:openocd.cfg", "")
     if len(openocd_cfg):
         env.collect(":build:openocd.source", openocd_cfg)
 
@@ -140,7 +140,7 @@ def build(env):
 
 def post_build(env, buildlog):
     target = env[":target"]
-    gitignore = [env.reloutpath(ignore, "modm") for ignore in
+    gitignore = [env.relative_outpath(ignore, "modm") for ignore in
                  env.collector_values("gitignore", filterfunc=lambda s: s.repository == "modm")]
     elf_files = {
         "release": env.collector_values("elf.release")[0],

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -1,7 +1,7 @@
-%% for path in metadata.get("openocd.search", []) | sort
+%% for path in collector_values["path.openocd"] | sort
 add_script_search_dir {{ path }}
 %% endfor
-%% for file in metadata.get("openocd.configfile", []) | sort
+%% for file in collector_values["openocd.source"] | sort
 source [find {{ file }}]
 %% endfor
 
@@ -12,11 +12,9 @@ proc modm_program { SOURCE } {
 	shutdown
 }
 
-%% for profile in ["release", "debug"]
-%% if "elf." ~ profile in metadata
+%% for profile, path in elf_files.items()
 proc program_{{ profile }} {} {
-	modm_program {{ metadata["elf." ~ profile][0]  | modm.windowsify }}
+	modm_program {{ path | modm.windowsify }}
 }
-%% endif
 %% endfor
 

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -23,11 +23,11 @@ def prepare(module, options):
         BooleanOption(name="include_sconstruct", default=True,
                       description=descr_include_sconstruct))
     module.add_option(
-        StringOption(name="cache_dir", default="/cache",
-                     description=descr_cache_dir))
+        PathOption(name="cache_dir", default="/cache", empty_ok=True,
+                   description=descr_cache_dir))
     module.add_option(
-        StringOption(name="image.source", default="",
-                     description=descr_image_source))
+        PathOption(name="image.source", default="", empty_ok=True,
+                   description=descr_image_source))
     module.add_option(
         EnumerationOption(name="info.git", default="Disabled",
                           enumeration=["Disabled", "Info", "Info+Status"],

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -36,6 +36,9 @@ def prepare(module, options):
         BooleanOption(name="info.build", default=False,
                       description=descr_info_build))
 
+    module.add_collector(
+        CallableCollector(name="flag_format",
+                          description="Formatting compile flags for SCons"))
 
     return True
 
@@ -43,13 +46,13 @@ def prepare(module, options):
 def build(env):
     project_name = env[":build:project.name"]
     build_path = env[":build:build.path"]
-    env.add_metadata("elf.release", join(build_path, "release", project_name + ".elf"))
-    env.add_metadata("elf.debug",   join(build_path, "debug",   project_name + ".elf"))
+    env.collect("::elf.release", join(build_path, "release", project_name + ".elf"))
+    env.collect("::elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
     if env["info.git"] != "Disabled":
-        env.add_metadata("gitignore", "modm/src/info_git.h")
+        env.collect(":build:gitignore", "modm/src/info_git.h")
     if env["info.build"]:
-        env.add_metadata("gitignore", "modm/src/info_build.h")
+        env.collect(":build:gitignore", "modm/src/info_build.h")
 
     def flag_format(flag):
         subs = {
@@ -63,7 +66,7 @@ def build(env):
             return flag
         return None
 
-    env.add_metadata("flag_format", flag_format)
+    env.collect("flag_format", flag_format)
 
 
 def post_build(env, buildlog):
@@ -111,53 +114,70 @@ def post_build(env, buildlog):
     subs["memories"] = env.query("::memories")
     # Add SCons specific data
     subs.update({
-        "metadata": buildlog.metadata,
+        "cache_dir": cache_dir,
         "generated_paths": repositories,
         "build_tools": build_tools,
         "is_unittest": is_unittest,
+
         "has_image_source": has_image_source,
-        "image_source": env["image.source"],
-        "cache_dir": cache_dir,
         "has_xpcc_generator": has_xpcc_generator,
-        "generator_source": env.get_option(":communication:xpcc:generator:source", ""),
-        "generator_container": env.get_option(":communication:xpcc:generator:container", ""),
-        "generator_path": env.get_option(":communication:xpcc:generator:path", ""),
-        "generator_namespace": env.get_option(":communication:xpcc:generator:namespace", ""),
-        "avrdude_programmer": env.get_option(":build:avrdude.programmer", ""),
-        "avrdude_port": env.get_option(":build:avrdude.port", ""),
-        "avrdude_options": env.get_option(":build:avrdude.options", ""),
-        "avrdude_baudrate": env.get_option(":build:avrdude.baudrate", 0),
     })
+    if has_image_source:
+        subs["image_source"] = env["image.source"]
+    if has_xpcc_generator:
+        subs.update({
+            "generator_source": env.get(":communication:xpcc:generator:source", ""),
+            "generator_container": env.get(":communication:xpcc:generator:container", ""),
+            "generator_path": env.get(":communication:xpcc:generator:path", ""),
+            "generator_namespace": env.get(":communication:xpcc:generator:namespace", ""),
+        })
+    if subs["platform"] == "avr":
+        default_programmer = env.collector_values(":build:default.avrdude.programmer", "")[0]
+        default_port = env.collector_values(":build:default.avrdude.port", "")[0]
+        default_baudrate = env.collector_values(":build:default.avrdude.baudrate", 0)[0]
+        subs.update({
+            "avrdude_programmer": env.get(":build:avrdude.programmer", default_programmer),
+            "avrdude_port": env.get(":build:avrdude.port", default_port),
+            "avrdude_baudrate": env.get(":build:avrdude.baudrate", default_baudrate),
+            "avrdude_options": env.get(":build:avrdude.options", ""),
+        })
     # Set these substitutions for all templates
     env.substitutions = subs
 
-    common_file_flags = env.query("::file_flags")
-    common_metadata_flags = env.query("::metadata_flags")
     for repo in repositories:
         files = []
+        repo_filter = lambda scope: scope.repository == repo
+        repo_flags = env.query("::collect_flags")(env, repo_filter)
+
         for f in sources[repo]:
-            flags = common_file_flags(buildlog, f)
-            for key, profiles in flags.items():
-                if "" not in profiles: profiles[""] = []
-                profiles[""].insert(0, "${}".format(key))
-            files.append( (env.reloutpath(f, repo), flags) )
+            for flag, profiles in repo_flags[f].items():
+                profiles[""].insert(0, "${}".format(flag.upper()))
+            files.append( (f, repo_flags[f]) )
+
+        include_paths = env.collector_values("::path.include", filterfunc=repo_filter)
+        libary_paths = env.collector_values("::path.library", filterfunc=repo_filter)
+        libaries = env.collector_values("::library", filterfunc=repo_filter)
+        packages = env.collector_values("::pkg-config", filterfunc=repo_filter)
 
         subs.update({
             "repo": repo,
-            "flags": common_metadata_flags(buildlog, repo),
+            "flags": repo_flags[None],
             "sources": files,
-            "libraries": buildlog.repo_metadata["required_library"][repo],
-            "library_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["required_library_path"][repo]],
-            "include_paths": [env.reloutpath(p, repo) for p in buildlog.repo_metadata["include_path"][repo]],
+            "libraries": libaries,
+            "library_paths": libary_paths,
+            "include_paths": include_paths,
+            "packages": packages,
         })
         def flags_format(flag):
-            for fmt in buildlog.metadata["flag_format"]:
+            for fmt in env.collector_values("flag_format"):
                 nflag = fmt(flag)
                 if nflag: return nflag;
             return '"{}"'.format(flag)
         # Generate library SConscript
         env.outbasepath = repo
-        env.template("resources/SConscript.in", "SConscript", filters={"flags_format": flags_format})
+        env.template("resources/SConscript.in", "SConscript",
+                     filters={"flags_format": flags_format,
+                              "relocate": lambda p: env.reloutpath(p, repo)})
 
     env.outbasepath = "modm"
     # Copy the scons-build-tools

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -69,16 +69,16 @@ def build(env):
     env.collect("flag_format", flag_format)
 
 
-def post_build(env, buildlog):
+def post_build(env):
     is_unittest = env.has_module(":test")
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["image.source"])
-    repositories = [p for p in buildlog.repositories if isdir(env.outpath(p, basepath="."))]
+    repositories = [p for p in env.buildlog.repositories if isdir(env.real_outpath(p, basepath="."))]
     repositories = sorted(repositories, key=lambda name: "0" if name == "modm" else name)
 
     target = env["modm:target"]
     subs = env.query("::device")
-    sources = env.query("::source_files")(buildlog)
+    sources = env.query("::source_files")
 
     build_tools = [
         "settings_buildpath",
@@ -177,7 +177,7 @@ def post_build(env, buildlog):
         env.outbasepath = repo
         env.template("resources/SConscript.in", "SConscript",
                      filters={"flags_format": flags_format,
-                              "relocate": lambda p: env.reloutpath(p, repo)})
+                              "relocate": lambda p: env.relative_outpath(p, repo)})
 
     env.outbasepath = "modm"
     # Copy the scons-build-tools

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -35,7 +35,7 @@ env.InfoBuild()
 %% endif
 
 %% macro generate_flags_for_profile(name, profile, append=False)
-env{% if append %}.Append({{name}}{% else %}["{{name}}"]{% endif %} = [
+env{% if append %}.Append({{name | upper}}{% else %}["{{name | upper}}"]{% endif %} = [
 %% for flag in flags[name][profile] | sort
     {{ flag | flags_format }},
 %% endfor
@@ -55,13 +55,13 @@ if profile == "{{ profile }}":
 %% endmacro
 
 # Toolchain configuration
-{{ generate_flags("CPPDEFINES", True) }}
-{{ generate_flags("CCFLAGS", repo != "modm") }}
-{{ generate_flags("CFLAGS", repo != "modm") }}
-{{ generate_flags("CXXFLAGS", repo != "modm") }}
-{{ generate_flags("ASFLAGS", repo != "modm") }}
-{{ generate_flags("LINKFLAGS", repo != "modm") }}
-{{ generate_flags("ARCHFLAGS", repo != "modm") }}
+{{ generate_flags("cppdefines", True) }}
+{{ generate_flags("ccflags", repo != "modm") }}
+{{ generate_flags("cflags", repo != "modm") }}
+{{ generate_flags("cxxflags", repo != "modm") }}
+{{ generate_flags("asflags", repo != "modm") }}
+{{ generate_flags("linkflags", repo != "modm") }}
+{{ generate_flags("archflags", repo != "modm") }}
 
 %% if repo == "modm"
 # ARCHFLAGS must be known for compiling *and* linking
@@ -122,24 +122,24 @@ env.AppendUnique(CPPPATH=[
 	"/usr/local/include",
 %% endif
 %% for path in include_paths | sort
-    abspath("{{ path }}"),
+    abspath("{{ path | relocate }}"),
 %% endfor
 ])
 
 files = [
 %% for file, flags in sources if not flags | length
-    env.File("{{ file }}"),
+    env.File("{{ file | relocate }}"),
 %% endfor
 ]
 %% for file, flags in sources
     %% if flags | length
-flags = { {%- for key, profiles in flags.items() if "" in profiles %}"{{key}}": {{profiles[""]}}, {% endfor -%} }
+flags = { {%- for key, profiles in flags.items() if "" in profiles %}"{{ key | upper }}": {{profiles[""]}}, {% endfor -%} }
     %% for key, profiles in flags.items()
         %% for profile, flags in profiles.items() if "" != profile
-if profile == "{{profile}}": flags["{{key}}"].extend({{flags}});
+if profile == "{{profile}}": flags["{{ key | upper }}"].extend({{flags}});
         %% endfor
     %% endfor
-files.append(env.Object("{{ file }}", **flags))
+files.append(env.Object("{{ file | relocate }}", **flags))
     %% endif
 %% endfor
 
@@ -157,11 +157,11 @@ env.AppendUnique(LIBPATH=[
 %% endif
     abspath(str(library[0].get_dir())),
 %% for library in library_paths | sort
-    abspath("{{ library }}"),
+    abspath("{{ library | relocate }}"),
 %% endfor
 ])
-%% if "required_pkg" in metadata
-env.ParseConfig("pkg-config --cflags --libs {{ metadata.required_pkg | sort | join(" ") }}")
+%% if packages | length
+env.ParseConfig("pkg-config --cflags --libs {{ packages | sort | join(" ") }}")
 %% endif
 
 Return("library")

--- a/tools/xpcc_generator/module.lb
+++ b/tools/xpcc_generator/module.lb
@@ -17,14 +17,14 @@ def init(module):
 
 def prepare(module, options):
     module.add_option(
-        StringOption(name="source", default="",
-                     description="Path to the XPCC source file"))
+        PathOption(name="source", default="", empty_ok=True,
+                   description="Path to the XPCC source file"))
     module.add_option(
         StringOption(name="container", default="",
                      description="Name of the XPCC container to generate for"))
     module.add_option(
-        StringOption(name="path", default="generated/xpcc",
-                     description="Path to the XPCC generated folder"))
+        PathOption(name="path", default="generated/xpcc",
+                   description="Path to the XPCC generated folder"))
     module.add_option(
         StringOption(name="namespace", default="robot",
                      description="Namespace of the generated XPCC communications"))


### PR DESCRIPTION
This refactors the modules for important changes in lbuild v1.8.0, namely:

- Using type-safe lbuild [Collectors](https://github.com/modm-io/lbuild/#collectors) for post-build metadata.
- Using a [validator](https://github.com/modm-io/lbuild/#stringoption) for compile flag collection.
- Using a [PathOption](https://github.com/modm-io/lbuild/#pathoption) to validate paths inputs from the user.
- Replacing SetOption with the type-safe variant [`module.add_set_option(Option)`](https://github.com/modm-io/lbuild/#options). This is particularly helpful for generating more universal LuTs in the `modm:ui:led` module.
- Replacing reprecated lbuild methods.