### PR TITLE
Add RCC module to abstract clock enable and reset

### DIFF
--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -11,15 +11,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-import os
 import re
+from pathlib import Path
+from collections import defaultdict
 
 def getDefineForDevice(device_id, familyDefines):
+    """
+    Returns the STM32 specific define from an identifier
+    """
     # get all defines for this device name
-    devName = "STM32{}{}".format(device_id["family"].upper(), device_id["name"].upper())
+    devName = "STM32{}{}".format(device_id.family.upper(), device_id.name.upper())
 
     # Map STM32F7x8 -> STM32F7x7
-    if device_id["family"] == "f7" and devName[8] == "8":
+    if device_id.family == "f7" and devName[8] == "8":
         devName = devName[:8] + "7"
 
     deviceDefines = sorted([define for define in familyDefines if define.startswith(devName)])
@@ -28,18 +32,71 @@ def getDefineForDevice(device_id, familyDefines):
         return deviceDefines[0]
 
     # now we match for the size-id.
-    devNameMatch = devName + "x{}".format(device_id["size"].upper())
+    devNameMatch = devName + "x{}".format(device_id.size.upper())
     for define in deviceDefines:
         if devNameMatch <= define:
             return define
 
     # now we match for the pin-id.
-    devNameMatch = devName + "{}x".format(device_id["pin"].upper())
+    devNameMatch = devName + "{}x".format(device_id.pin.upper())
     for define in deviceDefines:
         if devNameMatch <= define:
             return define
 
     return None
+
+bprops = {}
+def common_rcc_map(env):
+    device = env[":target"]
+
+    core = device.get_driver("core")["type"]
+    core = core.replace("cortex-m", "").replace("+", "plus").replace("f", "").replace("d", "")
+    core_header = "core_cm{}.h".format(core)
+    core_header = repopath("ext/arm/cmsis/CMSIS/Core/Include", core_header)
+
+    folder = "stm32{}xx".format(device.identifier.family)
+    family_header = folder + ".h"
+    folder = "stm32/{}/Include".format(folder)
+    define = None
+
+    content = Path(localpath(folder, family_header)).read_text(encoding="utf-8", errors="replace")
+    match = re.findall(r"if defined\((?P<define>STM32[F|L].....)\)", content)
+    define = getDefineForDevice(device.identifier, match)
+    if define is None or match is None:
+        raise ValidateException("No device define found for '{}'!".format(device.partname))
+    device_header = define.lower() + ".h"
+
+    content = ""
+    for header_path in [core_header, localpath(folder, device_header)]:
+        content += Path(header_path).read_text(encoding="utf-8", errors="replace")
+
+    # find mpu and fpu features
+    features = re.findall(r"#define +__([MF]PU)_PRESENT +([01])", content)
+    core_features = {f[0]:bool(int(f[1])) for f in features}
+    # find all peripherals
+    mperipherals = re.findall(r"#define +(.*?) +\(\((.*?_Type(?:Def)?)", content)
+    # We only care about the absolute peripheral addresses
+    peripherals = [(p[0],p[1]) for p in mperipherals]
+    # filter out MPU and/or FPU if required
+    peripherals = filter(lambda p: p[0] not in core_features or core_features[p[0]], peripherals)
+    peripherals = sorted(peripherals, key=lambda p: p[0])
+    # print("\n".join([s+" -> "+hex(a) for (s,k,a) in peripherals]))
+
+    # Find all RCC enable and reset definitions
+    match = re.findall(r"RCC_([A-Z0-9]+?)_([A-Z0-9]+?)_(EN|RST) ", content)
+    rcc_map = defaultdict(dict)
+    for (reg, per, typ) in match:
+        rcc_map[per][typ] = reg
+
+    bprops.update({
+        "folder": folder,
+        "define": define,
+        "device_header": device_header,
+        "system_header": "system_" + family_header,
+        "peripherals": peripherals,
+    })
+    return rcc_map
+
 
 # -----------------------------------------------------------------------------
 def init(module):
@@ -52,56 +109,14 @@ def prepare(module, options):
     if device.identifier["platform"] != "stm32":
         return False
 
+    module.add_query(
+        EnvironmentQuery(name="rcc-map", factory=common_rcc_map))
+
     module.depends(":cmsis:core")
     return True
 
