### PR TITLE
Also check if toolchain is broken on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+os: osx
+osx_image: xcode11
+
+before_install:
+  - brew update
+  - brew upgrade python3 || true
+  - brew install scons git doxygen || true
+  - pip3 install modm
+
+script:
+  - cd examples/darwin/logger
+  - lbuild build
+  - /usr/bin/env python3 $(which scons)

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,7 +94,7 @@ make gdb
 
 ## Interesting Examples
 
-We have a lot of examples, <!--examplecount-->190<!--/examplecount--> to be
+We have a lot of examples, <!--examplecount-->191<!--/examplecount--> to be
 exact, but here are some of our favorite examples for our supported development
 boards:
 

--- a/examples/darwin/logger/main.cpp
+++ b/examples/darwin/logger/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2011, Fabian Greif
+ * Copyright (c) 2013, Sascha Schade
+ * Copyright (c) 2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/platform.hpp>
+#include <modm/debug/logger.hpp>
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::DEBUG
+
+int
+main()
+{
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << MODM_FILE_INFO << "debug"   << modm::endl;
+	MODM_LOG_INFO    << MODM_FILE_INFO << "info"    << modm::endl;
+	MODM_LOG_WARNING << MODM_FILE_INFO << "warning" << modm::endl;
+	MODM_LOG_ERROR   << MODM_FILE_INFO << "error"   << modm::endl;
+
+	return 0;
+}

--- a/examples/darwin/logger/project.xml
+++ b/examples/darwin/logger/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-darwin</option>
+    <option name="modm:build:build.path">../../../build/darwin/logger</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -16,8 +16,8 @@ profile = ARGUMENTS.get("profile", "release")
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
 env["BASEPATH"] = abspath(".")
 %% if family == "darwin"
-# Using homebrew gcc-8 on macOS
-env["COMPILERSUFFIX"] = "-8"
+# Detect gcc version from homebrew
+env["COMPILERSUFFIX"] = env.Detect(["gcc-8", "gcc-9"])[3:]
 %% endif
 %% endif
 


### PR DESCRIPTION
... or check if TravisCI is broken ...

I know all the bad experience with TravisCI, but I didn't like that the install instructions for macOS were not up-to-date. I would not depend a PR on successful run of TravisCI, but this can help not to break macOS easily. TravisCI is the only CI which has a macOS in the free plan.

There are a bunch of warnings and many other examples do not compile yet. So this is an indication that the hosted port may need some attention.