### PR TITLE
[math] Fix typo

### DIFF
--- a/src/modm/math/geometry/vector3.hpp
+++ b/src/modm/math/geometry/vector3.hpp
@@ -205,7 +205,7 @@ namespace modm
 	template<typename T, typename U>
 	static inline Vector<U, 3> operator * (const Matrix<T, 3, 3> &lhs, const Vector<U, 3> &rhs)
 	{
-		return lhs * rhs.asTMatrix();
+		return lhs * rhs.asTransposedMatrix();
 	}
 
 


### PR DESCRIPTION
Vector3 doesn't have a member called `v.asTMatrix()` is has been refactored to `v.asTransposedMatrix()`.