### PR TITLE
Fix missing .fastdata copy for STM32 linkerscript

### DIFF
--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -93,10 +93,12 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_table_zero(sections)
+%% macro section_table_zero(sections=[])
 	.table.zero.intern : ALIGN(4)
 	{
 		__table_zero_intern_start = .;
+		LONG(__bss_start)
+		LONG(__bss_end)
 	%% for section in sections
 		LONG(__{{section}}_start)
 		LONG(__{{section}}_end)
@@ -106,13 +108,19 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_table_copy(sections)
+%% macro section_table_copy(sections=[])
 	%% if vector_table_location == "ram"
 		%% do sections.append("vector_table_ram")
 	%% endif
 	.table.copy.intern : ALIGN(4)
 	{
 		__table_copy_intern_start = .;
+		LONG(__data_load)
+		LONG(__data_start)
+		LONG(__data_end)
+		LONG(__fastdata_load)
+		LONG(__fastdata_start)
+		LONG(__fastdata_end)
 	%% for section in sections
 		LONG(__{{section}}_load)
 		LONG(__{{section}}_start)

--- a/src/modm/platform/core/stm32/linkerscript/stm32_dccm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_dccm.ld.in
@@ -46,9 +46,9 @@ SECTIONS
 {{ linkerscript_sections | indent(first=True) }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
-{{ linker.section_table_zero(["bss"]) }}
+{{ linker.section_table_zero() }}
 
-%% set copy_table = ["data", "fastdata"]
+%% set copy_table = []
 %% if "backup" in regions
 	%% do copy_table.append("backup")
 %% endif

--- a/src/modm/platform/core/stm32/linkerscript/stm32_iccm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_iccm.ld.in
@@ -32,10 +32,9 @@ SECTIONS
 {{ linkerscript_sections | indent(first=True) }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
-{{ linker.section_table_zero(["bss"]) }}
+{{ linker.section_table_zero() }}
 
-%% set copy_table = ["data", "fastdata", "fastcode"]
-{{ linker.section_table_copy(copy_table) }}
+{{ linker.section_table_copy(["fastcode"]) }}
 
 {{ linker.section_table_extern() }}
 

--- a/src/modm/platform/core/stm32/linkerscript/stm32_idtcm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_idtcm.ld.in
@@ -42,10 +42,9 @@ SECTIONS
 {{ linkerscript_sections | indent(first=True) }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
-{{ linker.section_table_zero(["bss"]) }}
+{{ linker.section_table_zero() }}
 
-%% set copy_table = ["data", "fastdata", "fastcode"]
-{{ linker.section_table_copy(copy_table) }}
+{{ linker.section_table_copy(["fastcode"]) }}
 
 {{ linker.section_table_extern() }}
 

--- a/src/modm/platform/core/stm32/linkerscript/stm32_ram.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_ram.ld.in
@@ -42,10 +42,9 @@ SECTIONS
 {{ linkerscript_sections | indent(first=True) }}
 
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
-{{ linker.section_table_zero(["bss"]) }}
+{{ linker.section_table_zero() }}
 
-%% set copy_table = ["data"]
-{{ linker.section_table_copy(copy_table) }}
+{{ linker.section_table_copy() }}
 
 {{ linker.section_table_extern() }}
 


### PR DESCRIPTION
This defaults the table copy and zero sections to always include `.bss`, `.data` and `.fastdata` as they are always needed.

cc @strongly-typed 