### PR TITLE
[scons] Set default `tools` to empty

### DIFF
--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -20,7 +20,7 @@ CacheDir("{{ cache_dir }}")
 %% endif
 
 # SCons environment with all tools
-env = Environment(ENV=os.environ)
+env = DefaultEnvironment(tools=[], ENV=os.environ)
 env["CONFIG_BUILD_BASE"] = abspath(build_path)
 env["CONFIG_PROJECT_NAME"] = project_name
 


### PR DESCRIPTION
Sets the default environment to not include any tools automatically. The
correct tools are manually added in the generated SConscript files.

Without this, scons will try to find and set up a default toolchain, and
this takes quite a long time on Windows with MSVC.