-bprops = {}
 def validate(env):
-    device = env[":target"]
-
-    core = device.get_driver("core")["type"]
-    core = core.replace("cortex-m", "").replace("+", "plus").replace("f", "").replace("d", "")
-    core_header = "core_cm{}.h".format(core)
-    core_header = localpath("..", "arm", "cmsis", "CMSIS", "Core", "Include", core_header)
-
-    folder = "stm32{}xx".format(device.identifier["family"])
-    family_header = folder + ".h"
-    folder = os.path.join("stm32", folder, "Include")
-    define = None
-
-    with open(localpath(folder, family_header), "r", errors="replace") as headerFile:
-        match = re.findall(r"if defined\((?P<define>STM32[F|L].....)\)", headerFile.read())
-        if match:
-            define = getDefineForDevice(device.identifier, match)
-    if define is None:
-        raise ValidateException("No device define found for '{}'!".format(device.partname))
-
-    device_header = define.lower() + ".h"
-    peripherals = []
-    core_features = {}
-
-    for header_path in [core_header, localpath(folder, device_header)]:
-        with open(header_path, "r", errors="replace") as deviceFile:
-            deviceFileContent = deviceFile.read()
-            # find mpu and fpu features
-            features = re.findall(r"#define +__([MF]PU)_PRESENT +([01])", deviceFileContent)
-            core_features.update({f[0]:bool(int(f[1])) for f in features})
-            # find all peripherals
-            mperipherals = re.findall(r"#define +(.*?) +\(\((.*?_Type(?:Def)?)", deviceFileContent)
-            # We only care about the absolute peripheral addresses
-            peripherals.extend([(p[0],p[1]) for p in mperipherals])
-    # filter out MPU and/or FPU if required
-    peripherals = filter(lambda p: p[0] not in core_features or core_features[p[0]], peripherals)
-    peripherals = sorted(peripherals, key=lambda p: p[0])
-    # print("\n".join([s+" -> "+hex(a) for (s,k,a) in peripherals]))
-
-    bprops.update({
-        "folder": folder,
-        "define": define,
-        "device_header": device_header,
-        "system_header": "system_" + family_header,
-        "peripherals": peripherals
-    })
+    env.query("rcc-map")
 
 def build(env):
     env.collect(":build:path.include", "modm/ext")

--- a/src/modm/platform/clock/stm32-rcc/module.lb
+++ b/src/modm/platform/clock/stm32-rcc/module.lb
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = "rcc"
+    module.parent = "platform"
+    module.description = "Reset and Clock Control (RCC)"
+
+def prepare(module, options):
+    if not options[":target"].has_driver("rcc:stm32*"):
+        return False
+
+    module.depends(":cmsis:device")
+    # FIXME: Generate peripherals.hpp from :platform:core module
+    module.depends(":platform:gpio")
+    return True
+
+def build(env):
+    device = env[":target"]
+
+    all_peripherals = []
+    all_drivers = [d for d in device._properties["driver"] if d["name"] not in ["gpio", "core"]]
+    translate = lambda s: "".join(p.capitalize() for p in s.split("_"))
+    for d in all_drivers:
+        dname = translate(d["name"])
+        if "instance" in d:
+            all_peripherals.extend([dname + translate(i) for i in d["instance"]])
+        else:
+            all_peripherals.append(dname)
+    all_peripherals = sorted(list(set(all_peripherals)))
+
+    rcc_map = env.query(":cmsis:device:rcc-map")
+    rcc_map = {per:v for per,v in rcc_map.items() if per.capitalize() in all_peripherals}
+
+    env.substitutions = {
+        "peripherals": rcc_map.keys(),
+        "rcc_map": rcc_map,
+    }
+    env.outbasepath = "modm/src/modm/platform/clock"
+    env.template("rcc.hpp.in")

