### PR TITLE
[driver] Adds APA102 and SK6812 LED drivers, fixes WS2812 unaligned access

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,13 @@ can easily configure them for you specific needs.
 <td align="center">SIEMENS-S65</td>
 </tr><tr>
 <td align="center">SIEMENS-S75</td>
+<td align="center">SK6812</td>
 <td align="center">SSD1306</td>
 <td align="center">TCS3414</td>
 <td align="center">TCS3472</td>
 <td align="center">TLC594X</td>
-<td align="center">TMP102</td>
 </tr><tr>
+<td align="center">TMP102</td>
 <td align="center">TMP175</td>
 <td align="center">VL53L0</td>
 <td align="center">VL6180</td>

--- a/README.md
+++ b/README.md
@@ -166,62 +166,64 @@ can easily configure them for you specific needs.
 <td align="center">ADNS9800</td>
 <td align="center">ADS7843</td>
 <td align="center">AMS5915</td>
-<td align="center">SPI-FLASH</td>
+<td align="center">APA102</td>
 </tr><tr>
+<td align="center">SPI-FLASH</td>
 <td align="center">BME280</td>
 <td align="center">BMP085</td>
 <td align="center">BNO055</td>
 <td align="center">DRV832X</td>
 <td align="center">DS1302</td>
-<td align="center">DS1631</td>
 </tr><tr>
+<td align="center">DS1631</td>
 <td align="center">DS18B20</td>
 <td align="center">EA-DOG</td>
 <td align="center">FT245</td>
 <td align="center">FT6X06</td>
 <td align="center">HCLAx</td>
-<td align="center">HD44780</td>
 </tr><tr>
+<td align="center">HD44780</td>
 <td align="center">HMC58x</td>
 <td align="center">HMC6343</td>
 <td align="center">I2C-EEPROM</td>
 <td align="center">ITG3200</td>
 <td align="center">L3GD20</td>
-<td align="center">LAWICEL</td>
 </tr><tr>
+<td align="center">LAWICEL</td>
 <td align="center">LIS302DL</td>
 <td align="center">LIS3DSH</td>
 <td align="center">LM75</td>
 <td align="center">LSM303A</td>
 <td align="center">LTC2984</td>
-<td align="center">MAX6966</td>
 </tr><tr>
+<td align="center">MAX6966</td>
 <td align="center">MAX7219</td>
 <td align="center">MCP23X17</td>
 <td align="center">MCP2515</td>
 <td align="center">NOKIA5110</td>
 <td align="center">NRF24</td>
-<td align="center">TFT-DISPLAY</td>
 </tr><tr>
+<td align="center">TFT-DISPLAY</td>
 <td align="center">PAT9125EL</td>
 <td align="center">PCA8574</td>
 <td align="center">PCA9535</td>
 <td align="center">PCA9548A</td>
 <td align="center">PCA9685</td>
-<td align="center">SIEMENS-S65</td>
 </tr><tr>
+<td align="center">SIEMENS-S65</td>
 <td align="center">SIEMENS-S75</td>
 <td align="center">SK6812</td>
 <td align="center">SSD1306</td>
 <td align="center">TCS3414</td>
 <td align="center">TCS3472</td>
-<td align="center">TLC594X</td>
 </tr><tr>
+<td align="center">TLC594X</td>
 <td align="center">TMP102</td>
 <td align="center">TMP175</td>
 <td align="center">VL53L0</td>
 <td align="center">VL6180</td>
 <td align="center">WS2812</td>
+</tr><tr>
 </tr>
 </table>
 <!--/drivertable-->

