### PR TITLE
[stm32] Add support for the STM32L1 family

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,10 @@ jobs:
           command: |
             (cd examples && ../tools/scripts/examples_compile.py nucleo_g071rb)
       - run:
+          name: Examples STM32L1 Series
+          command: |
+            (cd examples && ../tools/scripts/examples_compile.py nucleo_l152re)
+      - run:
           name: Examples STM32L4 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,23 @@ jobs:
           path: test/all/log
           destination: log
 
+  stm32l1-compile-all:
+    docker:
+      - image: modm/modm-build:latest
+    steps:
+      - checkout
+      - run:
+          name: Checkout code and update modm tools
+          command: |
+            (git submodule sync && git submodule update --init --jobs 8) & pip3 install --upgrade modm & wait
+      - run:
+          name: Compile HAL for all STM32L1
+          command: |
+            (cd test/all && python3 run_all.py stm32l1)
+      - store_artifacts:
+          path: test/all/log
+          destination: log
+
   stm32l4-compile-all:
     docker:
       - image: modm/modm-build:latest
@@ -376,6 +393,10 @@ workflows:
           requires:
             - unittests-linux-generic
             - stm32-examples
+      - stm32l1-compile-all:
+          requires:
+            - unittests-linux-generic
+            - stm32-examples
       - stm32l4-compile-all:
           requires:
             - unittests-linux-generic
@@ -394,6 +415,7 @@ workflows:
             - stm32f4-compile-all
             - stm32f7-compile-all
             - stm32g0-compile-all
+            - stm32l1-compile-all
             - stm32l4-compile-all
       - build-docs:
           requires:

--- a/README.md
+++ b/README.md
@@ -127,24 +127,25 @@ documentation.
 </tr><tr>
 <td align="center">DISCO-F746NG</td>
 <td align="center">DISCO-F769NI</td>
+<td align="center">DISCO-L152RC</td>
 <td align="center">DISCO-L476VG</td>
-<td align="center">NUCLEO-F031K6</td>
 </tr><tr>
+<td align="center">NUCLEO-F031K6</td>
 <td align="center">NUCLEO-F042K6</td>
 <td align="center">NUCLEO-F103RB</td>
 <td align="center">NUCLEO-F303K8</td>
-<td align="center">NUCLEO-F401RE</td>
 </tr><tr>
+<td align="center">NUCLEO-F401RE</td>
 <td align="center">NUCLEO-F411RE</td>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
-<td align="center">NUCLEO-G071RB</td>
 </tr><tr>
+<td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
-<td align="center">OLIMEXINO-STM32</td>
 </tr><tr>
+<td align="center">OLIMEXINO-STM32</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -70,16 +70,17 @@ git clone --recurse-submodules https://github.com/modm-io/modm.git
 
 ## Targets
 
-modm can generate code for <!--avrcount-->78<!--/avrcount--> AVR and <!--stmcount-->958<!--/stmcount-->
+modm can generate code for <!--avrcount-->78<!--/avrcount--> AVR and <!--stmcount-->1039<!--/stmcount-->
 STM32 devices, however, there are different levels of support and testing.
 
 <center>
 
 | Device Family | Support | Device Family | Support | Device Family | Support |
 |:--------------|:--------|:--------------|:--------|:--------------|:--------|
-| AVR           | ★★★     | STM32F2       | ★★★     | STM32F7       | ★★★★    |
-| STM32F0       | ★★★★    | STM32F3       | ★★★★★   | STM32L4       | ★★★★    |
-| STM32F1       | ★★★★    | STM32F4       | ★★★★★   | STM32G0       | ★★★★    |
+| AVR           | ★★★     | STM32F0       | ★★★★    | STM32F1       | ★★★★    |
+| STM32F2       | ★★★★    | STM32F3       | ★★★★★   | STM32F4       | ★★★★★   |
+| STM32F7       | ★★★★    | STM32L1       | ★★★★    | STM32L4       | ★★★★    |
+| STM32L4+      | ★★★★    | STM32G0       | ★★★★    |
 
 </center>
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ documentation.
 <td align="center">NUCLEO-F446RE</td>
 <td align="center">NUCLEO-G071RB</td>
 </tr><tr>
+<td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
-<td align="center">STM32F030F4P6-DEMO</td>
 </tr><tr>
+<td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/nucleo_l152re/blink/main.cpp
+++ b/examples/nucleo_l152re/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delayMilliseconds(Button::read() ? 100 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l152re/blink/project.xml
+++ b/examples/nucleo_l152re/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-l152re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l152re/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/stm32l1_discovery/blink/main.cpp
+++ b/examples/stm32l1_discovery/blink/main.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	uint8_t counter{0};
+	while (true)
+	{
+		Leds::write(1ul << (counter++ % Leds::width));
+		modm::delayMilliseconds(Button::read() ? 500 : 1000);
+	}
+
+	return 0;
+}

--- a/examples/stm32l1_discovery/blink/project.xml
+++ b/examples/stm32l1_discovery/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:disco-l152rc</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/disco_l152rc/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/repo.lb
+++ b/repo.lb
@@ -83,7 +83,7 @@ class DevicesCache(dict):
         # roughly filter to supported devices
         supported = ["stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
                      "stm32g0",
-                     "stm32l4",
+                     "stm32l1", "stm32l4",
                      "at90", "attiny", "atmega",
                      "hosted"]
         device_file_names = [dfn for dfn in device_file_names if any(s in dfn for s in supported)]

