### PR TITLE
[scons] Refactor info tool output into char strings

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -49,10 +49,14 @@ def build(env):
     env.collect("::elf.release", join(build_path, "release", project_name + ".elf"))
     env.collect("::elf.debug",   join(build_path, "debug",   project_name + ".elf"))
 
+    env.outbasepath = "modm/src/"
     if env["info.git"] != "Disabled":
-        env.collect(":build:gitignore", "modm/src/info_git.h")
+        env.collect(":build:gitignore", "modm/src/info_git.c")
+        env.template("resources/info_git.h.in", "info_git.h",
+                     substitutions={"with_status": "Status" in env["info.git"]},)
     if env["info.build"]:
-        env.collect(":build:gitignore", "modm/src/info_build.h")
+        env.collect(":build:gitignore", "modm/src/info_build.c")
+        env.copy("resources/info_build.h", "info_build.h")
 
     def flag_format(flag):
         subs = {
@@ -79,6 +83,10 @@ def post_build(env):
     target = env["modm:target"]
     subs = env.query("::device")
     sources = env.query("::source_files")
+    if env["info.git"] != "Disabled":
+        sources["modm"].append("modm/src/info_git.c")
+    if env["info.build"]:
+        sources["modm"].append("modm/src/info_build.c")
 
     build_tools = [
         "settings_buildpath",

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -293,22 +293,6 @@ this define to the command line CPP options:
 
 You can enable this by setting the `modm:build:scons:info.build` option.
 
-!!! danger "Only include in source files"
-    Since this information may change often, you must only `#include` the
-    generated header files in source files, not in header files. Otherwise
-    **you risk a complete rebuild of your project every time this information
-    changes**! If you need to use the information in a header file, expose it
-    as a `extern const char *info_git_{name};` and initialize it with
-    the defines in a separate source file. Then only this source file needs to
-    be rebuild and the project relinked, which is significantly faster:
-
-    ```c
-    // In header file
-    extern const char *info_git_sha;
-    // In source file
-    const char info_git_sha[] = MODM_GIT_SHA;
-    ```
-
 !!! warning "Respect developers privacy"
     This information is placed into the firmware in **cleartext**, so it will
     be trivial to extract from a memory dump. Consider this information public
@@ -318,7 +302,7 @@ You can enable this by setting the `modm:build:scons:info.build` option.
 
 ### Git Information
 
-These are the values defines as strings in `<info_git.h>`:
+These are the values defined as `const char *` strings in `<info_git.h>`:
 
 - `MODM_GIT_SHA`: commit hash: `%H`.
 - `MODM_GIT_SHA_ABBR`: short commit hash: `%h`.
@@ -381,7 +365,7 @@ Info:    Untracked: 6
 
 ### Build Information
 
-These are the values defines as strings in `<info_build.h>`:
+These are the values defined as `const char *` strings in `<info_build.h>`:
 
 - `MODM_BUILD_PROJECT_NAME`: as defined in the `modm:build:project.name` option.
 - `MODM_BUILD_MACHINE`: machine information.

--- a/tools/build_script_generator/scons/resources/info_build.h
+++ b/tools/build_script_generator/scons/resources/info_build.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#define MODM_BUILD_INFO 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const char *MODM_BUILD_PROJECT_NAME;
+extern const char *MODM_BUILD_MACHINE;
+extern const char *MODM_BUILD_USER;
+extern const char *MODM_BUILD_OS;
+extern const char *MODM_BUILD_COMPILER;
+
+#ifdef __cplusplus
+}
+#endif

--- a/tools/build_script_generator/scons/resources/info_git.h.in
+++ b/tools/build_script_generator/scons/resources/info_git.h.in
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#define MODM_GIT_INFO 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const char *MODM_GIT_SHA;
+extern const char *MODM_GIT_SHA_ABBR;
+extern const char *MODM_GIT_AUTHOR;
+extern const char *MODM_GIT_AUTHOR_EMAIL;
+extern const char *MODM_GIT_AUTHOR_DATE;
+extern const char *MODM_GIT_AUTHOR_DATE_TIMESTAMP;
+extern const char *MODM_GIT_COMMITTER;
+extern const char *MODM_GIT_COMMITTER_EMAIL;
+extern const char *MODM_GIT_COMMITTER_DATE;
+extern const char *MODM_GIT_COMMITTER_DATE_TIMESTAMP;
+extern const char *MODM_GIT_SUBJECT;
+extern const char *MODM_GIT_CONFIG_USER_NAME;
+extern const char *MODM_GIT_CONFIG_USER_EMAIL;
+
+%% if with_status
+#define MODM_GIT_STATUS 1
+
+extern const char *MODM_GIT_MODIFIED;
+extern const char *MODM_GIT_ADDED;
+extern const char *MODM_GIT_DELETED;
+extern const char *MODM_GIT_RENAMED;
+extern const char *MODM_GIT_COPIED;
+extern const char *MODM_GIT_UPDATED_NOT_MERGED;
+extern const char *MODM_GIT_UNTRACKED;
+%% endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/tools/build_script_generator/scons/site_tools/info.c.in
+++ b/tools/build_script_generator/scons/site_tools/info.c.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Niklas Hauser
+ * Copyright (c) 2019, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -9,11 +9,8 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_INFO_{{ type | upper }}_HPP
-#define MODM_INFO_{{ type | upper }}_HPP
+#include "info_{{ type }}.h"
 
 %% for name, value in defines.items()
-#define {{ name | upper }} {{ value }}
+const char *{{ name | upper }} = {{ value }};
 %% endfor
-
-#endif // MODM_INFO_{{ type | upper }}_HPP

--- a/tools/build_script_generator/scons/site_tools/info.py
+++ b/tools/build_script_generator/scons/site_tools/info.py
@@ -21,7 +21,7 @@ import re
 from collections import defaultdict
 from os.path import join, dirname, abspath
 
-TEMPLATE_SOURCE = join(dirname(abspath(__file__)), "info.h.in")
+TEMPLATE_SOURCE = join(dirname(abspath(__file__)), "info.c.in")
 
 def is_git_available():
 	git_exists = subprocess.call(['which', 'git'], cwd=os.getcwd(), stdout=open(os.devnull, 'wb')) is 0
@@ -102,7 +102,7 @@ def git_info_defines(env, with_status=False):
 		return
 
 	env.AppendUnique(CPPDEFINES=defines)
-	target = join(env['BASEPATH'], 'src', 'info_git.h')
+	target = join(env['BASEPATH'], 'src', 'info_git.c')
 	subs = {"type": "git", "defines": {k:u"\"{}\"".format(v) for k, v in subs.items()}}
 	return env.Jinja2Template(target=target, source=TEMPLATE_SOURCE, substitutions=subs)
 
@@ -137,7 +137,7 @@ def build_info_defines(env):
 	subs['MODM_BUILD_COMPILER'] = comp
 
 	env.AppendUnique(CPPDEFINES=defines)
-	target = join(env['BASEPATH'], 'src', 'info_build.h')
+	target = join(env['BASEPATH'], 'src', 'info_build.c')
 	subs = {"type": "build", "defines": {k:u"\"{}\"".format(v) for k, v in subs.items()}}
 	return env.Jinja2Template(target=target, source=TEMPLATE_SOURCE, substitutions=subs)
 


### PR DESCRIPTION
This exposes the info tool outputs as C char strings instead of `#define`-ing them in the header file. This prevents recompilation of the entire project if it changes and instead only compiling the `.c` file and relinking.