### PR TITLE
Add WS2812B driver (SPI-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ can easily configure them for you specific needs.
 <td align="center">VL53L0</td>
 </tr><tr>
 <td align="center">VL6180</td>
+<td align="center">WS2812</td>
 </tr>
 </table>
 <!--/drivertable-->

--- a/README.md
+++ b/README.md
@@ -73,12 +73,11 @@ STM32 devices, however, there are different levels of support and testing.
 
 <center>
 
-| Device Family | Support | Device Family | Support |
-|:--------------|:--------|:--------------|:--------|
-| AVR           | ★★★     | STM32F3       | ★★★★★   |
-| STM32F0       | ★★★★    | STM32F4       | ★★★★★   |
-| STM32F1       | ★★★★    | STM32F7       | ★★★★    |
-| STM32F2       | ★★★     | STM32L4       | ★★★★    |
+| Device Family | Support | Device Family | Support | Device Family | Support |
+|:--------------|:--------|:--------------|:--------|:--------------|:--------|
+| AVR           | ★★★     | STM32F2       | ★★★     | STM32F7       | ★★★★    |
+| STM32F0       | ★★★★    | STM32F3       | ★★★★★   | STM32L4       | ★★★★    |
+| STM32F1       | ★★★★    | STM32F4       | ★★★★★   | STM32G0       | ★★★★    |
 
 </center>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ make gdb
 
 ## Interesting Examples
 
-We have a lot of examples, <!--examplecount-->169<!--/examplecount--> to be
+We have a lot of examples, <!--examplecount-->170<!--/examplecount--> to be
 exact, but here are some of our favorite examples for our supported development
 boards:
 

--- a/examples/nucleo_f411re/ws2812b/main.cpp
+++ b/examples/nucleo_f411re/ws2812b/main.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/driver/pwm/ws2812b.hpp>
+#include <modm/ui/led/tables.hpp>
+#include <modm/processing/timer.hpp>
+
+using namespace Board;
+
+using Output = Board::D11;
+modm::Ws2812b<SpiMaster1, Output, 8*8> leds;
+modm::ShortPeriodicTimer tmr{33};
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+	leds.initialize<Board::SystemClock>();
+
+	constexpr uint8_t max = 62;
+	uint8_t r=0, g=max/3, b=max/3*2;
+
+	while (1)
+	{
+		for (size_t ii=0; ii < leds.size; ii++)
+		{
+			leds.setColor(ii,
+						  modm::ui::table22_8_256[r*3/2],
+						  modm::ui::table22_8_256[g*3/2],
+						  modm::ui::table22_8_256[b*3/2]);
+			if (r++ >= max) r = 0;
+			if (g++ >= max) g = 0;
+			if (b++ >= max) b = 0;
+		}
+		leds.write();
+
+		while(not tmr.execute()) ;
+		LedD13::toggle();
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f411re/ws2812b/project.xml
+++ b/examples/nucleo_f411re/ws2812b/project.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-f411re</extends>
+  <options>
+    <option name=":build:build.path">../../../build/nucleo_f411re/ws2812b</option>
+  </options>
+  <modules>
+    <module>:driver:ws2812</module>
+    <module>:platform:spi:1</module>
+    <module>:ui:led</module>
+    <module>:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/driver/pwm/ws2812.lb
+++ b/src/modm/driver/pwm/ws2812.lb
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.parent = "driver"
+    module.name = "ws2812"
+    module.description = """\
+# WS2812 Driver
+
+Drives any number of chained WS2812 LEDs using a 3-bit SPI encoding
+(0 -> 100, 1 -> 110) running at 3 MHz.
+Thus, writing one LED takes 24µs and 9 bytes of memory.
+
+There are several caveats:
+
+1. This only provides a blocking write API, due to technical limitations.
+2. Atomicity is not enforced, this should be done externally if required.
+3. The memory footprint is 3x as large, due to the bit stuffing for SPI.
+4. There is no enforced reset period of at least 50µs after the write is finished,
+   it is up to the user to not trigger another write too early.
+
+This driver directly accesses the STM32 HAL to keep the transmit register full,
+due to a lack of DMA capability in modm, thus this driver is STM32-only for now.
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:spi",
+        ":math:units")
+    return options[":target"].identifier.platform == "stm32"
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/pwm"
+    env.copy("ws2812b.hpp")

--- a/src/modm/driver/pwm/ws2812b.hpp
+++ b/src/modm/driver/pwm/ws2812b.hpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <modm/math/units.hpp>
+#include <modm/architecture/interface/spi_master.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_ws2812
+template< class SpiMaster, class Output, size_t LEDs >
+class Ws2812b
+{										  // 7654 3210 7654 3210 7654 3210
+	static constexpr uint32_t base_mask  = 0b0010'0100'1001'0010'0100'1001;
+	static constexpr uint32_t clear_mask = base_mask << 1;
+
+	static constexpr size_t length = LEDs * 9;
+	uint8_t rgb[length + 1]; // +1 for zero byte for reset
+
+	static constexpr uint16_t
+	spread(uint8_t nibble)
+	{
+		return ((nibble & 0b0001) << 10) | ((nibble & 0b0010) << 6) |
+			   ((nibble & 0b0100) <<  5) | ((nibble & 0b1000) << 1);
+	}
+
+public:
+	static constexpr size_t size = LEDs;
+
+	Ws2812b()
+	{
+		size_t ii=0;
+		for (;ii < length; ii += 3)
+		{
+			*reinterpret_cast<uint32_t*>(rgb + ii) = base_mask;
+		}
+		rgb[length] = 0;
+	}
+
+	template< class SystemClock >
+	void
+	initialize()
+	{
+		SpiMaster::template connect<Output::template Mosi>();
+		SpiMaster::template initialize<SystemClock, MHz(3), pct(10)>();
+		SpiMaster::setDataOrder(SpiMaster::DataOrder::LsbFirst);
+		SpiMaster::Hal::write(uint8_t(0));
+	}
+
+	void
+	setColor(size_t index, uint8_t r, uint8_t g, uint8_t b)
+	{
+		if (index >= LEDs) return;
+
+		const uint8_t color[3] = {g, r, b};
+		for (size_t ii = 0; ii < 3; ii++)
+		{
+			const uint32_t c = (spread(color[ii]) << 12) | spread(color[ii] >> 4);
+			uint32_t *const value = reinterpret_cast<uint32_t*>(rgb + index * 9 + ii*3);
+			*value = (*value & ~clear_mask) | c;
+		}
+	}
+
+	void
+	write()
+	{
+		for (const auto data : rgb) {
+			while (not SpiMaster::Hal::isTransmitRegisterEmpty()) ;
+			SpiMaster::Hal::write(data);
+		}
+	}
+};
+
+}	// namespace modm

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -42,6 +42,8 @@ class SpiMaster{{ id }} : public modm::SpiMaster
 	static void *context;
 	static ConfigurationHandler configuration;
 public:
+	using Hal = SpiHal{{ id }};
+
 	/// Spi Data Mode, Mode0 is the most common mode
 	enum class
 	DataMode : uint32_t


### PR DESCRIPTION
This adds a driver for any number of chained WS2812 leds using a 3-bit SPI encoding (0 -> 100, 1 -> 110) running at 3 MHz.

There are several caveats:

1. Since we don't have DMA, this uses the STM32 HAL directly to keep the transmit register full.
2. Atomic lock is not enforced, this should be done externally, if required. (Writing one LED takes 24µs, so this atomic section could become quite long).
3. The memory footprint is 3x as large, due to the bit stuffing for SPI.
4. There is no enforced reset period of at least 50µs after the write is finished, it is up to the user to not trigger another write too early.

Unfortunately due to the SPI HAL being used directly, this driver is STM32 specific.