--- a/src/modm/board/disco_l152rc/board.hpp
+++ b/src/modm/board/disco_l152rc/board.hpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_disco_l152rc
+namespace Board
+{
+using namespace modm::literals;
+
+/// STM32L152RC running at 32MHz generated from the external 8MHz ST-Link clock
+// Dummy clock for devices
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 32_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc    = Apb2;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Usart4 = Apb1;
+	static constexpr uint32_t Usart5 = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		// Enable power scaling for 1.8V
+		PWR->CR = (PWR->CR & ~PWR_CR_VOS) | PWR_CR_VOS_0;
+		while(PWR->CSR & PWR_CSR_VOSF) ;
+
+		/* From RM0038: 6.2.7 System clock (SYSCLK) selection (page ~135)
+		 *
+		 * The SYSCLK frequency change has to follow the rule that the final
+		 * frequency is less then 4 x initial frequency to limit the VCORE drop
+		 * due to a current consumption peak when the frequency increases. It
+		 * must also respect 5 μs delay between two changes.
+		 *
+		 * For example to switch from 2.1 MHz to 32 MHz, the user can switch
+		 * from 2.1 MHz to 8 MHz, wait 5 μs, then switch from 8 MHz to 32 MHz.
+		 */
+
+		Rcc::setFlashLatency<4.1_MHz>();
+		Rcc::updateCoreFrequency<4.1_MHz>();
+		Rcc::enableMultiSpeedInternalClock(Rcc::MsiFrequency::MHz4);
+		modm::delayMicroseconds(5);
+
+		Rcc::enableInternalClock();	// 16MHz
+		// set flash latency
+		Rcc::setFlashLatency<16_MHz>();
+		// switch system clock to HSE output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Hsi);
+		Rcc::updateCoreFrequency<16_MHz>();
+		modm::delayMicroseconds(5);
+
+		// internal clock 8MHz * 8 / 2 = 32MHz => bad for USB
+		Rcc::enablePll(Rcc::PllSource::InternalClock, Rcc::PllMultiplier::Mul4, 2);
+		// set flash latency
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		// All busses max. 32MHz
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+
+		return true;
+	}
+};
+
+using Button = GpioInputA0;
+using LedBlue = GpioOutputB6;
+using LedGreen = GpioOutputB7;
+
+using Leds = SoftwareGpioPort< LedBlue, LedGreen >;
+
+namespace lcd
+{
+using Com0 = GpioOutputA8;
+using Com1 = GpioOutputA9;
+using Com2 = GpioOutputA10;
+using Com3 = GpioOutputB9;
+
+using Seg0 = GpioOutputA1;
+using Seg1 = GpioOutputA2;
+using Seg2 = GpioOutputA3;
+using Seg7 = GpioOutputB3;
+using Seg8 = GpioOutputB4;
+using Seg9 = GpioOutputB5;
+using Seg10 = GpioOutputB10;
+using Seg11 = GpioOutputB11;
+using Seg12 = GpioOutputB12;
+using Seg13 = GpioOutputB13;
+using Seg14 = GpioOutputB14;
+using Seg15 = GpioOutputB15;
+using Seg16 = GpioOutputB8;
+using Seg17 = GpioOutputA15;
+using Seg18 = GpioOutputC0;
+using Seg19 = GpioOutputC1;
+using Seg20 = GpioOutputC2;
+using Seg21 = GpioOutputC3;
+using Seg24 = GpioOutputC6;
+using Seg25 = GpioOutputC7;
+using Seg26 = GpioOutputC8;
+using Seg27 = GpioOutputC9;
+using Seg28 = GpioOutputC10;
+using Seg29 = GpioOutputC11;
+}
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedGreen::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+}
+
+}

--- a/src/modm/board/disco_l152rc/board.xml
+++ b/src/modm/board/disco_l152rc/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32l152rct</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:disco-l152rc</module>
+  </modules>
+</library>

--- a/src/modm/board/disco_l152rc/module.lb
+++ b/src/modm/board/disco_l152rc/module.lb
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:disco-l152rc"
+    module.description = """\
+# DISCO-L152RC
+
+[Discovery kit for STM32L152RC](https://www.st.com/en/evaluation-tools/32l152cdiscovery.html)
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32l152rct":
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": False}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.collect(":build:openocd.source", "board/stm32ldiscovery.cfg");

--- a/src/modm/board/nucleo_l152re/board.hpp
+++ b/src/modm/board/nucleo_l152re/board.hpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_l152re
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_l152re
+namespace Board
+{
+using namespace modm::literals;
+
+/// STM32L152RE running at 32MHz generated from the external 8MHz ST-Link clock
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 32_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc    = Apb2;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Usart4 = Apb1;
+	static constexpr uint32_t Usart5 = Apb1;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		// Enable power scaling for 1.8V
+		PWR->CR = (PWR->CR & ~PWR_CR_VOS) | PWR_CR_VOS_0;
+		while(PWR->CSR & PWR_CSR_VOSF) ;
+
+		/* From RM0038: 6.2.7 System clock (SYSCLK) selection (page ~135)
+		 *
+		 * The SYSCLK frequency change has to follow the rule that the final
+		 * frequency is less then 4 x initial frequency to limit the VCORE drop
+		 * due to a current consumption peak when the frequency increases. It
+		 * must also respect 5 μs delay between two changes.
+		 *
+		 * For example to switch from 2.1 MHz to 32 MHz, the user can switch
+		 * from 2.1 MHz to 8 MHz, wait 5 μs, then switch from 8 MHz to 32 MHz.
+		 */
+
+		// MCO from ST-Link
+		Rcc::enableExternalClock();	// 8MHz
+		// set flash latency
+		Rcc::setFlashLatency<8_MHz>();
+		// switch system clock to HSE output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Hse);
+		Rcc::updateCoreFrequency<8_MHz>();
+
+		// internal clock 8MHz * 8 / 2 = 32MHz => bad for USB
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, Rcc::PllMultiplier::Mul8, 2);
+		// set flash latency
+		Rcc::setFlashLatency<Frequency>();
+		modm::delayMicroseconds(5);
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		// All busses max. 32MHz
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo64_arduino.hpp"
+
+using Button = GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Button::setInput();
+}
+
+}

--- a/src/modm/board/nucleo_l152re/board.xml
+++ b/src/modm/board/nucleo_l152re/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32l152ret</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-l152re</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_l152re/module.lb
+++ b/src/modm/board/nucleo_l152re/module.lb
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-l152re"
+    module.description = """\
+# NUCLEO-L152RE
+
+[Nucleo kit for STM32L152RE](https://www.st.com/en/evaluation-tools/nucleo-l152re.html)
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32l152ret":
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": True}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_l1.cfg");

