### PR TITLE
[scons] Fix generated SConscript on Windows

### DIFF
--- a/repo.lb
+++ b/repo.lb
@@ -20,6 +20,7 @@ import platform
 from pathlib import Path
 from distutils.version import StrictVersion
 from git import Repo
+from os.path import normpath
 
 sys.path.append(repopath("ext/modm-devices/tools/device"))
 try:
@@ -181,10 +182,14 @@ def init(repo):
         repo.add_configuration(name, config, description)
 
     # Add Jinja2 filters commonly used in this repository
-    def windowsify(path):
-        if 'Windows' in platform.platform():
-            path = path.replace('/','\\').replace("\\", "\\\\")
-        return path
+    if 'Windows' in platform.platform():
+        def windowsify(path, escape_level):
+            path = normpath(path)
+            escaped = "\\" * (2 ** escape_level)
+            return path.replace("\\", escaped)
+    else:
+        def windowsify(path, escape_level):
+            return normpath(path)
     repo.add_filter("windowsify", windowsify)
     repo.add_filter("ord", lambda letter: ord(letter[0].lower()) - ord("a"))
     repo.add_filter("chr", lambda num: chr(num + ord("A")))

--- a/tools/build_script_generator/gdbinit.in
+++ b/tools/build_script_generator/gdbinit.in
@@ -1,7 +1,7 @@
 %% for profile, path in elf_files.items()
 define file_{{profile}}
     file
-    file {{ path | modm.windowsify }}
+    file {{ path | modm.windowsify(escape_level=1) }}
 end
 %% endfor
 

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -1,8 +1,8 @@
 %% for path in collector_values["path.openocd"] | sort
-add_script_search_dir {{ path }}
+add_script_search_dir {{ path | modm.windowsify(escape_level=1) }}
 %% endfor
 %% for file in collector_values["openocd.source"] | sort
-source [find {{ file }}]
+source [find {{ file | modm.windowsify(escape_level=1) }}]
 %% endfor
 
 proc modm_program { SOURCE } {
@@ -14,7 +14,7 @@ proc modm_program { SOURCE } {
 
 %% for profile, path in elf_files.items()
 proc program_{{ profile }} {} {
-	modm_program {{ path | modm.windowsify }}
+	modm_program {{ path | modm.windowsify(escape_level=1) }}
 }
 %% endfor
 

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -122,13 +122,13 @@ env.AppendUnique(CPPPATH=[
 	"/usr/local/include",
 %% endif
 %% for path in include_paths | sort
-    abspath("{{ path | relocate }}"),
+    abspath(r"{{ path | relocate | modm.windowsify(escape_level=0) }}"),
 %% endfor
 ])
 
 files = [
 %% for file, flags in sources if not flags | length
-    env.File("{{ file | relocate }}"),
+    env.File(r"{{ file | relocate | modm.windowsify(escape_level=0) }}"),
 %% endfor
 ]
 %% for file, flags in sources
@@ -139,7 +139,7 @@ flags = { {%- for key, profiles in flags.items() if "" in profiles %}"{{ key | u
 if profile == "{{profile}}": flags["{{ key | upper }}"].extend({{flags}});
         %% endfor
     %% endfor
-files.append(env.Object("{{ file | relocate }}", **flags))
+files.append(env.Object(r"{{ file | relocate | modm.windowsify(escape_level=0) }}", **flags))
     %% endif
 %% endfor
 
@@ -157,7 +157,7 @@ env.AppendUnique(LIBPATH=[
 %% endif
     abspath(str(library[0].get_dir())),
 %% for library in library_paths | sort
-    abspath("{{ library | relocate }}"),
+    abspath(r"{{ library | relocate | modm.windowsify(escape_level=0) }}"),
 %% endfor
 ])
 %% if packages | length


### PR DESCRIPTION
I ended up with this solution after trying the raw strings version. The problem with that was that the generated `.gdbinit` file also needs to have double `\\`s, so I couldn't remove the doubling logic from `windowsify`.

This solves the immediate problem (at least for me), so I think it's worthwhile to merge this, and possibly come up with a cleaner solution later.

Fixes #192.