### PR TITLE
Modularize CMSIS-DSP and add full examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ make gdb
 
 ## Interesting Examples
 
-We have a lot of examples, <!--examplecount-->178<!--/examplecount--> to be
+We have a lot of examples, <!--examplecount-->189<!--/examplecount--> to be
 exact, but here are some of our favorite examples for our supported development
 boards:
 

--- a/examples/nucleo_f429zi/cmsis_dsp/class_marks/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/class_marks/main.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#define main arm_cmsis_dsp_example
+#define std var_std
+#define while return ARM_MATH_SUCCESS; void // has no status variable
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_class_marks_example/arm_class_marks_example_f32.c"
+#undef while
+#undef main
+#undef std
+
+#define example_name "class_marks"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/class_marks/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/class_marks/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/class_marks</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:matrix</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/convolution/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/convolution/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_convolution_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_convolution_example/math_helper.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_convolution_example/arm_convolution_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "convolution"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/convolution/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/convolution/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/convolution/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/convolution/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/convolution</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:support</module>
+    <module>modm:cmsis:dsp:complex_math</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/dotproduct/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/dotproduct/main.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#define main arm_cmsis_dsp_example
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "dotproduct"
+#include "../runner.cpp"
+

--- a/examples/nucleo_f429zi/cmsis_dsp/dotproduct/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/dotproduct/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/dotproduct</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/fft_bin/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/fft_bin/main.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fft_bin_example/arm_fft_bin_data.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fft_bin_example/arm_fft_bin_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "fft_bin"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/fft_bin/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/fft_bin/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/fft_bin</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:complex_math</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/fir/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/fir/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fir_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fir_example/math_helper.c"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fir_example/arm_fir_data.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_fir_example/arm_fir_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "fir"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/fir/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/fir/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/fir/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/fir/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/fir</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:filtering</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_graphic_equalizer_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_graphic_equalizer_example/math_helper.c"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_data.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example_q31.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "graphic_equalizer"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/graphic_equalizer/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/graphic_equalizer</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:filtering</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/linear_interp/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/linear_interp/main.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_linear_interp_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_linear_interp_example/math_helper.c"
+/* `float arm_linear_interep_table[188495]` is 736kB large and MUST be placed in Flash
+ * memory NOT SRAM otherwise it won't fit on the device. Since we don't want (=cannot)
+ * to change the example, we need to take drastic measures... */
+#define float const float
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_linear_interp_example/arm_linear_interp_data.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example_f32.c"
+#undef while
+#undef float
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "linear_interp"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/linear_interp/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/linear_interp/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/linear_interp/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/linear_interp/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/linear_interp</option>
+  </options>
+  <collectors>
+    <!-- We need to cast `&arm_linear_interep_table[0]` to (float*), but cannot change the example... -->
+  	<collect name="modm:build:cxxflags">-fpermissive</collect>
+  </collectors>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/matrix/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/matrix/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_matrix_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_matrix_example/math_helper.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_matrix_example/arm_matrix_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "matrix"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/matrix/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/matrix/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/matrix/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/matrix/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/matrix</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:matrix</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/runner.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/runner.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+int main()
+{
+	Board::initialize();
+
+	const uint32_t start{DWT->CYCCNT};
+	const int status = arm_cmsis_dsp_example();
+	const uint32_t diff{DWT->CYCCNT - start};
+
+	if (status != ARM_MATH_TEST_FAILURE) {
+		MODM_LOG_INFO << "Example '" << example_name << "' passed in ~" << (diff / modm::clock::fcpu_MHz) << "us!" << modm::endl;
+	} else {
+		MODM_LOG_ERROR << "Example '" << example_name << "' failed!" << modm::endl;
+	}
+
+	while(1) {
+		if (status != ARM_MATH_TEST_FAILURE) {
+			Board::LedBlue::toggle();
+		} else {
+			Board::LedRed::toggle();
+		}
+		modm::delayMilliseconds(1000);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f429zi/cmsis_dsp/signal_converge/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/signal_converge/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_signal_converge_example/math_helper.h"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_signal_converge_example/math_helper.c"
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_signal_converge_example/arm_signal_converge_data.c"
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_signal_converge_example/arm_signal_converge_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "signal_converge"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/signal_converge/math_helper.h
+++ b/examples/nucleo_f429zi/cmsis_dsp/signal_converge/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/nucleo_f429zi/cmsis_dsp/signal_converge/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/signal_converge/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/signal_converge</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:filtering</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/sin_cos/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/sin_cos/main.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#define main arm_cmsis_dsp_example
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "sin_cos"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/sin_cos/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/sin_cos/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/sin_cos</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+  </modules>
+</library>

--- a/examples/nucleo_f429zi/cmsis_dsp/variance/main.cpp
+++ b/examples/nucleo_f429zi/cmsis_dsp/variance/main.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <arm_math.h>
+
+#define main arm_cmsis_dsp_example
+#define while return status; void
+#include "../../../../ext/arm/cmsis/CMSIS/DSP/Examples/ARM/arm_variance_example/arm_variance_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "variance"
+#include "../runner.cpp"

--- a/examples/nucleo_f429zi/cmsis_dsp/variance/project.xml
+++ b/examples/nucleo_f429zi/cmsis_dsp/variance/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_f429zi/cmsis_dsp/variance</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+    <module>modm:cmsis:dsp:support</module>
+  </modules>
+</library>

--- a/ext/arm/cmsis.md
+++ b/ext/arm/cmsis.md
@@ -18,4 +18,4 @@ We use only use these parts of CMSIS:
   via CMSIS-DSP.
 
 [cmsis]: https://developer.arm.com/embedded/cmsis
-[overview]: https://developer.arm.com/-/media/developer/Block%20Diagrams/CMSIS%20Diagram%20v2.png
+[overview]: https://developer.arm.com/-/media/Arm%20Developer%20Community/Images/Block%20Diagrams/Cortex%20Microcontroller%20Software%20Interface%20Standard%20-%20CMSIS/CMSIS%20Diagram%20v2.png

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -12,7 +12,72 @@
 # -----------------------------------------------------------------------------
 
 from collections import defaultdict
+from pathlib import Path
 
+class CmsisDspModule(Module):
+
+    def __init__(self, path):
+        self.path = str(path.name)
+        self.name = self.path.replace("Functions", "").replace("Common", "") \
+                             .replace("Math", "_math").lower()
+
+    def init(self, module):
+        module.name = ":cmsis:dsp:{}".format(self.name)
+        module.description = "DSP {}".format(" ".join(s.capitalize()
+                                             for s in self.name.split("_")))
+
+    def prepare(self, module, options):
+        dependencies = {
+            "basic_math": [],
+            "complex_math": [":cmsis:dsp:fast_math"],
+            "controller": [":cmsis:dsp:tables"],
+            "fast_math": [":cmsis:dsp:tables"],
+            "filtering": [":cmsis:dsp:tables", ":cmsis:dsp:support"],
+            "matrix": [],
+            "statistics": [":cmsis:dsp:fast_math"],
+            "support": [],
+            "tables": [],
+            "transform": [":cmsis:dsp:tables"],
+        }
+        module.depends(*dependencies[self.name])
+        return True
+
+    def build(self, env):
+        metadata = defaultdict(list)
+        metadata[":build:cflags"].append("-fno-strict-aliasing")
+        metadata[":build:cflags"].append("-Wno-nested-externs")
+        metadata[":build:ccflags"].append("-Wno-sign-compare")
+        metadata[":build:ccflags"].append("-Wno-double-promotion")
+
+        core = env[":target"].get_driver("core")["type"]
+        if "f" in core:
+            metadata[":build:cppdefines"].append("__FPU_PRESENT=1")
+
+        if env[":cmsis:dsp:check_matrix_sizes"]:
+            metadata[":build:cppdefines"].append("ARM_MATH_MATRIX_CHECK")
+        else:
+            metadata[":build:cppdefines.debug"].append("ARM_MATH_MATRIX_CHECK")
+
+        if env[":cmsis:dsp:round_float_inputs"]:
+            metadata[":build:cppdefines"].append("ARM_MATH_ROUNDING")
+
+        if not env.get(":cmsis:dsp:unaligned_data", False):
+            metadata[":build:cppdefines"].append("UNALIGNED_SUPPORT_DISABLE")
+
+        env.outbasepath = "modm/ext/cmsis/dsp"
+        if "tables" in self.name:
+            env.copy("cmsis/CMSIS/DSP/Include/arm_common_tables.h", "arm_common_tables.h")
+            env.copy("cmsis/CMSIS/DSP/Include/arm_const_structs.h", "arm_const_structs.h")
+        operations = env.copy("cmsis/CMSIS/DSP/Source/{}".format(self.path), "{}".format(self.path),
+                              ignore=env.ignore_files("arm_bitreversal2.c", "CMakeLists.txt",
+                                                      "*Functions.c", "*Tables.c"))
+
+        # For all sources add these compile flags
+        for key, values in metadata.items():
+            env.collect(key, *values, operations=operations)
+
+
+# =============================================================================
 def init(module):
     module.name = ":cmsis:dsp"
     module.description = FileReader("dsp.md")
@@ -39,39 +104,20 @@ def prepare(module, options):
             description=descr_round_floats,
             default=True))
 