--- a/src/modm/platform/clock/stm32-rcc/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32-rcc/rcc.hpp.in
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_RCC_HPP
+#define MODM_STM32_RCC_HPP
+
+#include <stdint.h>
+#include "../device.hpp"
+#include <modm/platform/core/peripherals.hpp>
+
+namespace modm
+{
+
+namespace platform
+{
+
+/**
+ * Reset and Clock Control for STM32 devices.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_clock
+ */
+class Rcc
+{
+public:
+	template< Peripheral peripheral >
+	static void
+	enable();
+
+	template< Peripheral peripheral >
+	static void
+	disable();
+
+	template< Peripheral peripheral >
+	static void
+	reset();
+};
+
+template< Peripheral peripheral >
+inline void
+Rcc::enable()
+{
+	__DSB();
+	%% for peripheral in peripherals | sort if "EN" in rcc_map[peripheral]
+	%% set register = rcc_map[peripheral]["EN"]
+	if constexpr (peripheral == Peripheral::{{ peripheral | capitalize }})
+	{ RCC->{{register}} |= RCC_{{register}}_{{peripheral}}EN; }
+	%% endfor
+	__DSB();
+}
+
+template< Peripheral peripheral >
+inline void
+Rcc::disable()
+{
+	__DSB();
+	%% for peripheral in peripherals | sort if "EN" in rcc_map[peripheral]
+	%% set register = rcc_map[peripheral]["EN"]
+	if constexpr (peripheral == Peripheral::{{ peripheral | capitalize }})
+	{ RCC->{{register}} &= ~RCC_{{register}}_{{peripheral}}EN; }
+	%% endfor
+	__DSB();
+}
+
+template< Peripheral peripheral >
+inline void
+Rcc::reset()
+{
+	__DSB();
+	%% for peripheral in peripherals | sort if "RST" in rcc_map[peripheral]
+	%% set register = rcc_map[peripheral]["RST"]
+	if constexpr (peripheral == Peripheral::{{ peripheral | capitalize }})
+	{
+		RCC->{{register}} |=  RCC_{{register}}_{{peripheral}}RST; __DSB();
+		RCC->{{register}} &= ~RCC_{{register}}_{{peripheral}}RST;
+	}
+	%% endfor
+	__DSB();
+}
+
+}   // namespace platform
+
+}   // namespace modm
+
+#endif	//  MODM_STM32_RCC_HPP

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -11,6 +11,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
+
 def init(module):
     module.name = "clock"
     module.parent = "platform"
@@ -20,7 +21,7 @@ def prepare(module, options):
     if not options[":target"].has_driver("rcc:stm32*"):
         return False
 
-    module.depends(":cmsis:device", ":utils", ":platform:clock.cortex")
+    module.depends(":cmsis:device", ":utils", ":platform:clock.cortex", ":platform:rcc")
     if "stm32f100" in options[":target"].partname:
         module.depends(":architecture:clock")
     return True
@@ -29,10 +30,9 @@ def build(env):
     device = env[":target"]
     driver = device.get_driver("rcc")
 
-    properties = device.properties
+    properties = {}
     properties["target"] = target = device.identifier
     properties["partname"] = device.partname
-    properties["driver"] = driver
     properties["core"] = device.get_driver("core")["type"]
 
     if target["family"] in ["f1", "f3", "f4"]:

--- a/src/modm/platform/dma/stm32/dma_impl.hpp.in
+++ b/src/modm/platform/dma/stm32/dma_impl.hpp.in
@@ -13,6 +13,7 @@
 #ifndef MODM_STM32_DMA{{ id }}_HPP
 #	error 	"Don't include this file directly, use 'dma_{{ id }}.hpp' instead!"
 #endif
+#include <modm/platform/clock/rcc.hpp>
 
 %% if target["family"] == "f4"
 	%% set streams = range(0,8)
@@ -27,24 +28,14 @@
 void
 modm::platform::Dma{{ id }}::enable()
 {
-%% if target["family"] == "f4"
-	RCC->AHB1ENR  |= RCC_AHB1ENR_DMA{{ id }}EN;
-	RCC->AHB1RSTR |=  RCC_AHB1RSTR_DMA{{ id }}RST;
-	RCC->AHB1RSTR &= ~RCC_AHB1RSTR_DMA{{ id }}RST;
-%% elif target["family"] == "f3"
-	RCC->AHBENR  |= RCC_AHBENR_DMA{{ id }}EN;
-%% endif
+	Rcc::enable<Peripheral::Dma{{id}}>();
+	Rcc::reset<Peripheral::Dma{{id}}>();
 }
 
 void
 modm::platform::Dma{{ id }}::disable()
 {
-%% if target["family"] == "f4"
-	RCC->AHB1ENR &= ~RCC_AHB1ENR_DMA{{ id }}EN;
-%% elif target["family"] == "f3"
-	RCC->AHBENR &= ~RCC_AHBENR_DMA{{ id }}EN;
-%% endif
-
+	Rcc::disable<Peripheral::Dma{{id}}>();
 }
 
 