--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -62,7 +62,7 @@ modm::platform::Adc{{ id }}::initialize()
 			)));
 
 	Rcc::enable<Peripheral::Adc{{id}}>();
-	ADC{{ id }}->CR2 |= ADC_CR2_ADON;			// switch on ADC
+	ADC{{ per }}->CR2 |= ADC_CR2_ADON;			// switch on ADC
 
 	setPrescaler(prescaler);
 }
@@ -70,8 +70,8 @@ modm::platform::Adc{{ id }}::initialize()
 void
 modm::platform::Adc{{ id }}::setPrescaler(const Prescaler prescaler)
 {
-%% if target["family"] in ["f2", "f4", "f7"]
-	ADC->CCR = (ADC->CCR & ~(0b11 << 17)) | (uint32_t(prescaler) << 17);
+%% if target["family"] in ["f2", "f4", "f7", "l1"]
+	ADC->CCR = (ADC->CCR & ~ADC_CCR_ADCPRE) | (uint32_t(prescaler) << ADC_CCR_ADCPRE_Pos);
 %% elif target["family"] in ["f1", "f3"]
 	RCC->CFGR = (RCC->CFGR & ~(0b11 << 14)) | (uint32_t(prescaler) << 14);
 %% endif
@@ -84,7 +84,7 @@ modm::platform::Adc{{ id }}::enableTemperatureRefVMeasurement()
 	%% if target["family"] in ["f2", "f4", "f7"]
 	ADC->CCR |= ADC_CCR_TSVREFE;
 	%% elif target["family"] == "f1"
-	ADC{{ id }}->CR2 |= ADC_CR2_TSVREFE;
+	ADC{{ per }}->CR2 |= ADC_CR2_TSVREFE;
 	%% endif
 }
 
@@ -94,7 +94,7 @@ modm::platform::Adc{{ id }}::disableTemperatureRefVMeasurement()
 	%% if target["family"] in ["f2", "f4", "f7"]
 	ADC->CCR &= ~ADC_CCR_TSVREFE;
 	%% elif target["family"] == "f1"
-	ADC{{ id }}->CR2 &= ~ADC_CR2_TSVREFE;
+	ADC{{ per }}->CR2 &= ~ADC_CR2_TSVREFE;
 	%% endif
 }
 %% endif
@@ -102,13 +102,13 @@ modm::platform::Adc{{ id }}::disableTemperatureRefVMeasurement()
 void
 modm::platform::Adc{{ id }}::setLeftAdjustResult()
 {
-	ADC{{ id }}->CR2 |= ADC_CR2_ALIGN;
+	ADC{{ per }}->CR2 |= ADC_CR2_ALIGN;
 }
 
 void
 modm::platform::Adc{{ id }}::setRightAdjustResult()
 {
-	ADC{{ id }}->CR2 &= ~ADC_CR2_ALIGN;
+	ADC{{ per }}->CR2 &= ~ADC_CR2_ALIGN;
 }
 
 bool
@@ -118,9 +118,9 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel,
 	if (uint32_t(channel) > 18) return false;
 	// clear number of conversions in the sequence
 	// and set number of conversions to 1
-	ADC{{ id }}->SQR1 = 0;
-	ADC{{ id }}->SQR2 = 0;
-	ADC{{ id }}->SQR3 = uint32_t(channel) & 0x1f;
+	ADC{{ per }}->SQR1 = 0;
+	ADC{{ per }}->SQR2 = 0;
+	ADC{{ per }}->SQR3 = uint32_t(channel) & 0x1f;
 
 	setSampleTime(channel, sampleTime);
 	return true;
@@ -129,7 +129,7 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel,
 modm::platform::Adc{{ id }}::Channel
 modm::platform::Adc{{ id }}::getChannel()
 {
-	return Channel(ADC{{ id }}->SQR3 & 0x1f);
+	return Channel(ADC{{ per }}->SQR3 & 0x1f);
 }
 
 bool
