### PR TITLE
[scons] Add source/runner options for unittest tool

### DIFF
--- a/test/config/al-avreb-can.xml
+++ b/test/config/al-avreb-can.xml
@@ -2,6 +2,8 @@
 <library>
   <extends>modm:al-avreb-can</extends>
   <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/al-avreb-can/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/avr.cpp.in</option>
     <!-- <option name="modm:build:avrdude.programmer">avrispmkII</option> -->
     <option name="modm:build:avrdude.programmer">usbasp-clone</option>
     <option name="modm:build:scons:info.git">Disabled</option>

--- a/test/config/arduino-nano.xml
+++ b/test/config/arduino-nano.xml
@@ -2,6 +2,8 @@
 <library>
   <extends>modm:arduino-nano</extends>
   <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/arduino-nano/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/avr.cpp.in</option>
     <option name="modm:build:scons:info.git">Disabled</option>
     <option name="modm:build:avrdude.port">/dev/tty.usbserial-1410</option>
     <option name="modm:io:with_float">True</option>

--- a/test/config/arduino-uno.xml
+++ b/test/config/arduino-uno.xml
@@ -2,6 +2,8 @@
 <library>
   <extends>modm:arduino-uno</extends>
   <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/arduino-uno/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/avr.cpp.in</option>
     <option name="modm:build:scons:info.git">Disabled</option>
     <option name="modm:build:avrdude.port">/dev/tty.usbserial-1410</option>
     <option name="modm:io:with_float">True</option>

--- a/test/config/hosted.xml
+++ b/test/config/hosted.xml
@@ -1,5 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/hosted/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/hosted.cpp.in</option>
+  </options>
   <modules>
     <module>modm:platform:core</module>
     <module>modm-test:test:**</module>

--- a/test/config/nucleo-f103.xml
+++ b/test/config/nucleo-f103.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:nucleo-f103rb</extends>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/nucleo-f103/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/stm32.cpp.in</option>
+  </options>
   <modules>
     <!-- Not everything fits -->
     <!-- <module>modm-test:test:architecture</module>

--- a/test/config/nucleo-f401.xml
+++ b/test/config/nucleo-f401.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:nucleo-f401re</extends>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/nucleo-f401/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/stm32.cpp.in</option>
+  </options>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/test/config/nucleo-f411.xml
+++ b/test/config/nucleo-f411.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:nucleo-f411re</extends>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/nucleo-f411/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/stm32.cpp.in</option>
+  </options>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/test/config/nucleo-f446.xml
+++ b/test/config/nucleo-f446.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:nucleo-f446re</extends>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/nucleo-f446/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/stm32.cpp.in</option>
+  </options>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/test/config/nucleo-l432.xml
+++ b/test/config/nucleo-l432.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <library>
   <extends>modm:nucleo-l432kc</extends>
+  <options>
+    <option name="modm:build:scons:unittest.source">../../build/unittest/nucleo-l432/modm-test</option>
+    <option name="modm:build:scons:unittest.runner">../runner/stm32.cpp.in</option>
+  </options>
   <modules>
     <module>modm-test:test:**</module>
   </modules>

--- a/test/module.lb
+++ b/test/module.lb
@@ -20,16 +20,5 @@ def prepare(module, options):
     module.depends(":unittest")
     return True
 
-
 def build(env):
-    env.outbasepath = "modm-test/src"
-
-    env.collect(":build:path.include", "modm-test/src")
-
-    platform = env[":target"].identifier["platform"]
-    if platform in ["hosted"]:
-        env.copy("runner/hosted.cpp.in", "runner.cpp.in")
-    elif platform in ["stm32"]:
-        env.copy("runner/stm32.cpp.in", "runner.cpp.in")
-    elif platform in ["avr"]:
-        env.copy("runner/avr.cpp.in", "runner.cpp.in")
+    env.collect("modm:build:path.include", "modm-test/src")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -27,6 +27,13 @@ def prepare(module, options):
     module.add_option(
         PathOption(name="image.source", default="", empty_ok=True, absolute=True,
                    description=descr_image_source))
+
+    module.add_option(
+        PathOption(name="unittest.source", default="", empty_ok=True, absolute=True,
+                   description=descr_unittest_source))
+    module.add_option(
+        PathOption(name="unittest.runner", default="", empty_ok=True, absolute=True,
+                   description=descr_unittest_runner))
     module.add_option(
         EnumerationOption(name="info.git", default="Disabled",
                           enumeration=["Disabled", "Info", "Info+Status"],
@@ -133,7 +140,7 @@ def build(env):
 
 
 def post_build(env):
-    is_unittest = env.has_module(":test")
+    is_unittest = len(env["unittest.source"])
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["image.source"])
     repositories = [p for p in env.buildlog.repositories if isdir(env.real_outpath(p, basepath="."))]
@@ -166,6 +173,9 @@ def post_build(env):
     })
     if has_image_source:
         subs["image_source"] = env.relative_outpath(env["image.source"])
+    if is_unittest:
+        subs["unittest_source"] = env.relative_outpath(env["unittest.source"])
+        subs["unittest_runner"] = env.relative_outpath(env["unittest.runner"])
     if has_xpcc_generator:
         subs.update({
             "generator_source": env.relative_outpath(env.get(":communication:xpcc:generator:source", "")),
@@ -253,6 +263,19 @@ You can disable CacheDir by setting an empty string.
 """
 
 descr_image_source = """# Path to directory containing .pbm files"""
+
+descr_unittest_source = """# Path to directory containing unittests
+
+When this path is declared, the generated SConstruct will compile **only** the
+unittests, not your application source code!
+You should use separate project configurations for compiling your unittest and
+application!
+"""
+
+descr_unittest_runner = """# Path to unittests runner template
+
+See modm/test/runners/*.cpp.in
+"""
 
 descr_info_git = """# Generate git repository state information
 

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -29,8 +29,8 @@ env.SConscript(dirs=generated_paths, exports="env")
 
 %% if is_unittest
 # Building unit tests
-headers = env.FindHeaderFiles("modm-test/src/modm")
-sources = env.UnittestRunner(target="main.cpp", source=headers, template="modm-test/src/runner.cpp.in")
+headers = env.FindHeaderFiles("{{ unittest_source }}")
+sources = [env.UnittestRunner(target="main.cpp", source=headers, template="{{ unittest_runner }}")]
 %% else
 env.Append(CPPPATH=".")
 ignored = ["cmake-*", ".lbuild_cache", build_path] + generated_paths


### PR DESCRIPTION
This expands on an idea from @ASMfreaK in #220 to make the unittest runner accessible for outside projects too.

I think the unittest tool should be extracted into it's own python tool, and then wrapped by SCons like the XPCC tools. Then the unittests can also be integrated into any other build system or just used directly via python.