### PR TITLE
[build] Add CompilationDB module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ CMakeLists.txt
 
 # ignore generated code in the example folder
 examples/**/modm
+examples/**/compile_commands.json
 examples/**/SConstruct
 examples/**/Makefile
 examples/**/generated

--- a/tools/build_script_generator/compilation_db/module.lb
+++ b/tools/build_script_generator/compilation_db/module.lb
@@ -1,0 +1,100 @@
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+from os.path import join, relpath, isdir, exists
+
+with open(localpath("../common.py")) as common:
+    exec(common.read())
+
+def init(module):
+    module.name = ":build:compilation_db"
+    module.description = FileReader("module.md")
+
+def prepare(module, options):
+    module.add_collector(
+        CallableCollector(name="flag_format",
+                          description="Formatting compile flags for CompilationDB"))
+    return True
+
+
+def build(env):
+    def flag_format(flag):
+        subs = {
+            "target_base": "\"${TARGET.base}\"",
+            "linkdir": "\"modm/link\""
+        }
+        flag = '"{}"'.format(flag)
+        vals = ["{}={}".format(t, r) for t, r in subs.items() if "{{{}}}".format(t) in flag]
+        if len(vals):
+            flag = "{}.format({})".format(flag, ", ".join(vals))
+            return flag
+        return None
+
+    env.collect("flag_format", flag_format)
+
+
+def post_build(env):
+    repositories = [p for p in env.buildlog.repositories if isdir(env.real_outpath(p, basepath="."))]
+    repositories.sort(key=lambda name: "0" if name == "modm" else name)
+
+    subs = env.query("::device")
+
+    if subs["core"].startswith("cortex-m"):
+        # get memory information
+        subs["memories"] = env.query("::memories")
+    else:
+        subs["memories"] = []
+    # Add SCons specific data
+    subs.update({
+        "build_path": env.relative_outpath(env[":build:build.path"]),
+        "generated_paths": repositories,
+        "common_source_flag_map": common_source_flag_map,
+    })
+    if subs["platform"] == "avr":
+        subs.update(env.query("::avrdude_options"))
+    # Set these substitutions for all templates
+    env.substitutions = subs
+
+    sources = env.query("::source_files")
+    def flags_format(flag):
+        for fmt in env.collector_values("flag_format"):
+            nflag = fmt(flag)
+            if nflag: return nflag;
+        return '"{}"'.format(flag)
+
+    for repo in repositories:
+        files = []
+        repo_filter = lambda scope: scope.repository == repo
+        repo_flags = env.query("::collect_flags")(env, repo_filter)
+
+        for f in sources[repo]:
+            files.append( (f, repo_flags[f]) )
+
+        include_paths = env.collector_values("::path.include", filterfunc=repo_filter)
+        libary_paths = env.collector_values("::path.library", filterfunc=repo_filter)
+        libaries = env.collector_values("::library", filterfunc=repo_filter)
+
+        subs.update({
+            "repo": repo,
+            "flags": repo_flags[None],
+            "sources": files,
+            "libraries": libaries,
+            "library_paths": libary_paths,
+            "include_paths": include_paths,
+            "is_modm": repo == "modm",
+        })
+        # Generate library SConscript
+        env.outbasepath = repo
+        env.template("resources/compilation_db.py.in", "compilation_db.py",
+                     filters={"flags_format": flags_format,
+                              "relocate": lambda p: env.relative_outpath(p, repo)})
+
+    # these are the ONLY files that are allowed to NOT be namespaced with modm!
+    env.outbasepath = "modm/tools"
+    env.template("resources/builder_compilation_db.py.in", "builder_compilation_db.py")

--- a/tools/build_script_generator/compilation_db/module.md
+++ b/tools/build_script_generator/compilation_db/module.md
@@ -1,0 +1,42 @@
+# CompilationDB Generator
+
+This module generates a Python script that generates a CompilationDB file, which
+allows you to import your project into a code editor like CLion or Qt Creator
+with working code completion and enhanced refactoring.
+
+!!! note "CompilationDB is not a build system replacement"
+	CompilationDB support is currently only implemented as an import mechanism
+	in all IDEs, it cannot be used to compile *AND LINK* your application
+	correctly. Use a proper build system for that purpose.
+
+Since the CompilationDB requires absolute paths making it difficult to share
+with other users, this module instead generates a script that you can call
+whenever you need to generate a new `compile_commands.json` file.
+
+The script takes are argument the application folder or files that it should
+include. The search is recursive and looks only for source files while
+ignoring any generated files:
+
+```sh
+# When calling this from where project.xml is located
+# adding all sources contained in the current folder
+python3 modm/tools/builder_compilation_db.py .
+```
+
+To generate the CompilationDB for debug mode, use the `--debug` option:
+
+```sh
+# You can also add individual files
+python3 modm/tools/builder_compilation_db.py --debug main.cpp
+```
+
+## SCons integration
+
+When including this module together with the `modm:build:scons` module, a new
+command is added to SCons, which wraps the above command line invocation.
+
+```sh
+# This command safely wraps the generation script
+scons compilation_db profile=release
+scons compilation_db profile=debug
+```