@@ -137,22 +137,22 @@ modm::platform::Adc{{ id }}::addChannel(const Channel channel,
 									const SampleTime sampleTime)
 {
 	// read channel count
-	uint8_t channel_count = (ADC{{ id }}->SQR1 & ADC_SQR1_L) >> 20;
+	uint8_t channel_count = (ADC{{ per }}->SQR1 & ADC_SQR1_L) >> 20;
 	++channel_count;
 	if(channel_count > 0x0f) return false; // emergency exit
 	// write channel number
 	if(channel_count < 6) {
-		ADC{{ id }}->SQR3 |=
+		ADC{{ per }}->SQR3 |=
 			(uint32_t(channel) & 0x1f) << (channel_count*5);
 	} else 	if(channel_count < 12) {
-		ADC{{ id }}->SQR2 |=
+		ADC{{ per }}->SQR2 |=
 			(uint32_t(channel) & 0x1f) << ((channel_count-6)*5);
 	} else {
-		ADC{{ id }}->SQR1 |=
+		ADC{{ per }}->SQR1 |=
 			(uint32_t(channel) & 0x1f) << ((channel_count-12)*5);
 	}
 	// update channel count
-	ADC{{ id }}->SQR1 = (ADC{{ id }}->SQR1 & ~ADC_SQR1_L) | (channel_count << 20);
+	ADC{{ per }}->SQR1 = (ADC{{ per }}->SQR1 & ~ADC_SQR1_L) | (channel_count << 20);
 
 	setSampleTime(channel, sampleTime);
 	return true;
@@ -163,11 +163,11 @@ modm::platform::Adc{{ id }}::setSampleTime(const Channel channel,
 										const SampleTime sampleTime)
 {
 	if (uint32_t(channel) < 10) {
-		ADC{{ id }}->SMPR2 |= uint32_t(sampleTime)
+		ADC{{ per }}->SMPR2 |= uint32_t(sampleTime)
 								<< (uint32_t(channel) * 3);
 	}
 	else {
-		ADC{{ id }}->SMPR1 |= uint32_t(sampleTime)
+		ADC{{ per }}->SMPR1 |= uint32_t(sampleTime)
 								<< ((uint32_t(channel)-10) * 3);
 	}
 }
@@ -175,20 +175,20 @@ modm::platform::Adc{{ id }}::setSampleTime(const Channel channel,
 void
 modm::platform::Adc{{ id }}::enableFreeRunningMode()
 {
-	ADC{{ id }}->CR2 |= ADC_CR2_CONT;	// set to continuous mode
+	ADC{{ per }}->CR2 |= ADC_CR2_CONT;	// set to continuous mode
 }
 
 void
 modm::platform::Adc{{ id }}::disableFreeRunningMode()
 {
-	ADC{{ id }}->CR2 &= ~ADC_CR2_CONT;		// set to single mode
+	ADC{{ per }}->CR2 &= ~ADC_CR2_CONT;		// set to single mode
 }
 
 void
 modm::platform::Adc{{ id }}::disable()
 {
-	ADC{{ id }}->CR2 &= ~(ADC_CR2_ADON);		// switch off ADC
-	RCC->APB2ENR &= ~RCC_APB2ENR_ADC{{ id }}EN; // stop ADC Clock
+	ADC{{ per }}->CR2 &= ~(ADC_CR2_ADON);		// switch off ADC
+	RCC->APB2ENR &= ~RCC_APB2ENR_ADC{{ per }}EN; // stop ADC Clock
 }
 
 void
@@ -198,22 +198,22 @@ modm::platform::Adc{{ id }}::startConversion()
 %% if target["family"] == "f1"
 	// select the SWSTART event used to trigger the start of
 	// conversion of a regular group
-	ADC{{ id }}->CR2 |= ADC_CR2_EXTTRIG | ADC_CR2_EXTSEL_0 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_2;
+	ADC{{ per }}->CR2 |= ADC_CR2_EXTTRIG | ADC_CR2_EXTSEL_0 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_2;
 %% endif
 	// starts single conversion for the regular group
-	ADC{{ id }}->CR2 |= ADC_CR2_SWSTART;
+	ADC{{ per }}->CR2 |= ADC_CR2_SWSTART;
 }
 
 bool
 modm::platform::Adc{{ id }}::isConversionFinished()
 {
-	return (ADC{{ id }}->SR & ADC_SR_EOC);
+	return (ADC{{ per }}->SR & ADC_SR_EOC);
 }
 
 uint16_t
 modm::platform::Adc{{ id }}::getValue()
 {
-	return ADC{{ id }}->DR;
+	return ADC{{ per }}->DR;
 }
 
 
@@ -231,34 +231,14 @@ modm::platform::Adc{{ id }}::readChannel(Channel channel)
 }
 
 // ----------------------------------------------------------------------------
