### PR TITLE
Doxypress API documentation on https://docs.modm.io/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,12 @@ jobs:
           command: |
             (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
       - run:
+          name: Test run of docs.modm.io-generator-script
+          command: |
+            export TERM=xterm-256color
+            export COLUMNS=120
+            python3 tools/scripts/docs_modm_io_generator.py -t -c
+      - run:
           name: Build Homepage
           command: |
             python3 tools/scripts/synchronize_docs.py
@@ -378,6 +384,26 @@ jobs:
             git diff-index --quiet HEAD || git commit -m "Update"
             git push origin master
 
+  api-docs-all:
+    docker:
+      - image: modm/modm-build:latest
+    steps:
+      - checkout
+      - run:
+          name: Update submodules and install lbuild
+          command: |
+            (git submodule sync && git submodule update --init --jobs 8) & pip3 install -U lbuild & wait
+      - run:
+          name: Full run of docs.modm.io-generator-script with upload
+          command: |
+            export TERM=xterm-256color
+            export COLUMNS=120
+            python3 tools/scripts/docs_modm_io_generator.py -c -j4
+      - run:
+          name: Upload api documentation to docs.modm.io
+          command: |
+            curl https://docs.modm.io/upload/compressed --upload-file modm-api-docs.tar.gz --user $MODM_UPLOAD
+
 workflows:
   version: 2
   build:
@@ -387,6 +413,10 @@ workflows:
       - avr-examples
       - stm32-examples
 
+      - api-docs-all:
+          filters:
+            branches:
+              only: develop
       - avr-compile-all:
           requires:
             - unittests-linux-generic

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ process that you can fine-tune to your needs.
 - Feast your eyes on [lots of working examples][examples].
 - Our CI checks every contribution for regressions: ![Build Status](https://circleci.com/gh/modm-io/modm/tree/develop.svg?style=shield)
 - We care [about testing modm][testing].
+- [API reference is available here][api-docs].
 
-<!-- - [API reference is available here][reference]. -->
 <!-- - [Check out our latest quarterly release][releases] with a [beautiful changelog][changelog]. -->
 
 This project also has a [technical blog][blog] to document larger design concepts.
@@ -304,7 +304,7 @@ Georgi Grinshpun ([\@georgi-g](https://github.com/georgi-g)) and
 [contrib]:         https://github.com/modm-io/modm/tree/develop/CONTRIBUTING.md
 [devboards]:       https://github.com/modm-io/modm/tree/develop/src/modm/board
 [drivers]:         https://github.com/modm-io/modm/tree/develop/src/modm/driver
-[eurobot]:         http://www.eurobot.org/
+[eurobot]:         https://www.eurobot.org/
 [examples]:        https://github.com/modm-io/modm/tree/develop/examples
 [guide]:           https://modm.io/guide/getting-started
 [install]:         https://modm.io/guide/installation
@@ -313,8 +313,9 @@ Georgi Grinshpun ([\@georgi-g](https://github.com/georgi-g)) and
 [modm-devices]:    https://github.com/modm-io/modm-devices
 [porting]:         https://github.com/modm-io/modm/tree/develop/docs/PORTING.md
 [prs]:             https://github.com/modm-io/modm/pulls
-[rca_ev]:          http://www.roboterclub.rwth-aachen.de/
+[rca_ev]:          https://www.roboterclub.rwth-aachen.de/
 [reference]:       https://modm.io/reference/api
 [releases]:        https://github.com/modm-io/modm/releases
 [testing]:         https://modm.io/guide/testing
+[api-docs]:        https://docs.modm.io/
 <!--/links-->

--- a/docs/src/reference/documentation.md
+++ b/docs/src/reference/documentation.md
@@ -54,31 +54,36 @@ available for {target}*". Additionally the view does not show peripheral
 instance submodule to reduce visual noise.
 
 
-## Doxygen
+## Doxypress / Doxygen
 
-The generated C/C++ API is documented using Doxygen and therefore only available
-*after* code generation.
+The generated C/C++ API is documented using Doxypress or Doxygen and therefore only
+available *after* code generation.
 
 To view this documentation, include the `modm:docs` module in your `project.xml`
 configuration and run `lbuild build`. A `modm/docs` folder is created containing
-the `doxyfile.cfg` for modm as well as all the `@defgroup`s mirroring the
-module structure.
+the `doxypress.json` and `doxyfile.cfg` for modm as well as all the `@defgroup`s
+mirroring the module structure.
 
 You must then call Doxygen manually, which can take several minutes, and
 compiles the target-specific documentation into `modm/docs/html`:
 
 ```sh
 lbuild build -m "modm:docs"
+
+# With Doxypress
+(cd modm/docs && doxypress doxypress.json)
+# Or Doxygen
 (cd modm/docs && doxygen doxyfile.cfg)
+
 # then open: modm/docs/html/index.html
 ```
 
-The generated Doxygen documentation contains the original module documentation
+The generated Doxypress/Doxygen documentation contains the original module documentation
 *including the option choices you made*. This makes it easier to map the
 lbuild options to changes in the generated source code.
 
 
-!!! bug "No online API docs available (yet)"
-	Due to the complexity of creating a superimposed API documentation for
-	hundreds of different targets, we currently do not have an online API browser
-	available. Please generate the Doxygen API documentation locally for now.
+### Online API documentation
+
+API documentation is available at https://docs.modm.io/ for a large and representative
+number of targets with all modules enabled.

--- a/tools/doc_generator/doxypress.json.in
+++ b/tools/doc_generator/doxypress.json.in
@@ -1,0 +1,451 @@
+{
+    "clang": {
+        "clang-compilation-path": "",
+        "clang-dialect": "-std=c++17",
+        "clang-flags": [
+            ""
+        ],
+        "clang-parsing": false,
+        "clang-use-headers": true
+    },
+    "configuration": {
+        "allow-sub-grouping": true,
+        "allow-unicode-names": false,
+        "always-detailed-sec": false,
+        "auto-link": true,
+        "brief-member-desc": true,
+        "built-in-stl-support": false,
+        "case-sensitive-fname": true,
+        "cpp-cli-support": false,
+        "create-subdirs": false,
+        "duplicate-docs": false,
+        "enabled-sections": [
+            ""
+        ],
+        "extract-all": false,
+        "extract-anon-namespaces": false,
+        "extract-local-classes": true,
+        "extract-local-methods": false,
+        "extract-package": false,
+        "extract-private": false,
+        "extract-static": false,
+        "file-version-filter": "",
+        "force-local-includes": false,
+        "full-path-names": false,
+        "generate-bug-list": false,
+        "generate-deprecate-list": false,
+        "generate-test-list": false,
+        "generate-todo-list": false,
+        "group-nested-compounds": false,
+        "hide-compound-ref": false,
+        "hide-friend-compounds": false,
+        "hide-in-body-docs": false,
+        "hide-navtree-members": false,
+        "hide-scope-names": false,
+        "hide-undoc-classes": false,
+        "hide-undoc-members": false,
+        "idl-support": true,
+        "inherit-docs": true,
+        "inline-grouped-classes": false,
+        "inline-info": true,
+        "inline-inherited-member": false,
+        "inline-simple-struct": false,
+        "internal-docs": false,
+        "javadoc-auto-brief": false,
+        "language-mapping": [
+            ""
+        ],
+        "layout-file": "",
+        "main-page-name": "README.md",
+        "main-page-omit": false,
+        "markdown": true,
+        "max-init-lines": 30,
+        "multiline-cpp-brief": false,
+        "ns-alias": [
+            ""
+        ],
+        "qt-auto-brief": false,
+        "repeat-brief": true,
+        "separate-member-pages": false,
+        "short-names": false,
+        "show-file-page": true,
+        "show-grouped-members-inc": false,
+        "show-include-files": true,
+        "show-namespace-page": true,
+        "show-used-files": true,
+        "sip-support": false,
+        "sort-brief-docs": false,
+        "sort-by-scope-name": false,
+        "sort-class-case-sensitive": false,
+        "sort-constructors-first": false,
+        "sort-group-names": false,
+        "sort-member-docs": true,
+        "strict-sig-matching": false,
+        "tcl-subst": [
+            ""
+        ],
+        "toc-include-headers": 0,
+        "use-typedef-name": false
+    },
+    "dot": {
+        "class-diagrams": true,
+        "dia-file-dirs": [
+            ""
+        ],
+        "dia-path": "",
+        "directory-graph": true,
+        "dot-call": false,
+        "dot-called-by": false,
+        "dot-class-graph": true,
+        "dot-cleanup": true,
+        "dot-collaboration": true,
+        "dot-file-dirs": [
+            ""
+        ],
+        "dot-font-name": "Helvetica",
+        "dot-font-path": "",
+        "dot-font-size": 10,
+        "dot-graph-max-depth": 0,
+        "dot-graph-max-nodes": 50,
+        "dot-hierarchy": true,
+        "dot-image-format": "png",
+        "dot-include": true,
+        "dot-included-by": true,
+        "dot-multiple-targets": false,
+        "dot-num-threads": 0,
+        "dot-path": "",
+        "dot-transparent": false,
+        "generate-legend": true,
+        "group-graphs": true,
+        "have-dot": false,
+        "hide-undoc-relations": true,
+        "interactive-svg": false,
+        "msc-file-dirs": [
+            ""
+        ],
+        "mscgen-path": "",
+        "plantuml-cfg-file": "",
+        "plantuml-inc-path": [
+            ""
+        ],
+        "plantuml-jar-path": "",
+        "template-relations": false,
+        "uml-limit-num-fields": 10,
+        "uml-look": false
+    },
+    "doxypress-format": 1,
+    "doxypress-updated": "2018-Jun-30",
+    "external": {
+        "all-externals": false,
+        "external-groups": true,
+        "external-pages": true,
+        "generate-tagfile": "",
+        "perl-path": "/usr/bin/perl",
+        "tag-files": [
+            ""
+        ]
+    },
+    "general": {
+        "abbreviate-brief": [
+            "The $name class",
+            "The $name widget",
+            "The $name file",
+            "is",
+            "provides",
+            "specifies",
+            "contains",
+            "represents",
+            "a",
+            "an",
+            "the"
+        ],
+        "aliases": [
+            ""
+        ],
+        "lookup-cache-size": 0,
+        "optimize-c": false,
+        "optimize-cplus": true,
+        "optimize-fortran": false,
+        "optimize-java": false,
+        "optimize-python": false,
+        "output-dir": ".",
+        "output-language": "English",
+        "strip-from-inc-path": [
+            "../src"
+        ],
+        "strip-from-path": [
+            "../src"
+        ],
+        "tab-size": 4
+    },
+    "index": {
+        "alpha-index": true,
+        "cols-in-index": 5,
+        "ignore-prefix": [
+            ""
+        ]
+    },
+    "input": {
+        "example-patterns": [
+            "*"
+        ],
+        "example-recursive": false,
+        "example-source": [
+            ""
+        ],
+        "exclude-files": [
+            ""
+        ],
+        "exclude-patterns": [
+            "*_impl.hpp"
+        ],
+        "exclude-symbols": [
+            ""
+        ],
+        "exclude-symlinks": false,
+        "filter-patterns": [
+            ""
+        ],
+        "filter-program": "",
+        "filter-source-files": false,
+        "filter-source-patterns": [
+            ""
+        ],
+        "image-path": [
+            ""
+        ],
+        "input-encoding": "UTF-8",
+        "input-patterns": [
+            "*.as",
+            "*.c",
+            "*.cpp",
+            "*.dox",
+            "*.h",
+            "*.hpp"
+        ],
+        "input-recursive": true,
+        "input-source": [
+            "dox/",
+            "../src/"
+        ],
+        "mdfile-mainpage": "README.md"
+    },
+    "messages": {
+        "quiet": true,
+        "warn-doc-error": true,
+        "warn-format": "$file:$line: $text",
+        "warn-logfile": "",
+        "warn-undoc": false,
+        "warn-undoc-param": false,
+        "warnings": false
+    },
+    "output-chm": {
+        "binary-toc": false,
+        "chm-file": "",
+        "chm-index-encoding": "",
+        "generate-chi": false,
+        "generate-chm": false,
+        "hhc-location": "",
+        "toc-expanded": false
+    },
+    "output-docbook": {
+        "docbook-output": "docbook",
+        "docbook-program-listing": false,
+        "generate-docbook": false
+    },
+    "output-docset": {
+        "docset-bundle-id": "org.doxypress.Project",
+        "docset-feedname": "DoxyPress generated docs",
+        "docset-publisher-id": "org.doxypress.Publisher",
+        "docset-publisher-name": "Publisher",
+        "generate-docset": false
+    },
+    "output-eclipse": {
+        "eclipse-doc-id": "org.doxypress.Project",
+        "generate-eclipse": false
+    },
+    "output-html": {
+        "disable-index": false,
+        "enum-values-per-line": 4,
+        "external-links-in-window": false,
+        "formula-fontsize": 10,
+        "formula-transparent": true,
+        "generate-html": true,
+        "generate-treeview": true,
+        "ghostscript": "",
+        "html-colorstyle-gamma": 80,
+        "html-colorstyle-hue": 220,
+        "html-colorstyle-sat": 100,
+        "html-dynamic-sections": false,
+        "html-extra-files": [
+            ""
+        ],
+        "html-file-extension": ".html",
+        "html-footer": "",
+        "html-header": "",
+        "html-index-num-entries": 100,
+        "html-output": "html",
+        "html-search": true,
+        "html-stylesheets": [
+            ""
+        ],
+        "html-timestamp": false,
+        "mathjax-codefile": "",
+        "mathjax-extensions": [
+            ""
+        ],
+        "mathjax-format": "HTML-CSS",
+        "mathjax-relpath": "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/",
+        "search-data-file": "searchdata.xml",
+        "search-external": false,
+        "search-external-id": "",
+        "search-external-url": "",
+        "search-mappings": [
+            ""
+        ],
+        "search-server-based": false,
+        "treeview-width": 250,
+        "use-mathjax": false
+    },
+    "output-latex": {
+        "cite-bib-files": [
+            ""
+        ],
+        "generate-latex": false,
+        "latex-batch-mode": false,
+        "latex-bib-style": "plain",
+        "latex-cmd-name": "latex",
+        "latex-compact": false,
+        "latex-extra-files": [
+            ""
+        ],
+        "latex-extra-packages": [
+            ""
+        ],
+        "latex-footer": "",
+        "latex-header": "",
+        "latex-hide-indices": false,
+        "latex-hyper-pdf": true,
+        "latex-output": "latex",
+        "latex-paper-type": "a4",
+        "latex-pdf": true,
+        "latex-ps": true,
+        "latex-source-code": false,
+        "latex-stylesheets": [
+            ""
+        ],
+        "latex-timestamp": false,
+        "make-index-cmd-name": "makeindex"
+    },
+    "output-man": {
+        "generate-man": false,
+        "man-extension": ".3",
+        "man-links": false,
+        "man-output": "man",
+        "man-subdir": ""
+    },
+    "output-perl": {
+        "generate-perl": false,
+        "perl-latex": false,
+        "perl-prefix": "",
+        "perl-pretty": true
+    },
+    "output-qhelp": {
+        "generate-qthelp": false,
+        "qch-file": "",
+        "qhp-cust-attrib": [
+            ""
+        ],
+        "qhp-cust-filter-name": "",
+        "qhp-namespace": "org.doxypress.Project",
+        "qhp-sect-attrib": [
+            ""
+        ],
+        "qhp-virtual-folder": "doc",
+        "qthelp-gen-path": ""
+    },
+    "output-rtf": {
+        "generate-rtf": false,
+        "rtf-compact": false,
+        "rtf-extension": "",
+        "rtf-hyperlinks": false,
+        "rtf-output": "rtf",
+        "rtf-paper-type": "a4",
+        "rtf-source-code": false,
+        "rtf-stylesheet": ""
+    },
+    "output-xml": {
+        "generate-xml": false,
+        "xml-output": "xml",
+        "xml-program-listing": true
+    },
+    "preprocessor": {
+        "enable-preprocessing": true,
+        "expand-as-defined": [
+            ""
+        ],
+        "expand-only-predefined": false,
+        "include-path": [
+            ""
+        ],
+        "include-patterns": [
+            ""
+        ],
+        "macro-expansion": false,
+        "predefined-macros": [
+            "__DOXYGEN__"
+        ],
+        "search-includes": true,
+        "skip-function-macros": true
+    },
+    "project": {
+        "project-brief": "",
+        "project-logo": "",
+        "project-name": "modm API documentation for {{ device }}",
+        "project-version": ""
+    },
+    "source": {
+        "inline-source": false,
+        "ref-by-relation": false,
+        "ref-link-source": true,
+        "ref-relation": false,
+        "source-code": false,
+        "source-tooltips": true,
+        "strip-code-comments": false,
+        "suffix-exclude-navtree": [
+            "doc",
+            "dox",
+            "md",
+            "markdown",
+            "txt"
+        ],
+        "suffix-header-navtree": [
+            "h",
+            "hh",
+            "hxx",
+            "hpp",
+            "h++",
+            "idl",
+            "ddl",
+            "pidl"
+        ],
+        "suffix-source-navtree": [
+            "c",
+            "cc",
+            "cxx",
+            "cpp",
+            "c++",
+            "ii",
+            "ixx",
+            "ipp",
+            "i++",
+            "inl",
+            "java",
+            "m",
+            "mm",
+            "xml"
+        ],
+        "use-htags": false,
+        "verbatim-headers": true
+    }
+}

--- a/tools/doc_generator/module.lb
+++ b/tools/doc_generator/module.lb
@@ -76,8 +76,13 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/docs"
-    env.substitutions = {"xml": False, "qch": env["enable_qch"]}
+    env.substitutions = {
+        "xml": False,
+        "qch": env["enable_qch"],
+        "device": str(env[":target"].identifier).upper(),
+    }
     env.template("doxyfile.cfg.in")
+    env.template("doxypress.json.in")
     env.copy(repopath("README.md"), "README.md")
 
 def post_build(env, buildlog):

--- a/tools/doc_generator/module.md
+++ b/tools/doc_generator/module.md
@@ -1,12 +1,28 @@
 # Documentation Generator
 
-This module creates the Doxygen groups and hierarchy according to the modm
-module structure into `modm/docs`.
+This module creates the documentation groups and hierarchy according to
+the modm module structure into `modm/docs`.
+
+The documentation can be generated using Doxygen or Doxypress.
+
+## Doxygen
 
 To generate the C++ documentation call Doxygen manually:
 
 ```
 (cd modm/docs && doxygen doxyfile.cfg)
+```
+
+Then open `modm/docs/html/index.html` in your web browser of choice.
+
+## Doxypress
+
+[Install Doxypress.](https://www.copperspice.com/docs/doxypress/install-doxypress.html)
+
+To generate the C++ documentation call Doxypress:
+
+```
+(cd modm/docs && doxypress doxypress.json)
 ```
 
 Then open `modm/docs/html/index.html` in your web browser of choice.

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Niklas Hauser
+# Copyright (c) 2018-2019, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+import shutil
+import lbuild
+import zipfile
+import tempfile
+import argparse
+import datetime
+import multiprocessing
+import os, sys
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+from collections import defaultdict
+
+def repopath(path):
+    return Path(__file__).absolute().parents[2] / path
+def relpath(path):
+    return os.path.relpath(path, str(repopath(".")))
+
+sys.path.append(str(repopath("ext/modm-devices/tools/device")))
+from modm_devices.device_identifier import *
+
+
+def get_targets():
+    builder = lbuild.api.Builder()
+    builder._load_repositories(repopath("repo.lb"))
+    option = builder.parser.find_option(":target")
+    ignored = list(filter(lambda d: "#" not in d, repopath("test/all/ignored.txt").read_text().strip().splitlines()))
+    raw_targets = sorted(d for d in option.values if not any(d.startswith(i) for i in ignored))
+    minimal_targets = defaultdict(list)
+
+    for target in raw_targets:
+        option.value = target
+        target = option.value._identifier
+        short_id = target.copy()
+
+        if target.platform == "avr":
+            short_id.naming_schema = short_id.naming_schema \
+                .replace("{type}-{speed}{package}", "") \
+                .replace("-{speed}{package}", "")
+
+        elif target.platform == "stm32":
+            short_id.naming_schema = "{platform}{family}{name}"
+
+        elif target.platform == "hosted":
+            short_id.naming_schema = "{platform}"
+
+        short_id.set("platform", target.platform) # invalidate caches
+        minimal_targets[short_id.string].append(target)
+
+    target_list = []
+
+    # Force "hosted-linux" for hosted target family
+    minimal_targets["hosted"] = list(filter(lambda d: "linux" in d.string, minimal_targets["hosted"]))
+
+    for key, values in minimal_targets.items():
+        target_list.append(sorted(values, key=lambda d: d.string)[-1])
+
+    return target_list
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test", "-t", action='store_true', help="Test mode: generate only a few targets")
+    parser.add_argument("--jobs", "-j", type=int, default=2, help="Number of parallel doxygen processes")
+    parser.add_argument("--local-temp", "-l", action='store_true', help="Create temporary directory inside current working directory")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--compress", "-c", action='store_true', help="Compress output into gzip archive")
+    group.add_argument("--output", "-o", type=str, help="Output directory (absolute path)")
+    parser.add_argument("--overwrite", "-f", action='store_true', help="Overwrite existing data in output directory (Removes all files from output directory.)")
+    args = parser.parse_args()
+
+    device_list = []
+    if args.test:
+        # test list
+        device_list = ["hosted-linux", "at90can128-16ai", "stm32g474cet6"]
+    else:
+        device_list = get_targets()
+
+    template_path = os.path.realpath(os.path.dirname(sys.argv[0]))
+    cwd = Path().cwd()
+    if args.local_temp:
+        temp_dir = str(cwd)
+    else:
+        temp_dir = None
+    with tempfile.TemporaryDirectory(dir=temp_dir) as tempdir:
+        path_tempdir = Path(tempdir)
+        modm_path = os.path.abspath(os.path.dirname(sys.argv[0]) + "/../..")
+        print("Modm Path: {}".format(modm_path))
+        print("Temporary directory: {}".format(str(tempdir)))
+        output_dir = (path_tempdir / "output")
+        (output_dir / "develop/api").mkdir(parents=True)
+        os.chdir(tempdir)
+        print("Starting to generate documentation...")
+        template_overview(output_dir, device_list, template_path)
+        print("... for {} devices, estimated memory footprint is {} MB".format(len(device_list), (len(device_list)*70)+2000))
+        with multiprocessing.Pool(args.jobs) as pool:
+            # We can only pass one argument to pool.map
+            devices = ["{}|{}|{}".format(modm_path, path_tempdir, d) for d in device_list]
+            results = pool.map(create_target, devices)
+        # output_dir.rename(cwd / 'modm-api-docs')
+        if args.compress:
+            print("Zipping docs ...")
+            shutil.make_archive(str(cwd / 'modm-api-docs'), 'gztar', str(output_dir))
+        else:
+            final_output_dir = Path(args.output)
+            if args.overwrite:
+                for i in final_output_dir.iterdir():
+                    print('Removing {}'.format(i))
+                    if i.is_dir():
+                        shutil.rmtree(i)
+                    else:
+                        os.remove(i)
+            print('Moving {} -> {}'.format(output_dir, final_output_dir))
+            #shutil.move(str(output_dir) + '/', str(final_output_dir))
+            output_dir.rename(final_output_dir)
+        return results.count(False)
+
+
+def create_target(argument):
+    modm_path, tempdir, device = argument.split("|")
+    try:
+        tempdir = Path(tempdir)
+        print("Generating documentation for {} ...".format(device))
+        lbuild_options = '-r {1}/repo.lb -D "modm:target={0}" -p {0}/'.format(device, modm_path)
+        options = ''
+        if device.startswith("stm32"):
+            options += ' -m"modm:architecture:**" -m"modm:build:**" -m"modm:cmsis:**" -m"modm:communication:**" -m"modm:container:**" -m"modm:debug:**" -m"modm:docs:**" -m"modm:driver:**" -m"modm:fatfs:**" -m"modm:freertos:**" -m"modm:io:**" -m"modm:math:**" -m"modm:platform:**" -m"modm:processing:**" -m"modm:ros:**" -m"modm:tlsf:**" -m"modm:ui:**" -m"modm:unittest:**" -m"modm:utils"'
+        elif device.startswith("at"):
+            lbuild_options += ' -D"modm:platform:clock:f_cpu=16000000"'
+            options += ' -m"modm:**"'
+        else:
+            options += ' -m"modm:**"'
+        lbuild_command = 'lbuild {} build {}'.format(lbuild_options, options)
+        print('Executing: ' + lbuild_command)
+        os.system(lbuild_command)
+        print('Executing: (cd {}/modm/docs/ && doxypress doxypress.json)'.format(device))
+        os.system('(cd {}/modm/docs/ && doxypress doxypress.json > /dev/null 2>&1)'.format(device))
+        (tempdir / device / "modm/docs/html").rename(tempdir / 'output/develop/api' / device)
+        print("Finished generating documentation for device {}.".format(device))
+        return True
+    except:
+        print("Error generating documentation for device {}.".format(device))
+        return False
+
+
+def template_overview(output_dir, device_list, template_path):
+    html = Environment(loader=FileSystemLoader(template_path)).get_template("docs_modm_io_index.html.in").render(
+        devices=device_list,
+        date=datetime.datetime.now().strftime("%d.%m.%Y, %H:%M"),
+        num_devices=len(device_list))
+    with open(str(output_dir) + "/index.html","w+") as f:
+        f.write(html)
+    with open(str(output_dir) + "/robots.txt","w+") as f:
+        robots_txt = "User-agent: *\nDisallow: /\n"""
+        f.write(robots_txt)
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/tools/scripts/docs_modm_io_index.html.in
+++ b/tools/scripts/docs_modm_io_index.html.in
@@ -1,0 +1,231 @@
+<!doctype html>
+<html>
+<head>
+    <title>doc.modm.io API</title>
+    <meta charset="utf-8">
+
+<style type="text/css">
+body {
+    font-family: "Ubuntu", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    text-align: center;
+    padding: 0;
+    margin: 0;
+}
+header {
+    background-color: #3f51b5;
+    color: #fff;
+    padding: 0px;
+}
+table {
+    margin: auto;
+}
+td {
+    padding: 0em 0.5em;
+}
+
+*{
+    box-sizing: border-box;
+}
+.autocomplete {
+    position: relative;
+    display: inline-block;
+}
+input, select {
+    border: 1px solid transparent;
+    background-color: #f1f1f1;
+    padding: 10px;
+    font-size: 16px;
+    width: 100%;
+    border-width: 2px;
+    border-color: #fff;
+}
+input[type=text] {
+    background-color: #f1f1f1;
+    width: 100%;
+    text-transform: uppercase;
+}
+input[type=text]::placeholder {
+    text-transform: none;
+}
+input[type=submit] {
+    background-color: #3f51b5;
+    color: #fff;
+}
+.autocomplete-items {
+    position: absolute;
+    border: 1px solid #d4d4d4;
+    border-bottom: none;
+    border-top: none;
+    z-index: 99;
+    top: 100%;
+    left: 0;
+    right: 0;
+    text-transform: uppercase;
+}
+.autocomplete-items div {
+    padding: 10px;
+    cursor: pointer;
+    background-color: #fff;
+    border-bottom: 1px solid #d4d4d4;
+}
+.autocomplete-items div:hover {
+    background-color: #e9e9e9;
+}
+.autocomplete-active {
+    background-color: DodgerBlue !important;
+    color: #ffffff;
+}
+</style>
+</head>
+<body>
+<header>
+<a id="h1" href="https://modm.io/">
+<img style="height: 10em;" src="https://modm.io/images/logo.svg">
+</a>
+<h1>API documentation</h1>
+</header>
+<main>
+<p id="numtargets">Documentation is available for {{ num_devices }} devices.</p>
+<h3>Select your target:</h3>
+<form autocomplete="off" action="javascript:showDocumentation()">
+<table>
+    <tr>
+        <td>Version/Release</td>
+        <td>Microcontroller</td>
+        <td>&nbsp;</td>
+    </tr>
+    <tr>
+        <td>
+            <select id="releaseinput" name="releases">
+                <option>develop</option>
+            </select>
+        </td>
+        <td>
+            <div class="autocomplete" style="width:300px;">
+                <input id="targetinput" type="text" name="target" placeholder="Type e.g. 'F407'">
+            </div>
+        </td>
+        <td>
+            <input type="submit" value="Show Documentation">
+        </td>
+    </tr>
+</table>
+</form>
+<br />
+<small>For most microcontrollers-sub-families only the variant with largest pin-count and memory is available.</small>
+<p>Last updated: {{ date }}</p>
+
+<script type="text/javascript">
+var devices = [
+{% for d in devices %}
+"{{ d }}",
+{% endfor %}
+];
+var targetinput = document.getElementById("targetinput");
+var currentFocus;
+function showDocumentation() {
+    if(!targetinput.value) {
+        targetinput.style.transition = "border 5ms ease-out";
+        targetinput.style.borderColor = "red";
+        setTimeout(function(){
+            targetinput.style.transition = "border 5000ms ease-out";
+            targetinput.style.borderColor = "#fff";
+        }, 5000);
+        return;
+    }
+    if(!releaseinput.value) {
+        releaseinput.style.transition = "border 5ms ease-out";
+        releaseinput.style.borderColor = "red";
+        setTimeout(function(){
+            releaseinput.style.transition = "border 5000ms ease-out";
+            releaseinput.style.borderColor = "#fff";
+        }, 5000);
+        return;
+    }
+    var url = "/" + releaseinput.value + "/api/" + targetinput.value + "/";
+    location.href = url;
+}
+targetinput.addEventListener("input", function(event) {
+    var a, b, i, val = this.value;
+    closeAllLists();
+    if (!val) { return false;}
+    currentFocus = -1;
+    a = document.createElement("DIV");
+    a.setAttribute("id", this.id + "autocomplete-list");
+    a.setAttribute("class", "autocomplete-items");
+    this.parentNode.appendChild(a);
+    for (i = 0; i < devices.length; i++) {
+        var regex = RegExp(val.toLowerCase());
+        if (devices[i].toLowerCase().match(regex) != null) {
+            b = document.createElement("DIV");
+            b.innerHTML = devices[i].replace(regex, function(str) { return "<strong>" + str + "</strong>" })
+            b.innerHTML += "<input type='hidden' value='" + devices[i] + "'>";
+            b.addEventListener("click", function(event) {
+                targetinput.value = this.getElementsByTagName("input")[0].value;
+                closeAllLists();
+            });
+            a.appendChild(b);
+        }
+    }
+});
+targetinput.addEventListener("keydown", function(event) {
+    var list = document.getElementById(this.id + "autocomplete-list");
+    if (list) {
+        list = list.getElementsByTagName("div");
+    }
+    if (event.keyCode == 40) { // down key
+        currentFocus++;
+        makeItemActive(list);
+    } else if (event.keyCode == 38) { // up key
+        currentFocus--;
+        makeItemActive(list);
+    } else if (event.keyCode == 13) { // enter key
+        event.preventDefault();
+        if (currentFocus > -1) {
+            /*and simulate a click on the "active" item:*/
+            if (list) {
+                list[currentFocus].click();
+            }
+        }
+    }
+});
+function removeActiveFromList(list) {
+    for (var i = 0; i < list.length; i++) {
+        list[i].classList.remove("autocomplete-active");
+    }
+}
+function makeItemActive(list) {
+    if (!list) return false;
+    removeActiveFromList(list);
+    if (currentFocus >= list.length) {
+        currentFocus = 0;
+    }
+    if (currentFocus < 0) {
+        currentFocus = (list.length - 1);
+    }
+    list[currentFocus].classList.add("autocomplete-active");
+}
+function closeAllLists(element) {
+    var items = document.getElementsByClassName("autocomplete-items");
+    for (var i = 0; i < items.length; i++) {
+        if (element != items[i] && element != targetinput) {
+            items[i].parentNode.removeChild(items[i]);
+        }
+    }
+}
+document.addEventListener("click", function (element) {
+    closeAllLists(element.target);
+});
+</script>
+<noscript>
+<h3>Select your target</h3>
+<input type="text" id="input" placeholder="Type e.g. 'F407'" />
+<ul>
+{% for d in devices %}
+ <li id="{{ d }}"><a href="/develop/api/{{ d }}/">{{ d }}</a></li>
+{% endfor %}
+</ul>
+</noscript>
+</main>
+</body>
+</html>

--- a/tools/scripts/generate_module_docs.py
+++ b/tools/scripts/generate_module_docs.py
@@ -32,8 +32,8 @@ import lbuild
 def get_modules(builder, limit=None):
     builder._load_repositories(repopath("repo.lb"))
     option = builder.parser.find_option(":target")
-
-    raw_targets = list(set(option.values) - set(d for d in repopath("test/all/ignored.txt").read_text().strip().splitlines() if "#" not in d))
+    ignored = list(filter(lambda d: "#" not in d, repopath("test/all/ignored.txt").read_text().strip().splitlines()))
+    raw_targets = sorted(d for d in option.values if not any(d.startswith(i) for i in ignored))
 
     # Reduce device set a little to keep RAM usage in check
     # this should ~half the considered devices


### PR DESCRIPTION
Doxygen documentation is available here:
# [docs.modm.io](https://docs.modm.io/)

- [x] Script to batch-generate Doxygen documentation for all relevant targets. (Only the largest package and the largest memory for each series)
- [x] Automated updating: Daily.
- [x] Update target device list.
- [x] Hosting on https://doc.modm.io/; ~server provided by @roboterclubaachen, thanks!~ hosting on my server.
- [x] Optional/Later:
  - [x] Beautify frontpage with some CSS :wink:
  - [x] ~Fix Doxygen settings: SVG images, relative paths~
  - [x] ~Use of https://mcss.mosra.cz/documentation/doxygen/~ Does not work out of the box :unamused: 
- [x] Replace Doxygen with Doxypress
- [x] Automated building in a CI job (and deploy to server)