--- a/tools/build_script_generator/compilation_db/resources/builder_compilation_db.py.in
+++ b/tools/build_script_generator/compilation_db/resources/builder_compilation_db.py.in
@@ -1,0 +1,115 @@
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os, re, json, sys
+from collections import defaultdict
+from pathlib import Path
+
+env = defaultdict(list)
+
+env["CONFIG_PROJECT_NAME"] = "{{ options[":build:project.name"] }}"
+env["CONFIG_BUILD_BASE"] = "{{ build_path }}"
+env["CONFIG_BUILD_PROFILE"] = "debug" if "--debug" in sys.argv else "release"
+
+env["BUILDPATH"] = os.path.join(env["CONFIG_BUILD_BASE"], env["CONFIG_BUILD_PROFILE"])
+env["BASEPATH"] = os.path.abspath(".")
+
+generated_paths = {{ generated_paths }}
+
+for path in generated_paths:
+    with open("{}/compilation_db.py".format(path)) as compfile:
+        exec(compfile.read())
+
+source_flag_map = {{common_source_flag_map}}
+env["CPPDEFINES"] = map(lambda d: "-D"+d, env["CPPDEFINES"])
+
+# Search for application files
+project_files = set(sys.argv[1:])
+project_files.update(set(str(f) for p in project_files for f in Path(p).glob("**/*")))
+project_files = set(f for f in project_files if os.path.isfile(f) and
+                     any(re.search(pat, os.path.splitext(f)[-1]) for (pat, _) in source_flag_map.items()))
+project_files -= set(str(f) for p in generated_paths for f in Path(p).glob("**/*"))
+print("Generating CompilationDB with these application sources:\n- " + "\n- ".join(sorted(list(project_files))))
+
+commands = []
+env["FILES"].extend([(f, {}) for f in sorted(list(project_files))])
+# Compile all files to object files
+for file, fileflags in env["FILES"]:
+    suffix = os.path.splitext(file)[-1]
+    ftype, flagkeys = [(t,list(map(lambda s: s.upper(), f)))
+                        for t,(p,f) in source_flag_map.items()
+                            if re.search(p, suffix)][0]
+    if "CPPDEFINES" in fileflags:
+        fileflags["CPPDEFINES"] = map(lambda d: "-D"+d, fileflags["CPPDEFINES"])
+    flags = [f for key in flagkeys for f in env[key]]
+    flags.extend([f for key,flags in fileflags.items() if key in flagkeys
+                    for f in flags])
+
+    # print(fileflags, ftype, flagkeys, flags)
+
+    subs = {
+        "TOOL": {"c": env["CC"], "cpp": env["CXX"], "asm": env["CC"]}[ftype],
+        "BUILDPATH": env["BUILDPATH"],
+        "OBJECT": os.path.splitext(file)[0] + ".o",
+        "FILE": file,
+        "INCLUDE_PATHS": " ".join(map(lambda p: "-I"+os.path.relpath(p), env["CPPPATH"])),
+        "FLAGS": " ".join(flags),
+    }
+
+    command = "{TOOL} -o {BUILDPATH}/{OBJECT} -c {FLAGS} {INCLUDE_PATHS} {FILE}".format(**subs)
+    commands.append({
+        "command": command,
+        "directory": env["BASEPATH"],
+        "file": file,
+    })
+
+# CompilationDB does not support linking yet!
+"""
+# Archive all static libraries
+for lib, files in env["STATIC_LIBS"]:
+    subs = {
+        "TOOL": env["AR"],
+        "BUILDPATH": env["BUILDPATH"],
+        "LIBRARY": lib,
+        "FILES": " ".join(map(lambda file: "{}/{}.o".format(env["BUILDPATH"], os.path.splitext(file)[0]), files)),
+    }
+    command = "{TOOL} rc {BUILDPATH}/{LIBRARY} {FILES}".format(**subs)
+    commands.append({
+        "command": command,
+        "directory": env["BASEPATH"],
+        "file": join(env["BUILDPATH"], lib),
+    })
+
+    subs["TOOL"] = env["RANLIB"]
+    command = "{TOOL} {BUILDPATH}/{LIBRARY}".format(**subs)
+    commands.append({
+        "command": command,
+        "directory": env["BASEPATH"],
+        "file": join(env["BUILDPATH"], lib),
+    })
+
+# Link the entire executable
+subs = {
+    "TOOL": env["LINK"],
+    "BUILDPATH": env["BUILDPATH"],
+    "CONFIG_PROJECT_NAME": env["CONFIG_PROJECT_NAME"],
+    "FLAGS": " ".join(env["LINKFLAGS"]),
+    "FILES": " ".join(map(lambda file: "{}/{}.o".format(env["BUILDPATH"], os.path.splitext(file)[0]), project_files)),
+    "LIBPATHS": " ".join(map(lambda path: "{}/{}".format(env["BUILDPATH"], path), env["LIBPATH"])),
+    "LIBS": " ".join(map(lambda lib: "lib{}.a".format(lib), env["LIBS"])),
+}
+command = "{TOOL} {BUILDPATH}/{CONFIG_PROJECT_NAME}.elf {FLAGS} {FILES} {LIBPATHS} " \
+          "-Wl,--whole-archive -Wl,--start-group {LIBS} -Wl,--end-group -Wl,--no-whole-archive"
+commands.append({
+    "command": command.format(**subs),
+    "directory": env["BASEPATH"],
+    "file": join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".elf"),
+})
+"""
+
+Path("compile_commands.json").write_text(json.dumps(commands, indent=4, sort_keys=True))