-// TODO: move this to some shared header for all cortex m3 platforms
-// Re-implemented here to save some code space. As all arguments in the calls
-// below are constant the compiler is able to calculate everything at
-// compile time.
-
-#ifndef MODM_CUSTOM_NVIC_FUNCTIONS
-#define MODM_CUSTOM_NVIC_FUNCTIONS
-
-static modm_always_inline void
-nvicEnableInterrupt(const IRQn_Type IRQn)
-{
-	NVIC->ISER[(uint32_t(IRQn) >> 5)] = (1 << (uint32_t(IRQn) & 0x1F));
-}
-
-static modm_always_inline void
-nvicDisableInterrupt(IRQn_Type IRQn)
-{
-	NVIC_DisableIRQ(IRQn);
-}
-
-#endif // MODM_CUSTOM_NVIC_FUNCTIONS
-
 void
 modm::platform::Adc{{ id }}::enableInterruptVector(const uint32_t priority,
-												const bool enable)
+												   const bool enable)
 {
 %% if target["family"] in ["f2", "f4", "f7"]
 	const IRQn_Type InterruptVector = ADC_IRQn;
+%% elif  target["family"] in ["l1"]
+	const IRQn_Type InterruptVector = ADC1_IRQn;
 %% elif target["family"] in ["f1", "f3"]
 	%% if id < 3
 	const IRQn_Type InterruptVector = ADC1_2_IRQn;
@@ -269,7 +249,7 @@ modm::platform::Adc{{ id }}::enableInterruptVector(const uint32_t priority,
 
 	if (enable) {
 		NVIC_SetPriority(InterruptVector, priority);
-		nvicEnableInterrupt(InterruptVector);
+		NVIC_EnableIRQ(InterruptVector);
 	} else {
 		NVIC_DisableIRQ(InterruptVector);
 	}
@@ -278,19 +258,19 @@ modm::platform::Adc{{ id }}::enableInterruptVector(const uint32_t priority,
 void
 modm::platform::Adc{{ id }}::enableInterrupt(const Interrupt_t interrupt)
 {
-	ADC{{ id }}->CR1 |= interrupt.value;
+	ADC{{ per }}->CR1 |= interrupt.value;
 }
 
 void
 modm::platform::Adc{{ id }}::disableInterrupt(const Interrupt_t interrupt)
 {
-	ADC{{ id }}->CR1 &= ~interrupt.value;
+	ADC{{ per }}->CR1 &= ~interrupt.value;
 }
 
 modm::platform::Adc{{ id }}::InterruptFlag_t
 modm::platform::Adc{{ id }}::getInterruptFlags()
 {
-	return InterruptFlag_t(ADC{{ id }}->SR);
+	return InterruptFlag_t(ADC{{ per }}->SR);
 }
 
 void
@@ -298,5 +278,5 @@ modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t fla
 {
 	// Flags are cleared by writing a one to the flag position.
 	// Writing a zero is ignored.
-	ADC{{ id }}->SR = flags.value;
+	ADC{{ per }}->SR = flags.value;
 }

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -11,30 +11,26 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-instances = []
-
 class Instance(Module):
     def __init__(self, instance):
-        self.instance = instance
+        self.instance = "" if instance is None else instance
+        self.peripheral = 1 if instance is None else instance
 
     def init(self, module):
         module.name = str(self.instance)
         module.description = "Instance {}".format(self.instance)
 
     def prepare(self, module, options):
-        module.depends(":platform:adc")
         return True
-
-    def validate(self, env):
-        instances.append(self.instance)
 
     def build(self, env):
         device = env[":target"]
         driver = device.get_driver("adc")
 
-        properties = device.properties
+        properties = {}
         properties["target"] = target = device.identifier
         properties["id"] = self.instance
+        properties["per"] = self.peripheral
 
         # TODO: Consider moving this data to device file!
         properties["temperature_available"] = (target["family"] in ["f2", "f4", "f7"] or
@@ -73,7 +69,7 @@ def prepare(module, options):
     if not device.has_driver("adc:stm32"):
         return False
     global props
-    props = device.properties
+    props = {}
     driver = device.get_driver("adc")
     props["target"] = target = device.identifier
     props["driver"] = driver
@@ -102,7 +98,7 @@ def prepare(module, options):
         ":platform:rcc",
         ":utils")
 
-    for instance in listify(device.get_driver("adc")["instance"]):
+    for instance in listify(device.get_driver("adc").get("instance", [])):
         module.add_submodule(Instance(int(instance)))
 
     return True
@@ -115,5 +111,9 @@ def build(env):
 
     env.substitutions = props
     env.outbasepath = "modm/src/modm/platform/adc"
+
+    if device.get_driver("adc").get("instance", None) is None:
+        Instance(None).build(env)
+
     if any(i in props["shared_irq_ids"] for i in props["instances"]):
         env.template("adc_shared_interrupts.cpp.in")

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -37,6 +37,9 @@ def build(env):
     if target["family"] in ["f1", "f3", "f4"]:
         properties["hsi_frequency"] = 8
         properties["lsi_frequency"] = 40
+    elif target["family"] in ["l1"]:
+        properties["hsi_frequency"] = 2.097
+        properties["lsi_frequency"] = 37
     else:
         properties["hsi_frequency"] = 16
         properties["lsi_frequency"] = 32

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -61,13 +61,19 @@ modm::platform::Rcc::enableInternalClock(uint32_t waitCycles)
 	return retval;
 }
 
-%% if target["family"] in ["l4"]
+%% if target["family"] in ["l1", "l4"]
 bool
 modm::platform::Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, uint32_t waitCycles)
 {
 	bool retval;
+%% if target["family"] in ["l1"]
+	RCC->ICSCR = (RCC->ICSCR & ~RCC_ICSCR_MSIRANGE) | static_cast<uint32_t>(msi_frequency);
+	RCC->CR |= RCC_CR_MSION;
+	while (not (retval = (RCC->CR & RCC_CR_MSIRDY)) and --waitCycles)
+%% else
 	RCC->CR = (RCC->CR & ~RCC_CR_MSIRANGE) | static_cast<uint32_t>(msi_frequency) | RCC_CR_MSIRGSEL | RCC_CR_MSION;
 	while (not (retval = (RCC->CR & RCC_CR_MSIRDY)) and --waitCycles)
+%% endif
 		;
 	return retval;
 }
@@ -107,8 +113,13 @@ bool
 modm::platform::Rcc::enableLowSpeedExternalClock(uint32_t waitCycles)
 {
 	bool retval;
+%% if target["family"] in ["l1"]
+	RCC->CSR |= RCC_CSR_LSEBYP | RCC_CSR_LSEON;
+	while (not (retval = (RCC->CSR & RCC_CSR_LSERDY)) and --waitCycles)
+%% else
 	RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
 	while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
+%% endif
 		;
 	return retval;
 }
@@ -117,8 +128,13 @@ bool
 modm::platform::Rcc::enableLowSpeedExternalCrystal(uint32_t waitCycles)
 {
 	bool retval;
+%% if target["family"] in ["l1"]
+	RCC->CSR = (RCC->CSR & ~RCC_CSR_LSEBYP) | RCC_CSR_LSEON;
+	while (not (retval = (RCC->CSR & RCC_CSR_LSERDY)) and --waitCycles)
+%% else
 	RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_LSEBYP) | RCC_BDCR_LSEON;
 	while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
+%% endif
 		;
 	return retval;
 }
