### PR TITLE
Add option to define an offset at the beginning of the flash memory for linking

### DIFF
--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -1,7 +1,7 @@
 %# This File includes platform independent macros for Cortex-M linkerscripts
 %% macro copyright()
 /*
- * Copyright (c) 2011-2012, Fabian Greif
+ * Copyright (c) 2011-2012, 2019, Fabian Greif
  * Copyright (c) 2012, 2015-2018, Niklas Hauser
  * Copyright (c) 2013, Sascha Schade
  * Copyright (c) 2013, 2015, Kevin Läufer
@@ -18,9 +18,9 @@
 MEMORY
 {
 %% for memory in memories
-	{{ memory.name | upper }} ({{ memory.access }}) : ORIGIN = {{ memory.start }}, LENGTH = {{ memory.size }}
+	{{ memory.name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
 %% endfor
-	RAM (rwx) : ORIGIN = 0x{{ "%08x" % ram_origin }}, LENGTH = {{ ram_size }}
+	RAM (rwx) : ORIGIN = {{ "0x%08X" % ram_origin }}, LENGTH = {{ ram_size }}
 {{ linkerscript_memory | indent(first=True) }}
 }
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -11,8 +11,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
+
 def common_vector_table_location(env):
     return env.get(":platform:cortex-m:vector_table_location", "rom")
+
 
 def common_vector_table(env):
     """
@@ -73,11 +75,34 @@ def common_memories(env):
     """
     device = env[":target"]
     memories = listify(device.get_driver("core")["memory"])
+
+    # Convert from string to int and add offsets
+    flash_offset = env.get_option(":platform:cortex-m:linkerscript.flash_offset", 0)
+    for m in memories:
+        if m["name"] == "flash" and flash_offset != 0:
+            # The offset needs to be aligned regarding the number of interrupts
+            # in order for the vector table relocation to work. Every interrupt
+            # requires 4 bytes, and therefore two additional bits of alignment.
+            number_of_interrupts = env.query(":::vector_table")["highest_irq"] + 16
+            bit_alignment = number_of_interrupts.bit_length() + 2
+            mask = (1 << bit_alignment) - 1
+            if flash_offset & mask:
+                raise ValidateException("Invalid flash offset in option '{}'. "
+                                        "The offset needs to be {} bit aligned."
+                                        .format("linkerscript.flash_offset",
+                                                bit_alignment))
+
+            m["start"] = int(m["start"], 0) + flash_offset
+            m["size"] = int(m["size"], 0) - flash_offset
+        else:
+            m["start"] = int(m["start"], 0)
+            m["size"] = int(m["size"], 0)
+
     properties = {
         "memories": memories,
         "regions": [m["name"] for m in memories],
-        "ram_origin": min(int(m["start"], 16) for m in memories if "sram" in m["name"]),
-        "ram_size": sum(int(m["size"]) for m in memories if "sram" in m["name"]),
+        "ram_origin": min(m["start"] for m in memories if "sram" in m["name"]),
+        "ram_size": sum(m["size"] for m in memories if "sram" in m["name"]),
     }
     return properties
 
@@ -129,6 +154,7 @@ def init(module):
     module.parent = "platform"
     module.description = FileReader("module.md")
 
+
 def prepare(module, options):
     if not options[":target"].has_driver("core:cortex-m*"):
         return False
@@ -166,9 +192,10 @@ def prepare(module, options):
             maximum=2 ** 16,
             default=2 ** 10 * 3 - 32))
 
+    memories = listify(options[":target"].get_driver("core")["memory"])
+
     # Cortex-M0 does not have remappable vector table, so it will remain in Flash
     if not options[":target"].has_driver("core:cortex-m0*"):
-        memories = listify(options[":target"].get_driver("core")["memory"])
         default_location = "rom"
         if any((m["name"] == "ccm" and "x" in m["access"]) or m["name"] == "dtcm" for m in memories):
             default_location = "ram"
@@ -178,6 +205,19 @@ def prepare(module, options):
                 description=FileReader("option/vector_table_location.md"),
                 enumeration=["rom", "ram"],
                 default=default_location))
+
+    # Find the size of the flash memory
+    flash_size = next(int(x['size']) for x in memories if x['name'] == 'flash')
+    module.add_option(
+        NumericOption(
+            name="linkerscript.flash_offset",
+            description="Add an offset to the default start address of the "
+                        "flash memory. This might be required for bootloaders "
+                        "located there. WARNING: Not all offsets are compatible with "
+                        "the vector table relocation.",
+            minimum=0,
+            maximum=flash_size,
+            default=0))
 
     module.add_collector(
         StringCollector(
@@ -210,6 +250,7 @@ def prepare(module, options):
         EnvironmentQuery(name="linkerscript", factory=common_linkerscript))
 
     return True
+
 
 def build(env):
     env.substitutions = env.query("vector_table")

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -79,19 +79,7 @@ def common_memories(env):
     # Convert from string to int and add offsets
     flash_offset = env.get_option(":platform:cortex-m:linkerscript.flash_offset", 0)
     for m in memories:
-        if m["name"] == "flash" and flash_offset != 0:
-            # The offset needs to be aligned regarding the number of interrupts
-            # in order for the vector table relocation to work. Every interrupt
-            # requires 4 bytes, and therefore two additional bits of alignment.
-            number_of_interrupts = env.query(":::vector_table")["highest_irq"] + 16
-            bit_alignment = number_of_interrupts.bit_length() + 2
-            mask = (1 << bit_alignment) - 1
-            if flash_offset & mask:
-                raise ValidateException("Invalid flash offset in option '{}'. "
-                                        "The offset needs to be {} bit aligned."
-                                        .format("linkerscript.flash_offset",
-                                                bit_alignment))
-
+        if m["name"] == "flash":
             m["start"] = int(m["start"], 0) + flash_offset
             m["size"] = int(m["size"], 0) - flash_offset
         else:
@@ -250,6 +238,24 @@ def prepare(module, options):
         EnvironmentQuery(name="linkerscript", factory=common_linkerscript))
 
     return True
+
+
+def validate(env):
+    flash_offset_option_name = "modm:platform:cortex-m:linkerscript.flash_offset"
+    flash_offset = env[flash_offset_option_name]
+    if flash_offset != 0:
+        # The offset needs to be aligned regarding the number of interrupts
+        # in order for the vector table relocation to work. Every interrupt
+        # requires 4 bytes, and therefore two additional bits of alignment.
+        number_of_interrupts = env.query(":::vector_table")["highest_irq"] + 16
+        bit_alignment = number_of_interrupts.bit_length() + 2
+        mask = (1 << bit_alignment) - 1
+        if flash_offset & mask:
+            raise ValidateException("Invalid flash offset in option '{}' (value=0x{:X}). "
+                                    "The offset needs to be {} bit aligned."
+                                    .format(flash_offset_option_name,
+                                            flash_offset,
+                                            bit_alignment))
 
 
 def build(env):


### PR DESCRIPTION
This useful for using bootloaders like the stm32duino bootloader which require the program to be linked to address 0x08002000 (instead of 0x08000000).