### PR TITLE
Use lowest priority for undefined IRQs and disable them

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ make gdb
 
 ## Interesting Examples
 
-We have a lot of examples, <!--examplecount-->175<!--/examplecount--> to be
+We have a lot of examples, <!--examplecount-->176<!--/examplecount--> to be
 exact, but here are some of our favorite examples for our supported development
 boards:
 

--- a/examples/nucleo_f103rb/undefined_irq/main.cpp
+++ b/examples/nucleo_f103rb/undefined_irq/main.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/architecture/interface/assert.hpp>
+
+using namespace Board;
+
+MODM_ISR(EXTI0)
+{ MODM_LOG_DEBUG << "EXTI0 called!" << modm::endl; }
+MODM_ISR(EXTI1)
+{ MODM_LOG_DEBUG << "EXTI1 called!" << modm::endl; }
+MODM_ISR(EXTI2)
+{ MODM_LOG_DEBUG << "EXTI2 called!" << modm::endl; }
+MODM_ISR(EXTI3)
+{ MODM_LOG_DEBUG << "EXTI3 called!" << modm::endl; }
+
+// But we forgot about EXTI4
+// MODM_ISR(EXTI4)
+// { MODM_LOG_DEBUG << "EXTI4 called!" << modm::endl; }
+
+static modm::Abandonment
+core_assertion_handler(const char * module,
+					   const char * /*location*/,
+					   const char * /*failure*/,
+					   uintptr_t context)
+{
+	if (!memcmp(module, "core\0nvic\0undefined", 19)) {
+		MODM_LOG_ERROR.printf("Ignoring undefined IRQ handler %d!\n", int8_t(context));
+		return modm::Abandonment::Ignore;
+	}
+	return modm::Abandonment::DontCare;
+}
+// Uncomment to ignore the assertion
+// MODM_ASSERTION_HANDLER(core_assertion_handler);
+
+// Uncomment to overwrite the undefined handler
+// extern "C" void modm_undefined_handler(int32_t) {}
+
+int main()
+{
+	Board::initialize();
+	// Enable the Interrupt handlers
+	NVIC_EnableIRQ(EXTI0_IRQn);
+	NVIC_EnableIRQ(EXTI1_IRQn);
+	NVIC_EnableIRQ(EXTI2_IRQn);
+	NVIC_EnableIRQ(EXTI3_IRQn);
+	NVIC_EnableIRQ(EXTI4_IRQn);
+	// Give them the highest priority
+	NVIC_SetPriority(EXTI0_IRQn, 0);
+	NVIC_SetPriority(EXTI1_IRQn, 0);
+	NVIC_SetPriority(EXTI2_IRQn, 0);
+	NVIC_SetPriority(EXTI3_IRQn, 0);
+	NVIC_SetPriority(EXTI4_IRQn, 0);
+
+	MODM_LOG_INFO << "Push the Button to trigger EXTI interrupts!" << modm::endl;
+	int ii{0};
+
+	while (1)
+	{
+		if(Button::read())
+		{
+			NVIC_SetPendingIRQ(IRQn_Type(int(EXTI0_IRQn) + ii));
+			ii = (ii + 1) % 5;
+			// wait one second for debounce
+			modm::delayMilliseconds(500);
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f103rb/undefined_irq/project.xml
+++ b/examples/nucleo_f103rb/undefined_irq/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f103rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f103rb/undefined_irq</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/st/device.hpp.in
+++ b/ext/st/device.hpp.in
@@ -29,11 +29,13 @@
 #include <{{ header }}>
 %% endfor
 
+/// @cond
 // This is a hack to make the *_Typedef's known to GDB, so that you can debug
 // the peripherals directly in GDB in any context.
 // Otherwise GDB would throw a "no symbol 'GPIO_TypeDef' in current context".
 %% for (name, type) in peripherals
 extern {{ type | lbuild.pad(19) }}	___{{ name | lbuild.pad(15) }};
 %% endfor
+/// @endcond
 
 #endif  // MODM_DEVICE_HPP

--- a/src/modm/platform/core/cortex/assert.cpp
+++ b/src/modm/platform/core/cortex/assert.cpp
@@ -22,6 +22,16 @@ extern AssertionHandler __assertion_table_end;
 extern "C"
 {
 
+modm_weak void
+modm_undefined_handler(int32_t irqn)
+{
+	// Set the currently executing interrupt to the lowest priority to allow
+	// reporting of the assertion failure and disable it from firing again.
+	NVIC_SetPriority(IRQn_Type(irqn), (1ul << __NVIC_PRIO_BITS) - 1ul);
+	NVIC_DisableIRQ(IRQn_Type(irqn));
+	modm_assert(0, "core", "nvic", "undefined", irqn);
+}
+
 void
 modm_assert_fail(const char * identifier)
 {

--- a/src/modm/platform/core/cortex/vectors.c.in
+++ b/src/modm/platform/core/cortex/vectors.c.in
@@ -14,11 +14,12 @@
 #include <modm/architecture/interface/assert.h>
 
 // ----------------------------------------------------------------------------
+extern void modm_undefined_handler(int32_t);
 void Undefined_Handler(void)
 {
-	uint32_t irqn;
+	int32_t irqn;
 	asm volatile("mrs %[irqn], ipsr" :[irqn] "=r" (irqn));
-	modm_assert(0, "core", "nvic", "undefined", irqn);
+	modm_undefined_handler(irqn - 16);
 }
 /* Provide weak aliases for each Exception handler to Undefined_Handler.
  * As they are weak aliases, any function with the same name will override


### PR DESCRIPTION
This allows them to be preempted by other IRQs especially by the UART interrupts used by the buffered IODevice in modm_abandon to report the abondonment.
This also disables the IRQ so that it doesn't spam the assertion handlers.

cc @rleh 