### PR TITLE
Fix ADC on Blue-Pill

### DIFF
--- a/src/modm/board/black_pill/board.hpp
+++ b/src/modm/board/black_pill/board.hpp
@@ -31,9 +31,7 @@ struct SystemClock {
 	static constexpr uint32_t Apb1 = Frequency / 2;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Adc1 = Apb2;
-	static constexpr uint32_t Adc2 = Apb2;
-	static constexpr uint32_t Adc3 = Apb2;
+	static constexpr uint32_t Adc  = Apb2;
 
 	static constexpr uint32_t Spi1 = Apb2;
 	static constexpr uint32_t Spi2 = Apb1;

--- a/src/modm/board/blue_pill/board.hpp
+++ b/src/modm/board/blue_pill/board.hpp
@@ -32,9 +32,7 @@ struct SystemClock {
 	static constexpr uint32_t Apb1 = Frequency / 2;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Adc1 = Apb2;
-	static constexpr uint32_t Adc2 = Apb2;
-	static constexpr uint32_t Adc3 = Apb2;
+	static constexpr uint32_t Adc  = Apb2;
 
 	static constexpr uint32_t Spi1 = Apb2;
 	static constexpr uint32_t Spi2 = Apb1;

--- a/src/modm/board/nucleo_f103rb/board.hpp
+++ b/src/modm/board/nucleo_f103rb/board.hpp
@@ -34,9 +34,7 @@ struct SystemClock {
 	static constexpr uint32_t Apb1 = Frequency / 2;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Adc1   = Apb2;
-	static constexpr uint32_t Adc2   = Apb2;
-	static constexpr uint32_t Adc3   = Apb2;
+	static constexpr uint32_t Adc    = Apb2;
 
 	static constexpr uint32_t Spi1   = Apb2;
 	static constexpr uint32_t Spi2   = Apb1;


### PR DESCRIPTION
This fixes the issue of using ADC on boards like Blue Pill, which have `Adc1`, `Adc2` and `Adc3` in `SystemClock`. The ADC driver uses `SystemClock::Adc`.

I don't undestand which one (`Adc{{id}}` or just `Adc`) is the normal behavior, so this may not be the right place to fix this.