### PR TITLE
[lbuild] Fix PathOption issue with absolute paths

### DIFF
--- a/examples/lbuild.xml
+++ b/examples/lbuild.xml
@@ -8,7 +8,7 @@
   	<repository><path>../repo.lb</path></repository>
   </repositories>
   <options>
-    <option name="modm:build:scons:cache_dir">/cache</option>
+    <option name="modm:build:scons:cache_dir">$cache</option>
   </options>
   <modules>
   	<module>modm:docs</module>

--- a/repo.lb
+++ b/repo.lb
@@ -35,7 +35,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.11.1"
+min_lbuild_version = "1.11.6"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))

--- a/test/all/avr.xml
+++ b/test/all/avr.xml
@@ -8,7 +8,7 @@
 
   <options>
     <option name="modm:platform:clock:f_cpu">8000000</option>
-    <option name="modm:build:scons:cache_dir">/cache</option>
+    <option name="modm:build:scons:cache_dir">$cache</option>
   </options>
   <modules>
     <module>modm:platform:**</module>

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -86,6 +86,7 @@ class TestRun:
                 lbuild_command.append("-D:::cache_dir={}".format(self.cache_dir))
 
             lbuild_command.extend(["-D:target={}".format(self.device),
+                                   "-D:build:build.path={}/build".format(tempdir),
                                    "-p", str(tempdir),
                                    "build",
                                    "--no-log"])

--- a/test/all/stm32.xml
+++ b/test/all/stm32.xml
@@ -7,7 +7,7 @@
   </repositories>
 
   <options>
-    <option name="modm:build:scons:cache_dir">/cache</option>
+    <option name="modm:build:scons:cache_dir">$cache</option>
   </options>
   <modules>
     <module>modm:platform:**</module>

--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -8,7 +8,7 @@
     <option name="modm:build:scons:include_sconstruct">True</option>
     <option name="modm:build:scons:info.build">True</option>
     <option name="modm:build:scons:info.git">Info+Status</option>
-    <option name="modm:build:scons:cache_dir">../../cache</option>
+    <option name="modm:build:scons:cache_dir">../../build/cache</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -33,7 +33,7 @@ def prepare(module, options):
         StringOption(name="project.name", default=default_project_name,
                      description=descr_project_name))
     module.add_option(
-        PathOption(name="build.path", default="build/"+default_project_name,
+        PathOption(name="build.path", default="build/"+default_project_name, absolute=True,
                    description=descr_build_path))
 
     if platform in ["avr"]:
@@ -54,7 +54,7 @@ def prepare(module, options):
 
     elif is_cortex_m:
         module.add_option(
-            PathOption(name="openocd.cfg", default="", empty_ok=True,
+            PathOption(name="openocd.cfg", default="", empty_ok=True, absolute=True,
                        description=descr_openocd_cfg))
 
     # Queries
@@ -83,10 +83,12 @@ def prepare(module, options):
 
     module.add_collector(
         PathCollector(name="elf.release",
-                      description="Path to the compiled .elf file for the release profile"))
+                      description="Path to the compiled .elf file for the release profile",
+                      absolute=True))
     module.add_collector(
         PathCollector(name="elf.debug",
-                      description="Path to the compiled .elf file for the debug profile"))
+                      description="Path to the compiled .elf file for the debug profile",
+                      absolute=True))
     module.add_collector(
         PathCollector(name="gitignore",
                       description="Generated files that need to be ignored by Git"))
