### PR TITLE
[openocd] Do not hardcode user options in built-in configs

### DIFF
--- a/examples/stm32f030f4p6_demo_board/blink/openocd.cfg
+++ b/examples/stm32f030f4p6_demo_board/blink/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f030f4p6_demo_board/blink/project.xml
+++ b/examples/stm32f030f4p6_demo_board/blink/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:stm32f030_demo</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f030f4p6_demo/blink</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/examples/stm32f103c8t6_black_pill/blink/openocd.cfg
+++ b/examples/stm32f103c8t6_black_pill/blink/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_black_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_black_pill/blink/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:black-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_black_pill/blink</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/adns_9800/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/adns_9800</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink.cmake/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink.cmake</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:build:cmake</module>

--- a/examples/stm32f103c8t6_blue_pill/blink/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/blink/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/blink/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/blink/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/blink</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/examples/stm32f103c8t6_blue_pill/can/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/can/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/can/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/can/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/can</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f103c8t6_blue_pill/environment/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/environment/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/environment/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/environment/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/environment</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f103c8t6_blue_pill/logger/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/logger/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/logger/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/logger/project.xml
@@ -2,6 +2,7 @@
   <extends>modm:blue-pill</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/logger</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -22,6 +22,36 @@ Cheap and bread-board-friendly board for STM32 F1 series.
 Sold for less than 2 USD on well known Internet shops from China.
 
 http://wiki.stm32duino.com/index.php?title=Black_Pill
+""" + descr_programming
+
+descr_programming = """
+## Programming
+
+Since the board doesn't have a programmer on-board, you need to use your
+own and *specify* which one you're using in a custom `openocd.cfg` file:
+
+```
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]
+
+# If you use the clone CKS32F103C8T6 chip you need to overwrite this ID
+#set CPUTAPID 0x2ba01477
+
+# To select a specific programmer you can specify its serial number
+#hla_serial "\x53\x3f\x6f\x06\x50\x77\x50\x57\x12\x17\x14\x3f"
+# You can discover the serial via `stlink --hla-serial` or `st-info --hla-serial`.
+```
+
+Then include this file in your build options like so:
+
+```xml
+<library>
+  <extends>modm:black-pill</extends>
+  <options>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+</library>
+```
 """
 
 def prepare(module, options):
@@ -43,4 +73,8 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg")
+
+    # Warn the user if they forgot to set a custom openocd config
+    if env.has_option(":build:openocd.cfg") and not len(env.get(":build:openocd.cfg", "")):
+        env.log.warning("You need to provide the programmer via a custom OpenOCD config!\n" + descr_programming)

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -22,6 +22,36 @@ Cheap and bread-board-friendly board for STM32 F1 series.
 Sold for less than 2 USD on well known Internet shops from China.
 
 http://wiki.stm32duino.com/index.php?title=Blue_Pill
+""" + descr_programming
+
+descr_programming = """
+## Programming
+
+Since the board doesn't have a programmer on-board, you need to use your
+own and *specify* which one you're using in a custom `openocd.cfg` file:
+
+```
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]
+
+# If you use the clone CKS32F103C8T6 chip you need to overwrite this ID
+#set CPUTAPID 0x2ba01477
+
+# To select a specific programmer you can specify its serial number
+#hla_serial "\x53\x3f\x6f\x06\x50\x77\x50\x57\x12\x17\x13\x3f"
+# You can discover the serial via `stlink --hla-serial` or `st-info --hla-serial`.
+```
+
+Then include this file in your build options like so:
+
+```xml
+<library>
+  <extends>modm:blue-pill</extends>
+  <options>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+</library>
+```
 """
 
 def prepare(module, options):
@@ -43,4 +73,8 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f103_blue_pill.cfg"), "stm32f103_blue_pill.cfg")
-    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f103_blue_pill.cfg")
+
+    # Warn the user if they forgot to set a custom openocd config
+    if env.has_option(":build:openocd.cfg") and not len(env.get(":build:openocd.cfg", "")):
+        env.log.warning("You need to provide the programmer via a custom OpenOCD config!\n" + descr_programming)

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -23,6 +23,33 @@ Sold for less than 1.5 USD on well known Internet shops from China.
 
 http://www.hotmcu.com/stm32f030f4p6-minimum-systerm-boardcortexm0-p-208.html
 http://www.haoyuelectronics.com/Attachment/STM32F030-Dev-Board/STM32F030F4P6.pdf
