### PR TITLE
Support for STM32F411CEU "Mini-F411" dev board

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           name: Examples STM32F4 Series
           command: |
             (cd examples && ../tools/scripts/examples_compile.py stm32f4_discovery)
-            (cd examples && ../tools/scripts/examples_compile.py stm32f429_discovery stm32f469_discovery nucleo_f401re nucleo_f411re nucleo_f429zi nucleo_f446re)
+            (cd examples && ../tools/scripts/examples_compile.py stm32f429_discovery stm32f469_discovery nucleo_f401re nucleo_f411re nucleo_f429zi nucleo_f446re stm32f411ccu_mini_f401 stm32f411ceu_mini_f411)
 
   avr-examples:
     docker:

--- a/README.md
+++ b/README.md
@@ -130,23 +130,26 @@ documentation.
 <td align="center">DISCO-L152RC</td>
 <td align="center">DISCO-L476VG</td>
 </tr><tr>
+<td align="center">MINI-F401</td>
+<td align="center">MINI-F411</td>
 <td align="center">NUCLEO-F031K6</td>
 <td align="center">NUCLEO-F042K6</td>
+</tr><tr>
 <td align="center">NUCLEO-F103RB</td>
 <td align="center">NUCLEO-F303K8</td>
-</tr><tr>
 <td align="center">NUCLEO-F401RE</td>
 <td align="center">NUCLEO-F411RE</td>
+</tr><tr>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
-</tr><tr>
 <td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-G474RE</td>
+</tr><tr>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
-</tr><tr>
 <td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
+</tr><tr>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>

--- a/examples/stm32f401ccu_mini_f401/blink/main.cpp
+++ b/examples/stm32f401ccu_mini_f401/blink/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+/*
+ * Blinks the user LED with 1 Hz
+ * or 5 Hz is the user button is pressed.
+ */
+
+int
+main()
+{
+	Board::initialize();
+
+	LedGreen::set();
+
+	while (true)
+	{
+		LedGreen::toggle();
+		modm::delayMilliseconds(Button::read() ? 100 : 500);
+	}
+
+	return 0;
+}

--- a/examples/stm32f401ccu_mini_f401/blink/project.xml
+++ b/examples/stm32f401ccu_mini_f401/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:mini-f401</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f401ccu_mini_f401/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/stm32f411ceu_mini_f411/blink/main.cpp
+++ b/examples/stm32f411ceu_mini_f411/blink/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+/*
+ * Blinks the user LED with 1 Hz
+ * or 5 Hz is the user button is pressed.
+ */
+
+int
+main()
+{
+	Board::initialize();
+
+	LedGreen::set();
+
+	while (true)
+	{
+		LedGreen::toggle();
+		modm::delayMilliseconds(Button::read() ? 100 : 500);
+	}
+
+	return 0;
+}

--- a/examples/stm32f411ceu_mini_f411/blink/project.xml
+++ b/examples/stm32f411ceu_mini_f411/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:mini-f411</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f411ceu_mini_f411/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/mini_f401/board.xml
+++ b/src/modm/board/mini_f401/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f401ccu</option>
+  </options>
+  <modules>
+    <module>modm:board:mini-f401</module>
+  </modules>
+</library>