--- a/tools/build_script_generator/compilation_db/resources/compilation_db.py.in
+++ b/tools/build_script_generator/compilation_db/resources/compilation_db.py.in
@@ -1,0 +1,124 @@
+# Copyright (c) 2019, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from os.path import join, abspath
+import sys, shutil
+
+profile = env["CONFIG_BUILD_PROFILE"]
+
+%% if is_modm
+%% if core.startswith("avr")
+env["COMPILERPREFIX"] = "avr-"
+%% elif core.startswith("cortex-m")
+env["COMPILERPREFIX"] = "arm-none-eabi-"
+%% else
+%% if family == "darwin"
+# Using homebrew gcc on macOS instead of clang
+env["COMPILERSUFFIX"] = next(c[3:] for c in ["gcc-9", "gcc-8", "gcc-7"] if shutil.which(c) is not None)
+%% endif
+%% endif
+
+path = env.get("COMPILERPATH", "")
+prefix = env.get("COMPILERPREFIX", "")
+suffix = env.get("COMPILERSUFFIX", "")
+if suffix != "" and not suffix.startswith("-"):
+    suffix = "-" + suffix
+prefix = path + prefix
+env["CC"] = prefix + "gcc" + suffix
+env["CXX"] = prefix + "g++" + suffix
+env["AR"] = prefix + "ar"
+env["RANLIB"] = prefix + "ranlib"
+if suffix == "":
+    env["AS"] = prefix + "as"
+    env["NM"] = prefix + "nm"
+else:
+    env["AS"] = prefix + "gcc" + suffix
+    env["NM"] = prefix + "gcc-nm" + suffix
+    if sys.platform != "darwin":
+        env["AR"] = prefix + "gcc-ar" + suffix
+        env["RANLIB"] = prefix + "gcc-ranlib" + suffix
+env["OBJCOPY"] = prefix + "objcopy"
+env["OBJDUMP"] = prefix + "objdump"
+env["SIZE"] = prefix + "size"
+env["STRIP"] = prefix + "strip"
+env["LINK"] = env["CXX"]
+
+%% endif
+
+%% macro generate_flags_for_profile(name, profile, append=False)
+env["{{name | upper}}"]{% if append %}.extend({% else %} = {% endif %}[
+%% for flag in flags[name][profile] | sort
+    {{ flag | flags_format }},
+%% endfor
+]{% if append %}){% endif -%}
+%% endmacro
+
+%% macro generate_flags(name, append=False)
+%% if not append or flags[name][""] | length
+{{ generate_flags_for_profile(name, "", append) }}
+%% endif
+%% for profile in flags[name].keys()
+%% if profile != "" and flags[name][profile] | length
+if profile == "{{ profile }}":
+    {{ generate_flags_for_profile(name, profile, True) | lbuild.indent(4) }}
+%% endif
+%% endfor
+%% endmacro
+
+# Toolchain configuration
+{{ generate_flags("cppdefines", True) }}
+{{ generate_flags("ccflags", not is_modm) }}
+{{ generate_flags("cflags", not is_modm) }}
+{{ generate_flags("cxxflags", not is_modm) }}
+{{ generate_flags("asflags", not is_modm) }}
+{{ generate_flags("linkflags", not is_modm) }}
+{{ generate_flags("archflags", not is_modm) }}
+
+env["CPPPATH"].extend([
+%% for path in include_paths | sort
+    abspath(r"{{ path | modm.windowsify(escape_level=0) }}"),
+%% endfor
+])
+
+env["FILES"].extend([
+%% for file, flags in sources if not flags | length
+    (r"{{ file | modm.windowsify(escape_level=0) }}", {}),
+%% endfor
+])
+%% for file, flags in sources
+    %% if flags | length
+flags = { {%- for key, profiles in flags.items() if "" in profiles %}"{{ key | upper }}": {{profiles[""]}}, {% endfor -%} }
+    %% for key, profiles in flags.items()
+        %% for profile, flags in profiles.items() if "" != profile
+if profile == "{{profile}}": flags["{{ key | upper }}"].extend({{flags}});
+        %% endfor
+    %% endfor
+env["FILES"].append( (r"{{ file | modm.windowsify(escape_level=0) }}", flags) )
+    %% endif
+%% endfor
+
+env["STATIC_LIBS"].append(
+    ("{{repo}}/lib{{repo}}.a", [
+%% for file, flags in sources
+        r"{{ file | modm.windowsify(escape_level=0) }}",
+%% endfor
+    ])
+)
+
+env["LIBS"].extend([
+    "{{repo}}",
+%% for library in libraries | sort
+    "{{ library }}",
+%% endfor
+])
+env["LIBPATH"].extend([
+    abspath(join(env["BUILDPATH"], "{{repo}}")),
+%% for library in library_paths | sort
+    abspath(r"{{ library | modm.windowsify(escape_level=0) }}"),
+%% endfor
+])

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -143,6 +143,7 @@ def build(env):
     # Generate the env.BuildTarget tool
     env.substitutions = env.query("::device")
     env.substitutions["upload_with_artifact"] = env.has_module(":crashcatcher")