@@ -202,6 +218,26 @@ modm::platform::Rcc::enablePll(PllSource source,
 	// enable pll
 	RCC->CR |= RCC_CR_PLLON;
 
+	while (not (tmp = (RCC->CR & RCC_CR_PLLRDY)) and --waitCycles)
+		;
+
+	return tmp;
+}
+%% elif target["family"] in ["l1"]
+// ----------------------------------------------------------------------------
+bool
+modm::platform::Rcc::enablePll(PllSource source, PllMultiplier pllMul, uint8_t pllDiv, uint32_t waitCycles)
+{
+	uint32_t tmp = RCC->CFGR & ~(RCC_CFGR_PLLMUL | RCC_CFGR_PLLSRC | RCC_CFGR_PLLDIV);
+	// PLLSRC source for pll
+	tmp |= static_cast<uint32_t>(source);
+	// Pll multiplication factor
+	tmp |= static_cast<uint32_t>(pllMul);
+	tmp |= (static_cast<uint32_t>(pllDiv - 1) << RCC_CFGR_PLLDIV_Pos) & RCC_CFGR_PLLDIV;
+	RCC->CFGR = tmp;
+
+	// enable pll
+	RCC->CR |= RCC_CR_PLLON;
 	while (not (tmp = (RCC->CR & RCC_CR_PLLRDY)) and --waitCycles)
 		;
 

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -54,7 +54,7 @@ public:
 	%% endif
 		/// High speed external clock (see HseConfig)
 		Hse = RCC_CFGR_PLLSRC_HSE_PREDIV,
-%% elif target["family"] == "f1"
+%% elif target["family"] in ["f1", "l1"]
 		/// High speed internal clock (8 MHz)
 		Hsi = 0,
 		/// High speed external clock (see HseConfig)
@@ -74,6 +74,22 @@ public:
 		ExternalClock = Hse,
 		ExternalCrystal = Hse,
 	};
+
+%% if target["family"] in ["l1"]
+	enum class
+	PllMultiplier : uint32_t
+	{
+		Mul3 = RCC_CFGR_PLLMUL3,
+		Mul4 = RCC_CFGR_PLLMUL4,
+		Mul6 = RCC_CFGR_PLLMUL6,
+		Mul8 = RCC_CFGR_PLLMUL8,
+		Mul12 = RCC_CFGR_PLLMUL12,
+		Mul16 = RCC_CFGR_PLLMUL16,
+		Mul24 = RCC_CFGR_PLLMUL24,
+		Mul32 = RCC_CFGR_PLLMUL32,
+		Mul48 = RCC_CFGR_PLLMUL48,
+	};
+%% endif
 
 	enum class
 	SystemClockSource : uint32_t
@@ -98,9 +114,15 @@ public:
 	enum class
 	RealTimeClockSource : uint32_t
 	{
+%% if target["family"] in ["l1"]
+		Lsi = RCC_CSR_RTCSEL_1,
+		Lse = RCC_CSR_RTCSEL_0,
+		Hse = RCC_CSR_RTCSEL_0 | RCC_CSR_RTCSEL_1,
+%% else
 		Lsi = RCC_BDCR_RTCSEL_1,
 		Lse = RCC_BDCR_RTCSEL_0,
 		Hse = RCC_BDCR_RTCSEL_0 | RCC_BDCR_RTCSEL_1,
+%% endif
 
 		ExternalClock = Hse,
 		ExternalCrystal = Hse,
@@ -181,7 +203,7 @@ public:
 		Pll = RCC_CFGR_MCO2_1 | RCC_CFGR_MCO2_0,
 	};
 	%% endif
