### PR TITLE
[lbuild] Update for lbuild v1.11.0

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,8 +53,6 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details
-  - pymdownx.emoji:
-      emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.magiclink

--- a/docs/src/how-modm-works.md
+++ b/docs/src/how-modm-works.md
@@ -46,8 +46,8 @@ properties and calling `env.template` with the input and output file names.
 
 ```python
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
+    module.description = "UART driver"
 
 def prepare(module, options):
     module.depends(":architecture:interrupt", ":architecture:register",

--- a/ext/arm/cmsis.lb
+++ b/ext/arm/cmsis.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "cmsis"
+    module.name = ":cmsis"
     module.description = FileReader("cmsis.md")
 
 def prepare(module, options):

--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "cmsis"
-    module.name = "core"
+    module.name = ":cmsis:core"
     module.description = FileReader("core.md")
 
 def prepare(module, options):

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -14,8 +14,7 @@
 from collections import defaultdict
 
 def init(module):
-    module.parent = "cmsis"
-    module.name = "dsp"
+    module.name = ":cmsis:dsp"
     module.description = FileReader("dsp.md")
 
 def prepare(module, options):

--- a/ext/fatfs/module.lb
+++ b/ext/fatfs/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "fatfs"
+    module.name = ":fatfs"
     module.description = """\
 # FatFS
 

--- a/ext/freertos/module.lb
+++ b/ext/freertos/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "freertos"
+    module.name = ":freertos"
     module.description = """\
 # FreeRTOS
 

--- a/ext/gcc/module.lb
+++ b/ext/gcc/module.lb
@@ -14,7 +14,7 @@
 
 
 def init(module):
-    module.name = "stdc++"
+    module.name = ":stdc++"
     module.description = """\
 # C++ Standard Library
 

--- a/ext/nxp/module.lb
+++ b/ext/nxp/module.lb
@@ -13,8 +13,7 @@
 import os
 
 def init(module):
-    module.parent = "cmsis"
-    module.name = "device"
+    module.name = ":cmsis:device"
 
 def prepare(module, options):
     device = options[":target"]

--- a/ext/ros/module.lb
+++ b/ext/ros/module.lb
@@ -11,7 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "ros"
+    module.name = ":ros"
     module.description = """\
 # ROS Library
 

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -100,8 +100,7 @@ def common_rcc_map(env):
 
 # -----------------------------------------------------------------------------
 def init(module):
-    module.parent = "cmsis"
-    module.name = "device"
+    module.name = ":cmsis:device"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/ext/tlsf/module.lb
+++ b/ext/tlsf/module.lb
@@ -13,7 +13,7 @@
 import math
 
 def init(module):
-    module.name = "tlsf"
+    module.name = ":tlsf"
     module.description = FileReader("README.md")
 
 def prepare(module, options):

--- a/repo.lb
+++ b/repo.lb
@@ -35,7 +35,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.8.0"
+min_lbuild_version = "1.11.1"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))
@@ -190,9 +190,9 @@ def init(repo):
     else:
         def windowsify(path, escape_level):
             return normpath(path)
-    repo.add_filter("windowsify", windowsify)
-    repo.add_filter("ord", lambda letter: ord(letter[0].lower()) - ord("a"))
-    repo.add_filter("chr", lambda num: chr(num + ord("A")))
+    repo.add_filter("modm.windowsify", windowsify)
+    repo.add_filter("modm.ord", lambda letter: ord(letter[0].lower()) - ord("a"))
+    repo.add_filter("modm.chr", lambda num: chr(num + ord("A")))
 
     # Compute the available data from modm-devices
     devices = DevicesCache()

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -333,7 +333,7 @@ class Unaligned(Module):
 import re
 
 def init(module):
-    module.name = "architecture"
+    module.name = ":architecture"
     module.description = """\
 # Architecture Interfaces
 

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "al-avreb-can"
+    module.name = ":board:al-avreb-can"
     module.description = """\
 # AL-AVREB_CAN Board
 

--- a/src/modm/board/arduino_nano/module.lb
+++ b/src/modm/board/arduino_nano/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "arduino-nano"
+    module.name = ":board:arduino-nano"
     module.description = "Arduino NANO"
 
 def prepare(module, options):

--- a/src/modm/board/arduino_uno/module.lb
+++ b/src/modm/board/arduino_uno/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "arduino-uno"
+    module.name = ":board:arduino-uno"
     module.description = "Arduino UNO"
 
 def prepare(module, options):

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "black-pill"
+    module.name = ":board:black-pill"
     module.description = """\
 # Black Pill
 

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "blue-pill"
+    module.name = ":board:blue-pill"
     module.description = """\
 # Blue Pill
 

--- a/src/modm/board/disco_f051r8/module.lb
+++ b/src/modm/board/disco_f051r8/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f051r8"
+    module.name = ":board:disco-f051r8"
     module.description = """\
 # STM32F0DISCOVERY
 

--- a/src/modm/board/disco_f072rb/module.lb
+++ b/src/modm/board/disco_f072rb/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f072rb"
+    module.name = ":board:disco-f072rb"
     module.description = """\
 # STM32F072DISCOVERY
 

--- a/src/modm/board/disco_f100rb/module.lb
+++ b/src/modm/board/disco_f100rb/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f100rb"
+    module.name = ":board:disco-f100rb"
     module.description = """\
 # STM32VLDISCOVERY
 

--- a/src/modm/board/disco_f303vc/module.lb
+++ b/src/modm/board/disco_f303vc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f303vc"
+    module.name = ":board:disco-f303vc"
     module.description = """\
 # STM32F3DISCOVERY
 

--- a/src/modm/board/disco_f407vg/module.lb
+++ b/src/modm/board/disco_f407vg/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f407vg"
+    module.name = ":board:disco-f407vg"
     module.description = """\
 # STM32F4DISCOVERY
 

--- a/src/modm/board/disco_f429zi/module.lb
+++ b/src/modm/board/disco_f429zi/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f429zi"
+    module.name = ":board:disco-f429zi"
     module.description = """\
 # STM32F429IDISCOVERY
 

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f469ni"
+    module.name = ":board:disco-f469ni"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f746ng"
+    module.name = ":board:disco-f746ng"
     module.description = """\
 # STM32F7DISCOVERY
 

--- a/src/modm/board/disco_f769ni/module.lb
+++ b/src/modm/board/disco_f769ni/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-f769ni"
+    module.name = ":board:disco-f769ni"
     module.description = """\
 # STM32F769IDISCOVERY
 

--- a/src/modm/board/disco_l476vg/module.lb
+++ b/src/modm/board/disco_l476vg/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "disco-l476vg"
+    module.name = ":board:disco-l476vg"
     module.description = """\
 # STM32L476DISCOVERY
 

--- a/src/modm/board/module.lb
+++ b/src/modm/board/module.lb
@@ -11,7 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "board"
+    module.name = ":board"
     module.description = "Board Support Packages"
 
 def prepare(module, options):

--- a/src/modm/board/nucleo_f031k6/module.lb
+++ b/src/modm/board/nucleo_f031k6/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f031k6"
+    module.name = ":board:nucleo-f031k6"
     module.description = """\
 # NUCLEO-F031K6
 

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -13,8 +13,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f042k6"
+    module.name = ":board:nucleo-f042k6"
     module.description = """\
 # NUCLEO-F042K6
 

--- a/src/modm/board/nucleo_f103rb/module.lb
+++ b/src/modm/board/nucleo_f103rb/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f103rb"
+    module.name = ":board:nucleo-f103rb"
     module.description = """\
 # NUCLEO-F103RB
 

--- a/src/modm/board/nucleo_f303k8/module.lb
+++ b/src/modm/board/nucleo_f303k8/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f303k8"
+    module.name = ":board:nucleo-f303k8"
     module.description = """\
 # NUCLEO-F303K8
 

--- a/src/modm/board/nucleo_f401re/module.lb
+++ b/src/modm/board/nucleo_f401re/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f401re"
+    module.name = ":board:nucleo-f401re"
     module.description = """\
 # NUCLEO-F401RE
 

--- a/src/modm/board/nucleo_f411re/module.lb
+++ b/src/modm/board/nucleo_f411re/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f411re"
+    module.name = ":board:nucleo-f411re"
     module.description = """\
 # NUCLEO-F411RE
 

--- a/src/modm/board/nucleo_f429zi/module.lb
+++ b/src/modm/board/nucleo_f429zi/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-f429zi"
+    module.name = ":board:nucleo-f429zi"
     module.description = """\
 # NUCLEO-F429ZI
 

--- a/src/modm/board/nucleo_g071rb/module.lb
+++ b/src/modm/board/nucleo_g071rb/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-g071rb"
+    module.name = ":board:nucleo-g071rb"
     module.description = """\
 # NUCLEO-G071RB
 

--- a/src/modm/board/nucleo_l432kc/module.lb
+++ b/src/modm/board/nucleo_l432kc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-l432kc"
+    module.name = ":board:nucleo-l432kc"
     module.description = """\
 # NUCLEO-L432KC
 

--- a/src/modm/board/nucleo_l476rg/module.lb
+++ b/src/modm/board/nucleo_l476rg/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "nucleo-l476rg"
+    module.name = ":board:nucleo-l476rg"
     module.description = """\
 # NUCLEO-L476RG
 

--- a/src/modm/board/olimexino_stm32/module.lb
+++ b/src/modm/board/olimexino_stm32/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "olimexino-stm32"
+    module.name = ":board:olimexino-stm32"
     module.description = """\
 # Olimexino STM32
 

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "board"
-    module.name = "stm32f030_demo"
+    module.name = ":board:stm32f030_demo"
     module.description = """\
 # STM32F030 Demo Board
 

--- a/src/modm/communication/module.lb
+++ b/src/modm/communication/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "communication"
+    module.name = ":communication"
     module.description = "Communication Protocols"
 
 def prepare(module, options):

--- a/src/modm/communication/ros/module.lb
+++ b/src/modm/communication/ros/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "communication"
-    module.name = "ros"
+    module.name = ":communication:ros"
     module.description = "Drivers for rosserial"
 
 def prepare(module, options):

--- a/src/modm/communication/sab/module.lb
+++ b/src/modm/communication/sab/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "communication"
-    module.name = "sab"
+    module.name = ":communication:sab"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/communication/sab2/module.lb
+++ b/src/modm/communication/sab2/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "communication"
-    module.name = "sab2"
+    module.name = ":communication:sab2"
     description = str(FileReader("../sab/module.md")).replace(
                       "# Sensor Actuator Bus (SAB)",
                       "# Sensor Actuator Bus Version 2 (SAB2)")

--- a/src/modm/communication/xpcc/module.lb
+++ b/src/modm/communication/xpcc/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "communication"
-    module.name = "xpcc"
+    module.name = ":communication:xpcc"
     module.description = "Cross Platform Component Communication (XPCC)"
 
 def prepare(module, options):

--- a/src/modm/container/module.lb
+++ b/src/modm/container/module.lb
@@ -13,7 +13,7 @@
 
 
 def init(module):
-    module.name = "container"
+    module.name = ":container"
     module.description = FileReader("module.md")
 
 

--- a/src/modm/debug/module.lb
+++ b/src/modm/debug/module.lb
@@ -13,7 +13,7 @@
 
 
 def init(module):
-    module.name = "debug"
+    module.name = ":debug"
     module.description = FileReader("module.md")
 
 

--- a/src/modm/driver/adc/ad7280a.lb
+++ b/src/modm/driver/adc/ad7280a.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ad7280a"
+    module.name = ":driver:ad7280a"
     module.description = """\
 # AD7280A Lithium Ion Battery Monitoring System
 

--- a/src/modm/driver/adc/ad7928.lb
+++ b/src/modm/driver/adc/ad7928.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ad7928"
+    module.name = ":driver:ad7928"
     module.description = """\
 # AD79x8 ADC
 

--- a/src/modm/driver/adc/adc_sampler.lb
+++ b/src/modm/driver/adc/adc_sampler.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "adc_sampler"
+    module.name = ":driver:adc_sampler"
     module.description = """\
 # Oversampling of ADC inputs
 

--- a/src/modm/driver/bus/memory_bus.lb
+++ b/src/modm/driver/bus/memory_bus.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "memory_bus"
+    module.name = ":driver:memory_bus"
     module.description = "Parallel Busses"
 
 

--- a/src/modm/driver/can/lawicel.lb
+++ b/src/modm/driver/can/lawicel.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lawicel"
+    module.name = ":driver:lawicel"
     module.description = """\
 # Lawicel Format Converter
 

--- a/src/modm/driver/can/mcp2515.lb
+++ b/src/modm/driver/can/mcp2515.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "mcp2515"
+    module.name = ":driver:mcp2515"
     module.description = "MPC2515 External CAN Controller"
 
 

--- a/src/modm/driver/color/tcs3414.lb
+++ b/src/modm/driver/color/tcs3414.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "tcs3414"
+    module.name = ":driver:tcs3414"
     module.description = "TCS3414 Digital Color Sensor"
 
 

--- a/src/modm/driver/color/tcs3472.lb
+++ b/src/modm/driver/color/tcs3472.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "tcs3472"
+    module.name = ":driver:tcs3472"
     module.description = "TCS3472X Digital Color Sensor"
 
 

--- a/src/modm/driver/display/ea_dog.lb
+++ b/src/modm/driver/display/ea_dog.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ea_dog"
+    module.name = ":driver:ea_dog"
     module.description = "EA-DOG Displays"
 
 def prepare(module, options):

--- a/src/modm/driver/display/hd44780.lb
+++ b/src/modm/driver/display/hd44780.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "hd44780"
+    module.name = ":driver:hd44780"
     module.description = "HD44780 Displays"
 
 def prepare(module, options):

--- a/src/modm/driver/display/max7219.lb
+++ b/src/modm/driver/display/max7219.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "max7219"
+    module.name = ":driver:max7219"
     module.description = "MAX7219 Display"
 
 

--- a/src/modm/driver/display/nokia5110.lb
+++ b/src/modm/driver/display/nokia5110.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "nokia5110"
+    module.name = ":driver:nokia5110"
     module.description = "Nokia 5110 Displays"
 
 def prepare(module, options):

--- a/src/modm/driver/display/parallel_tft.lb
+++ b/src/modm/driver/display/parallel_tft.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "parallel_tft_display"
+    module.name = ":driver:parallel_tft_display"
     module.description = "Parallel Bus TFT Display"
 
 def prepare(module, options):

--- a/src/modm/driver/display/sdl_display.lb
+++ b/src/modm/driver/display/sdl_display.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "sdl_display"
+    module.name = ":driver:sdl_display"
     module.description = "SDL Display"
 
 def prepare(module, options):

--- a/src/modm/driver/display/siemens_s65.lb
+++ b/src/modm/driver/display/siemens_s65.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "siemens_s65"
+    module.name = ":driver:siemens_s65"
     module.description = "Siemens S65 Display"
 
 def prepare(module, options):

--- a/src/modm/driver/display/siemens_s75.lb
+++ b/src/modm/driver/display/siemens_s75.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "siemens_s75"
+    module.name = ":driver:siemens_s75"
     module.description = FileReader("siemens_s75.md")
 
 def prepare(module, options):

--- a/src/modm/driver/display/ssd1306.lb
+++ b/src/modm/driver/display/ssd1306.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ssd1306"
+    module.name = ":driver:ssd1306"
     module.description = "SSD1306 Display"
 
 def prepare(module, options):

--- a/src/modm/driver/gpio/mcp23x17.lb
+++ b/src/modm/driver/gpio/mcp23x17.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "mcp23x17"
+    module.name = ":driver:mcp23x17"
     module.description = """\
 # MCP23x17 16-Bit I/O Expander
 

--- a/src/modm/driver/gpio/pca8574.lb
+++ b/src/modm/driver/gpio/pca8574.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "pca8574"
+    module.name = ":driver:pca8574"
     module.description = "PCA8574 8-Bit I/O Expander"
 
 def prepare(module, options):

--- a/src/modm/driver/gpio/pca9535.lb
+++ b/src/modm/driver/gpio/pca9535.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "pca9535"
+    module.name = ":driver:pca9535"
     module.description = """\
 # PCA9535 16-Bit I/O Expander
 

--- a/src/modm/driver/gpio/pca9548a.lb
+++ b/src/modm/driver/gpio/pca9548a.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "pca9548a"
+    module.name = ":driver:pca9548a"
     module.description = """\
 PCA9548A/TCA9548A I2C Switch
 

--- a/src/modm/driver/inertial/hmc58x.lb
+++ b/src/modm/driver/inertial/hmc58x.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "hmc58x"
+    module.name = ":driver:hmc58x"
     module.description = """\
 # HMC58x3 3-Axis Digital Magnetometer
 

--- a/src/modm/driver/inertial/hmc6343.lb
+++ b/src/modm/driver/inertial/hmc6343.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "hmc6343"
+    module.name = ":driver:hmc6343"
     module.description = """\
 # HMC6343 3-Axis Compass
 

--- a/src/modm/driver/inertial/itg3200.lb
+++ b/src/modm/driver/inertial/itg3200.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "itg3200"
+    module.name = ":driver:itg3200"
     module.description = """\
 # ITG3200 Digital Gyroscope
 

--- a/src/modm/driver/inertial/l3gd20.lb
+++ b/src/modm/driver/inertial/l3gd20.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "l3gd20"
+    module.name = ":driver:l3gd20"
     module.description = """\
 # L3GD20 3-Axis Gyroscope
 

--- a/src/modm/driver/inertial/lis302dl.lb
+++ b/src/modm/driver/inertial/lis302dl.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lis302dl"
+    module.name = ":driver:lis302dl"
     module.description = """\
 # LIS302DL 3-Axis Accelerometer
 

--- a/src/modm/driver/inertial/lis3_transport.lb
+++ b/src/modm/driver/inertial/lis3_transport.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lis3.transport"
+    module.name = ":driver:lis3.transport"
     module.description = "LIS3xx Transport Layer"
 
 def prepare(module, options):

--- a/src/modm/driver/inertial/lis3dsh.lb
+++ b/src/modm/driver/inertial/lis3dsh.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lis3dsh"
+    module.name = ":driver:lis3dsh"
     module.description = """\
 # LIS3DSH 3-Axis Accelerometer
 

--- a/src/modm/driver/inertial/lsm303a.lb
+++ b/src/modm/driver/inertial/lsm303a.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lsm303a"
+    module.name = ":driver:lsm303a"
     module.description = """\
 # LSM303DLHC 3-Axis Accelerometer
 

--- a/src/modm/driver/module.lb
+++ b/src/modm/driver/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "driver"
+    module.name = ":driver"
     module.description = "External Device Drivers"
 
 def prepare(module, options):

--- a/src/modm/driver/motion/adns9800.lb
+++ b/src/modm/driver/motion/adns9800.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "adns9800"
+    module.name = ":driver:adns9800"
     module.description = """\
 # ADNS-9800 Laser Motion Sensor
 

--- a/src/modm/driver/motion/pat9125el.lb
+++ b/src/modm/driver/motion/pat9125el.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "pat9125el"
+    module.name = ":driver:pat9125el"
     module.description = "Driver for PAT9125EL motion sensor"
 
 def prepare(module, options):

--- a/src/modm/driver/motor/drv832x_spi.lb
+++ b/src/modm/driver/motor/drv832x_spi.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "drv832x_spi"
+    module.name = ":driver:drv832x_spi"
     module.description = """\
 # DRV832xS: Three-Phase Smart Gate Driver
 

--- a/src/modm/driver/position/vl53l0.lb
+++ b/src/modm/driver/position/vl53l0.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "vl53l0"
+    module.name = ":driver:vl53l0"
     module.description = "VL53L0X Proximity Sensor"
 
 def prepare(module, options):

--- a/src/modm/driver/position/vl6180.lb
+++ b/src/modm/driver/position/vl6180.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "vl6180"
+    module.name = ":driver:vl6180"
     module.description = "VL6180X Proximity Sensor"
 
 def prepare(module, options):

--- a/src/modm/driver/pressure/ams5915.lb
+++ b/src/modm/driver/pressure/ams5915.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ams5915"
+    module.name = ":driver:ams5915"
     module.description = """\
 # AMS 5915 Pressure Sensor
 

--- a/src/modm/driver/pressure/bme280.lb
+++ b/src/modm/driver/pressure/bme280.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "bme280"
+    module.name = ":driver:bme280"
     module.description = """\
 # BME280 Pressure Sensor
 

--- a/src/modm/driver/pressure/bmp085.lb
+++ b/src/modm/driver/pressure/bmp085.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "bmp085"
+    module.name = ":driver:bmp085"
     module.description = """\
 # BMP085 Pressure Sensor
 

--- a/src/modm/driver/pressure/hclax.lb
+++ b/src/modm/driver/pressure/hclax.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "hclax"
+    module.name = ":driver:hclax"
     module.description = """\
 # HCLA Pressure Sensor
 

--- a/src/modm/driver/pwm/max6966.lb
+++ b/src/modm/driver/pwm/max6966.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "max6966"
+    module.name = ":driver:max6966"
     module.description = """\
 # MAX6966 8-bit PWM Driver
 

--- a/src/modm/driver/pwm/pca9685.lb
+++ b/src/modm/driver/pwm/pca9685.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "pca9685"
+    module.name = ":driver:pca9685"
     module.description = """\
 # PCA9685 12-bit PWM Driver
 

--- a/src/modm/driver/pwm/ws2812.lb
+++ b/src/modm/driver/pwm/ws2812.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ws2812"
+    module.name = ":driver:ws2812"
     module.description = """\
 # WS2812 Driver
 

--- a/src/modm/driver/radio/nrf24/nrf24.lb
+++ b/src/modm/driver/radio/nrf24/nrf24.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "nrf24"
+    module.name = ":driver:nrf24"
     module.description = "NRF24 Drivers"
 
 def prepare(module, options):

--- a/src/modm/driver/rtc/ds1302.lb
+++ b/src/modm/driver/rtc/ds1302.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ds1302"
+    module.name = ":driver:ds1302"
     module.description = "DS1302 Real-Time Clock"
 
 def prepare(module, options):

--- a/src/modm/driver/storage/block_device.lb
+++ b/src/modm/driver/storage/block_device.lb
@@ -72,8 +72,7 @@ Microchip SST26VF064B 64MBit flash chip in SOIJ-8, WDFN-8 or SOIC-16.
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "driver"
-    module.name = "block.device"
+    module.name = ":driver:block.device"
     module.description = "Block Devices"
 
 def prepare(module, options):

--- a/src/modm/driver/storage/fat.lb
+++ b/src/modm/driver/storage/fat.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "fat"
+    module.name = ":driver:fat"
     module.description = "FAT File System"
 
 def prepare(module, options):

--- a/src/modm/driver/storage/i2c_eeprom.lb
+++ b/src/modm/driver/storage/i2c_eeprom.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "i2c.eeprom"
+    module.name = ":driver:i2c.eeprom"
     module.description = """\
 # I2C Eeprom
 

--- a/src/modm/driver/temperature/ds1631.lb
+++ b/src/modm/driver/temperature/ds1631.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ds1631"
+    module.name = ":driver:ds1631"
     module.description = "DS1x31 Temperature Sensor"
 
 def prepare(module, options):

--- a/src/modm/driver/temperature/ds18b20.lb
+++ b/src/modm/driver/temperature/ds18b20.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ds18b20"
+    module.name = ":driver:ds18b20"
     module.description = """\
 # 1-Wire Thermometer
 

--- a/src/modm/driver/temperature/lm75.lb
+++ b/src/modm/driver/temperature/lm75.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "lm75"
+    module.name = ":driver:lm75"
     module.description = """\
 # LM75 Thermometer
 

--- a/src/modm/driver/temperature/ltc2984.lb
+++ b/src/modm/driver/temperature/ltc2984.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ltc2984"
+    module.name = ":driver:ltc2984"
     module.description = """\
 # LTC298x Thermometer
 

--- a/src/modm/driver/temperature/tmp102.lb
+++ b/src/modm/driver/temperature/tmp102.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "tmp102"
+    module.name = ":driver:tmp102"
     module.description = """\
 # TMP102 Thermometer
 

--- a/src/modm/driver/temperature/tmp175.lb
+++ b/src/modm/driver/temperature/tmp175.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "tmp175"
+    module.name = ":driver:tmp175"
     module.description = """\
 # TMP175 Thermometer
 

--- a/src/modm/driver/touch/ads7843.lb
+++ b/src/modm/driver/touch/ads7843.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ads7843"
+    module.name = ":driver:ads7843"
     module.description = """\
 # ADS7843 Resistive Touch Controller
 

--- a/src/modm/driver/touch/ft6x06.lb
+++ b/src/modm/driver/touch/ft6x06.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.parent = "driver"
-    module.name = "ft6x06"
+    module.name = ":driver:ft6x06"
     module.description = "FT6x06 Capacitive Touch Controller"
 
 def prepare(module, options):

--- a/src/modm/driver/usb/ft245.lb
+++ b/src/modm/driver/usb/ft245.lb
@@ -10,10 +10,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-
 def init(module):
-    module.parent = "driver"
-    module.name = "ft245"
+    module.name = ":driver:ft245"
     module.description = """\
 # FT245 USB FIFO
 

--- a/src/modm/io/module.lb
+++ b/src/modm/io/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "io"
+    module.name = ":io"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/math/filter/module.lb
+++ b/src/modm/math/filter/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "filter"
+    module.name = ":math:filter"
     module.description = "Filters"
 
 def prepare(module, options):

--- a/src/modm/math/geometry/module.lb
+++ b/src/modm/math/geometry/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "geometry"
+    module.name = ":math:geometry"
     module.description = "Geometric Operations"
 
 def prepare(module, options):

--- a/src/modm/math/interpolation/module.lb
+++ b/src/modm/math/interpolation/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "interpolation"
+    module.name = ":math:interpolation"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/math/math.lb
+++ b/src/modm/math/math.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "math"
+    module.name = ":math"
     module.description = "Math"
 
 def prepare(module, options):

--- a/src/modm/math/matrix.lb
+++ b/src/modm/math/matrix.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "matrix"
+    module.name = ":math:matrix"
     module.description = "Matrix Math"
 
 def prepare(module, options):

--- a/src/modm/math/saturated/module.lb
+++ b/src/modm/math/saturated/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "saturated"
+    module.name = ":math:saturated"
     module.description = "Saturated Arithmetics"
 
 def prepare(module, options):

--- a/src/modm/math/units.lb
+++ b/src/modm/math/units.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = ":math"
-    module.name = "units"
+    module.name = ":math:units"
     module.description = """\
 # SI Units
 

--- a/src/modm/math/utils/module.lb
+++ b/src/modm/math/utils/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "math"
-    module.name = "utils"
+    module.name = ":math:utils"
     module.description = "Utilities"
 
 def prepare(module, options):

--- a/src/modm/platform/adc/at90_tiny_mega/module.lb
+++ b/src/modm/platform/adc/at90_tiny_mega/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "adc"
-    module.parent = "platform"
+    module.name = ":platform:adc"
     module.description = "Analog-to-Digital Converter (ADC)"
 
 def prepare(module, options):

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -62,8 +62,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "adc"
-    module.parent = "platform"
+    module.name = ":platform:adc"
     module.description = "Analog-to-Digital Converter (ADC)"
 
 def prepare(module, options):

--- a/src/modm/platform/adc/stm32f0/module.lb
+++ b/src/modm/platform/adc/stm32f0/module.lb
@@ -13,8 +13,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "adc"
-    module.parent = "platform"
+    module.name = ":platform:adc"
     module.description = "Analog-to-Digital Converter (ADC)"
 
 def prepare(module, options):

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -98,8 +98,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "adc"
-    module.parent = "platform"
+    module.name = ":platform:adc"
     module.description = "Analog-to-Digital Converter (ADC)"
 
 def prepare(module, options):

--- a/src/modm/platform/can/canusb/module.lb
+++ b/src/modm/platform/can/canusb/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.name = "canusb"
-    module.parent = "platform"
+    module.name = ":platform:canusb"
     module.description = "CANUSB Driver"
 
 

--- a/src/modm/platform/can/common/module.lb
+++ b/src/modm/platform/can/common/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "can.common"
-    module.parent = "platform"
+    module.name = ":platform:can.common"
     module.description = "CAN Common"
 
 def prepare(module, options):

--- a/src/modm/platform/can/lpc/module.lb
+++ b/src/modm/platform/can/lpc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "can"
-    module.parent = "platform"
+    module.name = ":platform:can"
 
 def prepare(module, options):
     if not options[":target"].has_driver("can:lpc"):

--- a/src/modm/platform/can/socketcan/module.lb
+++ b/src/modm/platform/can/socketcan/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "socketcan"
-    module.parent = "platform"
+    module.name = ":platform:socketcan"
     module.description = "SocketCAN"
 
 def prepare(module, options):

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -125,8 +125,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "can"
-    module.parent = "platform"
+    module.name = ":platform:can"
     module.description = "Controller Area Network (CAN)"
 
 def prepare(module, options):

--- a/src/modm/platform/clock/common/module.lb
+++ b/src/modm/platform/clock/common/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "clock"
-    module.parent = "platform"
+    module.name = ":platform:clock"
     module.description = "System Clock"
 
 def prepare(module, options):

--- a/src/modm/platform/clock/lpc/module.lb
+++ b/src/modm/platform/clock/lpc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "clock"
-    module.parent = "platform"
+    module.name = ":platform:clock"
 
 def prepare(module, options):
     if not options[":target"].has_driver("clock:lpc"):

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.parent = ":platform"
-    module.name = "rcc"
+    module.name = ":platform:rcc"
     module.description = "Reset and Clock Control (RCC)"
 
 def prepare(module, options):

--- a/src/modm/platform/clock/systick/module.lb
+++ b/src/modm/platform/clock/systick/module.lb
@@ -14,8 +14,7 @@
 import os
 
 def init(module):
-    module.parent = "platform"
-    module.name = "systick"
+    module.name = ":platform:systick"
     module.description = "ARM Cortex-M SysTick"
 
 def prepare(module, options):

--- a/src/modm/platform/comp/stm32/module.lb
+++ b/src/modm/platform/comp/stm32/module.lb
@@ -39,8 +39,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "comp"
-    module.parent = "platform"
+    module.name = ":platform:comp"
     module.description = "Comparator (COMP)"
 
 def prepare(module, options):

--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "core"
-    module.parent = "platform"
+    module.name = ":platform:core"
     module.description = "AVR Core"
 
 def prepare(module, options):

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -77,7 +77,7 @@ def common_memories(env):
     memories = listify(device.get_driver("core")["memory"])
 
     # Convert from string to int and add offsets
-    flash_offset = env.get_option(":platform:cortex-m:linkerscript.flash_offset", 0)
+    flash_offset = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
     for m in memories:
         if m["name"] == "flash":
             m["start"] = int(m["start"], 0) + flash_offset
@@ -138,8 +138,7 @@ def common_linkerscript(env):
 
 
 def init(module):
-    module.name = "cortex-m"
-    module.parent = "platform"
+    module.name = ":platform:cortex-m"
     module.description = FileReader("module.md")
 
 

--- a/src/modm/platform/core/hosted/module.lb
+++ b/src/modm/platform/core/hosted/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "core"
-    module.parent = "platform"
+    module.name = ":platform:core"
     module.description = "Hosted Core"
 
 def prepare(module, options):

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "core"
-    module.parent = "platform"
+    module.name = ":platform:core"
     module.description = """\
 # STM32 core module
 

--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -37,8 +37,7 @@ class Instance(Module):
         env.template("dma_impl.hpp.in", "dma_{}_impl.hpp".format(self.instance))
 
 def init(module):
-    module.name = "dma"
-    module.parent = "platform"
+    module.name = ":platform:dma"
     module.description = "Direct Memory Access (DMA)"
 
 def prepare(module, options):

--- a/src/modm/platform/fault/cortex/module.lb
+++ b/src/modm/platform/fault/cortex/module.lb
@@ -14,8 +14,7 @@
 import os
 
 def init(module):
-    module.parent = "platform"
-    module.name = "fault.cortex"
+    module.name = ":platform:fault.cortex"
     module.description = """\
 # ARM Cortex-M Fault Handling
 

--- a/src/modm/platform/fsmc/stm32/module.lb
+++ b/src/modm/platform/fsmc/stm32/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "fsmc"
-    module.parent = "platform"
+    module.name = ":platform:fsmc"
     module.description = "Flexible (Static) Memory Controller (FSMC/FMC)"
 
 def prepare(module, options):

--- a/src/modm/platform/gpio/at90_tiny_mega/module.lb
+++ b/src/modm/platform/gpio/at90_tiny_mega/module.lb
@@ -46,8 +46,7 @@ def extract_signals(signals):
     return afs
 
 def init(module):
-    module.name = "gpio"
-    module.parent = "platform"
+    module.name = ":platform:gpio"
     module.description = "General Purpose I/O (GPIO)"
 
 def prepare(module, options):

--- a/src/modm/platform/gpio/common/module.lb
+++ b/src/modm/platform/gpio/common/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "gpio.common"
-    module.parent = "platform"
+    module.name = ":platform:gpio.common"
     module.description = "GPIO Common"
 
 def prepare(module, options):

--- a/src/modm/platform/gpio/hosted/module.lb
+++ b/src/modm/platform/gpio/hosted/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.name = "gpio"
-    module.parent = "platform"
+    module.name = ":platform:gpio"
     module.description = "Hosted GPIO"
 
 

--- a/src/modm/platform/gpio/lpc/module.lb
+++ b/src/modm/platform/gpio/lpc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "gpio"
-    module.parent = "platform"
+    module.name = ":platform:gpio"
 
 def prepare(module, options):
     if not options[":target"].has_driver("gpio:lpc"):

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -127,8 +127,7 @@ bprops = {}
 
 # -----------------------------------------------------------------------------
 def init(module):
-    module.name = "gpio"
-    module.parent = "platform"
+    module.name = ":platform:gpio"
     module.description = "General Purpose I/O (GPIO)"
 
 def prepare(module, options):

--- a/src/modm/platform/i2c/at90_tiny_mega/module.lb
+++ b/src/modm/platform/i2c/at90_tiny_mega/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "i2c"
-    module.parent = "platform"
+    module.name = ":platform:i2c"
     module.description = "Inter-Integrated Circuit (I²C)"
 
 def prepare(module, options):

--- a/src/modm/platform/i2c/bitbang/module.lb
+++ b/src/modm/platform/i2c/bitbang/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "i2c.bitbang"
-    module.parent = "platform"
+    module.name = ":platform:i2c.bitbang"
     module.description = "Software Inter-Integrated Circuit (I²C)"
 
 def prepare(module, options):

--- a/src/modm/platform/i2c/stm32-extended/module.lb
+++ b/src/modm/platform/i2c/stm32-extended/module.lb
@@ -46,8 +46,7 @@ class Instance(Module):
         env.template("i2c_master.hpp.in", "i2c_master_{}.hpp".format(self.instance))
 
 def init(module):
-    module.name = "i2c"
-    module.parent = "platform"
+    module.name = ":platform:i2c"
     module.description = "Inter-Integrated Circuit (I²C)"
 
 def prepare(module, options):

--- a/src/modm/platform/i2c/stm32/module.lb
+++ b/src/modm/platform/i2c/stm32/module.lb
@@ -47,8 +47,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "i2c"
-    module.parent = "platform"
+    module.name = ":platform:i2c"
     module.description = "Inter-Integrated Circuit (I²C)"
 
 def prepare(module, options):

--- a/src/modm/platform/i2c/xmega/module.lb
+++ b/src/modm/platform/i2c/xmega/module.lb
@@ -42,8 +42,7 @@ class Instance(Module):
         env.template("i2c_master.cpp.in", "i2c_master_{}.cpp".format(self.instance.lower()))
 
 def init(module):
-    module.name = "i2c"
-    module.parent = "platform"
+    module.name = ":platform:i2c"
 
 def prepare(module, options):
     device = options[":target"]

--- a/src/modm/platform/id/stm32/module.lb
+++ b/src/modm/platform/id/stm32/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "id"
-    module.parent = "platform"
+    module.name = ":platform:id"
     module.description = "Unique ID"
 
 def prepare(module, options):

--- a/src/modm/platform/module.lb
+++ b/src/modm/platform/module.lb
@@ -14,7 +14,7 @@
 from os.path import join
 
 def init(module):
-    module.name = "platform"
+    module.name = ":platform"
     module.description = """\
 # Platform HAL
 

--- a/src/modm/platform/one_wire/bitbang/module.lb
+++ b/src/modm/platform/one_wire/bitbang/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "1-wire.bitbang"
-    module.parent = "platform"
+    module.name = ":platform:1-wire.bitbang"
     module.description = "Software 1-Wire"
 
 def prepare(module, options):

--- a/src/modm/platform/random/stm32/module.lb
+++ b/src/modm/platform/random/stm32/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "random"
-    module.parent = "platform"
+    module.name = ":platform:random"
     module.description = "Random Number Generator (RNG)"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/at90_tiny_mega/module.lb
+++ b/src/modm/platform/spi/at90_tiny_mega/module.lb
@@ -53,8 +53,7 @@ class Instance(Module):
         env.template("spi_master.cpp.in", "spi_master{}.cpp".format(self.instance))
 
 def init(module):
-    module.name = "spi"
-    module.parent = "platform"
+    module.name = ":platform:spi"
     module.description = "Serial Peripheral Interface (SPI)"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/at90_tiny_mega_uart/module.lb
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/module.lb
@@ -81,8 +81,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "uart.spi"
-    module.parent = "platform"
+    module.name = ":platform:uart.spi"
     module.description = "USART in SPI Mode"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/bitbang/module.lb
+++ b/src/modm/platform/spi/bitbang/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "spi.bitbang"
-    module.parent = "platform"
+    module.name = ":platform:spi.bitbang"
     module.description = "Software Serial Peripheral Interface (SPI)"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/lpc/module.lb
+++ b/src/modm/platform/spi/lpc/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "spi"
-    module.parent = "platform"
+    module.name = ":platform:spi"
 
 def prepare(module, options):
     if not options[":target"].has_driver("spi:lpc"):

--- a/src/modm/platform/spi/stm32/module.lb
+++ b/src/modm/platform/spi/stm32/module.lb
@@ -46,8 +46,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "spi"
-    module.parent = "platform"
+    module.name = ":platform:spi"
     module.description = "Serial Peripheral Interface (SPI)"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/stm32_uart/module.lb
+++ b/src/modm/platform/spi/stm32_uart/module.lb
@@ -43,8 +43,7 @@ class Instance(Module):
         env.template("uart_spi_master.cpp.in", "uart_spi_master_{}.cpp".format(self.instance))
 
 def init(module):
-    module.name = "uart.spi"
-    module.parent = "platform"
+    module.name = ":platform:uart.spi"
     module.description = "USART in SPI Mode"
 
 def prepare(module, options):

--- a/src/modm/platform/spi/xmega/module.lb
+++ b/src/modm/platform/spi/xmega/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "spi"
-    module.parent = "platform"
+    module.name = ":platform:spi"
 
 def prepare(module, options):
     target = options[":target"]

--- a/src/modm/platform/timer/lpc/module.lb
+++ b/src/modm/platform/timer/lpc/module.lb
@@ -43,8 +43,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "timer"
-    module.parent = "platform"
+    module.name = ":platform:timer"
 
 def prepare(module, options):
     device = options[":target"]

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -82,8 +82,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "timer"
-    module.parent = "platform"
+    module.name = ":platform:timer"
     module.description = "Timers (TIM)"
 
 def prepare(module, options):

--- a/src/modm/platform/timer/xmega/module.lb
+++ b/src/modm/platform/timer/xmega/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "timer"
-    module.parent = "platform"
+    module.name = ":platform:timer"
 
 def prepare(module, options):
     if not options[":target"].has_driver("timer:xmega"):

--- a/src/modm/platform/uart/at90_tiny_mega/module.lb
+++ b/src/modm/platform/uart/at90_tiny_mega/module.lb
@@ -70,8 +70,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
     module.description = "Universal Asynchronous Receiver Transmitter (UART)"
 
 def prepare(module, options):

--- a/src/modm/platform/uart/hosted/module.lb
+++ b/src/modm/platform/uart/hosted/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
     module.description = "UART and Serial"
 
 

--- a/src/modm/platform/uart/lpc/module.lb
+++ b/src/modm/platform/uart/lpc/module.lb
@@ -58,8 +58,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
 
 def prepare(module, options):
     device = options[":target"]

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -65,8 +65,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
     module.description = "Universal Asynchronous Receiver Transmitter (UART)"
 
 def prepare(module, options):

--- a/src/modm/platform/uart/xmega/module.lb
+++ b/src/modm/platform/uart/xmega/module.lb
@@ -64,8 +64,7 @@ class Instance(Module):
 
 
 def init(module):
-    module.name = "uart"
-    module.parent = "platform"
+    module.name = ":platform:uart"
 
 def prepare(module, options):
     device = options[":target"]

--- a/src/modm/processing/module.lb
+++ b/src/modm/processing/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "processing"
+    module.name = ":processing"
     module.description = """\
 # Processing
 

--- a/src/modm/processing/protothread/module.lb
+++ b/src/modm/processing/protothread/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "processing"
-    module.name = "protothread"
+    module.name = ":processing:protothread"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/processing/resumable/module.lb
+++ b/src/modm/processing/resumable/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.parent = "processing"
-    module.name = "resumable"
+    module.name = ":processing:resumable"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/processing/rtos/module.lb
+++ b/src/modm/processing/rtos/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "processing"
-    module.name = "rtos"
+    module.name = ":processing:rtos"
     module.description = """\
 # RTOS Abstractions
 

--- a/src/modm/processing/scheduler/module.lb
+++ b/src/modm/processing/scheduler/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "processing"
-    module.name = "scheduler"
+    module.name = ":processing:scheduler"
     module.description = """\
 # Generic Scheduler
 

--- a/src/modm/processing/timer/module.lb
+++ b/src/modm/processing/timer/module.lb
@@ -12,8 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "processing"
-    module.name = "timer"
+    module.name = ":processing:timer"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/ui/animation/module.lb
+++ b/src/modm/ui/animation/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "animation"
+    module.name = ":ui:animation"
     module.description = """\
 # Animators
 

--- a/src/modm/ui/button.lb
+++ b/src/modm/ui/button.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "button"
+    module.name = ":ui:button"
     module.description = """\
 # Debouncing Buttons
 

--- a/src/modm/ui/color.lb
+++ b/src/modm/ui/color.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "color"
+    module.name = ":ui:color"
     module.description = """\
 # Color
 

--- a/src/modm/ui/display/module.lb
+++ b/src/modm/ui/display/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "display"
+    module.name = ":ui:display"
     module.description = """\
 # Display Graphics
 

--- a/src/modm/ui/gui/module.lb
+++ b/src/modm/ui/gui/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "gui"
+    module.name = ":ui:gui"
     module.description = """\
 # Graphical User Interface
 

--- a/src/modm/ui/led/module.lb
+++ b/src/modm/ui/led/module.lb
@@ -13,8 +13,7 @@
 import itertools, math
 
 def init(module):
-    module.parent = "ui"
-    module.name = "led"
+    module.name = ":ui:led"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/src/modm/ui/menu/module.lb
+++ b/src/modm/ui/menu/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "menu"
+    module.name = ":ui:menu"
     module.description = """\
 # Display Menu
 

--- a/src/modm/ui/time/module.lb
+++ b/src/modm/ui/time/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "ui"
-    module.name = "time"
+    module.name = ":ui:time"
     module.description = "Date and Time"
 
 def prepare(module, options):

--- a/src/modm/ui/ui.lb
+++ b/src/modm/ui/ui.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "ui"
+    module.name = ":ui"
     module.description = """\
 # User interface
 

--- a/src/modm/utils/module.lb
+++ b/src/modm/utils/module.lb
@@ -12,7 +12,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "utils"
+    module.name = ":utils"
     module.description = "Utilities"
 
 def prepare(module, options):

--- a/src/unittest/module.lb
+++ b/src/unittest/module.lb
@@ -13,7 +13,7 @@
 
 
 def init(module):
-    module.name = "unittest"
+    module.name = ":unittest"
     module.description = """\
 # Unit Tests
 

--- a/test/modm/architecture/module.lb
+++ b/test/modm/architecture/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "architecture"
-    module.parent = "test"
+    module.name = ":test:architecture"
 
 
 def prepare(module, options):

--- a/test/modm/communication/module.lb
+++ b/test/modm/communication/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "communication"
-    module.parent = "test"
+    module.name = ":test:communication"
 
 
 def prepare(module, options):

--- a/test/modm/container/module.lb
+++ b/test/modm/container/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "container"
-    module.parent = "test"
+    module.name = ":test:container"
 
 
 def prepare(module, options):

--- a/test/modm/driver/module.lb
+++ b/test/modm/driver/module.lb
@@ -13,8 +13,7 @@
 
 
 def init(module):
-    module.name = "driver"
-    module.parent = "test"
+    module.name = ":test:driver"
 
 
 def prepare(module, options):

--- a/test/modm/io/module.lb
+++ b/test/modm/io/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "io"
-    module.parent = "test"
+    module.name = ":test:io"
 
 
 def prepare(module, options):

--- a/test/modm/math/module.lb
+++ b/test/modm/math/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "math"
-    module.parent = "test"
+    module.name = ":test:math"
 
 
 def prepare(module, options):

--- a/test/modm/platform/gpio/module.lb
+++ b/test/modm/platform/gpio/module.lb
@@ -76,8 +76,7 @@ def get_af(s):
 
 
 def init(module):
-    module.name = "gpio"
-    module.parent = "test:platform"
+    module.name = ":test:platform:gpio"
 
 def prepare(module, options):
     target = options[":target"].identifier

--- a/test/modm/platform/module.lb
+++ b/test/modm/platform/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "platform"
-    module.parent = "test"
+    module.name = ":test:platform"
 
 
 def prepare(module, options):

--- a/test/modm/platform/spi/mock/module.lb
+++ b/test/modm/platform/spi/mock/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = "spi"
-    module.parent = "test:platform"
+    module.name = ":test:platform:spi"
 
 def prepare(module, options):
     module.depends(

--- a/test/modm/processing/module.lb
+++ b/test/modm/processing/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "processing"
-    module.parent = "test"
+    module.name = ":test:processing"
 
 
 def prepare(module, options):

--- a/test/modm/ui/module.lb
+++ b/test/modm/ui/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "ui"
-    module.parent = "test"
+    module.name = ":test:ui"
 
 
 def prepare(module, options):

--- a/test/module.lb
+++ b/test/module.lb
@@ -12,7 +12,7 @@
 
 
 def init(module):
-    module.name = "test"
+    module.name = ":test"
     module.description = "Tests for modm"
 
 

--- a/test/stdc++/module.lb
+++ b/test/stdc++/module.lb
@@ -12,8 +12,7 @@
 
 
 def init(module):
-    module.name = "stdc++"
-    module.parent = "test"
+    module.name = ":test:stdc++"
 
 
 def prepare(module, options):

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -15,8 +15,7 @@ import os
 from os.path import join
 
 def init(module):
-    module.parent = "build"
-    module.name = "cmake"
+    module.name = ":build:cmake"
     module.description = FileReader("module.md")
 
 

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -18,7 +18,7 @@ with open(localpath("common.py")) as common:
 
 
 def init(module):
-    module.name = "build"
+    module.name = ":build"
     module.description = FileReader("module.md")
 
 
@@ -46,7 +46,7 @@ def prepare(module, options):
             StringOption(name="avrdude.port", default="",
                          description="AvrDude programmer port"))
         module.add_option(
-            NumericOption(name="avrdude.baudrate", default=0,
+            NumericOption(name="avrdude.baudrate", minimum=0, default=0,
                           description="AvrDude programmer baudrate"))
         module.add_option(
             StringOption(name="avrdude.options", default="",
@@ -113,7 +113,7 @@ def prepare(module, options):
     # Compile flag collectors
     def flag_validate(flag):
         if not flag.startswith("-"):
-            raise ValueError("Flag '{}' must start with '-'!".format(flag))
+            raise ValueError("Flags must start with '-'!")
         return flag
     for name in common_build_flag_names:
         module.add_collector(

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -13,8 +13,7 @@
 from os.path import join, relpath, isdir
 
 def init(module):
-    module.parent = "build"
-    module.name = "scons"
+    module.name = ":build:scons"
     module.description = FileReader("module.md")
 
 

--- a/tools/doc_generator/module.lb
+++ b/tools/doc_generator/module.lb
@@ -138,7 +138,7 @@ def replace(text, key, content):
 
 # -----------------------------------------------------------------------------
 def init(module):
-    module.name = "docs"
+    module.name = ":docs"
     module.description = FileReader("module.md")
 
 def prepare(module, options):

--- a/tools/xpcc_generator/module.lb
+++ b/tools/xpcc_generator/module.lb
@@ -11,8 +11,7 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.parent = "communication:xpcc"
-    module.name = "generator"
+    module.name = ":communication:xpcc:generator"
     module.description = "XPCC Generator"
 
 def prepare(module, options):


### PR DESCRIPTION
Main change is just the unification of module naming, since using `module.parent` is deprecated now.

For NumericOptions, you can put Python code to simplify your values (Like 16MB -> `2**24` instead of `16777216`).

Filters must be prefixed with the repository name now.