+    env.substitutions["with_compilation_db"] = env.has_module(":build:compilation_db")
     env.outbasepath = "modm/scons/site_tools"
     env.template("resources/build_target.py.in", "build_target.py")
 

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -11,7 +11,7 @@
 from os.path import join, abspath
 Import("env")
 
-profile = ARGUMENTS.get("profile", "release")
+profile = env["CONFIG_PROFILE"]
 %% if is_modm
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
 env["BASEPATH"] = abspath(".")

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -23,6 +23,7 @@ CacheDir("{{ cache_dir }}")
 env = DefaultEnvironment(tools=[], ENV=os.environ)
 env["CONFIG_BUILD_BASE"] = abspath(build_path)
 env["CONFIG_PROJECT_NAME"] = project_name
+env["CONFIG_PROFILE"] = ARGUMENTS.get("profile", "release")
 
 # Building all libraries
 env.SConscript(dirs=generated_paths, exports="env")

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -9,13 +9,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-from os.path import abspath
+from os.path import abspath, relpath
 
 def build_target(env, sources):
 	# Building application
 	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+".elf", source=sources)
 
-	# SCons functions
+%% if with_compilation_db
+	env.Command("compile_commands.json", sources,
+	            "python3 modm/tools/builder_compilation_db.py --{} {}".format(
+	                env["CONFIG_PROFILE"], " ".join(relpath(env.File(s).srcnode().abspath) for s in env.Flatten(sources))))
+	env.Alias("compilation_db", "compile_commands.json")
+%% endif
+
 	env.Alias("qtcreator", env.QtCreatorProject(sources))
 	env.Alias("symbols", env.Symbols(program))
 	env.Alias("listing", env.Listing(program))


### PR DESCRIPTION
This adds the `modm:build:compilation_db` as another build script generator module.

The code is loosely structured like the SConscript code, so there are `{repo}/compilation_db.py` files that are called by the "SConstruct" script in `modm/tools/builder_compilation_db.py`, and they place all their library specific code into a dictionary called `env`. Sounds familiar? I basically wrote a shitty version of SCons.

To create the `compile_commands.json` file you currently have to manually call the script:
```
lbuild build -m ::compilation_db
python3 modm/tools/builder_compilation_db.py
```

Tested this with Qt Creator, it works really well!

TODO: 
- [x] Understand if you can somehow remove the absolute path in the `directory` key: NO
- [x] Understand if CompilationDB can actually link applications: NO
- [x] Add code to search for application sources, currently `main.cpp` is hardcoded.
- [x] Add profile generation, currently only "release" profile is generated
- [x] Add some a better interface (Makefile?) to manage DB creation.
- [x] AVR support
- [x] STM32 support
- [x] Hosted support

cc @ASMfreaK @rleh @dergraaf