-%% elif target["family"] in ["l4", "g0"]
+%% elif target["family"] in ["l1", "l4", "g0"]
 	enum class
 	ClockOutputSource : uint32_t
 	{
@@ -190,7 +212,12 @@ public:
 %% if target["family"] in ["l4"]
 		MultiSpeedInternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // MSI
 %% endif
+%% if target["family"] in ["l1"]
+		InternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // HSI16
+		MultiSpeedInternalClock = (3 << RCC_CFGR_MCOSEL_Pos), // MSI
+%% else
 		InternalClock = (3 << RCC_CFGR_MCOSEL_Pos), // HSI16
+%% endif
 		ExternalClock = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
 		ExternalCrystal = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
 		Pll = (5 << RCC_CFGR_MCOSEL_Pos), // Main PLL
@@ -233,10 +260,19 @@ public:
 	enableInternalClockMHz48(uint32_t waitCycles = 2048);
 %% endif
 
-%% if target["family"] in ["l4"]
+%% if target["family"] in ["l1", "l4"]
 	enum class
 	MsiFrequency : uint32_t
 	{
+%% if target["family"] in ["l1"]
+		kHz65  = RCC_ICSCR_MSIRANGE_0,
+		kHz131 = RCC_ICSCR_MSIRANGE_1,
+		kHz262 = RCC_ICSCR_MSIRANGE_2,
+		kHz524 = RCC_ICSCR_MSIRANGE_3,
+		MHz1   = RCC_ICSCR_MSIRANGE_4,
+		MHz2   = RCC_ICSCR_MSIRANGE_5,
+		MHz4   = RCC_ICSCR_MSIRANGE_6,
+%% elif target["family"] in ["l4"]
 		kHz100 = RCC_CR_MSIRANGE_0,
 		kHz200 = RCC_CR_MSIRANGE_1,
 		kHz400 = RCC_CR_MSIRANGE_2,
@@ -249,6 +285,7 @@ public:
 		MHz24  = RCC_CR_MSIRANGE_9,
 		MHz32  = RCC_CR_MSIRANGE_10,
 		MHz48  = RCC_CR_MSIRANGE_11,
+%% endif
 	};
 
 	static bool
@@ -309,6 +346,10 @@ public:
 			  uint8_t pllP,
 %% endif
 			  uint32_t waitCycles = 2048);
+%% elif target["family"] in ["l1"]
+	static bool
+	enablePll(PllSource source, PllMultiplier pllMul, uint8_t pllDiv,
+	          uint32_t waitCycles = 2048);
 %% else
 	static bool
 	enablePll(PllSource source,
@@ -328,7 +369,11 @@ public:
 	static inline bool
 	enableRealTimeClock(RealTimeClockSource src)
 	{
+%% if target["family"] in ["l1"]
+		RCC->CSR = (RCC->CSR & ~RCC_CSR_RTCSEL) | RCC_CSR_RTCEN | uint32_t(src);
+%% else
 		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
+%% endif
 		return true;
 	}
 
@@ -356,7 +401,7 @@ public:
 		return true;
 	}
 	%% endif
-%% elif target["family"] in ["l4", "g0"]
+%% elif target["family"] in ["l1", "l4", "g0"]
 	enum class
 	ClockOutputPrescaler : uint32_t
 	{
@@ -375,7 +420,7 @@ public:
 	static inline bool
 	enableClockOutput(ClockOutputSource src, ClockOutputPrescaler div = ClockOutputPrescaler::Div1)
 	{
-		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCOSEL)) | uint32_t(src) | uint32_t(div);
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCOPRE)) | uint32_t(src) | uint32_t(div);
 		return true;
 	}
 %% else

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -71,11 +71,17 @@ Rcc::setFlashLatency()
 %% elif target["family"] == "f7"
 	// enable flash prefetch and flash accelerator
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
+%% elif target["family"] in ["l1"]
+	// enable 64-bit access, must be enabled *before* prefetch and latency!
+	FLASH->ACR |= FLASH_ACR_ACC64;
+	// enable flash prefetch
+	acr |= FLASH_ACR_PRFTEN;
 %% else
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTBE;
 %% endif
 	FLASH->ACR = acr;
+	__DSB(); __ISB();
 %% endif
 
 	return fl.max_frequency;

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -19,7 +19,7 @@ modm_gpio_enable(void)
 %%	set prefix = "GPIO"
 %% if target["family"] in ["f2", "f4", "f7"]
 %%	set clock_tree = "AHB1"
-%% elif target["family"] in ["f0", "f3"]
+%% elif target["family"] in ["f0", "f3", "l1"]
 %%	set clock_tree = "AHB"
 %% elif target["family"] in ["f1"]
 %%	set clock_tree = "APB2"

--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -244,7 +244,7 @@ struct Gpio{{ port ~ pin }}::{{ signal.name }}<Peripheral::{{ signal.driver }}>
 		%% if signal.driver.startswith("Adc") and signal.name.startswith("In")
 template<>
 constexpr int8_t
-Gpio{{ port ~ pin }}::AdcChannel<Peripheral::{{ signal.driver }}> = {{ signal.name.replace("In", "") }};
+Gpio{{ port ~ pin }}::AdcChannel<Peripheral::{{ signal.driver }}> = {{ signal.name.replace("In", "")[0] }};
 		%% endif
 	%% endfor
 

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -108,7 +108,7 @@ public:
 	};
 
 	// This type is the internal size of the counter.
-%% if id in [2, 5] and (target["family"] in ["f2", "f3", "f4", "f7", "l4"])
+%% if id in [2, 5] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4"])
 	// Timer 2 and 5 are the only one which have the size of 32 bit
 	typedef uint32_t Value;
 

--- a/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
@@ -33,8 +33,10 @@ public:
 		CaptureCompare2 = TIM_DIER_CC2DE,
 		CaptureCompare3 = TIM_DIER_CC3DE,
 		CaptureCompare4 = TIM_DIER_CC4DE,