--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -50,7 +50,7 @@ def prepare(module, options):
     if device.identifier["family"] not in ["f3", "f4"]:
         return False
 
-    module.depends(":cmsis:device")
+    module.depends(":cmsis:device", ":platform:rcc")
 
     for instance in device.get_driver("dma")["instance"]:
         module.add_submodule(Instance(int(instance)))

--- a/src/modm/platform/fsmc/stm32/fsmc.hpp.in
+++ b/src/modm/platform/fsmc/stm32/fsmc.hpp.in
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include "../device.hpp"
+#include <modm/platform/clock/rcc.hpp>
 
 namespace modm
 {
@@ -298,21 +299,14 @@ namespace modm
 			static inline void
 			enable()
 			{
-%% if target["family"] in ["f2", "f4", "f7"]
-				RCC->AHB3ENR |= RCC_AHB3ENR_{{ FMC }}EN;
-%% else
-				RCC->AHBENR |= RCC_AHBENR_{{ FMC }}EN;
-%% endif
+				Rcc::enable<Peripheral::{{ FMC | capitalize }}>();
+				Rcc::reset<Peripheral::{{ FMC | capitalize }}>();
 			}
 
 			static inline void
 			disable()
 			{
-%% if target["family"] in ["f2", "f4", "f7"]
-				RCC->AHB3ENR &= ~RCC_AHB3ENR_{{ FMC }}EN;
-%% else
-				RCC->AHBENR &= ~RCC_AHBENR_{{ FMC }}EN;
-%% endif
+				Rcc::disable<Peripheral::{{ FMC | capitalize }}>();
 			}
 		};
 	}

--- a/src/modm/platform/fsmc/stm32/module.lb
+++ b/src/modm/platform/fsmc/stm32/module.lb
@@ -21,13 +21,13 @@ def prepare(module, options):
     if not device.has_driver("fsmc:stm32*"):
         return False
 
-    module.depends(":cmsis:device")
+    module.depends(":cmsis:device", ":platform:rcc")
     return True
 
 def build(env):
     device = env[":target"]
 
-    properties = device.properties
+    properties = {}
     properties["target"] = device.identifier
 
     target = device.identifier

--- a/src/modm/platform/gpio/stm32/base.hpp.in
+++ b/src/modm/platform/gpio/stm32/base.hpp.in
@@ -15,23 +15,13 @@
 #include "../device.hpp"
 #include <modm/architecture/interface/gpio.hpp>
 #include <modm/math/utils/bit_operation.hpp>
