### PR TITLE
[literals] Remove bit/baudrate, tolerance enums

### DIFF
--- a/docs/src/how-modm-works.md
+++ b/docs/src/how-modm-works.md
@@ -260,7 +260,7 @@ for keeping code size in check on very resource constrained targets, like the AV
 ```cpp
 Uart4::connect<GpioA0::Tx, GpioA1::Rx>(Gpio::InputType::PullUp); // pull-up in RX pin
 Uart4::initialize<Board::SystemClock, 115'200_Bd>(); // Within 1% default tolerance
-Uart4::initialize<Board::SystemClock, 115'200_Bd> Tolerance::Exact>();
+Uart4::initialize<Board::SystemClock, 115.2_kBd, 0_pct>();
 // error: The closest available baudrate exceeds the tolerance of the requested baudrate!
 ```
 
@@ -320,7 +320,7 @@ using GpioExpander = modm::Mcp23x17< Transport >;
 GpioExpander expander;
 // Connect and initialize the peripherals
 SpiMaster1::connect<GpioA0::Sck, GpioA1::Mosi, GpioA2::Miso>();
-SpiMaster1::initialize<Board::SystemClock, 1MHz>();
+SpiMaster1::initialize<Board::SystemClock, 1_MHz>();
 expander.initialize();
 // Bind the expander pins to a simpler name
 using Pin0 = GpioExpander::P0< expander >;

--- a/examples/avr/can/mcp2515/main.cpp
+++ b/examples/avr/can/mcp2515/main.cpp
@@ -55,7 +55,7 @@ main()
 	Int::setInput(Gpio::InputType::PullUp);
 
 	// Configure MCP2515 and set the filters
-	mcp2515.initialize<8_MHz, modm::Can::Bitrate::kBps125>();
+	mcp2515.initialize<8_MHz, 125_kbps>();
 	mcp2515.setFilter(modm::accessor::asFlash(canFilter));
 
 	// Create a new message

--- a/examples/avr/can/mcp2515_uart/main.cpp
+++ b/examples/avr/can/mcp2515_uart/main.cpp
@@ -88,7 +88,7 @@ main()
 	Int::setInput(Gpio::InputType::PullUp);
 
 	// Configure MCP2515 and set the filters
-	mcp2515.initialize<8_MHz, modm::Can::Bitrate::kBps125>();
+	mcp2515.initialize<8_MHz, 125_kbps>();
 	mcp2515.setFilter(modm::accessor::asFlash(canFilter));
 
 	// Create a new message

--- a/examples/avr/xpcc/receiver/main.cpp
+++ b/examples/avr/xpcc/receiver/main.cpp
@@ -96,7 +96,7 @@ main()
 	Int::setInput(Gpio::InputType::PullUp);
 
 	// Configure MCP2515 and set the filters
-	device.initialize<8_MHz, modm::Can::Bitrate::kBps125>();
+	device.initialize<8_MHz, 125_kbps>();
 	device.setFilter(modm::accessor::asFlash(canFilter));
 
 	// Enable Interrupts

--- a/examples/avr/xpcc/sender/main.cpp
+++ b/examples/avr/xpcc/sender/main.cpp
@@ -96,7 +96,7 @@ main()
 	Int::setInput(Gpio::InputType::PullUp);
 
 	// Configure MCP2515 and set the filters
-	device.initialize<8_MHz, modm::Can::Bitrate::kBps125>();
+	device.initialize<8_MHz, 125_kbps>();
 	device.setFilter(modm::accessor::asFlash(canFilter));
 
 	// Enable Interrupts

--- a/examples/generic/i2c_multiplex/i2c_multiplex.cpp
+++ b/examples/generic/i2c_multiplex/i2c_multiplex.cpp
@@ -113,7 +113,7 @@ main()
 #endif
 
 	modm::platform::I2cMaster1::connect<modm::platform::GpioB7::Sda, modm::platform::GpioB6::Scl>();
-	modm::platform::I2cMaster1::initialize<Board::SystemClock, modm::platform::I2cMaster1::Baudrate::Standard>();
+	modm::platform::I2cMaster1::initialize<Board::SystemClock, 100_kHz>();
 
 	constexpr uint32_t rate = 1; // Hz
 	constexpr float interval = 1000.0 / rate; // msec

--- a/examples/generic/ros/can_bridge/main.cpp
+++ b/examples/generic/ros/can_bridge/main.cpp
@@ -106,7 +106,7 @@ main()
 	} else {
 		Can::connect<GpioInputB8::Rx, GpioOutputB9::Tx>(Gpio::InputType::PullUp);
 	}
