### PR TITLE
Fix to isConversionFinished()

### DIFF
--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -154,7 +154,7 @@ modm::platform::Adc::startConversion(void)
 bool
 modm::platform::Adc::isConversionFinished(void)
 {
-    return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfSampling);
+    return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfConversion);
 }
 
 void

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -193,7 +193,7 @@ modm::platform::Adc{{ id }}::startConversion(void)
 bool
 modm::platform::Adc{{ id }}::isConversionFinished(void)
 {
-	return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfSampling);
+	return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfConversion);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
It previously checked the EndOfSampling flag instead of EndOfConversion. This typically causes sampled values from the ADC to be invalid or from the previous conversion due to reading the value too early.