@@ -147,8 +149,8 @@ def post_build(env):
     gitignore = [env.relative_outpath(ignore, "modm") for ignore in
                  env.collector_values("gitignore", filterfunc=lambda s: s.repository == "modm")]
     elf_files = {
-        "release": env.collector_values("elf.release")[0],
-        "debug": env.collector_values("elf.debug")[0],
+        "release": env.relative_outpath(env.collector_values("elf.release")[0], "modm/"),
+        "debug": env.relative_outpath(env.collector_values("elf.debug")[0], "modm/"),
     }
 
     env.substitutions = {

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -22,10 +22,10 @@ def prepare(module, options):
         BooleanOption(name="include_sconstruct", default=True,
                       description=descr_include_sconstruct))
     module.add_option(
-        PathOption(name="cache_dir", default="", empty_ok=True,
+        PathOption(name="cache_dir", default="", empty_ok=True, absolute=True,
                    description=descr_cache_dir))
     module.add_option(
-        PathOption(name="image.source", default="", empty_ok=True,
+        PathOption(name="image.source", default="", empty_ok=True, absolute=True,
                    description=descr_image_source))
     module.add_option(
         EnumerationOption(name="info.git", default="Disabled",
@@ -148,7 +148,7 @@ def post_build(env):
         sources["modm"].append("modm/src/info_build.c")
 
     cache_dir = env["cache_dir"]
-    if cache_dir == "/cache":
+    if cache_dir.endswith("$cache"):
         cache_dir = env[":build:build.path"] + "/cache"
         if "build/" in cache_dir:
             cache_dir = "{}build/cache".format(cache_dir.split("build/")[0])
@@ -156,7 +156,8 @@ def post_build(env):
     subs["memories"] = env.query("::memories")
     # Add SCons specific data
     subs.update({
-        "cache_dir": cache_dir,
+        "build_path": env.relative_outpath(env[":build:build.path"]),
+        "cache_dir": env.relative_outpath(cache_dir),
         "generated_paths": repositories,
         "is_unittest": is_unittest,
 
@@ -164,12 +165,12 @@ def post_build(env):
         "has_xpcc_generator": has_xpcc_generator,
     })
     if has_image_source:
-        subs["image_source"] = env["image.source"]
+        subs["image_source"] = env.relative_outpath(env["image.source"])
     if has_xpcc_generator:
         subs.update({
-            "generator_source": env.get(":communication:xpcc:generator:source", ""),
+            "generator_source": env.relative_outpath(env.get(":communication:xpcc:generator:source", "")),
             "generator_container": env.get(":communication:xpcc:generator:container", ""),
-            "generator_path": env.get(":communication:xpcc:generator:path", ""),
+            "generator_path": env.relative_outpath(env.get(":communication:xpcc:generator:path", "")),
             "generator_namespace": env.get(":communication:xpcc:generator:namespace", ""),
         })
     if subs["platform"] == "avr":
@@ -247,7 +248,7 @@ descr_include_sconstruct = """# Generate a SConstruct file
 
 descr_cache_dir = """# Path to SConstruct CacheDir
 
-If value is `/cache`, the cache is placed into the top-level `build/` folder.
+If value is `$cache`, the cache is placed into the top-level `build/` folder.
 You can disable CacheDir by setting an empty string.
 """
 

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -13,7 +13,7 @@ from os.path import join, abspath
 
 # User Configurable Options
 project_name = "{{ options[":build:project.name"] }}"
-build_path = "{{ options[":build:build.path"] }}"
+build_path = "{{ build_path }}"
 generated_paths = {{ generated_paths }}
 %% if cache_dir | length
 CacheDir("{{ cache_dir }}")

--- a/tools/xpcc_generator/module.lb
+++ b/tools/xpcc_generator/module.lb
@@ -16,13 +16,13 @@ def init(module):
 
 def prepare(module, options):
     module.add_option(
-        PathOption(name="source", default="", empty_ok=True,
+        PathOption(name="source", default="", empty_ok=True, absolute=True,
                    description="Path to the XPCC source file"))
     module.add_option(
         StringOption(name="container", default="",
                      description="Name of the XPCC container to generate for"))
     module.add_option(
-        PathOption(name="path", default="generated/xpcc",
+        PathOption(name="path", default="generated/xpcc", absolute=True,
                    description="Path to the XPCC generated folder"))
     module.add_option(
         StringOption(name="namespace", default="robot",


### PR DESCRIPTION
An issue in lbuild didn't allow the declaration of absolute paths via the config option, instead all paths were interpreted as relative to the CWD. This was an issue particularly when declaring paths in inherited configruations like `board.xml` or `lbuild.xml`.

This fixes this issue by using `PathOption(absolute=True)` when required.

cc @dergraaf @rleh @se-bi (this fixes the `:build:openocd.cfg` path problem)