### PR TITLE
[ext] Fix missing define in our FreeRTOS port

### DIFF
--- a/ext/freertos/module.lb
+++ b/ext/freertos/module.lb
@@ -41,3 +41,6 @@ def build(env):
     env.outbasepath = "modm/ext/freertos"
     env.copy(".", ignore=env.ignore_files("*.in"))
     env.template("portable/FreeRTOSConfig.h.in", "portable/FreeRTOSConfig.h")
+
+    if env[":target"].identifier.family in ["f4"]:
+        env.collect(":build:cppdefines", "STM32F4XX")


### PR DESCRIPTION
Our FreeRTOS port needs to be nuked from orbit. Repeatedly!

This adds the required macro to get the port running on STM32F4 for our hacked together custom port.

cc @rleh @dergraaf 