--- a/examples/nucleo_f031k6/sk6812/main.cpp
+++ b/examples/nucleo_f031k6/sk6812/main.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/driver/pwm/sk6812w.hpp>
+#include <modm/ui/led/tables.hpp>
+#include <modm/processing/timer.hpp>
+
+using namespace Board;
+
+using Output = Board::D11;
+modm::Sk6812w<SpiMaster1, Output, 8*8> leds;
+modm::ShortPeriodicTimer tmr{33};
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+	leds.initialize<Board::SystemClock>();
+
+	constexpr uint8_t max = 62;
+	uint8_t r=0, g=max/3, b=max/3*2;
+
+	while (true)
+	{
+		for (size_t ii=0; ii < leds.size; ii++)
+		{
+			leds.setColor(ii,
+						  {modm::ui::table22_8_256[r*3/2],
+						   modm::ui::table22_8_256[g*3/2],
+						   modm::ui::table22_8_256[b*3/2]});
+			if (r++ >= max) r = 0;
+			if (g++ >= max) g = 0;
+			if (b++ >= max) b = 0;
+		}
+		leds.write();
+
+		while(not tmr.execute()) ;
+		LedD13::toggle();
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f031k6/sk6812/project.xml
+++ b/examples/nucleo_f031k6/sk6812/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f031k6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f031k6/sk6812</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:driver:sk6812</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:ui:led</module>
+  </modules>
+</library>

--- a/examples/nucleo_f411re/ws2812b/project.xml
+++ b/examples/nucleo_f411re/ws2812b/project.xml
@@ -5,9 +5,9 @@
     <option name=":build:build.path">../../../build/nucleo_f411re/ws2812b</option>
   </options>
   <modules>
-    <module>:driver:ws2812</module>
-    <module>:platform:spi:1</module>
-    <module>:ui:led</module>
-    <module>:build:scons</module>
+    <module>modm:driver:ws2812</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:ui:led</module>
+    <module>modm:build:scons</module>
   </modules>
 </library>

--- a/examples/nucleo_g071rb/apa102/main.cpp
+++ b/examples/nucleo_g071rb/apa102/main.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/driver/pwm/apa102.hpp>
+#include <modm/ui/led/tables.hpp>
+#include <modm/processing/timer.hpp>
+
+using namespace Board;
+
+modm::Apa102<SpiMaster1, 8*8> leds;
+modm::ShortPeriodicTimer tmr{33};
+
+int
+main()
+{
+	Board::initialize();
+	SpiMaster1::connect<Board::D13::Sck, Board::D11::Mosi>();
+	SpiMaster1::initialize<Board::SystemClock, 8_MHz>();
+
+	constexpr uint8_t max = 62;
+	uint8_t r=0, g=max/3, b=max/3*2;
+
+	while (true)
+	{
+		for (size_t ii=0; ii < leds.size; ii++)
+		{
+			leds.setColor(ii, {r, g, b});
+						  // {modm::ui::table22_8_256[r],
+						  //  modm::ui::table22_8_256[g],
+						  //  modm::ui::table22_8_256[b]});
+			if (r++ >= max) r = 0;
+			if (g++ >= max) g = 0;
+			if (b++ >= max) b = 0;
+		}
+		RF_CALL_BLOCKING(leds.write());
+
+		while(not tmr.execute()) ;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g071rb/apa102/project.xml
+++ b/examples/nucleo_g071rb/apa102/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-g071rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g071rb/apa102</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:driver:apa102</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:ui:led</module>
+  </modules>
+</library>

--- a/examples/stm32f072_discovery/unaligned_access/main.cpp
+++ b/examples/stm32f072_discovery/unaligned_access/main.cpp
@@ -58,8 +58,8 @@ main()
 		}
 
 		{
-			// `u32` is a pointer to a modm::unaligned_t<uint32_t> !
-			auto *u32 = modm::asUnaligned<uint32_t>(buffer + offset);
+			// `u32` is a pointer to a modm::unaligned_t<uint32_t*> !
+			auto *u32 = modm::asUnaligned<uint32_t*>(buffer + offset);
 			// this is short for:
 			// modm::unaligned_t<uint32_t> *u32 = reinterpret_cast<modm::unaligned_t<uint32_t>*>(buffer + offset);
 			// write to the unaligned location
@@ -70,7 +70,7 @@ main()
 
 			// Anonymous form
 			*modm::asUnaligned<uint32_t>(buffer + offset) = input;
-			output = *modm::asUnaligned<uint32_t>(buffer + offset);
+			output = *modm::asUnaligned<uint32_t*>(buffer + offset);
 			if (output != input) error();
 		}
 

--- a/src/modm/architecture/interface/unaligned.hpp
+++ b/src/modm/architecture/interface/unaligned.hpp
@@ -12,6 +12,8 @@
 #ifndef MODM_INTERFACE_UNALIGNED_ACCESS_HPP
 #define MODM_INTERFACE_UNALIGNED_ACCESS_HPP
 
+#include <type_traits>
+
 #ifndef __DOXYGEN__
 // These functions may be implemented as header files, so we cannot rely on
 // there being a link-able function and delegate this choice to the platform.
@@ -27,11 +29,11 @@ namespace modm
  *
  * This wrapper manages unaligned access to memory, by copying
  * the memory to and from the stack, which is always correctly aligned.
- * Use this with teh `asUnaligned` helper:
+ * Use this with the `asUnaligned` helper:
  * @code
  * uint8_t *buffer;
- * // `u32` is a pointer to a unaligned_t<uint32_t> !
- * auto *u32 = modm::asUnaligned<uint32_t>(buffer);
+ * // `u32` is a pointer to a unaligned_t<uint32_t*> !
+ * auto *u32 = modm::asUnaligned<uint32_t*>(buffer);
  * // write to the unaligned location
  * *u32 = input;
  * // read from the unaligned location
@@ -65,10 +67,11 @@ protected:
  * @ingroup	modm_architecture_unaligned
  */
 template< typename T, typename U>
-modm_always_inline unaligned_t<T>*
+modm_always_inline
+unaligned_t< typename std::remove_pointer<T>::type >*
 asUnaligned(U* value)
 {
-	return reinterpret_cast< unaligned_t<T>* >(value);
+	return reinterpret_cast< unaligned_t< typename std::remove_pointer<T>::type >* >(value);
 }
 
 }	// namespace modm

--- a/src/modm/driver/pwm/apa102.hpp
+++ b/src/modm/driver/pwm/apa102.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <modm/math/units.hpp>
+#include <modm/architecture/interface/spi_master.hpp>
+#include <modm/ui/color.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_apa102
+template< class SpiMaster, size_t LEDs >
+class Apa102
+{
+protected:
+	static constexpr size_t length = 4 + 4*LEDs + ((LEDs+15)/16);
+	uint8_t data[length];
+public:
+	static constexpr size_t size = LEDs;
+
+	Apa102() : data{0,0,0,0}
+	{
+		clear();
+		// set the flushing bits correctly
+		for (size_t ii=4 + 4*LEDs; ii < length; ii++)
+			data[ii] = 0xff;
+	}
+
+	void
+	clear()
+	{
+		for (size_t ii=0; ii < LEDs; ii++)
+			reinterpret_cast<uint32_t*>(data)[1+ii] = 0xff;
+	}
+
+	bool
+	setColorBrightness(size_t index, const color::Rgb &color, uint8_t brightness)
+	{
+		if (index >= LEDs) return false;
+		uint32_t value = (color.red << 24) | (color.green << 16) |
+						 (color.blue << 8) | (brightness | 0xe0);
+		reinterpret_cast<uint32_t*>(data)[1+index] = value;
+		return true;
+	}
+
+	bool
+	setColor(size_t index, const color::Rgb &color)
+	{
+		if (index >= LEDs) return false;
+		// read the brightness value and clear all colors
+		uint32_t value = reinterpret_cast<const uint32_t*>(data)[1+index] & 0xfful;
+		// set all colors
+		value |= (color.red << 24) | (color.green << 16) | (color.blue << 8);
+		// write back entire value
+		reinterpret_cast<uint32_t*>(data)[1+index] = value;
+		return true;
+	}
+
+	color::Rgb
+	getColor(size_t index) const
+	{
+		if (index >= LEDs) return {};
+		const uint32_t value = reinterpret_cast<const uint32_t*>(data)[1+index];
+		return {(value >> 24),
+				(value >> 16) & 0xfful,
+				(value >> 8) & 0xfful};
+	}
+
+	void
+	setBrightness(size_t index, uint8_t brightness)
+	{
+		if (index >= LEDs) return;
+		data[4 + index*4] = brightness | 0xe0;
+	}
+
+	uint8_t
+	getBrightness(size_t index) const
+	{
+		if (index >= LEDs) return 0;
+		return data[4 + index*4] & ~0xe0;
+	}
+
+	modm::ResumableResult<void>
+	write()
+	{
+		return SpiMaster::transfer(data, nullptr, length);
+	}
+};
+
+}	// namespace modm