+""" + descr_programming
+
+descr_programming = """
+## Programming
+
+Since the board doesn't have a programmer on-board, you need to use your
+own and *specify* which one you're using in a custom `openocd.cfg` file:
+
+```
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]
+
+# To select a specific programmer you can specify its serial number
+#hla_serial "\x53\x3f\x6f\x06\x51\x77\x50\x57\x12\x17\x13\x3f"
+# You can discover the serial via `stlink --hla-serial` or `st-info --hla-serial`.
+```
+
+Then include this file in your build options like so:
+
+```xml
+<library>
+  <extends>modm:stm32f030_demo</extends>
+  <options>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+</library>
+```
 """
 
 def prepare(module, options):
@@ -43,4 +70,8 @@ def build(env):
 
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/stm32f030_demo_board.cfg"), "stm32f030_demo_board.cfg")
-    env.collect(":build:openocd.source", "modm/board/stm32f030_demo_board.cfg");
+    env.collect(":build:openocd.source", "modm/board/stm32f030_demo_board.cfg")
+
+    # Warn the user if they forgot to set a custom openocd config
+    if env.has_option(":build:openocd.cfg") and not len(env.get(":build:openocd.cfg", "")):
+        env.log.warning("You need to provide the programmer via a custom OpenOCD config!\n" + descr_programming)

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -126,11 +126,6 @@ def prepare(module, options):
 
 
 def build(env):
-    # Append custom openocd config file to metadata
-    openocd_cfg = env.get(":build:openocd.cfg", "")
-    if len(openocd_cfg):
-        env.collect(":build:openocd.source", openocd_cfg)
-
     # Append common search paths to metadata
     if env.has_collector(":build:path.openocd"):
         env.collect(":build:path.openocd", "modm/openocd")
@@ -157,6 +152,10 @@ def post_build(env):
         "gitignore": gitignore,
         "elf_files": elf_files,
     }
+    # prepare custom path
+    openocd_cfg = env.get(":build:openocd.cfg", "")
+    if len(openocd_cfg):
+        env.substitutions["openocd_user_path"] = env.relative_outpath(openocd_cfg)
     env.outbasepath = "modm"
 
     # Currently a modm only feature

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -1,6 +1,10 @@
 %% for path in collector_values["path.openocd"] | sort
 add_script_search_dir {{ path | modm.windowsify(escape_level=1) }}
 %% endfor
+%# Include the users config before the modm config
+%% if openocd_user_path is defined
+source [find {{ openocd_user_path | modm.windowsify(escape_level=1) }}]
+%% endif
 %% for file in collector_values["openocd.source"] | sort
 source [find {{ file | modm.windowsify(escape_level=1) }}]
 %% endfor

--- a/tools/openocd/modm/stm32f030_demo_board.cfg
+++ b/tools/openocd/modm/stm32f030_demo_board.cfg
@@ -8,7 +8,8 @@
 
 # Cheap STM32F030F4P6 "Demo Board" Minimum System Development Board
 
-source [find interface/stlink-v2.cfg]
+# Must be specified by the user via `modm:build:openocd.cfg` option
+#source [find interface/stlink-v2.cfg]
 
 transport select hla_swd
 

--- a/tools/openocd/modm/stm32f103_blue_pill.cfg
+++ b/tools/openocd/modm/stm32f103_blue_pill.cfg
@@ -1,6 +1,7 @@
 # Cheap STM32F103C8T6 "Blue Pill" Minimum System Development Board
 
-source [find interface/stlink-v2.cfg]
+# Must be specified by the user via `modm:build:openocd.cfg` option
+#source [find interface/stlink-v2.cfg]
 
 transport select hla_swd
 


### PR DESCRIPTION
The modm board configurations hard-coded the programmer, which is an issue when using a different one.

This replaces #235 and fixes #234 and fixes #238.

cc @ASMfreaK 