+#include <modm/platform/core/peripherals.hpp>
 
 namespace modm
 {
 
 namespace platform
 {
-
-/// @cond
-enum class
-Peripheral
-{
-	BitBang,
-%% for per in all_peripherals
-	{{ per }},
-%% endfor
-};
-/// @endcond
 
 /// @ingroup modm_platform_gpio
 struct Gpio

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -273,3 +273,7 @@ def build(env):
     env.template("unused.hpp.in")
     if len(env["enable_ports"]):
         env.template("enable.cpp.in")
+
+    # FIXME: Move to modm:platform:core!
+    env.outbasepath = "modm/src/modm/platform/core"
+    env.template("peripherals.hpp.in")

--- a/src/modm/platform/gpio/stm32/peripherals.hpp.in
+++ b/src/modm/platform/gpio/stm32/peripherals.hpp.in
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_PERIPHERALS_HPP
+#define MODM_STM32_PERIPHERALS_HPP
+
+namespace modm::platform
+{
+
+enum class
+Peripheral
+{
+	BitBang,
+%% for per in all_peripherals
+	{{ per }},
+%% endfor
+	Syscfg = Sys,
+};
+
+}
+
+#endif // MODM_STM32_PERIPHERALS_HPP

--- a/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
@@ -51,6 +51,7 @@
 #include <modm/architecture/interface/atomic_lock.hpp>
 #include <modm/architecture/interface/interrupt.hpp>
 #include <modm/container.hpp>
+#include <modm/platform/clock/rcc.hpp>
 
 %% if not shared_interrupt
 MODM_ISR_DECL(I2C{{ id }}_ER);
@@ -495,12 +496,8 @@ MODM_ISR(I2C{{ id }}_ER)
 void
 modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint32_t timingRegisterValue)
 {
-	// Enable clock
-	RCC->APB1ENR{{aid}} |= RCC_APB1ENR{{aid}}_I2C{{ id }}EN;
-
-	// reset module
-	RCC->APB1RSTR{{aid}} |=  RCC_APB1RSTR{{aid}}_I2C{{ id }}RST;
-	RCC->APB1RSTR{{aid}} &= ~RCC_APB1RSTR{{aid}}_I2C{{ id }}RST;
+	Rcc::enable<Peripheral::I2c{{id}}>();
+	Rcc::reset<Peripheral::I2c{{id}}>();
 
 	// Disable the I2C peripheral which causes a software reset
 	I2C{{ id }}->CR1 &= ~I2C_CR1_PE;

--- a/src/modm/platform/i2c/stm32-extended/module.lb
+++ b/src/modm/platform/i2c/stm32-extended/module.lb
@@ -37,16 +37,7 @@ class Instance(Module):
         properties = device.properties
         properties["target"] = target = device.identifier
         properties["id"] = self.instance
-
-        if target["family"] == "l4":
-            properties["aid"] = "2" if self.instance == 4 else "1"
-        else:
-            properties["aid"] = ""
-
-        if target["family"] == "f0" or target["family"] == "l0":
-            properties["shared_interrupt"] = True
-        else:
-            properties["shared_interrupt"] = False
+        properties["shared_interrupt"] = "0" in target.family
 
         env.substitutions = properties
         env.outbasepath = "modm/src/modm/platform/i2c"

--- a/src/modm/platform/i2c/stm32/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.cpp.in
@@ -168,6 +168,7 @@
 #include <modm/architecture/interface/atomic_lock.hpp>
 #include <modm/architecture/interface/interrupt.hpp>
 #include <modm/container.hpp>
+#include <modm/platform/clock/rcc.hpp>
 
 MODM_ISR_DECL(I2C{{ id }}_ER);
 
@@ -591,8 +592,8 @@ modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint8_t peripheralFre
 {
 	// no reset, since we want to keep the transaction attached!
 
-	// Enable clock
-	RCC->APB1ENR |= RCC_APB1ENR_I2C{{ id }}EN;
+	Rcc::enable<Peripheral::I2c{{id}}>();
+	Rcc::reset<Peripheral::I2c{{id}}>();
 
 	I2C{{ id }}->CR1 = I2C_CR1_SWRST; 		// reset module
 	I2C{{ id }}->CR1 = 0;

--- a/src/modm/platform/random/stm32/module.lb
+++ b/src/modm/platform/random/stm32/module.lb
@@ -19,7 +19,7 @@ def prepare(module, options):
     if not options[":target"].has_driver("rng:stm32"):
         return False
 
-    module.depends(":cmsis:device")
+    module.depends(":cmsis:device", ":platform:rcc")
     return True
 
 def build(env):

--- a/src/modm/platform/random/stm32/random_number_generator.hpp.in
+++ b/src/modm/platform/random/stm32/random_number_generator.hpp.in
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include "../device.hpp"
+#include <modm/platform/clock/rcc.hpp>
 
 
 namespace modm
@@ -37,6 +38,8 @@ public:
 	static inline void
 	enable()
 	{
+		Rcc::enable<Peripheral::Rng>();
+		Rcc::reset<Peripheral::Rng>();
 		RNG->CR = RNG_CR_RNGEN;
 	}
 

--- a/src/modm/platform/spi/stm32/module.lb
+++ b/src/modm/platform/spi/stm32/module.lb
@@ -14,9 +14,8 @@
 def get_properties(env):
     device = env[":target"]
     driver = device.get_driver("spi")
-    properties = device.properties
+    properties = {}
     properties["target"] = device.identifier
-    properties["driver"] = driver
     properties["features"] = driver["feature"] if "feature" in driver else []
     return properties
 
@@ -36,8 +35,6 @@ class Instance(Module):
     def build(self, env):
         properties = get_properties(env)
         properties["id"] = self.instance
-        properties["apb"] = "2" if self.instance in [1, 4, 5, 6] else "1"
-        properties["apb_post"] = "1" if properties["target"]["family"] in ["l4"] and self.instance != 1 else ""
 
         env.substitutions = properties
         env.outbasepath = "modm/src/modm/platform/spi"
@@ -62,7 +59,8 @@ def prepare(module, options):
         ":architecture:register",
         ":architecture:spi",
         ":cmsis:device",
-        ":platform:gpio")
+        ":platform:gpio",
+        ":platform:rcc")
 
     for driver in device.get_all_drivers("spi:stm32"):
         for instance in driver["instance"]:

--- a/src/modm/platform/spi/stm32/spi_hal_impl.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_hal_impl.hpp.in
@@ -14,23 +14,21 @@
 #ifndef MODM_STM32_SPI_HAL{{ id }}_HPP
 #	error 	"Don't include this file directly, use 'spi_hal{{ id }}.hpp' instead!"
 #endif
+#include <modm/platform/clock/rcc.hpp>
 
 void inline
 modm::platform::SpiHal{{ id }}::enable()
 {
-	// enable clock
-	RCC->APB{{ apb }}ENR{{ apb_post }} |= RCC_APB{{ apb }}ENR{{ apb_post }}_SPI{{ id }}EN;
-	// reset spi
-	RCC->APB{{ apb }}RSTR{{ apb_post }} |=  RCC_APB{{ apb }}RSTR{{ apb_post }}_SPI{{ id }}RST;
-	RCC->APB{{ apb }}RSTR{{ apb_post }} &= ~RCC_APB{{ apb }}RSTR{{ apb_post }}_SPI{{ id }}RST;
+	Rcc::enable<Peripheral::Spi{{id}}>();
+	Rcc::reset<Peripheral::Spi{{id}}>();
 	SPI{{ id }}->CR1 |= SPI_CR1_SPE;		// SPI Enable
 }
 
 void inline
 modm::platform::SpiHal{{ id }}::disable()
 {
-	// disable clock
-	RCC->APB{{ apb }}ENR{{ apb_post }} &= ~RCC_APB{{ apb }}ENR{{ apb_post }}_SPI{{ id }}EN;
+	SPI{{ id }}->CR1 = 0;
+	Rcc::disable<Peripheral::Spi{{id}}>();
 }
 
 void inline

--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -14,28 +14,24 @@
 // ----------------------------------------------------------------------------
 
 #include "timer_{{ id }}.hpp"
+#include <modm/platform/clock/rcc.hpp>
 
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::enable()
 {
-	// enable clock
-	RCC->APB2ENR  |=  RCC_APB2ENR_TIM{{ id }}EN;
-
-	// reset timer
-	RCC->APB2RSTR |=  RCC_APB2RSTR_TIM{{ id }}RST;
-	RCC->APB2RSTR &= ~RCC_APB2RSTR_TIM{{ id }}RST;
+	Rcc::enable<Peripheral::Tim{{id}}>();
+	Rcc::reset<Peripheral::Tim{{id}}>();
 }
 
 void
 modm::platform::Timer{{ id }}::disable()
 {
-	// disable clock
-	RCC->APB2ENR &= ~RCC_APB2ENR_TIM{{ id }}EN;
-
 	TIM{{ id }}->CR1 = 0;
 	TIM{{ id }}->DIER = 0;
 	TIM{{ id }}->CCER = 0;
+
+	Rcc::disable<Peripheral::Tim{{id}}>();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/platform/timer/stm32/basic.cpp.in
+++ b/src/modm/platform/timer/stm32/basic.cpp.in
@@ -15,25 +15,22 @@
 // ----------------------------------------------------------------------------
 
 #include "timer_{{ id }}.hpp"
+#include <modm/platform/clock/rcc.hpp>
 
 void
 modm::platform::Timer{{ id }}::enable()
 {
-	// enable clock
-	RCC->APB1ENR{{ apb_post }}  |=  RCC_APB1ENR{{ apb_post }}_TIM{{ id }}EN;
-	// reset timer
-	RCC->APB1RSTR{{ apb_post }} |=  RCC_APB1RSTR{{ apb_post }}_TIM{{ id }}RST;
-	RCC->APB1RSTR{{ apb_post }} &= ~RCC_APB1RSTR{{ apb_post }}_TIM{{ id }}RST;
+	Rcc::enable<Peripheral::Tim{{id}}>();
+	Rcc::reset<Peripheral::Tim{{id}}>();
 }
 
 void
 modm::platform::Timer{{ id }}::disable()
 {
-	// disable clock
-	RCC->APB1ENR{{ apb_post }} &= ~RCC_APB1ENR{{ apb_post }}_TIM{{ id }}EN;
-
 	TIM{{ id }}->CR1 = 0;
 	TIM{{ id }}->DIER = 0;
+
+	Rcc::disable<Peripheral::Tim{{id}}>();
 }
 
 void

--- a/src/modm/platform/timer/stm32/general_purpose.cpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.cpp.in
@@ -14,56 +14,31 @@
  */
 // ----------------------------------------------------------------------------
 
-%% if target["family"] in ["l4"]
-%%   if id in range(2,8)
-%%     set apb  = "APB1"
-%%     set apb_post = "1"
-%%   elif id in [1,8] or id in [15,16,17]
-%%     set apb = "APB2"
-%%     set apb_post = ""
-%%   else
-       #error "Don't know on which APB this timer {{ id }} is."
-%%   endif
-%% else
-%%   if id in range(9,12) or id in range(15,21)
-%%     set apb = "APB2"
-%%   elif id in range(1,9) or id in range (12,15)
-%%     set apb = "APB1"
-%%   else
-       #error "Don't know on which APB this timer {{ id }} is."
-%%   endif
-%% endif
-
 #include "timer_{{ id }}.hpp"
+#include <modm/platform/clock/rcc.hpp>
 
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::clockEnable()
 {
-	// enable clock
-	RCC->{{ apb }}ENR{{ apb_post }}  |=  RCC_{{ apb }}ENR{{ apb_post }}_TIM{{ id }}EN;
+	Rcc::enable<Peripheral::Tim{{id}}>();
 }
 
 void
 modm::platform::Timer{{ id }}::enable()
 {
-	// enable clock
-	RCC->{{ apb }}ENR{{ apb_post }}  |=  RCC_{{ apb }}ENR{{ apb_post }}_TIM{{ id }}EN;
-
-	// reset timer
-	RCC->{{ apb }}RSTR{{ apb_post }} |=  RCC_{{ apb }}RSTR{{ apb_post }}_TIM{{ id }}RST;
-	RCC->{{ apb }}RSTR{{ apb_post }} &= ~RCC_{{ apb }}RSTR{{ apb_post }}_TIM{{ id }}RST;
+	Rcc::enable<Peripheral::Tim{{id}}>();
+	Rcc::reset<Peripheral::Tim{{id}}>();
 }
 
 void
 modm::platform::Timer{{ id }}::disable()
 {
-	// disable clock
-	RCC->{{ apb }}ENR{{ apb_post }} &= ~RCC_{{ apb }}ENR{{ apb_post }}_TIM{{ id }}EN;
-
 	TIM{{ id }}->CR1 = 0;
 	TIM{{ id }}->DIER = 0;
 	TIM{{ id }}->CCER = 0;
+
+	Rcc::disable<Peripheral::Tim{{id}}>();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -44,7 +44,6 @@ class Instance(Module):
         module.description = "Instance {}".format(self.instance)
 
     def prepare(self, module, options):
-        module.depends(":platform:timer")
         return True
 
     def validate(self, env):
@@ -74,7 +73,6 @@ class Instance(Module):
         global props
         props["id"] = self.instance
         props["connectors"] = get_connectors(self.instance)
-        props["apb_post"] = "1" if props["target"].family in ["l4"] else ""
         props["vectors"] = self.vectors
 
         env.substitutions = props
@@ -96,7 +94,8 @@ def prepare(module, options):
     module.depends(
         ":architecture:register",
         ":cmsis:device",
-        ":platform:gpio")
+        ":platform:gpio",
+        ":platform:rcc")
 
     timers = device.get_all_drivers("tim")
     instances = []

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -51,13 +51,6 @@ class Instance(Module):
         props["id"] = self.instance
         props["driver"] = self.driver
         props["features"] = self.driver["feature"] if "feature" in self.driver else []
-
-        if device.family == "f0":
-            props["apb"] = "2" if self.instance in [1, 6, 7, 8] else "1"
-        else:
-            props["apb"] = "2" if self.instance in [1, 6, 9, 10] else "1"
-        props["apb_post"] = "1" if device.family in ["l4"] and self.instance != 1 else ""
-
         props["uart_name"] = self.driver["name"].capitalize()
 
         env.substitutions = props
@@ -87,7 +80,8 @@ def prepare(module, options):
         ":architecture:register",
         ":architecture:uart",
         ":cmsis:device",
-        ":platform:gpio")
+        ":platform:gpio",
+        ":platform:rcc")
 
     global props
     drivers = (device.get_all_drivers("uart") + device.get_all_drivers("usart"))

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -20,6 +20,7 @@
 #ifndef MODM_STM32_UARTHAL_{{ id }}_HPP
 #	error 	"Don't include this file directly, use uart_hal_{{ id }}.hpp instead!"
 #endif