+%% if target.family not in ["l1"]
 		COM = TIM_DIER_COMDE,
 		Trigger = TIM_DIER_TDE,
+%% endif
 	};
 
 	enum class Interrupt : uint32_t
@@ -44,9 +46,11 @@ public:
 		CaptureCompare2 = TIM_DIER_CC2IE,
 		CaptureCompare3 = TIM_DIER_CC3IE,
 		CaptureCompare4= TIM_DIER_CC4IE,
-		COM = TIM_DIER_COMIE,
 		Trigger = TIM_DIER_TIE,
+%% if target.family not in ["l1"]
+		COM = TIM_DIER_COMIE,
 		Break = TIM_DIER_BIE,
+%% endif
 	};
 	MODM_FLAGS32(Interrupt);
 
@@ -57,13 +61,15 @@ public:
 		CaptureCompare2 = TIM_SR_CC2IF,
 		CaptureCompare3 = TIM_SR_CC3IF,
 		CaptureCompare4 = TIM_SR_CC4IF,
-		COM = TIM_SR_COMIF,
 		Trigger = TIM_SR_TIF,
-		Break = TIM_SR_BIF,
 		Overcapture1 = TIM_SR_CC1OF,
 		Overcapture2 = TIM_SR_CC2OF,
 		Overcapture3 = TIM_SR_CC3OF,
 		Overcapture4 = TIM_SR_CC4OF,
+%% if target.family not in ["l1"]
+		COM = TIM_SR_COMIF,
+		Break = TIM_SR_BIF,
+%% endif
 	};
 	MODM_FLAGS32(InterruptFlag);
 
@@ -183,6 +189,7 @@ public:
 		Enable = 1,
 	};
 
+%% if target.family not in ["l1"]
 	/* Different Resolution Depending on DeadTime[7:5]: */
 	enum class DeadTimeResolution : uint32_t
 	{
@@ -192,6 +199,7 @@ public:
 		From64usWith2usStep  = TIM_BDTR_DTG_7 | TIM_BDTR_DTG_6	//111
 											| TIM_BDTR_DTG_5,
 	};
+%% endif
 
 public:
 	/**

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -69,11 +69,13 @@ class Instance(Module):
                 raise ValidateException("Timer{} is only allowed to have one IRQ! Found {}"
                                     .format(self.instance, self.vectors))
 
+
     def build(self, env):
         global props
         props["id"] = self.instance
         props["connectors"] = get_connectors(self.instance)
         props["vectors"] = self.vectors
+        props["types"].add(self.type)
 
         env.substitutions = props
         env.outbasepath = "modm/src/modm/platform/timer"
@@ -106,6 +108,7 @@ def prepare(module, options):
     global props
     device = options[":target"]
     props["target"] = device.identifier
+    props["types"] = set()
 
     props["timer_vectors"] = tim_vectors = defaultdict(list)
     vectors = [v["name"] for v in device.get_driver("core")["vector"] if "TIM" in v["name"]]
@@ -123,6 +126,12 @@ def build(env):
     env.substitutions = props
     env.outbasepath = "modm/src/modm/platform/timer"
 
-    env.template("basic_base.hpp.in")
-    env.template("general_purpose_base.hpp.in")
-    env.template("advanced_base.hpp.in")
+    # Only generate the base types for timers that were generated
+    types = props["types"]
+    if "advanced" in types:
+        types.add("general_purpose")
+    if "general_purpose" in types:
+        types.add("basic")
+    for ttype in props["types"]:
+        env.template("{}_base.hpp.in".format(ttype))
+

--- a/src/modm/platform/uart/stm32/uart_base.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_base.hpp.in
@@ -22,8 +22,12 @@
 /// @cond
 %% if not extended_driver
 // STM has some weird ideas about continuity
+#ifndef USART_BRR_DIV_MANTISSA
 #define	USART_BRR_DIV_MANTISSA	USART_BRR_DIV_Mantissa
+#endif
+#ifndef USART_BRR_DIV_FRACTION
 #define	USART_BRR_DIV_FRACTION	USART_BRR_DIV_Fraction
+#endif
 %% endif
 %% if tcbgt
 #define USART_CR1_TXEIE   USART_CR1_TXEIE_TXFNFIE

--- a/test/all/ignored.txt
+++ b/test/all/ignored.txt
@@ -90,3 +90,8 @@ attiny4
 attiny40
 attiny5
 attiny9
+# FIXME: modm-devices cannot deal with -A/-X variants
+stm32l151qch
+stm32l151zct
+stm32l152qch
+stm32l152zct


### PR DESCRIPTION
STM32L1 support is coming.

- [x] Update modm-devices submodule
- [x] Update CMSIS Headers submodule
- [x] Port platform modules
  - [x] RCC
  - [x] UART
  - [x] ADC
  - [x] GPIO
- [x] Compile ALL test
- [x] Add Nucleo-L152RE BSP
  - [x] SystemClock
  - [x] ST-Link logger
  - [x] Test in hardware
- [x] Add Disco-L152RE BSP
  - [x] SystemClock
  - [x] Test in hardware

GPIO PinMux is weird with additional multiplexing in hardware (via AF14), this will have to be done manually when needed. Note the limitations (5µs delay, 4x initial frequency) on the clock system when switching clocks.

cc @bremoran