-	Can::initialize<Board::SystemClock, Can::Bitrate::kBps250>(9);
+	Can::initialize<Board::SystemClock, 250_kbps>(9);
 
 	// Receive every message
 	CanFilter::setFilter(0, CanFilter::FIFO0,

--- a/examples/generic/ros/environment/main.cpp
+++ b/examples/generic/ros/environment/main.cpp
@@ -66,7 +66,7 @@ main()
 	Board::stlink::Uart::initialize<Board::SystemClock, 1_MBd>(12);
 
     MyI2cMaster::connect<Board::D14::Sda, Board::D15::Scl>();
-    MyI2cMaster::initialize<Board::SystemClock, MyI2cMaster::Baudrate::Standard>();
+    MyI2cMaster::initialize<Board::SystemClock, 100_kHz>();
 
 	Board::LedGreen::set();
 

--- a/examples/linux/can_debugger/main.cpp
+++ b/examples/linux/can_debugger/main.cpp
@@ -17,6 +17,7 @@
 #include <modm/platform/can/canusb.hpp>
 
 using namespace modm::platform;
+using namespace modm::literals;
 
 /**
  * Simple example that listens to a CAN bus connected by a CAN2USB.
@@ -33,7 +34,7 @@ using namespace modm::platform;
  * - All CAN messages on the bus should appear on the screen.
  */
 
-static constexpr modm::Can::Bitrate canBusBitRate = modm::Can::kBps125;
+static constexpr modm::bitrate_t canBusBitRate = 125_kbps;
 
 SerialInterface port("/dev/ttyUSB0", 115200);
 CanUsb<SerialInterface> canUsb(port);

--- a/examples/nucleo_f429zi/pat9125el/main.cpp
+++ b/examples/nucleo_f429zi/pat9125el/main.cpp
@@ -86,7 +86,7 @@ main()
 	MODM_LOG_INFO << "\n\nPAT9125EL I2C example\n\n";
 
 	I2c::connect<Sda::Sda, Scl::Scl>();
-	I2c::initialize<Board::SystemClock, 400_kHz, modm::Tolerance::TwentyPercent>();
+	I2c::initialize<Board::SystemClock, 400_kHz, 20_pct>();
 
 	while (1) {
 		thread.update();

--- a/examples/nucleo_l432kc/gyroscope/main.cpp
+++ b/examples/nucleo_l432kc/gyroscope/main.cpp
@@ -96,7 +96,7 @@ main()
 	Board::initialize();
 
 	UartSpi::Master::connect<UartSpi::Ck::Ck, UartSpi::Tx::Tx, UartSpi::Rx::Rx>();
-	UartSpi::Master::initialize<Board::SystemClock, 8_MHz, modm::Tolerance::Exact>();
+	UartSpi::Master::initialize<Board::SystemClock, 8_MHz, 0_pct>();
 
 	while (1) {
 		reader.update();

--- a/examples/nucleo_l432kc/uart_spi/main.cpp
+++ b/examples/nucleo_l432kc/uart_spi/main.cpp
@@ -22,7 +22,7 @@ main()
 
 	// Enable Uart SPI 1
 	UartSpiMaster1::connect<GpioA8::Ck, GpioA9::Tx, GpioA10::Rx>();
-	UartSpiMaster1::initialize<Board::SystemClock, 1_MHz, modm::Tolerance::Exact>();
+	UartSpiMaster1::initialize<Board::SystemClock, 1_MHz, 0_pct>();
 
 	while (1)
 	{

--- a/examples/nucleo_l476rg/i2c_test/main.cpp
+++ b/examples/nucleo_l476rg/i2c_test/main.cpp
@@ -14,6 +14,7 @@
 #include <modm/processing/protothread.hpp>
 #include <modm/processing/resumable.hpp>
 #include <modm/architecture/interface/i2c_device.hpp>
+using namespace modm::literals;
 
 /*
  * Test of I2C transaction with STM32L4
@@ -134,7 +135,7 @@ main()
 	Board::initialize();
 
 	MyI2cMaster::connect<Board::D14::Sda, Board::D15::Scl>();
-	MyI2cMaster::initialize<Board::SystemClock, MyI2cMaster::Baudrate::Standard>();
+	MyI2cMaster::initialize<Board::SystemClock, 100_kHz>();
 
 	LedGreen::set();
 

--- a/examples/stm32f072_discovery/can/main.cpp
+++ b/examples/stm32f072_discovery/can/main.cpp
@@ -83,7 +83,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can ..." << modm::endl;
 	// Initialize Can
 	Can::connect<GpioInputB8::Rx, GpioOutputB9::Tx>(Gpio::InputType::PullUp);
-	Can::initialize<Board::SystemClock, Can::Bitrate::kBps125>(9);
+	Can::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can ..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f103c8t6_blue_pill/can/main.cpp
+++ b/examples/stm32f103c8t6_blue_pill/can/main.cpp
@@ -73,7 +73,7 @@ main()
 	} else {
 		Can::connect<GpioInputB8::Rx, GpioOutputB9::Tx>(Gpio::InputType::PullUp);
 	}
-	Can::initialize<Board::SystemClock, Can::Bitrate::kBps125>(9);
+	Can::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can1..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f3_discovery/can/main.cpp
+++ b/examples/stm32f3_discovery/can/main.cpp
@@ -84,7 +84,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can ..." << modm::endl;
 	// Initialize Can
 	Can::connect<GpioInputB8::Rx, GpioOutputB9::Tx>(Gpio::InputType::PullUp);
-	Can::initialize<Board::SystemClock, Can::Bitrate::kBps125>(9);
+	Can::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can ..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f469_discovery/can/main.cpp
+++ b/examples/stm32f469_discovery/can/main.cpp
@@ -15,6 +15,7 @@
 #include <modm/board.hpp>
 #include <modm/processing/timer.hpp>
 #include <modm/debug/logger.hpp>
+using namespace modm::literals;
 
 /**
  * Example of CAN Hardware on STM32 F469 Discovery Board (with display).
@@ -75,7 +76,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can ..." << modm::endl;
 	// Initialize Can
 	Can2::connect<GpioB13::Tx, GpioB5::Rx>(Gpio::InputType::PullUp);
-	Can2::initialize<Board::SystemClock, Can2::Bitrate::kBps125>(9);
+	Can2::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can ..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f4_discovery/barometer_bmp085_bmp180/main.cpp
+++ b/examples/stm32f4_discovery/barometer_bmp085_bmp180/main.cpp
@@ -131,7 +131,7 @@ main()
 	Usart2::initialize<Board::SystemClock, 115200_Bd>();
 
 	MyI2cMaster::connect<GpioB9::Sda, GpioB8::Scl>();
-	MyI2cMaster::initialize<Board::SystemClock, MyI2cMaster::Baudrate::Standard>();
+	MyI2cMaster::initialize<Board::SystemClock, 100_kHz>();
 
 	stream << "\n\nWelcome to BMP085 demo!\n\n";
 

--- a/examples/stm32f4_discovery/can/main.cpp
+++ b/examples/stm32f4_discovery/can/main.cpp
@@ -71,7 +71,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can1..." << modm::endl;
 	// Initialize Can1
 	Can1::connect<GpioB8::Rx, GpioB9::Tx>(Gpio::InputType::PullUp);
-	Can1::initialize<Board::SystemClock, Can1::Bitrate::kBps125>(9);
+	Can1::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can1..." << modm::endl;
 	// Receive every message
@@ -82,7 +82,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can2..." << modm::endl;
 	// Initialize Can2
 	Can2::connect<GpioB5::Rx, GpioB6::Tx>(Gpio::InputType::PullUp);
-	Can2::initialize<Board::SystemClock, Can2::Bitrate::kBps125>(12);
+	Can2::initialize<Board::SystemClock, 125_kbps>(12);
 
 	MODM_LOG_INFO << "Setting up Filter for Can2..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f4_discovery/can2/main.cpp
+++ b/examples/stm32f4_discovery/can2/main.cpp
@@ -85,7 +85,7 @@ main()
 	MODM_LOG_INFO << "Initializing Can ..." << modm::endl;
 	// Initialize Can
 	Can1::connect<GpioInputB8::Rx, GpioOutputB9::Tx>(Gpio::InputType::PullUp);
-	Can1::initialize<Board::SystemClock, Can1::Bitrate::kBps125>(9);
+	Can1::initialize<Board::SystemClock, 125_kbps>(9);
 
 	MODM_LOG_INFO << "Setting up Filter for Can ..." << modm::endl;
 	// Receive every message

--- a/examples/stm32f4_discovery/radio/nrf24-basic-comm/main.cpp
+++ b/examples/stm32f4_discovery/radio/nrf24-basic-comm/main.cpp
@@ -102,11 +102,11 @@ main()
 
 	// Enable SPI 1
 	SpiMaster1::connect<GpioB5::Mosi, GpioB4::Miso, GpioB3::Sck>();
-	SpiMaster1::initialize<Board::SystemClock, 10.5_MHz, modm::Tolerance::Exact>();
+	SpiMaster1::initialize<Board::SystemClock, 10.5_MHz, 0_pct>();
 
 	// Enable SPI 2
 	SpiMaster2::connect<GpioB15::Mosi, GpioB14::Miso, GpioB13::Sck>();
-	SpiMaster2::initialize<Board::SystemClock, 10.5_MHz, modm::Tolerance::Exact>();
+	SpiMaster2::initialize<Board::SystemClock, 10.5_MHz, 0_pct>();
 
 	// Enable UART 2
 	Usart2::connect<GpioA2::Tx>();

--- a/examples/stm32f4_discovery/rtos/float_check/main.cpp
+++ b/examples/stm32f4_discovery/rtos/float_check/main.cpp
@@ -15,6 +15,7 @@
 #include <modm/processing/rtos.hpp>
 
 using namespace modm::platform;
+using namespace modm::literals;
 
 /**
  * Check FPU support in FreeRTOS for STM32F4.
@@ -98,7 +99,7 @@ main()
 	Board::initialize();
 
 	Usart2::connect<GpioA2::Tx>();
-	Usart2::initialize<Board::SystemClock, Usart2::B115200>();
+	Usart2::initialize<Board::SystemClock, 115200_Bd>();
 
 	while (1)
 	{

--- a/examples/stm32f4_discovery/uart_spi/main.cpp
+++ b/examples/stm32f4_discovery/uart_spi/main.cpp
@@ -21,7 +21,7 @@ main()
 
 	// Enable Uart SPI 2
 	UartSpiMaster2::connect<GpioA4::Ck, GpioA2::Tx, GpioA3::Rx>();
-	UartSpiMaster2::initialize<Board::SystemClock, 5.25_MHz, modm::Tolerance::Exact>();
+	UartSpiMaster2::initialize<Board::SystemClock, 5.25_MHz, 0_pct>();
 
 	while (1)
 	{

--- a/examples/zmq/1_stm32/main.cpp
+++ b/examples/zmq/1_stm32/main.cpp
@@ -23,6 +23,7 @@
 #include <identifier.hpp>
 
 using namespace Board;
+using namespace modm::literals;
 
 namespace Led
 {
@@ -95,7 +96,7 @@ main()
 
 	// Initialize Can1
 	Can1::connect<GpioB8::Rx, GpioB9::Tx>(Gpio::InputType::PullUp);
-	Can1::initialize<Board::SystemClock, Can1::Bitrate::kBps125>(10);
+	Can1::initialize<Board::SystemClock, 125_kbps>(10);
 	CanFilter::setFilter(0, CanFilter::FIFO0,
 						CanFilter::ExtendedIdentifier(0),
 						CanFilter::ExtendedFilterMask(0));

--- a/examples/zmq/2_zmq_gateway/main.cpp
+++ b/examples/zmq/2_zmq_gateway/main.cpp
@@ -21,6 +21,7 @@
 
 #include <modm/communication/xpcc/backend/can/connector.hpp>
 #include <modm/communication/xpcc/backend/zeromq/connector.hpp>
+using namespace modm::literals;
 
 /**
  * Listens to a CAN bus connected by a CAN2USB and publishes modm messages with zeromq.
@@ -38,7 +39,7 @@
  */
 
 // Default CAN bitrate
-static constexpr modm::Can::Bitrate canBusBitRate = modm::Can::kBps125;
+static constexpr modm::bitrate_t canBusBitRate = 125_kbps;
 
 /* Either use an USB CAN2USB adaptor with modm Lawicel interpreter
    or use a CAN controller supported by Linux' SocketCAN.

--- a/src/modm/architecture/interface/adc.hpp
+++ b/src/modm/architecture/interface/adc.hpp
@@ -79,8 +79,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed relative tolerance for the resulting clock frequency
 	 */
-	template< class SystemClock, uint32_t frequency=200000,
-			uint16_t tolerance = Tolerance::TenPercent >
+	template< class SystemClock, frequency_t frequency=200_kHz, percent_t tolerance=10_pct >
 	static void
 	initialize();
 

--- a/src/modm/architecture/interface/can.hpp
+++ b/src/modm/architecture/interface/can.hpp
@@ -35,20 +35,6 @@ public:
 		ListenOnlyLoopBack	= 0b11,	///< combination of both modes
 	};
 
-	/// Supported CAN bitrates; maybe different on a per device basis
-	enum
-	Bitrate : uint32_t
-	{
-		kBps10  =   10000,
-		kBps20  =   20000,
-		kBps50  =   50000,
-		kBps100 =  100000,
-		kBps125 =  125000,
-		kBps250 =  250000,
-		kBps500 =  500000,
-		MBps1   = 1000000,
-	};
-
 	enum class
 	BusState : uint8_t
 	{
@@ -92,8 +78,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed relative tolerance for the resulting baudrate
 	 */
-	template< class SystemClock, uint32_t bitrate = Bitrate::kBps125,
-			uint16_t tolerance = Tolerance::OnePercent >
+	template< class SystemClock, bitrate_t bitrate = 125_kbps, percent_t tolerance = 1_pct >
 	static void
 	initialize(Mode startupMode);
 

--- a/src/modm/architecture/interface/clock.hpp
+++ b/src/modm/architecture/interface/clock.hpp
@@ -64,22 +64,6 @@ protected:
 	static Type time;
 };
 
-
-using frequency_t = uint32_t;
-namespace literals
-{
-	constexpr frequency_t operator "" _Hz(unsigned long long int frequency)
-	{ return frequency; }
-	constexpr frequency_t operator "" _kHz(unsigned long long int frequency)
-	{ return frequency * 1'000; }
-	constexpr frequency_t operator "" _kHz(long double frequency)
-	{ return frequency * 1'000; }
-	constexpr frequency_t operator "" _MHz(unsigned long long int frequency)
-	{ return frequency * 1'000'000; }
-	constexpr frequency_t operator "" _MHz(long double frequency)
-	{ return frequency * 1'000'000; }
-}
-
 }	// namespace modm
 
 #endif	// MODM_INTERFACE_CLOCK_HPP

--- a/src/modm/architecture/interface/delay.md
+++ b/src/modm/architecture/interface/delay.md
@@ -10,12 +10,11 @@ to use these delay functions.
 The only guarantee given to you is to delay for _at least_ the specified time.
 Note that invocation of interrupts during spinning may add delay too.
 
-!!!warning
-   You must not rely on delay functions for ANY time-keeping!
+!!! warning "No real-time guarantees!"
+    You must not rely on delay functions for ANY time-keeping!
 
 Delay functions work at any CPU clock speed, even if changed dynamically and
 are available very early in the startup process at hardware-init time.
 
-!!!warning
-   Correct behavior is not guaranteed for delays over 1000ns, us or ms!
-   Make sure to use the largest time unit possible.
+!!! warning "Use the largest time unit possible!"
+    Correct behavior is not guaranteed for delays over 1000ns, us or ms!

--- a/src/modm/architecture/interface/i2c_master.hpp
+++ b/src/modm/architecture/interface/i2c_master.hpp
@@ -48,17 +48,6 @@ public:
 		Unknown				///< Unknown error condition
 	};
 
-	/// Baudrate of the I2C bus. Most slaves only work in Standard or Fast mode.
-	enum
-	Baudrate : uint32_t
-	{
-		LowSpeed =   10000,	///< Low-Speed datarate of 10kHz
-		Standard =  100000,	///< Standard datarate of 100kHz
-		Fast     =  400000,	///< Fast datarate of 400kHz
-		FastPlus = 1000000,	///< Fast Plus datarate of 1.0MHz (rarely supported)
-		High     = 3400000	///< Super datarate of 3.4MHz (rarely supported)
-	};
-
 	enum class
 	PullUps
 	{
@@ -111,8 +100,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed absolute tolerance for the resulting baudrate
 	 */
-	template< class SystemClock, uint32_t baudrate = Baudrate::Standard,
-			uint16_t tolerance = Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate=100_kBd, percent_t tolerance=5_pct >
 	static void
 	initialize();
 

--- a/src/modm/architecture/interface/peripheral.hpp
+++ b/src/modm/architecture/interface/peripheral.hpp
@@ -17,37 +17,10 @@
 #include <stdint.h>
 #include <cstddef>
 #include <modm/math/tolerance.hpp>
+#include <modm/math/units.hpp>
 
 namespace modm
 {
-
-using baudrate_t = uint32_t;
-using bitrate_t = uint32_t;
-
-namespace literals
-{
-	constexpr baudrate_t operator "" _Bd(unsigned long long int baudrate)
-	{ return baudrate; }
-	constexpr baudrate_t operator "" _kBd(unsigned long long int baudrate)
-	{ return baudrate * 1'000; }
-	constexpr baudrate_t operator "" _kBd(long double baudrate)
-	{ return baudrate * 1'000; }
-	constexpr baudrate_t operator "" _MBd(unsigned long long int baudrate)
-	{ return baudrate * 1'000'000; }
-	constexpr baudrate_t operator "" _MBd(long double baudrate)
-	{ return baudrate * 1'000'000; }
-
-	constexpr baudrate_t operator "" _bps(unsigned long long int baudrate)
-	{ return baudrate; }
-	constexpr baudrate_t operator "" _kbps(unsigned long long int baudrate)
-	{ return baudrate * 1'000; }
-	constexpr baudrate_t operator "" _kbps(long double baudrate)
-	{ return baudrate * 1'000; }
-	constexpr baudrate_t operator "" _Mbps(unsigned long long int baudrate)
-	{ return baudrate * 1'000'000; }
-	constexpr baudrate_t operator "" _Mbps(long double baudrate)
-	{ return baudrate * 1'000'000; }
-}
 
 /**
  * Peripheral class
@@ -110,7 +83,7 @@ public:
 	 * This method checks if the user requested baudrate is within error
 	 * tolerance of the system achievable baudrate.
 	 */
-	template< baudrate_t available, baudrate_t requested, uint16_t tolerance >
+	template< baudrate_t available, baudrate_t requested, percent_t tolerance >
 	static void
 	assertBaudrateInTolerance()
 	{

--- a/src/modm/architecture/interface/spi_master.hpp
+++ b/src/modm/architecture/interface/spi_master.hpp
@@ -55,8 +55,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed relative tolerance for the resulting baudrate
 	 */
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=5_pct >
 	static void
 	initialize();
 

--- a/src/modm/architecture/interface/uart.hpp
+++ b/src/modm/architecture/interface/uart.hpp
@@ -30,40 +30,6 @@ namespace modm
  */
 class Uart : public ::modm::PeripheralDriver
 {
-public:
-	/**
-	 * Commonly used baudrates.
-	 *
-	 * Most Serial-to-USB converters only support baudrates up to 115200 Baud
-	 */
-	enum
-	Baudrate : uint32_t
-	{
-#ifndef B300	// termios.h defines B300 .. B38400
-		    B300 =     300,
-		    B600 =     600,
-		   B1200 =    1200,
-		   B1800 =    1800,
-		   B2400 =    2400,
-		   B4800 =    4800,
-		   B9600 =    9600,
-		  B14400 =   14400,
-		  B19200 =   19200,
-		  B28800 =   28800,
-		  B38400 =   38400,
-		  B57600 =   57600,
-		  B76800 =   76800,
-		 B115200 =  115200,
-		 B230400 =  230400,
-		 B250000 =  250000,
-		 kBps250 =  250000,
-		 B500000 =  500000,
-		 kBps500 =  500000,
-		B1000000 = 1000000,
-		   MBps1 = 1000000
-#endif
-	};
-
 #ifdef __DOXYGEN__
 public:
 	/// Size of the receive buffer.
@@ -95,8 +61,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed absolute tolerance for the resulting baudrate
 	 */
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = Tolerance::OnePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=10_pct >
 	static void
 	initialize();
 

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -341,7 +341,7 @@ All hardware peripherals with common interfaces.
 """
 
 def prepare(module, options):
-    module.depends(":math") # for tolerance.hpp
+    module.depends(":math:units")
 
     module.add_submodule(Accessor())
     module.add_submodule(Adc())

--- a/src/modm/board/disco_f407vg/board.hpp
+++ b/src/modm/board/disco_f407vg/board.hpp
@@ -209,7 +209,7 @@ initializeCs43()
 	cs43::Reset::setOutput(modm::Gpio::High);
 
 	cs43::I2cMaster::connect<cs43::Scl::Scl, cs43::Sda::Sda>();
-	cs43::I2cMaster::initialize<SystemClock, cs43::I2cMaster::Baudrate::Standard>();
+	cs43::I2cMaster::initialize<SystemClock, 100_kHz>();
 }
 
 /// not supported yet, due to missing I2S driver

--- a/src/modm/driver/can/mcp2515.hpp
+++ b/src/modm/driver/can/mcp2515.hpp
@@ -118,9 +118,7 @@ namespace modm
     class Mcp2515 : public ::modm::Can
 	{
 	public:
-		template< int32_t ExternalClockFrequency,
-			   uint32_t bitrate = Bitrate::kBps125,
-			   uint16_t tolerance = Tolerance::OnePercent >
+		template<frequency_t ExternalClock, bitrate_t bitrate=kbps(125), percent_t tolerance=pct(1) >
 		static inline bool
 		initialize();
 

--- a/src/modm/driver/can/mcp2515_bit_timings.hpp
+++ b/src/modm/driver/can/mcp2515_bit_timings.hpp
@@ -36,28 +36,28 @@ private:
 		using namespace modm::literals;
 		return (Clk ==  8_MHz)? 1 :
 			   (Clk == 16_MHz)? 1 :
-			   (Clk == 20_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 1 : 3 ) : 0;
+			   (Clk == 20_MHz)? ( (Bitrate == 1_Mbps) ? 1 : 3 ) : 0;
 	}
 
 	static constexpr uint8_t calcProp() {
 		using namespace modm::literals;
 		return (Clk ==  8_MHz)? 1 :
-			   (Clk == 16_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 1 : 3 ) :
-			   (Clk == 20_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 3 : 5 ) : 0;
+			   (Clk == 16_MHz)? ( (Bitrate == 1_Mbps) ? 1 : 3 ) :
+			   (Clk == 20_MHz)? ( (Bitrate == 1_Mbps) ? 3 : 5 ) : 0;
 	}
 
 	static constexpr uint8_t calcPS1() {
 		using namespace modm::literals;
-		return (Clk ==  8_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 1 : 4 ) :
-			   (Clk == 16_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 4 : 8 ) :
-			   (Clk == 20_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 4 : 8 ) : 0;
+		return (Clk ==  8_MHz)? ( (Bitrate == 1_Mbps) ? 1 : 4 ) :
+			   (Clk == 16_MHz)? ( (Bitrate == 1_Mbps) ? 4 : 8 ) :
+			   (Clk == 20_MHz)? ( (Bitrate == 1_Mbps) ? 4 : 8 ) : 0;
 	}
 
 	static constexpr uint8_t calcPS2() {
 		using namespace modm::literals;
-		return (Clk ==  8_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 1 : 2) :
-			   (Clk == 16_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 2 : 4 ) :
-			   (Clk == 20_MHz)? ( (Bitrate == modm::Can::Bitrate::MBps1) ? 2 : 4 ) : 0;
+		return (Clk ==  8_MHz)? ( (Bitrate == 1_Mbps) ? 1 : 2) :
+			   (Clk == 16_MHz)? ( (Bitrate == 1_Mbps) ? 2 : 4 ) :
+			   (Clk == 20_MHz)? ( (Bitrate == 1_Mbps) ? 2 : 4 ) : 0;
 	}
 
 	static constexpr uint8_t calcPrescaler(uint8_t sjw, uint8_t prop, uint8_t ps1, uint8_t ps2) {

--- a/src/modm/driver/can/mcp2515_impl.hpp
+++ b/src/modm/driver/can/mcp2515_impl.hpp
@@ -111,9 +111,7 @@ modm::Mcp2515<SPI, CS, INT>::initializeWithPrescaler(
 
 
 template <typename SPI, typename CS, typename INT>
-template <int32_t externalClockFrequency,
-			uint32_t bitrate,
-			uint16_t tolerance>
+template <modm::frequency_t externalClockFrequency, modm::bitrate_t bitrate, modm::percent_t tolerance>
 bool
 modm::Mcp2515<SPI, CS, INT>::initialize()
 {

--- a/src/modm/math/math.lb
+++ b/src/modm/math/math.lb
@@ -16,6 +16,7 @@ def init(module):
     module.description = "Math"
 
 def prepare(module, options):
+    module.depends(":math:units")
     return True
 
 def build(env):

--- a/src/modm/math/tolerance.hpp
+++ b/src/modm/math/tolerance.hpp
@@ -13,15 +13,10 @@
 #define MODM_MATH_TOLERANCE_HPP
 
 #include <stdint.h>
+#include <modm/math/units.hpp>
 
 namespace modm
 {
-
-namespace literals
-{
-	constexpr uint16_t operator "" _percent(long double percent)
-	{ return percent * 10; }
-}
 
 /**
  * This class checks if values are within a certain tolerance.
@@ -35,19 +30,6 @@ class
 Tolerance
 {
 public:
-	///@{
-	/// Common tolerances in percent
-	static constexpr uint16_t Exact			=    0;
-	static constexpr uint16_t ZeroPercent	=    0;
-	static constexpr uint16_t HalfPercent	=    5;
-	static constexpr uint16_t OnePercent	=   10;
-	static constexpr uint16_t TwoPercent	=   20;
-	static constexpr uint16_t FivePercent	=   50;
-	static constexpr uint16_t TenPercent	=  100;
-	static constexpr uint16_t TwentyPercent	=  200;
-	static constexpr uint16_t DontCare		= 1000;
-	///@}
-
 	static constexpr int64_t
 	absoluteError(uint32_t reference, uint32_t actual)
 	{
@@ -61,18 +43,18 @@ public:
 	}
 
 	static constexpr bool
-	isErrorInTolerance(float error, uint16_t tolerance)
+	isErrorInTolerance(float error, percent_t tolerance)
 	{
-		return (error == 0) or (((error > 0) ? error : -error) * 1000 <= tolerance);
+		return (error == 0) or (((error > 0) ? error : -error) <= pct2f(tolerance));
 	}
 
 	static constexpr bool
-	isValueInTolerance(uint32_t reference, uint32_t actual, uint16_t tolerance)
+	isValueInTolerance(uint32_t reference, uint32_t actual, percent_t tolerance)
 	{
 		return isErrorInTolerance(relativeError(reference, actual), tolerance);
 	}
 
-	template< uint32_t reference, uint32_t actual, uint16_t tolerance >
+	template< uint32_t reference, uint32_t actual, percent_t tolerance >
 	static void
 	assertValueInTolerance()
 	{

--- a/src/modm/math/units.hpp
+++ b/src/modm/math/units.hpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_MATH_UNITS_HPP
+#define MODM_MATH_UNITS_HPP
+
+#include <stdint.h>
+#include <modm/architecture/utils.hpp>
+
+#ifdef __DOXYGEN__
+
+namespace modm
+{
+	/// @ingroup modm_math_units
+	/// @{
+	using frequency_t = uint32_t;
+	template<typename T> constexpr frequency_t Hz(T value);
+	template<typename T> constexpr frequency_t kHz(T value);
+	template<typename T> constexpr frequency_t MHz(T value);
+
+	using baudrate_t = uint32_t;
+	template<typename T> constexpr baudrate_t Bd(T value);
+	template<typename T> constexpr baudrate_t kBd(T value);
+	template<typename T> constexpr baudrate_t MBd(T value);
+
+	using bitrate_t = uint32_t;
+	template<typename T> constexpr bitrate_t bps(T value);
+	template<typename T> constexpr bitrate_t kbps(T value);
+	template<typename T> constexpr bitrate_t Mbps(T value);
+
+	using percent_t = uint16_t;
+	template<typename T> constexpr percent_t pct(T value);
+	/// @}
+
+	namespace literals
+	{
+		/// @ingroup modm_math_units
+		/// @{
+		constexpr operator""_Hz(unsigned long long int value);
+		constexpr operator""_kHz(T value);
+		constexpr operator""_MHz(T value);
+
+		constexpr operator""_Bd(T value);
+		constexpr operator""_kBd(T value);
+		constexpr operator""_MBd(T value);
+
+		constexpr operator""_bps(T value);
+		constexpr operator""_kbps(T value);
+		constexpr operator""_Mbps(T value);
+
+		constexpr operator""_pct(T value);
+		/// @}
+	}
+}
+
+#else
+
+#define MODM_LITERAL_DEFINITION(type, name, symbol) \
+namespace modm { \
+using MODM_CONCAT(name, _t) = type; \
+template<typename T> constexpr MODM_CONCAT(name, _t) symbol(T value) { return value; } \
+template<typename T> constexpr MODM_CONCAT(name, _t) MODM_CONCAT(k, symbol)(T value) { return value * 1'000ul; } \
+template<typename T> constexpr MODM_CONCAT(name, _t) MODM_CONCAT(M, symbol)(T value) { return value * 1'000'000ul; } \
+namespace literals { \
+	constexpr MODM_CONCAT(name, _t) MODM_CONCAT(operator""_ , symbol)(unsigned long long int value) { return symbol(value); } \
+	constexpr MODM_CONCAT(name, _t) MODM_CONCAT(operator""_k, symbol)(unsigned long long int value) { return MODM_CONCAT(k, symbol)(value); } \
+	constexpr MODM_CONCAT(name, _t) MODM_CONCAT(operator""_k, symbol)(long double value)            { return MODM_CONCAT(k, symbol)(value); } \
+	constexpr MODM_CONCAT(name, _t) MODM_CONCAT(operator""_M, symbol)(unsigned long long int value) { return MODM_CONCAT(M, symbol)(value); } \
+	constexpr MODM_CONCAT(name, _t) MODM_CONCAT(operator""_M, symbol)(long double value)            { return MODM_CONCAT(M, symbol)(value); } \
+}}
+
+MODM_LITERAL_DEFINITION(uint32_t, frequency, Hz)
+MODM_LITERAL_DEFINITION(uint32_t, baudrate, Bd)
+MODM_LITERAL_DEFINITION(uint32_t, bitrate, bps)
+
+namespace modm {
+enum class percent_t : uint16_t {};
+template<typename T> constexpr percent_t pct(T value) { return percent_t(uint16_t(value * 600ul)); }
+constexpr float pct2f(percent_t value) { return uint16_t(value) / 60'000.f; }
+namespace literals
+{
+	constexpr percent_t operator""_pct(long double value) { return pct(value); }
+	constexpr percent_t operator""_pct(unsigned long long int value) { return pct(value); }
+}
+}
+
+#endif	// __DOXYGEN__
+
+#endif	// MODM_MATH_UNITS_HPP

--- a/src/modm/math/units.lb
+++ b/src/modm/math/units.lb
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.parent = ":math"
+    module.name = "units"
+    module.description = """\
+# SI Units
+
+modm uses a couple of common SI units for configuration of peripherals:
+
+- `frequency_t` in Hertz: `Hz`, `kHz` and `MHz`.
+- `baudrate_t` in Baud: `Bd`, `kBd`, `MBd`.
+- `bitrate_t` in bit/s, `bps`.
+
+These are integral units, so 1 Hz/Bd/bps cannot be split further, and are cast
+directly to `uint32_t` type, so they can be used as a non-type template argument.
+
+Conversion can be done via constexpr functions from *any* numerical type:
+
+- `modm::Hz(T value)`, `modm::kHz(T value)`, `modm::MHz(T value)`.
+- `modm::Bd(T value)`, `modm::kBd(T value)`, `modm::MBd(T value)`.
+- `modm::bps(T value)`, `modm::kbps(T value)`, `modm::Mbps(T value)`.
+
+In addition, user-defined literals are provided in the `modm::literals` namespace:
+
+```cpp
+using namespace modm::literals;
+
+frequency_t frequency = modm::Mhz(10.5);
+            frequency = 10.5_MHz;
+baudrate_t baudrate = 115.2_kBd;
+           baudrate = modm::kBd(115.2);
+bitrate_t bitrate = modm::kbps(125);
+          bitrate = 125_kbps;
+
+frequency = 4295_MHz; // OVERFLOW at 2^32 units!
+```
+
+## Integral Percentages
+
+Since `float` cannot be used as a non-type template argument, an integer type
+for providing tolerances in `percent_t` is available.
+Note that `percent_t` is implemented as an enum class, which prevents implicit
+conversions, since the base for this is not 1.
+You must therefore use the `modm::pct(T value)` or `_pct` constructors.
+
+```cpp
+using namespace modm::literals;
+
+percent_t tolerance = modm::pct(10);
+          tolerance = 10_pct;
+
+// convert back to float. *internal use only*
+float percent = modm::pct2f(tolerance);
+```
+
+!!! warning "This type is not guaranteed to hold more than 100 percent!"
+
+"""
+
+def prepare(module, options):
+    module.depends(":architecture")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/math"
+    env.copy("units.hpp")

--- a/src/modm/platform/adc/at90_tiny_mega/adc_mega.hpp.in
+++ b/src/modm/platform/adc/at90_tiny_mega/adc_mega.hpp.in
@@ -119,8 +119,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t frequency=100000,
-			uint16_t tolerance = modm::Tolerance::TenPercent >
+	template< class SystemClock, frequency_t frequency=kHz(100), percent_t tolerance=pct(10) >
 	static void
 	initialize()
 	{

--- a/src/modm/platform/adc/at90_tiny_mega/adc_tiny.hpp.in
+++ b/src/modm/platform/adc/at90_tiny_mega/adc_tiny.hpp.in
@@ -165,8 +165,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t frequency=100000,
-			uint16_t tolerance = modm::Tolerance::TenPercent >
+	template< class SystemClock, frequency_t frequency=kHz(100), percent_t tolerance=pct(10) >
 	static void
 	initialize()
 	{

--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -197,8 +197,7 @@ public:
 	 * The ADC clock must not exceed 14 MHz.
 %% endif
 	 */
-	template< class SystemClock, uint32_t frequency=10000000,
-			uint16_t tolerance = modm::Tolerance::TenPercent >
+	template< class SystemClock, frequency_t frequency=MHz(10), percent_t tolerance=pct(10) >
 	static void
 	initialize();
 

--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -15,7 +15,7 @@
 #	error 	"Don't include this file directly, use 'adc_{{ id }}.hpp' instead!"
 #endif
 
-template< class SystemClock, uint32_t frequency, uint16_t tolerance >
+template< class SystemClock, modm::frequency_t frequency, modm::percent_t tolerance >
 void
 modm::platform::Adc{{ id }}::initialize()
 {

--- a/src/modm/platform/can/canusb/canusb.hpp
+++ b/src/modm/platform/can/canusb/canusb.hpp
@@ -45,7 +45,7 @@ public:
 	~CanUsb();
 
 	bool
-	open(modm::Can::Bitrate canBitrate = modm::Can::kBps125);
+	open(bitrate_t canBitrate = kbps(125));
 
 	void
 	close();

--- a/src/modm/platform/can/canusb/canusb_impl.hpp
+++ b/src/modm/platform/can/canusb/canusb_impl.hpp
@@ -51,8 +51,9 @@ modm::platform::CanUsb<SerialPort>::~CanUsb()
 
 template <typename SerialPort>
 bool
-modm::platform::CanUsb<SerialPort>::open(modm::Can::Bitrate canBitrate)
+modm::platform::CanUsb<SerialPort>::open(bitrate_t canBitrate)
 {
+	using namespace literals;
 	if (this->serialPort.open())
 	{
 		MODM_LOG_DEBUG << MODM_FILE_INFO << "SerialPort opened in canusb" << modm::endl;
@@ -73,28 +74,28 @@ modm::platform::CanUsb<SerialPort>::open(modm::Can::Bitrate canBitrate)
 
 		switch (canBitrate)
 		{
-			case kBps10:
+			case 10_kbps:
 				this->serialPort.write("S0\r");
 			break;
-			case kBps20:
+			case 20_kbps:
 				this->serialPort.write("S1\r");
 			break;
-			case kBps50:
+			case 50_kbps:
 				this->serialPort.write("S2\r");
 			break;
-			case kBps100:
+			case 100_kbps:
 				this->serialPort.write("S3\r");
 			break;
-			case kBps125:
+			case 125_kbps:
 				this->serialPort.write("S4\r");
 			break;
-			case kBps250:
+			case 250_kbps:
 				this->serialPort.write("S5\r");
 			break;
-			case kBps500:
+			case 500_kbps:
 				this->serialPort.write("S6\r");
 			break;
-			case MBps1:
+			case 1_Mbps:
 				this->serialPort.write("S8\r");
 			break;
 		}

--- a/src/modm/platform/can/common/can_bit_timings.hpp
+++ b/src/modm/platform/can/common/can_bit_timings.hpp
@@ -16,6 +16,7 @@
 #define MODM_COMMON_CAN_BIT_TIMINGS_HPP
 
 #include <modm/architecture/interface/clock.hpp>
+#include <modm/math/units.hpp>
 #include <cmath>
 
 namespace modm
@@ -98,10 +99,10 @@ public:
 	static constexpr uint8_t getSJW() { return BestConfig.sjw; }
 	static constexpr uint8_t getPrescaler() { return BestConfig.prescaler; }
 
-	template<uint16_t tolerance>
+	template<percent_t tolerance>
 	static constexpr void assertBitrateInTolerance()
 	{
-		static_assert(tolerance >= static_cast<uint16_t>(BestConfig.minError * 1000.f),
+		static_assert(pct2f(tolerance) >= BestConfig.minError,
 			"The closest available bitrate exceeds the specified maximum tolerance!");
 	}
 

--- a/src/modm/platform/can/lpc/c_can.hpp.in
+++ b/src/modm/platform/can/lpc/c_can.hpp.in
@@ -60,8 +60,7 @@ class Can : public ::modm::Can
 {
 public:
 
-	template< class SystemClock, uint32_t bitrate = Bitrate::kBps125,
-			uint16_t tolerance = Tolerance::OnePercent >
+	template< class SystemClock, bitrate_t bitrate=kbps(125), percent_t tolerance=pct(1) >
 	static inline void
 	initialize()
 	{

--- a/src/modm/platform/can/socketcan/socketcan.cpp
+++ b/src/modm/platform/can/socketcan/socketcan.cpp
@@ -38,7 +38,7 @@ modm::platform::SocketCan::~SocketCan()
 }
 
 bool
-modm::platform::SocketCan::open(std::string deviceName /*, modm::Can::Bitrate canBitrate */)
+modm::platform::SocketCan::open(std::string deviceName /*, bitrate_t canBitrate */)
 {
 	skt = socket(PF_CAN, SOCK_RAW, CAN_RAW);
 

--- a/src/modm/platform/can/socketcan/socketcan.hpp
+++ b/src/modm/platform/can/socketcan/socketcan.hpp
@@ -32,7 +32,7 @@ public:
 	~SocketCan();
 
 	bool
-	open(std::string deviceName /*, modm::Can::Bitrate canBitrate = modm::Can::kBps125 */);
+	open(std::string deviceName /*, bitrate_t canBitrate = kbps(125) */);
 
 	void
 	close();

--- a/src/modm/platform/can/stm32/can.hpp.in
+++ b/src/modm/platform/can/stm32/can.hpp.in
@@ -106,8 +106,7 @@ public:
 	 * \warning	Has to called after connect(), but before any
 	 * 			other function from this class!
 	 */
-	template< class SystemClock, uint32_t bitrate = Bitrate::kBps125,
-			uint16_t tolerance = Tolerance::OnePercent >
+	template< class SystemClock, bitrate_t bitrate=kbps(125), percent_t tolerance=pct(1) >
 	static inline void
 	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
 				bool overwriteOnOverrun = true)

--- a/src/modm/platform/clock/systick/systick_timer.hpp.in
+++ b/src/modm/platform/clock/systick/systick_timer.hpp.in
@@ -46,7 +46,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed absolute tolerance for the resulting clock rate
 	 */
-	template< class SystemClock, uint16_t tolerance = modm::Tolerance::ZeroPercent >
+	template< class SystemClock, percent_t tolerance=pct(0) >
 	static void
 	initialize()
 	{

--- a/src/modm/platform/i2c/at90_tiny_mega/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/at90_tiny_mega/i2c_master.hpp.in
@@ -61,8 +61,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t baudrate=Baudrate::Standard,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate=kHz(100), percent_t tolerance=pct(5) >
 	static modm_always_inline void
 	initialize()
 	{

--- a/src/modm/platform/i2c/bitbang/bitbang_i2c_master.hpp.in
+++ b/src/modm/platform/i2c/bitbang/bitbang_i2c_master.hpp.in
@@ -53,8 +53,7 @@ public:
 	connect(PullUps pullups = PullUps::External);
 
 	/// Initializes the hardware, with the baudrate limited to about 250kbps.
-	template< class SystemClock, uint32_t baudrate=Baudrate::Standard,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate=kHz(100), percent_t tolerance=pct(5) >
 	static void
 	initialize();
 

--- a/src/modm/platform/i2c/bitbang/bitbang_i2c_master_impl.hpp
+++ b/src/modm/platform/i2c/bitbang/bitbang_i2c_master_impl.hpp
@@ -46,11 +46,11 @@ template <class Scl, class Sda>
 modm::I2cTransaction::Reading modm::platform::BitBangI2cMaster<Scl, Sda>::reading(nullptr, 0, modm::I2c::OperationAfterRead::Stop);
 
 template <class Scl, class Sda>
-template< class SystemClock, uint32_t baudrate, uint16_t tolerance >
+template< class SystemClock, modm::baudrate_t baudrate, modm::percent_t tolerance >
 void
 modm::platform::BitBangI2cMaster<Scl, Sda>::initialize()
 {
-	delayTime = uint32_t(250000000) / baudrate;
+	delayTime = 250'000'000ul / baudrate;
 	if (delayTime == 0) delayTime = 1;
 
 	SCL::set();

--- a/src/modm/platform/i2c/stm32-extended/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.hpp.in
@@ -42,7 +42,7 @@ public:
 	static constexpr size_t TransactionBufferSize = {{ options["buffer.transaction"] }};
 
 private:
-	template<class SystemClock, uint32_t baudrate, uint16_t tolerance>
+	template<class SystemClock, baudrate_t baudrate, percent_t tolerance>
 	static constexpr std::optional<uint32_t>
 	calculateTimings()
 	{
@@ -95,8 +95,7 @@ public:
 	 * @param	rate
 	 *		`Standard` or `Fast`, `High` datarate is not supported
 	 */
-	template<class SystemClock, uint32_t baudrate=Baudrate::Standard,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template<class SystemClock, baudrate_t baudrate=kBd(100), percent_t tolerance=pct(5)>
 	static modm_always_inline void
 	initialize()
 	{

--- a/src/modm/platform/i2c/stm32-extended/i2c_timing_calculator.hpp
+++ b/src/modm/platform/i2c/stm32-extended/i2c_timing_calculator.hpp
@@ -36,7 +36,7 @@ struct I2cParameters
 {
 	uint32_t peripheralClock;
 	uint32_t targetSpeed;
-	uint16_t tolerance;
+	percent_t tolerance;
 	uint8_t digitalFilterLength;
 	bool enableAnalogFilter;
 	float riseTime;
@@ -95,7 +95,7 @@ public:
 				float speed = calculateSpeed(prescaler, sclLow, sclHigh);
 				auto error = std::fabs((speed / params.targetSpeed) - 1.0f);
 				// modm::Tolerance value is in unit [1/1000]
-				if (((error*1000) < params.tolerance) && (error <= lastError) && (prescaler<=bestPrescaler)) {
+				if ((error < pct2f(params.tolerance)) && (error <= lastError) && (prescaler <= bestPrescaler)) {
 					lastError = error;
 					bestPrescaler = prescaler;
 					bestSclLow = sclLow;
@@ -288,7 +288,7 @@ private:
 		auto clockPeriod = float(prescaler + 1) / params.peripheralClock;
 
 		auto targetSclTime = 1.f / params.targetSpeed;
-		auto sclTimeMax = targetSclTime * (1.f + params.tolerance / 1000.f);
+		auto sclTimeMax = targetSclTime * (1.f + pct2f(params.tolerance));
 		auto maxSclSum = ((sclTimeMax - params.riseTime - params.fallTime - 2*SyncTime)
 				/ clockPeriod) - 2;
 

--- a/src/modm/platform/i2c/stm32/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.hpp.in
@@ -67,8 +67,7 @@ public:
 	 * @param	rate
 	 *		`Standard` or `Fast`, `High` datarate is not supported
 	 */
-	template<class SystemClock, uint32_t baudrate=Baudrate::Standard,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template<class SystemClock, baudrate_t baudrate=kBd(100), percent_t tolerance=pct(5)>
 	static modm_always_inline void
 	initialize()
 	{

--- a/src/modm/platform/i2c/xmega/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/xmega/i2c_master.hpp.in
@@ -46,8 +46,7 @@ public:
 	 * @param	baudrate
 	 *		`Standard` or `Fast`, `High` datarate is not supported by the Xmega
 	 */
-	template<class SystemClock, uint32_t baudrate=Baudrate::Standard,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template<class SystemClock, baudrate_t baudrate=kHz(100), percent_t tolerance=pct(5) >
 	static modm_always_inline void
 	initialize()
 	{

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
@@ -83,8 +83,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static inline void
 	initialize()
 	{

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
@@ -87,8 +87,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static inline void
 	initialize()
 	{

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
@@ -50,8 +50,7 @@ public:
 	connect();
 
 	/// Baudrate is limited to 500kbps.
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static void
 	initialize();
 

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
@@ -61,11 +61,11 @@ modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::connect()
 
 
 template <typename Sck, typename Mosi, typename Miso>
-template< class SystemClock, uint32_t baudrate, uint16_t tolerance >
+template< class SystemClock, modm::baudrate_t baudrate, modm::percent_t tolerance >
 void
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::initialize()
 {
-	delayTime = 500000000 / baudrate;
+	delayTime = 500'000'000ul / baudrate;
 	if (delayTime == 0) delayTime = 1;
 
 	Sck::reset();

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -79,8 +79,7 @@ public:
 	}
 
 	// start documentation inherited
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static void
 	initialize()
 	{

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
@@ -68,8 +68,7 @@ public:
 		Connector::connect();
 	}
 
-	template< 	class SystemClock, uint32_t baudrate,
-				uint16_t tolerance = modm::Tolerance::FivePercent >
+	template< 	class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static void
 	initialize()
 	{

--- a/src/modm/platform/uart/at90_tiny_mega/uart.hpp.in
+++ b/src/modm/platform/uart/at90_tiny_mega/uart.hpp.in
@@ -60,8 +60,7 @@ public:
 	}
 
 	// start documentation inherited
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = modm::Tolerance::TwoPercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(2) >
 	static modm_always_inline void
 	initialize()
 	{

--- a/src/modm/platform/uart/hosted/static_serial_interface.hpp
+++ b/src/modm/platform/uart/hosted/static_serial_interface.hpp
@@ -42,7 +42,7 @@ namespace modm
 			 * @tparam	baudrate
 			 *		desired baud rate in Hz
 			 */
-			template<uint32_t baudrate>
+			template<baudrate_t baudrate>
 			static bool
 			initialize(SerialInterface& interface);
 

--- a/src/modm/platform/uart/hosted/static_serial_interface_impl.hpp
+++ b/src/modm/platform/uart/hosted/static_serial_interface_impl.hpp
@@ -21,7 +21,7 @@ modm::platform::SerialInterface*
 modm::platform::StaticSerialInterface<N>::backend = 0;
 
 template<int N>
-template<uint32_t baudrate>
+template<modm::baudrate_t baudrate>
 bool
 modm::platform::StaticSerialInterface<N>::initialize(SerialInterface& interface)
 {

--- a/src/modm/platform/uart/lpc/uart.hpp.in
+++ b/src/modm/platform/uart/lpc/uart.hpp.in
@@ -61,8 +61,7 @@ public:
 	static constexpr size_t TxBufferSize = {{ option["buffer.tx"] }};
 
 public:
-	template< class SystemClock, uint32_t baudrate,
-			uint16_t tolerance = modm::Tolerance::OnePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
 	static void modm_always_inline
 	initialize()
 	{

--- a/src/modm/platform/uart/stm32/uart.hpp.in
+++ b/src/modm/platform/uart/stm32/uart.hpp.in
@@ -72,8 +72,7 @@ public:
 		Connector::connect();
 	}
 
-	template< class SystemClock, uint32_t baudrate,
-		uint16_t tolerance = modm::Tolerance::OnePercent >
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
 	static void modm_always_inline
 %% if options["buffered"]
 	initialize(uint32_t interruptPriority = 12, Parity parity = Parity::Disabled)

--- a/src/modm/platform/uart/stm32/uart_baudrate.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_baudrate.hpp.in
@@ -45,7 +45,7 @@ public:
 	 * Returns the highest Oversampling Mode that is possible for this configuration.
 	 */
 	static constexpr UartBase::OversamplingMode
-	getOversamplingMode(uint32_t clockrate, uint32_t baudrate)
+	getOversamplingMode(frequency_t clockrate, baudrate_t baudrate)
 	{
 		return (baudrate <= clockrate / 16) ? UartBase::OversamplingMode::By16 : UartBase::OversamplingMode::By8;
 	}
@@ -61,7 +61,7 @@ public:
 	 * @tparam	tolerance
 	 * 		the allowed absolute tolerance for the resulting baudrate
 	 */
-	template< uint32_t clockrate, uint32_t baudrate, uint16_t tolerance = 1000 >
+	template< frequency_t clockrate, baudrate_t baudrate, percent_t tolerance=pct(10) >
 	static uint16_t modm_always_inline
 	getBrr()
 	{

--- a/src/modm/platform/uart/stm32/uart_hal.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal.hpp.in
@@ -64,7 +64,7 @@ public:
 	* Enables clocks, the UART peripheral (but neither TX nor RX)
 	* Sets baudrate and parity.
 	*/
-	template<	class SystemClock, uint32_t baudrate >
+	template<	class SystemClock, baudrate_t baudrate >
 	static void
 	initialize(	Parity parity = Parity::Disabled);
 
@@ -75,7 +75,7 @@ public:
 	 * Enables clocks, the UART peripheral (but neither TX nor RX)
 	 * Sets baudrate and parity.
 	 */
-	template<	class SystemClock, uint32_t baudrate,
+	template<	class SystemClock, baudrate_t baudrate,
 				OversamplingMode oversample = OversamplingMode::By16 >
 	static void
 	initialize(	Parity parity = Parity::Disabled);

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -65,7 +65,7 @@ modm::platform::{{ name }}::disable()
 	Rcc::disable<Peripheral::{{ uart_name ~ id }}>();
 }
 %% if target["family"] != "f1"
-template<class SystemClock, uint32_t baudrate,
+template<class SystemClock, modm::baudrate_t baudrate,
 		modm::platform::{{ name }}::OversamplingMode oversample>
 void modm_always_inline
 modm::platform::{{ name }}::initialize(Parity parity)
@@ -76,7 +76,7 @@ modm::platform::{{ name }}::initialize(Parity parity)
 }
 %% endif
 
-template<class SystemClock, uint32_t baudrate>
+template<class SystemClock, modm::baudrate_t baudrate>
 void modm_always_inline
 modm::platform::{{ name }}::initialize(Parity parity)
 {

--- a/test/modm/driver/can/mcp2515_can_bit_timings_test.cpp
+++ b/test/modm/driver/can/mcp2515_can_bit_timings_test.cpp
@@ -20,37 +20,37 @@ using namespace modm;
 using namespace modm::literals;
 
 #define TEST_TIMING(clk, bitrate, sjw, prop, ps1, ps2, prescaler) \
-	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, Can::Bitrate::bitrate>::getSJW()), sjw); \
-	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, Can::Bitrate::bitrate>::getProp()), prop); \
-	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, Can::Bitrate::bitrate>::getPS1()), ps1); \
-	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, Can::Bitrate::bitrate>::getPS2()), ps2); \
-	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, Can::Bitrate::bitrate>::getPrescaler()), prescaler);
+	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, bitrate>::getSJW()), sjw); \
+	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, bitrate>::getProp()), prop); \
+	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, bitrate>::getPS1()), ps1); \
+	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, bitrate>::getPS2()), ps2); \
+	TEST_ASSERT_EQUALS((modm::CanBitTimingMcp2515<clk, bitrate>::getPrescaler()), prescaler);
 
 void
 Mcp2515CanBitTimingsTest::testPrecalculatedValues()
 {
 	//          Clock  Baud    SJW Prop PS1 PS2 Prescaler
-	TEST_TIMING(8_MHz,  kBps10,   1,   1,  4,  2,  100);
-	TEST_TIMING(8_MHz,  kBps20,   1,   1,  4,  2,   50);
-	TEST_TIMING(8_MHz,  kBps125,  1,   1,  4,  2,    8);
-	TEST_TIMING(8_MHz,  kBps250,  1,   1,  4,  2,    4);
-	TEST_TIMING(8_MHz,  kBps500,  1,   1,  4,  2,    2);
-	TEST_TIMING(8_MHz,  MBps1,    1,   1,  1,  1,    2);
+	TEST_TIMING(8_MHz,  10_kbps,   1,   1,  4,  2,  100);
+	TEST_TIMING(8_MHz,  20_kbps,   1,   1,  4,  2,   50);
+	TEST_TIMING(8_MHz,  125_kbps,  1,   1,  4,  2,    8);
+	TEST_TIMING(8_MHz,  250_kbps,  1,   1,  4,  2,    4);
+	TEST_TIMING(8_MHz,  500_kbps,  1,   1,  4,  2,    2);
+	TEST_TIMING(8_MHz,  1_Mbps,    1,   1,  1,  1,    2);
 
 	//          Clock  Baud    SJW Prop PS1 PS2 Prescaler
-	TEST_TIMING(16_MHz, kBps10,   1,   3,  8,  4,  100);
-	TEST_TIMING(16_MHz, kBps20,   1,   3,  8,  4,   50);
-	TEST_TIMING(16_MHz, kBps125,  1,   3,  8,  4,    8);
-	TEST_TIMING(16_MHz, kBps250,  1,   3,  8,  4,    4);
-	TEST_TIMING(16_MHz, kBps500,  1,   3,  8,  4,    2);
-	TEST_TIMING(16_MHz, MBps1,    1,   1,  4,  2,    2);
+	TEST_TIMING(16_MHz, 10_kbps,   1,   3,  8,  4,  100);
+	TEST_TIMING(16_MHz, 20_kbps,   1,   3,  8,  4,   50);
+	TEST_TIMING(16_MHz, 125_kbps,  1,   3,  8,  4,    8);
+	TEST_TIMING(16_MHz, 250_kbps,  1,   3,  8,  4,    4);
+	TEST_TIMING(16_MHz, 500_kbps,  1,   3,  8,  4,    2);
+	TEST_TIMING(16_MHz, 1_Mbps,    1,   1,  4,  2,    2);
 
 	//          Clock  Baud    SJW Prop PS1 PS2 Prescaler
-	TEST_TIMING(20_MHz, kBps10,   3,   5,  8,  4,  100);
-	TEST_TIMING(20_MHz, kBps20,   3,   5,  8,  4,   50);
-	TEST_TIMING(20_MHz, kBps125,  3,   5,  8,  4,    8);
-	TEST_TIMING(20_MHz, kBps250,  3,   5,  8,  4,    4);
-	TEST_TIMING(20_MHz, kBps500,  3,   5,  8,  4,    2);
-	TEST_TIMING(20_MHz, MBps1,    1,   3,  4,  2,    2);
+	TEST_TIMING(20_MHz, 10_kbps,   3,   5,  8,  4,  100);
+	TEST_TIMING(20_MHz, 20_kbps,   3,   5,  8,  4,   50);
+	TEST_TIMING(20_MHz, 125_kbps,  3,   5,  8,  4,    8);
+	TEST_TIMING(20_MHz, 250_kbps,  3,   5,  8,  4,    4);
+	TEST_TIMING(20_MHz, 500_kbps,  3,   5,  8,  4,    2);
+	TEST_TIMING(20_MHz, 1_Mbps,    1,   3,  4,  2,    2);
 }
 

--- a/test/modm/platform/can_bit_timings_test.cpp
+++ b/test/modm/platform/can_bit_timings_test.cpp
@@ -22,9 +22,9 @@ using namespace modm;
 using namespace modm::literals;
 
 #define TEST_TIMING(clk, bitrate, bs1, bs2, prescaler) \
-	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, Can::Bitrate::bitrate>::getBS1()), bs1); \
-	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, Can::Bitrate::bitrate>::getBS2()), bs2); \
-	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, Can::Bitrate::bitrate>::getPrescaler()), prescaler);
+	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, bitrate>::getBS1()), bs1); \
+	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, bitrate>::getBS2()), bs2); \
+	TEST_ASSERT_EQUALS((modm::CanBitTiming<clk, bitrate>::getPrescaler()), prescaler);
 
 void
 CanBitTimingsTest::testPrecalculatedValues()
@@ -46,44 +46,44 @@ CanBitTimingsTest::testPrecalculatedValues()
 	//							(SystemClock::Can{{ id }} == 42_MHz)?  6 : 0;
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-	TEST_TIMING(8_MHz,  kBps125, 11, 4,  4);
-	TEST_TIMING(8_MHz,  kBps250, 11, 4,  2);
-	TEST_TIMING(8_MHz,  kBps500, 11, 4,  1);
-	// @ 8MHZ MBps1 was not supported (resulted in prescaler = 0)
+	TEST_TIMING(8_MHz,  125_kbps, 11, 4,  4);
+	TEST_TIMING(8_MHz,  250_kbps, 11, 4,  2);
+	TEST_TIMING(8_MHz,  500_kbps, 11, 4,  1);
+	// @ 8MHZ 1_Mbps was not supported (resulted in prescaler = 0)
 
-	TEST_TIMING(48_MHz, kBps125, 11, 4, 24);
-	TEST_TIMING(48_MHz, kBps250, 11, 4, 12);
-	TEST_TIMING(48_MHz, kBps500, 11, 4,  6);
-	TEST_TIMING(48_MHz,   MBps1, 11, 4,  3);
+	TEST_TIMING(48_MHz, 125_kbps, 11, 4, 24);
+	TEST_TIMING(48_MHz, 250_kbps, 11, 4, 12);
+	TEST_TIMING(48_MHz, 500_kbps, 11, 4,  6);
+	TEST_TIMING(48_MHz,   1_Mbps, 11, 4,  3);
 
-	TEST_TIMING(30_MHz, kBps125, 14, 5, 12);
-	TEST_TIMING(30_MHz, kBps250, 14, 5,  6);
-	TEST_TIMING(30_MHz, kBps500, 14, 5,  3);
-	TEST_TIMING(30_MHz,   MBps1, 10, 4,  2);
+	TEST_TIMING(30_MHz, 125_kbps, 14, 5, 12);
+	TEST_TIMING(30_MHz, 250_kbps, 14, 5,  6);
+	TEST_TIMING(30_MHz, 500_kbps, 14, 5,  3);
+	TEST_TIMING(30_MHz,   1_Mbps, 10, 4,  2);
 
-	TEST_TIMING(36_MHz, kBps125, 12, 5, 16);
-	TEST_TIMING(36_MHz, kBps250, 12, 5,  8);
-	TEST_TIMING(36_MHz, kBps500, 12, 5,  4);
-	TEST_TIMING(36_MHz,   MBps1, 12, 5,  2);
+	TEST_TIMING(36_MHz, 125_kbps, 12, 5, 16);
+	TEST_TIMING(36_MHz, 250_kbps, 12, 5,  8);
+	TEST_TIMING(36_MHz, 500_kbps, 12, 5,  4);
+	TEST_TIMING(36_MHz,   1_Mbps, 12, 5,  2);
 
-	TEST_TIMING(42_MHz, kBps125, 14, 6, 16);
-	TEST_TIMING(42_MHz, kBps250, 14, 6,  8);
-	TEST_TIMING(42_MHz, kBps500, 14, 6,  4);
-	TEST_TIMING(42_MHz,   MBps1, 14, 6,  2);
+	TEST_TIMING(42_MHz, 125_kbps, 14, 6, 16);
+	TEST_TIMING(42_MHz, 250_kbps, 14, 6,  8);
+	TEST_TIMING(42_MHz, 500_kbps, 14, 6,  4);
+	TEST_TIMING(42_MHz,   1_Mbps, 14, 6,  2);
 
-	TEST_TIMING(32_MHz, kBps125, 11, 4, 16);
-	TEST_TIMING(32_MHz, kBps250, 11, 4,  8);
-	TEST_TIMING(32_MHz, kBps500, 11, 4,  4);
-	TEST_TIMING(32_MHz,   MBps1, 11, 4,  2);
+	TEST_TIMING(32_MHz, 125_kbps, 11, 4, 16);
+	TEST_TIMING(32_MHz, 250_kbps, 11, 4,  8);
+	TEST_TIMING(32_MHz, 500_kbps, 11, 4,  4);
+	TEST_TIMING(32_MHz,   1_Mbps, 11, 4,  2);
 
-	TEST_TIMING(80_MHz,  kBps125, 14, 5, 32);
-	TEST_TIMING(80_MHz,  kBps250, 14, 5, 16);
-	TEST_TIMING(80_MHz,  kBps500, 14, 5,  8);
-	TEST_TIMING(80_MHz,    MBps1, 14, 5,  4);
+	TEST_TIMING(80_MHz,  125_kbps, 14, 5, 32);
+	TEST_TIMING(80_MHz,  250_kbps, 14, 5, 16);
+	TEST_TIMING(80_MHz,  500_kbps, 14, 5,  8);
+	TEST_TIMING(80_MHz,    1_Mbps, 14, 5,  4);
 
-	TEST_TIMING(180_MHz,  kBps125, 14, 5, 72);
-	TEST_TIMING(180_MHz,  kBps250, 14, 5, 36);
-	TEST_TIMING(180_MHz,  kBps500, 14, 5, 18);
-	TEST_TIMING(180_MHz,    MBps1, 14, 5,  9);
+	TEST_TIMING(180_MHz,  125_kbps, 14, 5, 72);
+	TEST_TIMING(180_MHz,  250_kbps, 14, 5, 36);
+	TEST_TIMING(180_MHz,  500_kbps, 14, 5, 18);
+	TEST_TIMING(180_MHz,    1_Mbps, 14, 5,  9);
 }
 


### PR DESCRIPTION
More aggressively deprecates bitrate, baudrate and tolerance enums in favor of user-defined literals.

@se-bi @chris-durand @rleh 