+    for path in Path(localpath("cmsis/CMSIS/DSP/Source")).iterdir():
+        if path.is_dir():
+            module.add_submodule(CmsisDspModule(path))
+
     return True
 
 def build(env):
-    metadata = defaultdict(list)
-    metadata[":build:cflags"].append("-fno-strict-aliasing")
-
     core = env[":target"].get_driver("core")["type"]
-    if "f" in core:
-        metadata[":build:cppdefines"].append("__FPU_PRESENT=1")
-
     core = core.replace("cortex-m", "CM").replace("+", "PLUS").replace("f", "").replace("d", "")
     env.collect(":build:cppdefines", "ARM_MATH_{}".format(core))
-
-    if env["check_matrix_sizes"]:
-        metadata[":build:cppdefines"].append("ARM_MATH_MATRIX_CHECK")
-    else:
-        metadata[":build:cppdefines.debug"].append("ARM_MATH_MATRIX_CHECK")
-
-    if env["round_float_inputs"]:
-        metadata[":build:cppdefines"].append("ARM_MATH_ROUNDING")
-
-    if not env.get("unaligned_data", False):
-        metadata[":build:cppdefines"].append("UNALIGNED_SUPPORT_DISABLE")
-
     env.collect(":build:path.include", "modm/ext/cmsis/dsp")
 
     env.outbasepath = "modm/ext/cmsis/dsp"
-    env.copy("cmsis/CMSIS/DSP/Include", ".")
-    operations = env.copy("cmsis/CMSIS/DSP/Source", ".")
-
-    # For all sources add these compile flags
-    for key, values in metadata.items():
-        env.collect(key, *values, operations=operations)
+    env.copy("cmsis/CMSIS/DSP/Include/arm_math.h", "arm_math.h")
 
 
 # ============================ Option Descriptions ============================

--- a/repo.lb
+++ b/repo.lb
@@ -35,7 +35,7 @@ except Exception as e:
     exit(1)
 
 import lbuild
-min_lbuild_version = "1.11.6"
+min_lbuild_version = "1.12.1"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))


### PR DESCRIPTION
This modularizes CMSIS-DSP to reduce the amount of source files that need to be compiled for your project and fixes #239.

This also wraps all CMSIS-DSP examples into modm examples to check for regressions in future.

cc @se-bi @chris-durand 