+#include <modm/platform/clock/rcc.hpp>
 
 // ----------------------------------------------------------------------------
 void
@@ -51,14 +52,8 @@ modm::platform::{{ name }}::setParity(const Parity parity)
 void
 modm::platform::{{ name }}::enable()
 {
-	// FIXME: there seems to be a bug in the stm32f3xxlib which does not provide
-	//        the necessary RCC_APB1ENR_UART5EN define and probably defines
-	//        RCC_APB1ENR_UART4EN incorrectly (0x00100000 instead of 0x00080000)
-	// enable clock
-	RCC->APB{{ apb }}ENR{{ apb_post }} |= RCC_APB{{ apb }}ENR{{ apb_post }}_{{ peripheral }}EN;
-	// reset uart
-	RCC->APB{{ apb }}RSTR{{ apb_post }} |=  RCC_APB{{ apb }}RSTR{{ apb_post }}_{{ peripheral }}RST;
-	RCC->APB{{ apb }}RSTR{{ apb_post }} &= ~RCC_APB{{ apb }}RSTR{{ apb_post }}_{{ peripheral }}RST;
+	Rcc::enable<Peripheral::{{ uart_name ~ id }}>();
+	Rcc::reset<Peripheral::{{ uart_name ~ id }}>();
 	{{ peripheral }}->CR1 |= USART_CR1_UE;		// Uart Enable
 }
 
