### PR TITLE
Add GNU Build ID to identify firmware

### DIFF
--- a/examples/nucleo_f103rb/hard_fault/main.cpp
+++ b/examples/nucleo_f103rb/hard_fault/main.cpp
@@ -54,12 +54,11 @@ main()
 	if (FaultReporter::hasReport())
 	{
 		MODM_LOG_ERROR << "\n\nHardFault! Copy the data into a 'coredump.txt' file, ";
-		MODM_LOG_ERROR << "then execute 'scons postmortem firmware=";
-		MODM_LOG_ERROR << modm::hex << FaultReporter::firmware() << "'.\n\n";
-		for (const uint8_t data : FaultReporter())
-		{
+		MODM_LOG_ERROR << "then execute\n\n\tscons postmortem firmware=" << modm::hex;
+		for (const auto data : FaultReporter::buildId()) MODM_LOG_ERROR << data;
+		MODM_LOG_ERROR << "\n\n";
+		for (const auto data : FaultReporter())
 			MODM_LOG_ERROR << modm::hex << data << modm::flush;
-		}
 		MODM_LOG_ERROR << "\n\n\n" << modm::flush;
 		FaultReporter::clearAndReboot();
 	}

--- a/examples/stm32f072_discovery/hard_fault/main.cpp
+++ b/examples/stm32f072_discovery/hard_fault/main.cpp
@@ -40,9 +40,10 @@ main()
 	if (FaultReporter::hasReport())
 	{
 		MODM_LOG_ERROR << "\n\nHardFault! Copy the data into a 'coredump.txt' file, ";
-		MODM_LOG_ERROR << "then execute 'scons postmortem firmware=";
-		MODM_LOG_ERROR << modm::hex << FaultReporter::firmware() << "'.\n\n";
-		for (const uint8_t data : FaultReporter())
+		MODM_LOG_ERROR << "then execute\n\n\tscons postmortem firmware=" << modm::hex;
+		for (const auto data : FaultReporter::buildId()) MODM_LOG_ERROR << data;
+		MODM_LOG_ERROR << "\n\n";
+		for (const auto data : FaultReporter())
 			MODM_LOG_ERROR << modm::hex << data << modm::flush;
 		MODM_LOG_ERROR << "\n\n\n" << modm::flush;
 		FaultReporter::clearAndReboot();

--- a/examples/stm32f469_discovery/hard_fault/main.cpp
+++ b/examples/stm32f469_discovery/hard_fault/main.cpp
@@ -54,12 +54,11 @@ main()
 	if (FaultReporter::hasReport())
 	{
 		MODM_LOG_ERROR << "\n\nHardFault! Copy the data into a 'coredump.txt' file, ";
-		MODM_LOG_ERROR << "then execute 'scons postmortem firmware=";
-		MODM_LOG_ERROR << modm::hex << FaultReporter::firmware() << "'.\n\n";
-		for (const uint8_t data : FaultReporter())
-		{
+		MODM_LOG_ERROR << "then execute\n\n\tscons postmortem firmware=" << modm::hex;
+		for (const auto data : FaultReporter::buildId()) MODM_LOG_ERROR << data;
+		MODM_LOG_ERROR << "\n\n";
+		for (const auto data : FaultReporter())
 			MODM_LOG_ERROR << modm::hex << data << modm::flush;
-		}
 		MODM_LOG_ERROR << "\n\n\n" << modm::flush;
 		FaultReporter::clearAndReboot();
 	}

--- a/src/modm/architecture/interface/build_id.hpp
+++ b/src/modm/architecture/interface/build_id.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <array>
+
+namespace modm
+{
+
+/**
+ * Return the GNU Build ID as a 160-bit SHA1 array.
+ *
+ * @ingroup modm_architecture_build_id
+ */
+[[nodiscard]]
+const std::array<uint8_t, 20>&
+build_id();
+
+}

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -88,6 +88,19 @@ class BlockDevice(Module):
         env.copy("interface/block_device.hpp")
 # -----------------------------------------------------------------------------
 
+class BuildId(Module):
+    def init(self, module):
+        module.name = "build_id"
+        module.description = "GNU Build ID"
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        env.outbasepath = "modm/src/modm/architecture"
+        env.copy("interface/build_id.hpp")
+# -----------------------------------------------------------------------------
+
 class Can(Module):
     def init(self, module):
         module.name = "can"
@@ -348,6 +361,7 @@ def prepare(module, options):
     module.add_submodule(Assert())
     module.add_submodule(Atomic())
     module.add_submodule(BlockDevice())
+    module.add_submodule(BuildId())
     module.add_submodule(Can())
     module.add_submodule(Clock())
     module.add_submodule(Delay())

--- a/src/modm/platform/core/cortex/build_id.cpp
+++ b/src/modm/platform/core/cortex/build_id.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/architecture/interface/build_id.hpp>
+
+typedef struct {
+    uint32_t namesz;
+    uint32_t descsz;
+    uint32_t type;
+    uint8_t data[];
+} ElfNoteSection_t;
+extern "C" const ElfNoteSection_t __build_id[];
+
+namespace modm
+{
+
+const std::array<uint8_t, 20>&
+build_id()
+{
+	const uint8_t *const sha1 = &__build_id->data[__build_id->namesz];
+	auto *const hash = reinterpret_cast<const std::array<uint8_t, 20> *>(sha1);
+	return *hash;
+}
+
+}

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -287,6 +287,12 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		KEEP(*(.assertion))
 		__assertion_table_end = .;
 	} >{{memory}}