--- a/src/modm/board/mini_f401/module.lb
+++ b/src/modm/board/mini_f401/module.lb
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:mini-f401"
+    module.description = """\
+# Mini-F401
+
+STM32F401CCU "Mini-F401" Minimum System Development Board
+
+Cheap and bread-board-friendly board for STM32F401 series.
+Sold for less than 4 USD on well known Internet shops from China.
+Attention: There are two variants: Mini-F411 and the cheaper Mini-F401.
+
+[Schematic](https://pbs.twimg.com/media/EGcCd4NWsAUkWFx?format=jpg&name=orig)
+""" + descr_programming
+
+descr_programming = """
+## Programming
+
+Since the board has no St-Link programmer on the board,
+you must use DFU (Device Firmware Update (via USB)) to program the board.
+A DFU command is integrated into the modm:build:scons tool and can be called as follows:
+
+```
+scons dfu
+```
+
+Alternatively you can go for an external programmer
+and *specify* which one you're using in a custom `openocd.cfg` file:
+
+```
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]
+```
+
+Then include this file in your build options like so:
+
+```xml
+<library>
+  <extends>modm:mini-f401</extends>
+  <options>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+</library>
+```
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32f401ccu":
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": False}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('../mini_f411/board.hpp', 'board.hpp')
+    env.copy('board.xml')
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/stm32f4x1_mini_f4x1.cfg"), "stm32f4x1_mini_f4x1.cfg")
+    env.collect(":build:openocd.source", "modm/board/stm32f4x1_mini_f4x1.cfg")

--- a/src/modm/board/mini_f411/board.hpp
+++ b/src/modm/board/mini_f411/board.hpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_F4X1CEU_MINI_F4X1_HPP
+#define MODM_STM32_F4X1CEU_MINI_F4X1_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+
+using namespace modm::platform;
+
+
+/// @ingroup modm_board_blue_pill
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32F4x1 running at 84MHz generated from the external 25MHz crystal
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 84_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc  = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Spi4 = Apb2;
+	static constexpr uint32_t Spi5 = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+	static constexpr uint32_t I2c3   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableExternalCrystal();
+		Rcc::enablePll(
+			Rcc::PllSource::ExternalCrystal,
+			25,		// 25MHz / N=25 -> 1MHz
+			336,	// 1MHz * M=336 -> 336MHz
+			4,		// 336MHz / P=4 -> 84MHz = F_cpu
+			7		// 336MHz / Q=7 -> 48MHz for USB
+		);
+
+		// set flash latency
+		Rcc::setFlashLatency<Frequency>();
+
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div2);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// User LED (inverted, because connected to 3V3)
+using LedGreen = GpioInverted< GpioOutputC13 >;
+using Leds = SoftwareGpioPort< LedGreen >;
+
+using Button = GpioInverted< GpioInputA0 >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+	Button::setInput(Gpio::InputType::PullUp);
+}
+
+} // Board namespace
+
+#endif	// MODM_STM32_F4X1CEU_MINI_F4X1_HPP

--- a/src/modm/board/mini_f411/board.xml
+++ b/src/modm/board/mini_f411/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f411ceu</option>
+  </options>
+  <modules>
+    <module>modm:board:mini-f411</module>
+  </modules>
+</library>

--- a/src/modm/board/mini_f411/module.lb
+++ b/src/modm/board/mini_f411/module.lb
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:mini-f411"
+    module.description = """\
+# Mini-F411
+
+STM32F411CEU "Mini-F411" Minimum System Development Board
+
+Cheap and bread-board-friendly board for STM32F411 series.
+Sold for less than 5 USD on well known Internet shops from China.
+Attention: There are two variants: Mini-F411 and the cheaper Mini-F401.
+
+[Schematic](https://pbs.twimg.com/media/EGcCd4NWsAUkWFx?format=jpg&name=orig)
+""" + descr_programming
+
+descr_programming = """
+## Programming
+
+Since the board has no St-Link programmer on the board,
+you must use DFU (Device Firmware Update (via USB)) to program the board.
+A DFU command is integrated into the modm:build:scons tool and can be called as follows:
+
+```
+scons dfu
+```
+
+Alternatively you can go for an external programmer
+and *specify* which one you're using in a custom `openocd.cfg` file:
+
+```
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]
+```
+
+Then include this file in your build options like so:
+
+```xml
+<library>
+  <extends>modm:mini-f411</extends>
+  <options>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+</library>
+```
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "stm32f411ceu":
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {"board_has_logger": False}
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/stm32f4x1_mini_f4x1.cfg"), "stm32f4x1_mini_f4x1.cfg")
+    env.collect(":build:openocd.source", "modm/board/stm32f4x1_mini_f4x1.cfg")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2017-2018, Niklas Hauser
+# Copyright (c) 2019, Raphael Lehmann
 #
 # This file is part of the modm project.
 #
@@ -108,7 +109,8 @@ def build(env):
     device = env.query("::device")
     if device["core"].startswith("cortex-m"):
         tools.update({"compiler_arm_none_eabi_gcc", "program_openocd",
-                      "black_magic_probe", "utils_buildsize", "postmortem_gdb"})
+                      "black_magic_probe", "dfu_stm32_programmer",
+                      "utils_buildsize", "postmortem_gdb"})
     elif device["core"].startswith("avr"):
         tools.update({"compiler_avr_gcc", "utils_buildsize", "program_avrdude"})
     else: # hosted

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -129,6 +129,62 @@ shutdown command invoked
 ```
 
 
+#### scons dfu
+
+Writes the executable onto your target via Device Firmware Update (DFU) over USB.
+A DFU bootloader is available on many STM32 microcontrollers
+and can be accessed by pressing the BOOT0-Button during startup.
+(\* *only ARM Cortex-M targets*)
+
+Example:
+
+```
+$ scons dfu
+scons: Reading SConscript files ...
+scons: done reading SConscript files.
+scons: Building targets ...
+dfu_stm32_programmer: program [...]/blink/release/blink.bin
+dfu-util 0.9
+
+Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+Copyright 2010-2016 Tormod Volden and Stefan Schmidt
+This program is Free Software and has ABSOLUTELY NO WARRANTY
+Please report bugs to http://sourceforge.net/p/dfu-util/tickets/
+
+dfu-util: Invalid DFU suffix signature
+dfu-util: A valid DFU suffix will be required in a future dfu-util release!!!
+Opening DFU capable USB device...
+ID 0483:df11
+Run-time device DFU version 011a
+Claiming USB DFU Interface...
+Setting Alternate Setting #0 ...
+Determining device status: state = dfuERROR, status = 10
+dfuERROR, clearing status
+Determining device status: state = dfuIDLE, status = 0
+dfuIDLE, continuing
+DFU mode device DFU version 011a
+Device returned transfer size 2048
+DfuSe interface name: "Internal Flash  "
+Memory segment at 0x08000000   4 x 16384 = 65536 (rew)
+Memory segment at 0x08010000   1 x 65536 = 65536 (rew)
+Memory segment at 0x08020000   1 x 131072 = 131072 (rew)
+Downloading to address = 0x08000000, size = 2060
+Download        [                         ]   0%            0 bytes   Poll timeout 100 ms
+   Poll timeout 0 ms
+ Download from image offset 00000000 to memory 08000000-080007ff, size 2048
+   Poll timeout 104 ms
+   Poll timeout 0 ms
+ Download from image offset 00000800 to memory 08000800-0800080b, size 12
+   Poll timeout 104 ms
+   Poll timeout 0 ms
+File downloaded successfully
+   Poll timeout 104 ms
+   Poll timeout 0 ms
+Transitioning to dfuMANIFEST state
+scons: done building targets.
+```
+
+
 #### scons bmp
 
 [Black Magic Probe][bmp] is convenient tool to convert cheap USB ST-LINK V2 clones

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2018-2019, Niklas Hauser
+# Copyright (c) 2019, Raphael Lehmann
 #
 # This file is part of the modm project.
 #
@@ -43,9 +44,11 @@ def build_target(env, sources):
 		%% if upload_with_artifact
 	env.Alias("program", [env.OpenOcd(program, commands=["modm_program {$SOURCE}"]), "artifact"])
 	env.Alias("bmp", [env.BlackMagicProbe(program), "artifact"])
+	env.Alias('dfu', [env.DfuStm32Programmer(env.Bin(program)), "artifact"])
 		%% else
 	env.Alias("program", env.OpenOcd(program, commands=["modm_program {$SOURCE}"]))
 	env.Alias("bmp", env.BlackMagicProbe(program))
+	env.Alias('dfu', env.DfuStm32Programmer(env.Bin(program)))
 		%% endif
 
 	%% elif core.startswith("avr")

--- a/tools/build_script_generator/scons/site_tools/dfu_stm32_programmer.py
+++ b/tools/build_script_generator/scons/site_tools/dfu_stm32_programmer.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2013, Sascha Schade
 # Copyright (c) 2014, 2016, Daniel Krebs
 # Copyright (c) 2017, Michael Thies
+# Copyright (c) 2019, Raphael Lehmann
 #
 # This file is part of the modm project.
 #
@@ -14,11 +15,10 @@
 #
 # Usage:
 # Add to your SConstruct file
-# binfile = env.Bin(program)
-# env.Alias('program', env.DfuStm32Programmer(binfile))
+# env.Alias('dfu', env.DfuStm32Programmer(env.Bin(program)))
 #
 # Call
-#   scons program
+#   scons dfu
 # from your command line
 
 import platform

--- a/tools/openocd/modm/stm32f4x1_mini_f4x1.cfg
+++ b/tools/openocd/modm/stm32f4x1_mini_f4x1.cfg
@@ -1,0 +1,10 @@
+# Cheap STM32F4x1 "Mini-F4x1" Minimum System Development Board
+
+# Must be specified by the user via `modm:build:openocd.cfg` option
+#source [find interface/stlink-v2.cfg]
+
+transport select hla_swd
+
+source [find target/stm32f4x.cfg]
+
+reset_config none


### PR DESCRIPTION
#### STM32F411CEU "Mini-F411" Minimum System Development Board
Cheap and bread-board-friendly board for STM32 F4 series.
Sold for less than 5 USD on well known Internet shops from China.

Attention: There are two variants: F411 (with USB and DFU support)
and the cheaper Mini-F401 without USB support.

![Schematic](https://pbs.twimg.com/media/EGcCd4NWsAUkWFx?format=jpg&name=orig)

---

Should I add support for the F401 variant too?