### PR TITLE
[docs] Expose Collectors and Queries in module docs

### DIFF
--- a/docs/src/guide/testing.md
+++ b/docs/src/guide/testing.md
@@ -116,9 +116,9 @@ Total:  209
 	You can access them in [the Artifacts tab of a build][logs].
 
 
-## Continous Integration
+## Continuous Integration
 
-modm uses [CircleCI as a Continous Integration service][circleci]. It compiles
+modm uses [CircleCI as a Continuous Integration service][circleci]. It compiles
 all the examples and executes the unit tests on Linux, then generates and
 compiles the full library for a blinky example for all targets that we support.
 

--- a/tools/doc_generator/module.lb
+++ b/tools/doc_generator/module.lb
@@ -173,7 +173,7 @@ def post_build(env, buildlog):
                   "pref": ref_name(m.parent.fullname),
                   "ref": ref_name(m.fullname),
                   "dependencies": sorted([d.fullname for d in m.dependencies]),
-                  "options": []}
+                  "options": [], "collectors": [], "queries": []}
         for o in m.options:
             title, descr = split_description(o._description)
             oprops = {"name": o.fullname,
@@ -182,6 +182,19 @@ def post_build(env, buildlog):
                       "default": str(o._default) if o._default is not None else None,
                       "possibles": o.format_values()}
             mprops["options"].append(oprops)
+        for c in m.collectors:
+            title, descr = split_description(c._description)
+            cprops = {"name": c.fullname,
+                      "title": title,
+                      "description": descr,
+                      "type": c.format_values()}
+            mprops["collectors"].append(cprops)
+        mprops["collectors"].sort(key=lambda c: c["name"])
+        for q in m.queries:
+            qprops = {"name": q.fullname,
+                      "description": q._description}
+            mprops["queries"].append(qprops)
+        mprops["queries"].sort(key=lambda c: c["name"])
         modules.append(mprops)
 
     for m in modules:

--- a/tools/doc_generator/module.md.in
+++ b/tools/doc_generator/module.md.in
@@ -4,30 +4,50 @@
 
 {{module.description}}
 
-{% if module.options | length %}
+%% if module.options | length
 ## Options
-{% for o in module.options %}
+%% for o in module.options
 #### {{o.name | replace(module.name + ":", "")}}
 
 {{o.title if o.title else ("Default" if o.default else "Values")}}: {% if o.default %}`{{o.default}}` ∈ {% endif %}`{ {{ o.possibles }} }`
 
 {{o.description}}
-{% endfor %}
-{% endif %}
+%% endfor
+%% endif
 
-{% if objects | length %}
+%% if objects | length
 ## Content
 
 ```cpp
-{% for kind, objs in objects.items() %}
+%% for kind, objs in objects.items()
 // {{ kind | capitalize }}{% for obj in objs %}
 {{ obj }}{% endfor %}
-{% endfor %}
+%% endfor
 ```
-{% endif %}
+%% endif
 
-{% if (module.dependencies | length or module.dependents | length) %}
+%% if module.collectors | length
+## Collectors
+%% for c in module.collectors
+#### {{c.name | replace(module.name + ":", "")}}
+
+{{c.title}} ∈ `{{c.type}}`
+
+{{c.description}}
+%% endfor
+%% endif
+
+%% if module.queries | length
+## Queries
+%% for q in module.queries
+#### {{q.name | replace(module.name + ":", "")}}
+
+{{q.description}}
+%% endfor
+%% endif
+
+%% if (module.dependencies | length or module.dependents | length)
 ## Dependencies
 
 {{module.graph}}
-{% endif %}
+%% endif


### PR DESCRIPTION
Adds the module collectors and queries that are only discoverable with `lbuild discover --developer`.