+
+	.build_id :
+	{
+		__build_id = .;
+		KEEP(*(.note.gnu.build-id))
+	} > {{memory}}
 %% endmacro
 
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -152,6 +152,7 @@ def prepare(module, options):
         ":architecture:interrupt",
         ":architecture:memory",
         ":architecture:unaligned",
+        ":architecture:build_id",
         ":platform:clock",
         ":cmsis:device")
 
@@ -273,6 +274,9 @@ def build(env):
     # busy-waiting delays
     env.template("delay.cpp.in")
     env.copy("delay.hpp")
+
+    # GNU Build ID
+    env.copy("build_id.cpp")
 
     # modm-test implements the clock methods itself
     if not env.has_module(":test:architecture"):

--- a/src/modm/platform/fault/crashcatcher/fault.hpp
+++ b/src/modm/platform/fault/crashcatcher/fault.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "fault_storage.hpp"
+#include <modm/architecture/interface/build_id.hpp>
 
 /**
  * Called first after a HardFault occurred.
@@ -44,8 +45,8 @@ public:
 
 	/// @returns report size > 0
 	static inline bool hasReport() { return begin() != end(); }
-	/// @returns a 32-bit hash of the firmware for identification
-	static inline uint32_t firmware() { return FaultStorage::firmwareHash(); }
+	/// @returns a 20-bytes SHA1 of the firmware for identification
+	static inline const std::array<uint8_t, 20>& buildId() { return modm::build_id(); }
 	/// Clears the report
 	static inline void clear() { FaultStorage::closeRead(); }
 	/// Clears the report and reboots the device

--- a/src/modm/platform/fault/crashcatcher/fault_storage.cpp
+++ b/src/modm/platform/fault/crashcatcher/fault_storage.cpp
@@ -11,7 +11,6 @@
 
 #include "fault_storage.hpp"
 #include <modm/architecture/utils.hpp>
-#include <modm/math/utils/crc32.hpp>
 
 typedef struct
 {
@@ -22,8 +21,6 @@ typedef struct
 
 extern "C" const table_pool_t __table_heap_start[];
 extern "C" const table_pool_t __table_heap_end[];
-extern "C" const uint8_t __rom_start[];
-extern "C" const uint8_t __rom_end[];
 
 static constexpr uint32_t magic_start = 0xBAADC0DE;
 static constexpr uint32_t magic_end = 0xC0FFEEEE;
@@ -74,13 +71,6 @@ FaultStorage::closeRead()
 {
 	marker_start = 0;
 	marker_end_ptr = nullptr;
-}
-
-uint32_t
-FaultStorage::firmwareHash()
-{
-	// Compute the CRC32 of the loaded binary image
-	return modm::math::crc32(__rom_start, __rom_end - __rom_start);
 }
 
 void

--- a/src/modm/platform/fault/crashcatcher/fault_storage.hpp
+++ b/src/modm/platform/fault/crashcatcher/fault_storage.hpp
@@ -24,7 +24,6 @@ class FaultStorage
 public:
 	static size_t openRead();
 	static void closeRead();
-	static uint32_t firmwareHash();
 
 	class Iterator
 	{

--- a/src/modm/platform/fault/crashcatcher/module.lb
+++ b/src/modm/platform/fault/crashcatcher/module.lb
@@ -25,7 +25,7 @@ def prepare(module, options):
             enumeration=["core", "core+stack", "core+stack+data"],
             default="core+stack+data"))
 
-    module.depends(":crashcatcher", ":cmsis:device", ":math:utils")
+    module.depends(":crashcatcher", ":cmsis:device", ":architecture:build_id")
 
     return True
 

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -203,7 +203,8 @@ def common_compiler_flags(compiler, target):
             "-Wl,--fatal-warnings",
             "-Wl,--gc-sections",
             "-Wl,--relax",
-            "-Wl,-Map,{target_base}.map,--cref",
+            "-Wl,--build-id=sha1",
+            # "-Wl,-Map,{target_base}.map,--cref",
         ]
     # C Preprocessor defines
     flags["cppdefines"] = []

--- a/tools/build_script_generator/scons/site_tools/artifact.py
+++ b/tools/build_script_generator/scons/site_tools/artifact.py
@@ -14,7 +14,7 @@ import os
 import shutil
 from SCons.Script import *
 import subprocess
-import binascii
+from elftools.elf.elffile import ELFFile
 
 def run_store_artifact(target, source, env):
 	artifactpath = os.path.join(env["CONFIG_BUILD_BASE"], "artifacts")
@@ -22,15 +22,20 @@ def run_store_artifact(target, source, env):
 		os.makedirs(artifactpath)
 	except:
 		pass
-	source = str(source[0])
-	binary = os.path.splitext(source)[0]+".bin"
-	subprocess.call(env.subst("$OBJCOPY -O binary {} {}".format(source, binary)), shell=True)
-	with open(binary, "rb") as binfile:
-		firmware = binascii.crc32(binfile.read()) & 0xFFFFFFFF
 
-	artifact = os.path.join(artifactpath, "{:08X}.elf".format(firmware))
-	shutil.copy2(source, artifact)
-	shutil.copy2(binary, os.path.splitext(artifact)[0]+".bin")
+	with open(source[0].path, "rb") as src:
+		elffile = ELFFile(src)
+		build_id = elffile.get_section_by_name(".build_id")
+		if build_id is not None:
+			for note in build_id.iter_notes():
+				if note['n_type'] == "NT_GNU_BUILD_ID":
+					build_id = note['n_desc']
+
+	if build_id is not None:
+		artifact = os.path.join(artifactpath, "{}.elf".format(build_id.lower()))
+		shutil.copy2(source[0].path, artifact)
+	else:
+		print("Unable to find Build ID for '{}'!".format(source[0].path))
 	return 0
 
 def store_artifact(env, source, alias="store_artifact"):

--- a/tools/build_script_generator/scons/site_tools/postmortem_gdb.py
+++ b/tools/build_script_generator/scons/site_tools/postmortem_gdb.py
@@ -23,6 +23,7 @@ def run_post_mortem_gdb(target, source, env):
 		print("\n> Using the newest firmware may be inaccurate!\n"
 		      "> Use 'firmware={hash}' argument to specify a specific firmware.\n")
 	else:
+		artifact = artifact.lower()
 		artifactpath = os.path.join(env["CONFIG_BUILD_BASE"], "artifacts", "{}.elf".format(artifact))
 		if os.path.isfile(artifactpath):
 			source = artifactpath


### PR DESCRIPTION
This uses the GNU Build ID to properly identify firmware and uses this mechanism instead of CRC32 for the coredump functionality added in #52.

Adds 32 bytes containing a 160-bit SHA1 to the firmware.
Inspired by https://interrupt.memfault.com/blog/gnu-build-id-for-firmware.

cc @dergraaf: This solves my dependence on `objcopy` and reads the data directly from the ELF file.