### PR TITLE
[format] Use thousands separator to improve readability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,15 +254,20 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update submodules and install lbuild
           command: |
-            (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+            if [ ! -z "$CIRCLE_PULL_REQUESTS" ]; then
+              (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+            fi
       - run:
           name: Build Homepage
           command: |
-            python3 tools/scripts/synchronize_docs.py
-            (cd examples/stm32f469_discovery/blink; lbuild -D ::generate_module_docs=True build -m "modm:**")
-            (cd docs/src/reference && ln -s ../../../examples/stm32f469_discovery/blink/modm/docs/module)
-            (cd docs && mkdocs build)
+            if [ ! -z "$CIRCLE_PULL_REQUESTS" ]; then
+              python3 tools/scripts/synchronize_docs.py
+              (cd examples/stm32f469_discovery/blink; lbuild -D ::generate_module_docs=True build -m "modm:**")
+              (cd docs/src/reference && ln -s ../../../examples/stm32f469_discovery/blink/modm/docs/module)
+              (cd docs && mkdocs build)
+            fi
 
   build-docs-upload:
     docker:
@@ -354,9 +359,6 @@ workflows:
             - stm32g0-compile-all
             - stm32l4-compile-all
       - build-docs:
-          filters:
-            branches:
-              only: /^pull\/.*$/
           requires:
             - avr-compile-all
             - stm32f0-compile-all

--- a/src/modm/architecture/interface/block_device.hpp
+++ b/src/modm/architecture/interface/block_device.hpp
@@ -101,7 +101,7 @@ public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 1;
 	static constexpr bd_size_t BlockSizeErase = 1;
-	static constexpr bd_size_t BlockDevice = 1024;
+	static constexpr bd_size_t BlockDevice = 1'024;
 
 #endif
 };

--- a/src/modm/architecture/interface/i2c.hpp
+++ b/src/modm/architecture/interface/i2c.hpp
@@ -112,12 +112,12 @@ struct I2c
 	 *
 	 * @tparam	Scl		The clock pin of the bus to be reset.
  	 */
-	template< class Scl, uint32_t baudrate = 100000 >
+	template< class Scl, uint32_t baudrate = 100'000 >
 	static void
 	resetDevices()
 	{
-		static_assert(baudrate <= 500000, "I2c::resetDevices() can only do max. 500kHz!");
-		constexpr uint32_t delay = 500000 / baudrate;
+		static_assert(baudrate <= 500'000, "I2c::resetDevices() can only do max. 500kHz!");
+		constexpr uint32_t delay = 500'000 / baudrate;
 
 		for (uint_fast8_t ii = 0; ii < 9; ++ii) {
 			Scl::reset();

--- a/src/modm/architecture/interface/i2c_master.hpp
+++ b/src/modm/architecture/interface/i2c_master.hpp
@@ -58,10 +58,10 @@ public:
 	enum class
 	ResetDevices : uint32_t
 	{
-		NoReset  =       0,	///< Do not reset devices
-		LowSpeed =   10000,	///< Low-Speed datarate of 10kHz
-		Standard =  100000,	///< Standard datarate of 100kHz
-		Fast     =  400000,	///< Fast datarate of 400kHz
+		NoReset  =        0,	///< Do not reset devices
+		LowSpeed =   10'000,	///< Low-Speed datarate of 10kHz
+		Standard =  100'000,	///< Standard datarate of 100kHz
+		Fast     =  400'000,	///< Fast datarate of 400kHz
 	};
 
 #ifdef __DOXYGEN__

--- a/src/modm/board/al_avreb_can/board.hpp
+++ b/src/modm/board/al_avreb_can/board.hpp
@@ -44,25 +44,25 @@ initialize()
 	SystemClock::enable();
 
 	Uart1::connect<GpioD3::Txd, GpioD2::Rxd>();
-	Uart1::initialize<SystemClock, 38400_Bd>();
+	Uart1::initialize<SystemClock, 38'400_Bd>();
 
 	// modm::Clock initialization
 	// Clear Timer on Compare Match Mode
 	TCCR0A = (1 << WGM01);
 	TIMSK0 = (1 << OCIE0A);
-#if F_CPU > 16000000
+#if F_CPU > 16'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 256);
+	OCR0A = F_CPU / (1'000ul * 256);
 	// Set prescaler 256 and enable timer
 	TCCR0A = (1 << CS02);
-#elif F_CPU > 2000000
+#elif F_CPU > 2'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 64);
+	OCR0A = F_CPU / (1'000ul * 64);
 	// Set prescaler 64 and enable timer
 	TCCR0A = (1 << CS01) | (1 << CS00);
-#elif F_CPU > 1000000
+#elif F_CPU > 1'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 8);
+	OCR0A = F_CPU / (1'000ul * 8);
 	// Set prescaler 8 and enable timer
 	TCCR0A = (1 << CS01);
 #endif

--- a/src/modm/board/arduino_uno/board.hpp
+++ b/src/modm/board/arduino_uno/board.hpp
@@ -62,25 +62,25 @@ initialize()
 
 	// Uart0 is connected to onboard USB bridge
 	Uart0::connect<D1::Txd, D0::Rxd>();
-	Uart0::initialize<SystemClock, 9600_Bd>();
+	Uart0::initialize<SystemClock, 9'600_Bd>();
 
 	// modm::Clock initialization
 	// Clear Timer on Compare Match Mode
 	TCCR0A = (1 << WGM01);
 	TIMSK0 = (1 << OCIE0A);
-#if F_CPU > 16000000
+#if F_CPU > 16'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 256);
+	OCR0A = F_CPU / (1'000ul * 256);
 	// Set prescaler 256 and enable timer
 	TCCR0B = (1 << CS02);
-#elif F_CPU > 2000000
+#elif F_CPU > 2'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 64);
+	OCR0A = F_CPU / (1'000ul * 64);
 	// Set prescaler 64 and enable timer
 	TCCR0B = (1 << CS01) | (1 << CS00);
-#elif F_CPU > 1000000
+#elif F_CPU > 1'000'000
 	// Set and enable output compare A
-	OCR0A = F_CPU / (1000ul * 8);
+	OCR0A = F_CPU / (1'000ul * 8);
 	// Set prescaler 8 and enable timer
 	TCCR0B = (1 << CS01);
 #endif

--- a/src/modm/board/disco_f429zi/board.hpp
+++ b/src/modm/board/disco_f429zi/board.hpp
@@ -250,7 +250,7 @@ initializeL3g()
 	l3g::Cs::setOutput(modm::Gpio::High);
 
 	l3g::SpiMaster::connect<l3g::Sck::Sck, l3g::Mosi::Mosi, l3g::Miso::Miso>();
-	l3g::SpiMaster::initialize<SystemClock, 11250000ul>();
+	l3g::SpiMaster::initialize<SystemClock, 11.25_MHz>();
 	l3g::SpiMaster::setDataMode(l3g::SpiMaster::DataMode::Mode3);
 }
 

--- a/src/modm/board/disco_f469ni/board_dsi.cpp
+++ b/src/modm/board/disco_f469ni/board_dsi.cpp
@@ -30,13 +30,13 @@ board_initialize_display(uint8_t ColorCoding)
 		// Enable regulator
 		DSI->WRPCR = DSI_WRPCR_REGEN;
 		// Wait until stable
-		for (int t = 1024; not (DSI->WISR & DSI_WISR_RRS) and t; t--) {
+		for (int t = 1'024; not (DSI->WISR & DSI_WISR_RRS) and t; t--) {
 			modm::delayMilliseconds(1);
 		}
 		// Set up PLL and enable it
 		DSI->WRPCR |= (0 << 16) | (2 << 11) | (125 << 2) | DSI_WRPCR_PLLEN;
 		// Wait until stable
-		for (int t = 1024; not (DSI->WISR & DSI_WISR_PLLLS) and t; t--) {
+		for (int t = 1'024; not (DSI->WISR & DSI_WISR_PLLLS) and t; t--) {
 			modm::delayMilliseconds(1);
 		}
 		// D-PHY clock and digital enable
@@ -130,7 +130,7 @@ board_initialize_display(uint8_t ColorCoding)
 		RCC->DCKCFGR = RCC_DCKCFGR_CK48MSEL;
 		// Enable PLLSAI
 		RCC->CR |= RCC_CR_PLLSAION;
-		for (int t = 1024; not (RCC->CR & RCC_CR_PLLSAIRDY) and t; t--) {
+		for (int t = 1'024; not (RCC->CR & RCC_CR_PLLSAIRDY) and t; t--) {
 			modm::delayMilliseconds(1);
 		}
 	}

--- a/src/modm/board/disco_f469ni/board_otm8009a.cpp
+++ b/src/modm/board/disco_f469ni/board_otm8009a.cpp
@@ -14,7 +14,7 @@
 static void dsi_write_command(uint32_t count, uint8_t const * const p)
 {
 	/* Wait for Command FIFO Empty */
-	for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+	for (int t = 1'024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
 		modm::delayMilliseconds(1);
 	}
 
@@ -30,7 +30,7 @@ static void dsi_write_command(uint32_t count, uint8_t const * const p)
 					(p[2] << 24);
 		uint16_t counter = 3;
 
-		for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+		for (int t = 1'024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
 			modm::delayMilliseconds(1);
 		}
 
@@ -42,7 +42,7 @@ static void dsi_write_command(uint32_t count, uint8_t const * const p)
 						(p[counter + 3] << 24);
 			counter += 4;
 
-			for (int t = 1024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
+			for (int t = 1'024; not (DSI->GPSR & DSI_GPSR_CMDFE) and t; t--) {
 				modm::delayMilliseconds(1);
 			}
 		}

--- a/src/modm/communication/sab/interface_impl.hpp
+++ b/src/modm/communication/sab/interface_impl.hpp
@@ -41,7 +41,7 @@ template <typename Device>
 void
 modm::sab::Interface<Device>::initialize()
 {
-	//Device::setBaudrate(115200UL);
+	//Device::setBaudrate(115'200UL);
 	state = SYNC;
 }
 

--- a/src/modm/driver/position/vl53l0.hpp
+++ b/src/modm/driver/position/vl53l0.hpp
@@ -263,8 +263,8 @@ public:
 	static constexpr uint8_t ModelID[2] = { 0xEE, 0xAA };
 	static constexpr uint8_t RevisionID = 0x10;
 
-	// 30000 us = 30 ms
-	static constexpr uint32_t DefaultMeasurementTime = 30000;
+    // 30'000 us = 30 ms
+	static constexpr uint32_t DefaultMeasurementTime = 30'000;
 
 	// required signal rate per time period (unknown unit)
 	// this is the default value used by ST and will probably work fine
@@ -273,7 +273,7 @@ public:
 	struct TimeOverhead
 	{
 		// in microseconds
-		static constexpr uint16_t Start = 1910;
+		static constexpr uint16_t Start = 1'910;
 		static constexpr uint16_t End = 960;
 		static constexpr uint16_t MSRC = 660;
 		static constexpr uint16_t TCC = 590;
@@ -385,9 +385,9 @@ public:
 	/// Set the maximum measurement time.
 	///
 	/// Increasing this value will improve the accuracy.
-	/// The default is ~30ms. ST recommends 2000000us = 200ms for high precision.
+	/// The default is ~30ms. ST recommends 2'000'000us = 200ms for high precision.
 	///
-	/// useful range of values: ~20000us - 2000000us (20ms - 2s)
+	/// useful range of values: ~20'000us - 2'000'000us (20ms - 2s)
 	modm::ResumableResult<bool>
 	setMaxMeasurementTime(uint32_t timeUs);
 
@@ -497,7 +497,7 @@ private:
 	// Maximum argument value for setMaxMeasurementTime()
 	// Its only purpose is to prevent int overflows.
 	// The maximum value the sensor accepts is probably lower (~ 2*10^6 us = 2s).
-	static constexpr uint32_t MaxMeasurementTimeUs = 4000000;
+	static constexpr uint32_t MaxMeasurementTimeUs = 4'000'000;
 
 	Data &data;
 

--- a/src/modm/driver/pressure/bme280_data_impl_double.hpp
+++ b/src/modm/driver/pressure/bme280_data_impl_double.hpp
@@ -83,24 +83,24 @@ DataDouble::calculateCalibratedPressure()
 	double P8 = double(calibration.P8);
 	double P9 = double(calibration.P9);
 
-	double var1 = (t_fine / double(2.0)) - double(64000.0);
+	double var1 = (t_fine / double(2.0)) - double(64'000.0);
 
-	double var2 = var1 * var1 * P6 / double(32768.0);
+	double var2 = var1 * var1 * P6 / double(32'768.0);
 	var2 = var2 + var1 * P5 * double(2.0);
-	var2 = var2 / double(4.0) + (P4 * double(65636.0));
+	var2 = var2 / double(4.0) + (P4 * double(65'636.0));
 
-	var1 = (P3 * var1 * var1 / double(524288.0) + P2 * var1) / double(524288.0);
-	var1 = (double(1.0) + var1 / double(32768.0)) * P1;
+	var1 = (P3 * var1 * var1 / double(524'288.0) + P2 * var1) / double(524'288.0);
+	var1 = (double(1.0) + var1 / double(32'768.0)) * P1;
 	if (var1 == double(0.0)) {
 		calibratedPressureDouble = double(0.0);
 		return;
 	}
 
-	double p = double(1048576.0) - double(adc);
-	p = (p - (var2 / double(4096.0))) * double(6250.0) / var1;
+	double p = double(1'048'576.0) - double(adc);
+	p = (p - (var2 / double(4'096.0))) * double(6'250.0) / var1;
 
-	var1 = P9 * p * p / double(2147483648.0);
-	var2 = p * P8 / double(32768.0);
+	var1 = P9 * p * p / double(2'147'483'648.0);
+	var2 = p * P8 / double(32'768.0);
 
 	p = p + (var1 + var2 + P7) / double(16.0);
 

--- a/src/modm/driver/pressure/bme280_data_impl_fp.hpp
+++ b/src/modm/driver/pressure/bme280_data_impl_fp.hpp
@@ -86,7 +86,7 @@ Data::calculateCalibratedPressure()
 	int64_t P8 = calibration.P8;
 	int64_t P9 = calibration.P9;
 
-	int64_t var1 = t_fine - 128000;
+	int64_t var1 = t_fine - 128'000;
 	int64_t var2 = var1 * var1 * P6;
 	var2 = var2 + ((var1 * P5) << 17);
 	var2 = var2 + (P4 << 35);
@@ -125,16 +125,16 @@ Data::calculateCalibratedHumidity()
 	int32_t H5 = calibration.H5;
 	int32_t H6 = calibration.H6;
 
-  	int32_t v = (t_fine - int32_t(76800));
+  	int32_t v = (t_fine - int32_t(76'800));
 
-	v = (((((adc << 14) - (H4 << 20) - (H5 * v)) + (int32_t(16384))) >> 15) *
-		  (((((((v * H6) >> 10) * (((v * (H3)) >> 11) + (int32_t(32768)))) >> 10) +
-		  	(int32_t(2097152))) * H2 + 8192) >> 14));
+    v = (((((adc << 14) - (H4 << 20) - (H5 * v)) + (int32_t(16'384))) >> 15) *
+		  (((((((v * H6) >> 10) * (((v * (H3)) >> 11) + (int32_t(32'768)))) >> 10) +
+		  	(int32_t(2'097'152))) * H2 + 8'192) >> 14));
 
 	v = (v - (((((v >> 15) * (v >> 15)) >> 7) * H1) >> 4));
 
 	v = (v < 0) ? 0 : v;
-	v = (v > 419430400) ? 419430400 : v;
+	v = (v > 419'430'400) ? 419'430'400 : v;
 
 	calibratedHumidity = (v >> 12);
 	meta |= HUMIDITY_CALCULATED;

--- a/src/modm/driver/pressure/bmp085_data_impl_fp.hpp
+++ b/src/modm/driver/pressure/bmp085_data_impl_fp.hpp
@@ -63,7 +63,7 @@ Data::calculateCalibratedPressure()
 	calculateCalibratedTemperature();
 
 	uint32_t up = ( (uint32_t(raw[2]) << 16) | (uint16_t(raw[3]) << 8) | raw[4] ) >> (8 - oss);
-	b6 = int16_t(b5 - 4000);
+	b6 = int16_t(b5 - 4'000);
 	x1 = modm::math::mul(calibration.b2, modm::math::mul(b6, b6) >> 12) >> 11;
 	x2 = modm::math::mul(calibration.ac2, b6) >> 11;
 	x3 = x1 + x2;
@@ -72,17 +72,17 @@ Data::calculateCalibratedPressure()
 	x1 = modm::math::mul(calibration.ac3, b6) >> 13;
 	x2 = modm::math::mul(calibration.b1, modm::math::mul(b6, b6) >> 12) >> 16;
 	x3 = ((x1 + x2) + 2) >> 2;
-	b4 = modm::math::mul(calibration.ac4, uint16_t(x3 + 32768)) >> 15;
-	b7 = (up - b3) * (50000 >> oss);
+	b4 = modm::math::mul(calibration.ac4, uint16_t(x3 + 32'768)) >> 15;
+    b7 = (up - b3) * (50'000 >> oss);
 	if (b7 < 0x80000000)
 		p = (b7 << 1) / b4;
 	else
 		p = (b7 / b4) << 1;
 
 	x1 = modm::math::mul(uint16_t(p >> 8), uint16_t(p >> 8));
-	x1 = (x1 * 3038) >> 16;
-	x2 = (-7357 * p) >> 16;
-	calibratedPressure = p + ((x1 + x2 + 3791) >> 4);
+	x1 = (x1 * 3'038) >> 16;
+	x2 = (-7'357 * p) >> 16;
+	calibratedPressure = p + ((x1 + x2 + 3'791) >> 4);
 	meta |= PRESSURE_CALCULATED;
 }
 

--- a/src/modm/driver/storage/block_device_spiflash.hpp
+++ b/src/modm/driver/storage/block_device_spiflash.hpp
@@ -148,7 +148,7 @@ public:
 public:
 	static constexpr bd_size_t BlockSizeRead = 1;
 	static constexpr bd_size_t BlockSizeWrite = 256;
-	static constexpr bd_size_t BlockSizeErase = 4 * 1024;
+	static constexpr bd_size_t BlockSizeErase = 4 * 1'024;
 	static constexpr bd_size_t DeviceSize = flashSize;
 
 private:

--- a/src/modm/driver/temperature/ltc2984.hpp
+++ b/src/modm/driver/temperature/ltc2984.hpp
@@ -72,10 +72,10 @@ struct ltc2984
 		float
 		getTemperatureFloat() const
 		{
-			return getTemperatureFixed() / 1024.f;
+			return getTemperatureFixed() / 1'024.f;
 		}
 
-		/// @return the temperature in the configured unit divided by 1024
+		/// @return the temperature in the configured unit divided by 1'024
 		int32_t
 		getTemperatureFixed() const
 		{
@@ -87,7 +87,7 @@ struct ltc2984
 		int16_t
 		getTemperatureInteger() const
 		{
-			return ((getTemperatureFixed() + (1ul << 9)) / 1024);
+			return ((getTemperatureFixed() + (1ul << 9)) / 1'024);
 		}
 
 	public:
@@ -295,7 +295,7 @@ struct ltc2984
 			};*/
 
 			// Rsense resistance value in Resistance_t has a width of 27 bits
-			// Unit: 1/1024 ohms
+			// Unit: 1/1'024 ohms
 			typedef uint32_t Resistance_t;
 		};
 

--- a/src/modm/io/iostream_printf.cpp.in
+++ b/src/modm/io/iostream_printf.cpp.in
@@ -91,7 +91,7 @@ void
 IOStream::writeInteger(int16_t value)
 {
 %% if core.startswith("avr") and not options["with_printf"]
-	// hard coded for -32768
+	// hard coded for -32'768
 	char str[7 + 1]; // +1 for '\0'
 	itoa(value, str, 10);
 	device->write(str);
@@ -109,7 +109,7 @@ void
 IOStream::writeInteger(uint16_t value)
 {
 %% if core.startswith("avr") and not options["with_printf"]
-	// hard coded for 32768
+	// hard coded for 32'768
 	char str[6 + 1]; // +1 for '\0'
 	utoa(value, str, 10);
 	device->write(str);

--- a/src/modm/platform/can/common/can_bit_timings.hpp
+++ b/src/modm/platform/can/common/can_bit_timings.hpp
@@ -70,7 +70,7 @@ private:
 		constexpr uint8_t minBs1Bs2 = 14;
 		constexpr uint8_t maxBs1Bs2 = 20;
 
-		float minError = 10000;
+		float minError = 10'000.0;
 		uint16_t bestPrescaler = 0;
 		uint8_t bestBs1Bs2 = 0;
 

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -95,7 +95,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 
 	// Request initialization
 	{{ reg }}->MCR |= CAN_MCR_INRQ;
-	int deadlockPreventer = 10000; // max ~10ms
+	int deadlockPreventer = 10'000; // max ~10ms
 	while ((({{ reg }}->MSR & CAN_MSR_INAK) == 0) and (deadlockPreventer-- > 0)) {
 		modm::delayMicroseconds(1);
 		// Wait until the initialization mode is entered.
@@ -148,7 +148,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 
 	// Request leave initialization
 	{{ reg }}->MCR &= ~(uint32_t)CAN_MCR_INRQ;
-	deadlockPreventer = 10000; // max ~10ms
+	deadlockPreventer = 10'000; // max ~10ms
 	while ((({{ reg }}->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) and (deadlockPreventer-- > 0))  {
 		// wait for the normal mode
 	}

--- a/src/modm/platform/clock/lpc/static.hpp.in
+++ b/src/modm/platform/clock/lpc/static.hpp.in
@@ -42,9 +42,9 @@ namespace modm
 			{
 				Rcc::enablePll(Source, p::PllM, p::PllP);
 				modm::clock::fcpu     = OutputFrequency;
-				modm::clock::fcpu_kHz = OutputFrequency / 1000;
-				modm::clock::fcpu_MHz = OutputFrequency / 1000000;
-				modm::clock::ns_per_loop = ::round(1000000000.f / OutputFrequency * 4.f);
+				modm::clock::fcpu_kHz = OutputFrequency / 1'000;
+				modm::clock::fcpu_MHz = OutputFrequency / 1'000'000;
+				modm::clock::ns_per_loop = ::round(1'000'000'000.f / OutputFrequency * 4.f);
 				return StartupError::None;
 			}
 		};

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -20,10 +20,10 @@
 
 namespace modm::clock
 {
-uint32_t modm_fastdata fcpu({{ hsi_frequency|int * 1000000 }});
-uint32_t modm_fastdata fcpu_kHz({{ hsi_frequency|int * 1000 }});
+uint32_t modm_fastdata fcpu({{ "{0:,}".format(hsi_frequency|int * 1000000).replace(',', "'") }});
+uint32_t modm_fastdata fcpu_kHz({{ "{0:,}".format(hsi_frequency|int * 1000).replace(',', "'") }});
 uint16_t modm_fastdata fcpu_MHz({{ hsi_frequency }});
-uint16_t modm_fastdata ns_per_loop({{ loops * 1000.0 / hsi_frequency|int}});
+uint16_t modm_fastdata ns_per_loop({{ "{0:,}".format((loops * 1000.0 / hsi_frequency)|int).replace(',', "'") }});
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/platform/core/avr/ram.cpp.in
+++ b/src/modm/platform/core/avr/ram.cpp.in
@@ -268,7 +268,7 @@ main()
 		j = rand() % 16 + 15;
 		l = rand() % 80 + 7;
 
-		for (i = s = 0; i < j && s < 4096; i++)
+		for (i = s = 0; i < j && s < 4'096; i++)
 		{
 			sizes[i] = rand() % l + 1;
 			s += sizes[i];
@@ -276,7 +276,7 @@ main()
 
 		j = i;
 
-		for (m = om = 1, p = 1, f = 0; m < 1000; m++)
+		for (m = om = 1, p = 1, f = 0; m < 1'000; m++)
 		{
 			for (i = s = 0; i < j; i++) {
 				if (handles[i])

--- a/src/modm/platform/core/hosted/clock.cpp.in
+++ b/src/modm/platform/core/hosted/clock.cpp.in
@@ -23,7 +23,7 @@ modm::Clock::now()
 	struct timeval now;
 	gettimeofday(&now, 0);
 
-	time = typename TimestampType::Type( now.tv_sec*1000 + now.tv_usec/1000 );
+	time = typename TimestampType::Type( (now.tv_sec * 1'000) + (now.tv_usec / 1'000) );
 	return time;
 }
 
@@ -37,7 +37,7 @@ modm::Clock::now()
 	SYSTEMTIME now;
 	GetSystemTime(&now);
 
-	time = typename TimestampType::Type( now.wMilliseconds + now.wSecond*1000 + now.wMinute*1000*60 );
+	time = typename TimestampType::Type( now.wMilliseconds + (now.wSecond * 1'000) + (now.wMinute * 1'000 * 60) );
 	return time;
 }
 %% endif

--- a/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
@@ -242,7 +242,7 @@ namespace
 		if (queue.isNotEmpty())
 		{
 			// wait until the stop condition has been generated
-			uint_fast32_t deadlockPreventer = 100000;
+			uint_fast32_t deadlockPreventer = 100'000;
 			while ((I2C{{ id }}->ISR & I2C_ISR_STOPF) and (deadlockPreventer-- > 0))
 				{};
 

--- a/src/modm/platform/i2c/stm32/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.cpp.in
@@ -215,7 +215,7 @@ namespace
 	static inline void
 	callStarting()
 	{
-		uint_fast32_t deadlockPreventer = 100000;
+		uint_fast32_t deadlockPreventer = 100'000;
 		while ((I2C{{ id }}->CR1 & I2C_CR1_STOP) and (deadlockPreventer-- > 0))
 			;
 
@@ -224,7 +224,7 @@ namespace
 		if ((I2C{{ id }}->SR2 & I2C_SR2_BUSY) and (nextOperation != modm::I2c::Operation::Restart))
 		{
 			// we wait a short amount of time for the bus to become free.
-			deadlockPreventer = 10000;
+			deadlockPreventer = 10'000;
 			while ((I2C{{ id }}->SR2 & I2C_SR2_BUSY) and (deadlockPreventer-- > 0))
 				;
 
@@ -262,7 +262,7 @@ namespace
 		if (queue.isNotEmpty())
 		{
 			// wait until the stop condition has been generated
-			uint_fast32_t deadlockPreventer = 100000;
+			uint_fast32_t deadlockPreventer = 100'000;
 			while (I2C{{ id }}->CR1 & I2C_CR1_STOP && deadlockPreventer-- > 0)
 				;
 
@@ -378,7 +378,7 @@ MODM_ISR(I2C{{ id }}_EV)
 			I2C{{ id }}->CR1 |= I2C_CR1_STOP;
 
 			DEBUG_STREAM("waiting for stop");
-			uint_fast32_t deadlockPreventer = 100000;
+			uint_fast32_t deadlockPreventer = 100'000;
 			while (I2C{{ id }}->CR1 & I2C_CR1_STOP && deadlockPreventer-- > 0)
 				;
 
@@ -461,7 +461,7 @@ MODM_ISR(I2C{{ id }}_EV)
 			*reading.buffer++ = dr & 0xff;
 
 			DEBUG_STREAM("waiting for stop");
-			uint_fast32_t deadlockPreventer = 100000;
+			uint_fast32_t deadlockPreventer = 100'000;
 			while (I2C{{ id }}->CR1 & I2C_CR1_STOP && deadlockPreventer-- > 0)
 				;
 

--- a/src/modm/platform/i2c/stm32/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.hpp.in
@@ -72,7 +72,7 @@ public:
 	initialize()
 	{
 		// calculate the expected clock ratio
-		constexpr uint8_t scalar = (baudrate <= 100000) ? 2 : ((baudrate <= 300000) ? 3 : 25);
+		constexpr uint8_t scalar = (baudrate <= 100'000) ? 2 : ((baudrate <= 300'000) ? 3 : 25);
 
 		// calculate the fractional prescaler value
 		constexpr float pre_raw  = float(SystemClock::I2c{{ id }}) / (scalar * baudrate);
@@ -104,14 +104,14 @@ public:
 				((scalar == 25) ? (1 << 14) : 0);
 
 		// peripheral frequency clock
-		constexpr uint8_t freq = SystemClock::I2c{{ id }} / 1000000;
+		constexpr uint8_t freq = SystemClock::I2c{{ id }} / 1'000'000;
 
 		// maximum rise time: assuming its linear:
 		// 1000ns @ 100kHz and 300ns @ 400kHz
-		//   => y = x * m + b, with m = -2.3333ns/kHz, b = 1233.3333ns
-		constexpr float max_rise_time = -2.333333f * (float(baudrate) / 1000.f) + 1233.333333f;
+		//   => y = x * m + b, with m = -2.3333ns/kHz, b = 1'233.3333ns
+		constexpr float max_rise_time = -2.333333f * (float(baudrate) / 1'000.f) + 1'233.333333f;
 		// calculate trise
-		constexpr float trise_raw = max_rise_time < 0 ? 0 : std::floor(max_rise_time / (1000.f / freq));
+		constexpr float trise_raw = max_rise_time < 0 ? 0 : std::floor(max_rise_time / (1'000.f / freq));
 		constexpr uint8_t trise = trise_raw > 62 ? 63 : (trise_raw + 1);
 
 		initializeWithPrescaler(freq, trise, prescaler);

--- a/src/modm/platform/i2c/xmega/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/xmega/i2c_master.hpp.in
@@ -50,7 +50,7 @@ public:
 	static modm_always_inline void
 	initialize()
 	{
-		static_assert(baudrate <= 400000, "The Xmega does not support I2C baudrates above 400kHz.");
+		static_assert(baudrate <= 400'000, "The Xmega does not support I2C baudrates above 400kHz.");
 		static_assert(F_CPU/10 >= baudrate, "The CPU frequency needs to be at least 10x higher than I2C baudrate.");
 
 		// set the baud rate register

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -161,11 +161,11 @@ public:
 	{
 		// This will be inaccurate for non-smooth frequencies (last six digits
 		// unequal to zero)
-		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1000000UL);
-		uint16_t prescaler = (cycles + 65535) / 65536;	// always round up
+		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1'000'000UL);
+		uint16_t prescaler = (cycles + 65'535) / 65'536;	// always round up
 		uint16_t overflow = cycles / prescaler;
 
-		overflow = overflow - 1;	// e.g. 36000 cycles are from 0 to 35999
+		overflow = overflow - 1;	// e.g. 36'000 cycles are from 0 to 35'999
 
 		setPrescaler(prescaler);
 		setOverflow(overflow);

--- a/src/modm/platform/timer/stm32/basic.hpp.in
+++ b/src/modm/platform/timer/stm32/basic.hpp.in
@@ -105,12 +105,11 @@ public:
 	{
 		// This will be inaccurate for non-smooth frequencies (last six digits
 		// unequal to zero)
-		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1000000UL);
-
-		uint16_t prescaler = (cycles + 65535) / 65536;	// always round up
+		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1'000'000UL);
+		uint16_t prescaler = (cycles + 65'535) / 65'536;	// always round up
 		uint16_t overflow = cycles / prescaler;
 
-		overflow = overflow - 1;	// e.g. 36000 cycles are from 0 to 35999
+		overflow = overflow - 1;	// e.g. 36'000 cycles are from 0 to 35'999
 		setPrescaler(prescaler);
 		setOverflow(overflow);
 

--- a/src/modm/platform/timer/stm32/basic_base.hpp.in
+++ b/src/modm/platform/timer/stm32/basic_base.hpp.in
@@ -93,7 +93,7 @@ public:
 	 * Set new prescaler
 	 *
 	 * The prescaler can divide the counter clock frequency by any
-	 * factor between 1 and 65536. The new prescaler ratio is taken
+	 * factor between 1 and 65'536. The new prescaler ratio is taken
 	 * into account at the next update event.
 	 *
 	 * @see		applyAndReset()

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -175,11 +175,11 @@ public:
 	{
 		// This will be inaccurate for non-smooth frequencies (last six digits
 		// unequal to zero)
-		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1000000UL);
-		uint16_t prescaler = (cycles + 65535) / 65536;	// always round up
+		uint32_t cycles = microseconds * (SystemClock::Timer{{ id }} / 1'000'000UL);
+		uint16_t prescaler = (cycles + 65'535) / 65'536;	// always round up
 		Value overflow = cycles / prescaler;
 
-		overflow = overflow - 1;	// e.g. 36000 cycles are from 0 to 35999
+		overflow = overflow - 1;	// e.g. 36'000 cycles are from 0 to 35'999
 
 		setPrescaler(prescaler);
 		setOverflow(overflow);

--- a/src/modm/platform/uart/hosted/serial_interface.cpp
+++ b/src/modm/platform/uart/hosted/serial_interface.cpp
@@ -83,13 +83,13 @@ modm::platform::SerialInterface::setBaudRate(unsigned int rate)
 	this->baudRate = rate;
 
 	speed_t baudRateConstant =
-		(rate == 2400) ? B2400 :
-		(rate == 4800) ? B4800 :
-		(rate == 9600) ? B9600 :
-		(rate == 19200) ? B19200 :
-		(rate == 38400) ? B38400 :
-		(rate == 57600) ? B57600 :
-		(rate == 115200) ? B115200 : B0;
+		(rate == 2'400) ? B2400 :
+		(rate == 4'800) ? B4800 :
+		(rate == 9'600) ? B9600 :
+		(rate == 19'200) ? B19200 :
+		(rate == 38'400) ? B38400 :
+		(rate == 57'600) ? B57600 :
+		(rate == 115'200) ? B115200 : B0;
 
 	// Change the configuration structure
 	int result1 = cfsetispeed(&configuration, baudRateConstant);

--- a/src/modm/platform/uart/hosted/serial_interface.hpp
+++ b/src/modm/platform/uart/hosted/serial_interface.hpp
@@ -90,13 +90,13 @@ namespace modm
 			 * Set the baud rate of the device.
 			 *
 			 * Possible values for the baudrate:
-			 * - 2400
-			 * - 4800
-			 * - 9600
-			 * - 19200
-			 * - 38400
-			 * - 57600
-			 * - 115200
+			 * - 2'400
+			 * - 4'800
+			 * - 9'600
+			 * - 19'200
+			 * - 38'400
+			 * - 57'600
+			 * - 115'200
 			 */
 			bool
 			setBaudRate(unsigned int baudRate);

--- a/src/modm/platform/uart/stm32/uart_baudrate.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_baudrate.hpp.in
@@ -70,7 +70,7 @@ public:
 %% else
 		constexpr uint32_t scalar = (baudrate * 16l > clockrate) ? 8 : 16;
 %% endif
-		constexpr uint32_t max = (scalar == 16) ? 65536 : 32768;
+		constexpr uint32_t max = (scalar == 16) ? 65'536 : 32'768;
 
 		// calculate the fractional prescaler value
 		constexpr float pre_raw = static_cast<float>(clockrate) / (baudrate);
@@ -108,4 +108,3 @@ public:
 }	// namespace modm
 
 #endif // MODM_STM32_UART_BAUDRATE_HPP
-

--- a/src/modm/platform/uart/xmega/uart.cpp.in
+++ b/src/modm/platform/uart/xmega/uart.cpp.in
@@ -83,7 +83,7 @@ modm::platform::Uart{{ id }}::read(uint8_t *b, uint8_t n)
 	 * The delay of 1.5 times frame time could be calculated at compile time
 	 * if the baud rate was known. It's only known in the constructor, not here.
 	 *
-	 * This manual calculation assumes a baud rate of 115200.
+	 * This manual calculation assumes a baud rate of 115'200.
 	 * On cycle of the loop if(USART{{ id }}_STATUS ...) takes nine instructions:
 	 *
 	 * if (USART...)		LDS		2
@@ -92,20 +92,20 @@ modm::platform::Uart{{ id }}::read(uint8_t *b, uint8_t n)
 	 * if (--delay == 0)	SUBI	1
 	 * 						BRNE	2
 	 *
-	 * Assuming a baud rate of 115200 a frame (1 stop, 8 data, 1 stop bit)
+	 * Assuming a baud rate of 115'200 a frame (1 stop, 8 data, 1 stop bit)
 	 * lasts 86.6usec. At a CPU frequency of F_CPU a CPU cycle lasts
 	 * 1/F_CPU seconds. So a frame takes (86.6usec * F_CPU) cycles, or
-	 * 86.6 * (F_CPU/1000000) = (F_CPU / 11547) cycles. Adding a margin of
-	 * 50% (F_CPU / 7698) cycles are equal to 1.5 times the frame time.
+	 * 86.6 * (F_CPU/1'000'000) = (F_CPU / 11'547) cycles. Adding a margin of
+	 * 50% (F_CPU / 7'698) cycles are equal to 1.5 times the frame time.
 	 * The loop needs nine instructions so the loop should loop
-	 * (F_CPU / 69282) times.
+	 * (F_CPU / 69'282) times.
 	 *
 	 * Example for 32 MHz:
-	 * A CPU cycle takes 31.25nsec. In 86.6usec 2771.2 CPU cycles are executed.
+	 * A CPU cycle takes 31.25nsec. In 86.6usec 2'771.2 CPU cycles are executed.
 	 * The loop takes nine instructions so it is enough to loop 308 times for
 	 * one frame time.  After adding 50% the loop should loop 462 times.
 	 *
-	 * This is the same result as (32000000 / 69282) = 462.
+	 * This is the same result as (32'000'000 / 69'282) = 462.
 	 */
 	uint8_t rcvd = 0;
 	uint16_t const delayStart = (F_CPU / 69282);		// TODO Make depend on baudrate

--- a/src/modm/processing/rtos/stdlib/scheduler.cpp
+++ b/src/modm/processing/rtos/stdlib/scheduler.cpp
@@ -29,6 +29,6 @@ modm::rtos::Scheduler::schedule()
 	{
 		// Threads are started and will do all the work. Just
 		// sleep a bit here when there is nothing else to do.
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+		std::this_thread::sleep_for(std::chrono::milliseconds(1'000));
 	}
 }

--- a/src/modm/ui/animation/interpolation.hpp
+++ b/src/modm/ui/animation/interpolation.hpp
@@ -32,7 +32,7 @@ namespace ui
  *
  * Be aware that the algortihm for 8bit types is optimized for low computational costs.
  * Therefore the steps are limited to `128 steps * value_difference`, which is
- * 32768 steps over the full 8bit range.
+ * 32'768 steps over the full 8bit range.
  * If you specify a more steps in this case, the ramp simply is 'steeper'.
  * If this is a problem, consider using a 16bit type, which does not have
  * this limitation.
@@ -97,7 +97,7 @@ private:
 	 * The maximum change can be +-255 since the value type is 8 bit wide.
 	 * The remaining 7 bits are used for fractional delta value:
 	 * 1 value difference can take at most 128 steps, which is equivalent
-	 * to 2^15 (32768) steps over the whole 8bit range.
+     * to 2^15 (32'768) steps over the whole 8bit range.
 	 */
 	template< typename Type >
 	struct Computations <Type, uint8_t>
@@ -138,7 +138,7 @@ private:
 	 * uint16_t implementation using signed 16.15 fixed point arithmetic.
 	 * The maximum change can be +-65535 since the value type is 16 bit wide.
 	 * The remaining 15 bits are used for fractional delta value:
-	 * 1 value difference can take at most 32768 steps, which is equivalent
+	 * 1 value difference can take at most 32'768 steps, which is equivalent
 	 * to 2^31 steps over the whole 16bit range.
 	 */
 	template< typename Type >

--- a/src/modm/ui/gui/widgets/numberfield.cpp
+++ b/src/modm/ui/gui/widgets/numberfield.cpp
@@ -55,7 +55,7 @@ modm::gui::FloatField::render(View* view)
 	out->setCursor(box_x + 10, box_y + (box_height - stringHeight) / 2);
 
 	int beforeComma = static_cast<int>(this->getValue());
-	int afterComma = std::abs(static_cast<int>((this->getValue() - beforeComma) * 1000));
+    int afterComma = std::abs(static_cast<int>((this->getValue() - beforeComma) * 1'000));
 
 	*out << beforeComma << ".";
 	out->printf("%03d", afterComma);

--- a/src/modm/ui/gui/widgets/stringfield.cpp
+++ b/src/modm/ui/gui/widgets/stringfield.cpp
@@ -50,7 +50,7 @@ modm::gui::StringField::render(View* view)
 	out->setCursor(box_x + 10, box_y + (box_height - stringHeight) / 2);
 
 //	int beforeComma = static_cast<int>(this->getValue());
-//	int afterComma = std::abs(static_cast<int>((this->getValue() - beforeComma) * 1000));
+//	int afterComma = std::abs(static_cast<int>((this->getValue() - beforeComma) * 1'000));
 //
 //	*out << beforeComma << ".";
 //	out->printf("%03ld", afterComma);

--- a/test/modm/architecture/driver/clock_test.cpp
+++ b/test/modm/architecture/driver/clock_test.cpp
@@ -26,14 +26,14 @@ ClockTest::testClock()
 	TestingClock::time = 10;
 	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(10));
 
-	TestingClock::time = 65000;
-	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(65000));
+	TestingClock::time = 65'000;
+	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(65'000));
 
-	TestingClock::time = 65535;
-	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(65535));
+	TestingClock::time = 65'535;
+	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(65'535));
 
 	// overflow in timestamp, but not the Clock!
-	TestingClock::time = 65536;
+	TestingClock::time = 65'536;
 	TEST_ASSERT_EQUALS(modm::Clock::nowShort(), modm::ShortTimestamp(0));
 
 
@@ -44,13 +44,13 @@ ClockTest::testClock()
 	TestingClock::time = 10;
 	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(10));
 
-	TestingClock::time = 65536;
-	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(65536));
+	TestingClock::time = 65'536;
+	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(65'536));
 
-	TestingClock::time = 4294967295;
-	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(4294967295));
+	TestingClock::time = 4'294'967'295;
+	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(4'294'967'295));
 
 	// overflow in both timestamp and Clock!
-	TestingClock::time = uint32_t(4294967296);
+	TestingClock::time = uint32_t(4'294'967'296);
 	TEST_ASSERT_EQUALS(modm::Clock::now(), modm::Timestamp(0));
 }


### PR DESCRIPTION
After looking too long for a 10x error in frequency, I discovered this nice new feature.

How to deal with the inconsistency in the comment of vl53l0.hpp?