### PR TITLE
Bugfix: STM32 acknowledge of interrupt clears all pending bits 

### DIFF
--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -156,7 +156,7 @@ public:
 	{ EXTI->FPR1 |= mask; EXTI->RPR1 |= mask; }
 %% else
 	inline static bool getExternalInterruptFlag() { return (EXTI->PR{{pf}} & mask); }
-	inline static void acknowledgeExternalInterruptFlag() { EXTI->PR{{pf}} |= mask; }
+	inline static void acknowledgeExternalInterruptFlag() { EXTI->PR{{pf}} = mask; }
 %% endif
 	// GpioIO
 	// start documentation inherited

--- a/src/modm/platform/gpio/stm32/pin_f1.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin_f1.hpp.in
@@ -137,7 +137,7 @@ public:
 		}
 	}
 	inline static bool getExternalInterruptFlag() { return (EXTI->PR & mask); }
-	inline static void acknowledgeExternalInterruptFlag() { EXTI->PR |= mask; }
+	inline static void acknowledgeExternalInterruptFlag() { EXTI->PR = mask; }
 	// GpioIO
 	// start documentation inherited
 	inline static Direction getDirection() {


### PR DESCRIPTION
Fixes #243:

When using `inline static void acknowledgeExternalInterruptFlag() { EXTI->PR |= mask; }`,
EXTI->PR is read into a cpu-register which will then be ORed with the mask (so it does basicaly nothing) and then the register value is written back to PR which then clears all set interrupt pending bits (and not just the desired one).