### PR TITLE
[board] Fix can clock name in Nucleo F303K8 SystemClock

### DIFF
--- a/src/modm/board/nucleo_f303k8/board.hpp
+++ b/src/modm/board/nucleo_f303k8/board.hpp
@@ -37,7 +37,7 @@ struct SystemClock {
 	static constexpr uint32_t Adc1   = Apb2;
 	static constexpr uint32_t Adc2   = Apb2;
 
-	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can    = Apb1;
 
 	static constexpr uint32_t Spi1   = Apb2;
 


### PR DESCRIPTION
The F303K8 can peripheral instance is named just `Can`, not `Can1` as defined in `Board::SystemClock`. Thus `Can::initialize<Board::SystemClock>()` currently doesn't compile with the default system clock.