### PR TITLE
[scons] fix Windows path handling in "program"

### DIFF
--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -35,10 +35,10 @@ def build_target(env, sources):
 	env.Alias("artifact", env.CacheArtifact(program))
 
 		%% if upload_with_artifact
-	env.Alias("program", [env.OpenOcd(program, commands=["modm_program $SOURCE"]), "artifact"])
+	env.Alias("program", [env.OpenOcd(program, commands=["modm_program {$SOURCE}"]), "artifact"])
 	env.Alias("bmp", [env.BlackMagicProbe(program), "artifact"])
 		%% else
-	env.Alias("program", env.OpenOcd(program, commands=["modm_program $SOURCE"]))
+	env.Alias("program", env.OpenOcd(program, commands=["modm_program {$SOURCE}"]))
 	env.Alias("bmp", env.BlackMagicProbe(program))
 		%% endif
 


### PR DESCRIPTION
The backslashes in a Windows-style path weren't interpreted correctly when passing the source path to openocd. This caused the following beautiful error:

![image](https://user-images.githubusercontent.com/3310349/64598758-1cd30c00-d36d-11e9-9bce-ab50fe978f9f.png)

The strange line rewriting in the error message was enough to convince me to go learn Tcl and start escaping stuff.