### PR TITLE
Move support repos to modm-ext organisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
           command: |
             (git submodule sync && git submodule update --init --jobs 8) &
             pip3 install -U lbuild &
-            git clone git@github.com:modm-io/modm.io.git docs/modm.io &
+            git clone git@github.com:modm-ext/modm.io.git docs/modm.io &
             wait
       - run:
           name: Build Homepage

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/modm-io/ros-lib
 [submodule "ext/arm/cmsis"]
 	path = ext/arm/cmsis
-	url = https://github.com/modm-io/cmsis-5-partial.git
+	url = https://github.com/modm-ext/cmsis-5-partial.git
 [submodule "ext/gcc/libstdc++"]
 	path = ext/gcc/libstdc++
 	url = https://github.com/modm-io/avr-libstdcpp.git


### PR DESCRIPTION
I've transferred a bunch of support repos and several forks out of the modm-io org to the modm-ext org, in oder to focus this repository on the essential part of modm.

The repos were transferred by GitHub and there is a backwards compatible redirect, so previous checkouts of modm's submodules are not impacted.