--- a/src/modm/driver/pwm/apa102.lb
+++ b/src/modm/driver/pwm/apa102.lb
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:apa102"
+    module.description = """\
+# APA102 RGB LED Driver
+
+Drives any number of chained APA102 RGB LEDs using SPI signals SCK and MOSI up
+to a few dozen MHz. Due to the synchronous clock, there are no special
+restrictions on protocol timing, making this driver safe to use with interrupts
+enabled and/or with an RTOS.
+
+The internal data buffer size is 4B for start of frame, 4B for every LED and 1B
+for every 16 LEDs as end of frame.
+
+References:
+
+- ["APA102 aka Superled"][led].
+- ["Understanding the APA102 Superled"][protocol].
+
+[led]: https://cpldcpu.wordpress.com/2014/08/27/apa102/
+[protocol]: https://cpldcpu.wordpress.com/2014/11/30/understanding-the-apa102-superled
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:spi",
+        ":processing:resumable",
+        ":ui:color")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/pwm"
+    env.copy("apa102.hpp")

--- a/src/modm/driver/pwm/sk6812.lb
+++ b/src/modm/driver/pwm/sk6812.lb
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:sk6812"
+    module.description = """\
+# SK6812 RGBW Driver
+
+Drives any number of chained SK6812 RGBW LEDs using a 3-bit SPI encoding
+(0 -> 100, 1 -> 110) running at 3 MHz.
+Thus, writing one LED takes 32µs and 12 bytes of memory.
+
+There are several caveats:
+
+1. This only provides a blocking write API, due to technical limitations.
+2. Atomicity is not enforced, this should be done externally if required.
+3. The memory footprint is 4x as large, due to the bit stuffing for SPI.
+4. There is no enforced reset period of at least 50µs after the write is finished,
+   it is up to the user to not trigger another write too early.
+
+This driver directly accesses the STM32 HAL to keep the transmit register full,
+due to a lack of DMA capability in modm, thus this driver is STM32-only for now.
+
+!!! warning "SystemClock Limitations"
+    This driver requires a 3 MHz ±10% SPI clock in order to get the protocol
+    timing right. Depending on your device clock tree and the SPI prescalers,
+    this might require *lowering* the frequency of the entire device! If this is
+    unacceptable, consider using APA102.
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:spi",
+        ":architecture:unaligned",
+        ":math:units",
+        ":ui:color")
+    return options[":target"].identifier.platform == "stm32"
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/pwm"
+    env.copy("sk6812w.hpp")