@@ -67,11 +62,7 @@ modm::platform::{{ name }}::disable()
 {
 	// TX, RX, Uart, etc. Disable
 	{{ peripheral }}->CR1 = 0;
-	// FIXME: there seems to be a bug in the stm32f3xxlib which does not provide
-	//        the necessary RCC_APB1ENR_UART5EN define and probably defines
-	//        RCC_APB1ENR_UART4EN incorrectly (0x00100000 instead of 0x00080000)
-	// disable clock
-	RCC->APB{{ apb }}ENR{{ apb_post }} &= ~RCC_APB{{ apb }}ENR{{ apb_post }}_{{ peripheral }}EN;
+	Rcc::disable<Peripheral::{{ uart_name ~ id }}>();
 }
 %% if target["family"] != "f1"
 template<class SystemClock, uint32_t baudrate,


### PR DESCRIPTION
This adds a `modm::platform::Rcc` class with
- `Rcc::enable<Peripheral>()`
- `Rcc::disable<Peripheral>()`
- `Rcc::reset<Peripheral>()`

methods, which are implemented by parsing the CMSIS header files to extract the peripheral name, register name and bit masks. This information be moved to modm-devices in the future, but for now this "hack" significantly improves modm by moving the `A{H,P}B{1,2}` decisions from all peripherals into a common module.

cc @rleh @chris-durand