### PR TITLE
Fixed condition in I2C ISR for continued writes

### DIFF
--- a/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
@@ -422,7 +422,8 @@ MODM_ISR(I2C{{ id }}_EV)
 
 		if (writing.length == 0)
 		{
-			if (nextOperation == modm::I2c::Operation::Restart)
+			if ((nextOperation == modm::I2c::Operation::Restart) or
+				(nextOperation == modm::I2c::Operation::Write))
 			{
 				DEBUG_STREAM("Wait for TC IRQ");
 				I2C{{ id }}->CR1 |= I2C_CR1_TCIE;


### PR DESCRIPTION
Fixed the condition to wait for continued writes.
When a write operation followed by another write operation occurs, the ISR will falsely wait for a STOP condition, which will not be triggered as more data from the following write operation has to be transmitted.
This fix will wait for a TC interrupt if the next operation is a restart **or a write operation** and wait for a STOP interrupt otherwise

Fixes #290.