--- a/src/modm/driver/pwm/sk6812w.hpp
+++ b/src/modm/driver/pwm/sk6812w.hpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <modm/math/units.hpp>
+#include <modm/architecture/interface/spi_master.hpp>
+#include <modm/architecture/interface/unaligned.hpp>
+#include <modm/ui/color.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_sk6812
+template< class SpiMaster, class Output, size_t LEDs >
+class Sk6812w
+{
+protected:								  // 7654 3210 7654 3210 7654 3210
+	static constexpr uint32_t base_mask  = 0b0010'0100'1001'0010'0100'1001;
+	static constexpr uint32_t clear_mask = base_mask << 1;
+
+	static constexpr size_t length = LEDs * 12;
+	uint8_t data[length + 1]; // +1 for zero byte for reset
+
+	static constexpr uint16_t
+	spread(uint8_t nibble)
+	{
+		return ((nibble & 0b0001) << 10) | ((nibble & 0b0010) << 6) |
+			   ((nibble & 0b0100) <<  5) | ((nibble & 0b1000) << 1);
+	}
+
+	static constexpr uint8_t
+	gather(uint32_t pattern)
+	{
+		return ((pattern >> 10) & 0b0001) | ((pattern >> 6) & 0b0010) |
+			   ((pattern >> 5) & 0b0100) | ((pattern >> 1) & 0b1000);
+	}
+
+public:
+	static constexpr size_t size = LEDs;
+
+	Sk6812w()
+	{
+		clear();
+	}
+
+	template< class SystemClock >
+	void
+	initialize()
+	{
+		SpiMaster::template connect<Output::template Mosi>();
+		SpiMaster::template initialize<SystemClock, MHz(3), pct(10)>();
+		SpiMaster::setDataOrder(SpiMaster::DataOrder::LsbFirst);
+		SpiMaster::Hal::write(uint8_t(0));
+	}
+
+	void
+	clear()
+	{
+		for (size_t ii=0; ii < length; ii += 3)
+		{
+			*modm::asUnaligned<uint32_t*>(data + ii) = base_mask;
+		}
+		data[length] = 0;
+	}
+
+	void
+	setColorBrightness(size_t index, const color::Rgb &color, uint8_t brightness)
+	{
+		if (index >= LEDs) return;
+
+		const uint8_t colors[] = {color.green, color.red, color.blue, brightness};
+		for (size_t ii = 0; ii < 4; ii++)
+		{
+			const uint32_t c = (spread(colors[ii]) << 12) | spread(colors[ii] >> 4);
+			auto *value = modm::asUnaligned<uint32_t*>(data + index * 12 + ii*3);
+			*value = (uint32_t(*value) & ~clear_mask) | c;
+		}
+	}
+
+	void
+	setColor(size_t index, const color::Rgb &color)
+	{
+		if (index >= LEDs) return;
+
+		const uint8_t colors[] = {color.green, color.red, color.blue};
+		for (size_t ii = 0; ii < 3; ii++)
+		{
+			const uint32_t c = (spread(colors[ii]) << 12) | spread(colors[ii] >> 4);
+			auto *value = modm::asUnaligned<uint32_t*>(data + index * 12 + ii*3);
+			*value = (uint32_t(*value) & ~clear_mask) | c;
+		}
+	}
+
+	color::Rgb
+	getColor(size_t index) const
+	{
+		if (index >= LEDs) return {};
+
+		uint8_t color[3];
+		for (size_t ii = 0; ii < 3; ii++)
+		{
+			const auto value = *modm::asUnaligned<const uint32_t*>(data + index * 12 + ii*3);
+			const uint8_t c = (gather(value) << 4) | gather(value >> 12);
+			color[ii] = c;
+		}
+		return {color[1], color[0], color[2]};
+	}
+
+	void
+	setBrightness(size_t index, uint8_t brightness)
+	{
+		if (index >= LEDs) return;
+
+		const uint32_t c = (spread(brightness) << 12) | spread(brightness >> 4);
+		auto *value = modm::asUnaligned<uint32_t*>(data + index * 12 + 3*3);
+		*value = (uint32_t(*value) & ~clear_mask) | c;
+	}
+
+	uint8_t
+	getBrightness(size_t index) const
+	{
+		if (index >= LEDs) return {};
+
+		const auto value = *modm::asUnaligned<const uint32_t*>(data + index * 12 + 3*3);
+		return (gather(value) << 4) | gather(value >> 12);
+	}
+
+	void
+	write()
+	{
+		for (const auto value : data) {
+			while (not SpiMaster::Hal::isTransmitRegisterEmpty()) ;
+			SpiMaster::Hal::write(value);
+		}
+	}
+};
+
+}	// namespace modm

--- a/src/modm/driver/pwm/ws2812.lb
+++ b/src/modm/driver/pwm/ws2812.lb
@@ -30,11 +30,18 @@ There are several caveats:
 
 This driver directly accesses the STM32 HAL to keep the transmit register full,
 due to a lack of DMA capability in modm, thus this driver is STM32-only for now.
+
+!!! warning "SystemClock Limitations"
+    This driver requires a 3 MHz ±10% SPI clock in order to get the protocol
+    timing right. Depending on your device clock tree and the SPI prescalers,
+    this might require *lowering* the frequency of the entire device! If this is
+    unacceptable, consider using APA102.
 """
 
 def prepare(module, options):
     module.depends(
         ":architecture:spi",
+        ":architecture:unaligned",
         ":math:units",
         ":ui:color")
     return options[":target"].identifier.platform == "stm32"


### PR DESCRIPTION
Driver additions and driver upgrades:

- [x] Refactores BNO055 driver for a better API.
- [x] Fixed unaligned access issues for WS2812 driver on Cortex-M0 devices.
- [x] Allow using pointer types in `modm::asUnaligned<T*>(U)`.
- [x] Add driver for SK6812 LEDs with 4-channels.
- [x] Add driver for APA102 RGB LEDs with brightness control.
- [x] Example for APA102.
- [x] Example for SK6812 on Cortex-M0