### PR TITLE
[ext] Update submodules, use full target identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git clone --recurse-submodules https://github.com/modm-io/modm.git
 
 ## Targets
 
-modm can generate code for <!--avrcount-->78<!--/avrcount--> AVR and <!--stmcount-->1158<!--/stmcount-->
+modm can generate code for <!--avrcount-->530<!--/avrcount--> AVR and <!--stmcount-->1857<!--/stmcount-->
 STM32 devices, however, there are different levels of support and testing.
 
 <center>

--- a/examples/avr/1-wire/ds18b20/project.xml
+++ b/examples/avr/1-wire/ds18b20/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/1-wire/ds18b20</option>
   </options>

--- a/examples/avr/adc/basic/project.xml
+++ b/examples/avr/adc/basic/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/adc/basic</option>
   </options>

--- a/examples/avr/adc/oversample/project.xml
+++ b/examples/avr/adc/oversample/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/adc/oversample</option>
   </options>

--- a/examples/avr/app_can2usb/project.xml
+++ b/examples/avr/app_can2usb/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">at90can128</option>
+    <option name="modm:target">at90can128-16au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
     <option name="modm:build:build.path">../../../build/avr/app_can2usb</option>
   </options>

--- a/examples/avr/block_device_mirror/project.xml
+++ b/examples/avr/block_device_mirror/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../build/avr/block_device_mirror</option>
     <option name="modm:io:with_printf">True</option>

--- a/examples/avr/can/mcp2515/project.xml
+++ b/examples/avr/can/mcp2515/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/can/mcp2515</option>
     <option name="modm:io:with_printf">True</option>

--- a/examples/avr/can/mcp2515_uart/project.xml
+++ b/examples/avr/can/mcp2515_uart/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/can/mcp2515_uart</option>
     <option name="modm:io:with_printf">True</option>

--- a/examples/avr/display/dogm128/benchmark/project.xml
+++ b/examples/avr/display/dogm128/benchmark/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/benchmark</option>
     <option name="modm:build:scons:image.source">images</option>

--- a/examples/avr/display/dogm128/caged_ball/project.xml
+++ b/examples/avr/display/dogm128/caged_ball/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/caged_ball</option>
   </options>

--- a/examples/avr/display/dogm128/draw/project.xml
+++ b/examples/avr/display/dogm128/draw/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/draw</option>
   </options>

--- a/examples/avr/display/dogm128/image/project.xml
+++ b/examples/avr/display/dogm128/image/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/image</option>
     <option name="modm:build:scons:image.source">images</option>

--- a/examples/avr/display/dogm128/text/project.xml
+++ b/examples/avr/display/dogm128/text/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/text</option>
   </options>

--- a/examples/avr/display/dogm128/touch/project.xml
+++ b/examples/avr/display/dogm128/touch/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/touch</option>
   </options>

--- a/examples/avr/display/dogm132/project.xml
+++ b/examples/avr/display/dogm132/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/display/dogm132</option>
   </options>

--- a/examples/avr/display/dogm163/project.xml
+++ b/examples/avr/display/dogm163/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
     <option name="modm:build:build.path">../../../../build/avr/display/dogm163</option>
   </options>

--- a/examples/avr/display/hd44780/project.xml
+++ b/examples/avr/display/hd44780/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/display/hd44780</option>
   </options>

--- a/examples/avr/display/siemens_s65/project.xml
+++ b/examples/avr/display/siemens_s65/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
     <option name="modm:build:build.path">../../../../build/avr/display/siemens_s65</option>
   </options>

--- a/examples/avr/flash/project.xml
+++ b/examples/avr/flash/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega328p</option>
+    <option name="modm:target">atmega328p-au</option>
     <option name="modm:platform:clock:f_cpu">1000000</option>
     <option name="modm:build:build.path">../../../build/avr/flash</option>
   </options>

--- a/examples/avr/gpio/basic/project.xml
+++ b/examples/avr/gpio/basic/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">attiny85</option>
+    <option name="modm:target">attiny85v-10mu</option>
     <option name="modm:platform:clock:f_cpu">8000000</option>
     <option name="modm:build:build.path">../../../../build/avr/gpio/basic</option>
   </options>

--- a/examples/avr/gpio/blinking/project.xml
+++ b/examples/avr/gpio/blinking/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega328p</option>
+    <option name="modm:target">atmega328p-au</option>
     <option name="modm:platform:clock:f_cpu">1000000</option>
     <option name="modm:build:build.path">../../../../build/avr/gpio/blinking</option>
   </options>

--- a/examples/avr/gpio/button_group/project.xml
+++ b/examples/avr/gpio/button_group/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/gpio/button_group</option>
   </options>

--- a/examples/avr/logger/project.xml
+++ b/examples/avr/logger/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../build/avr/logger</option>
   </options>

--- a/examples/avr/protothread/project.xml
+++ b/examples/avr/protothread/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../build/avr/protothread</option>
   </options>

--- a/examples/avr/pwm/pca9685/project.xml
+++ b/examples/avr/pwm/pca9685/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega168p</option>
+    <option name="modm:target">atmega168p-20au</option>
     <option name="modm:platform:clock:f_cpu">8000000</option>
     <option name="modm:build:build.path">../../../../build/avr/pwm/pca9685</option>
   </options>

--- a/examples/avr/sab/master/project.xml
+++ b/examples/avr/sab/master/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/sab/master</option>
   </options>

--- a/examples/avr/sab/slave/project.xml
+++ b/examples/avr/sab/slave/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/sab/slave</option>
   </options>

--- a/examples/avr/timeout/project.xml
+++ b/examples/avr/timeout/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../build/avr/timeout</option>
   </options>

--- a/examples/avr/uart/basic/project.xml
+++ b/examples/avr/uart/basic/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644pa</option>
+    <option name="modm:target">atmega644pa-au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/uart/basic</option>
   </options>

--- a/examples/avr/uart/basic_mega8/project.xml
+++ b/examples/avr/uart/basic_mega8/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega8</option>
+    <option name="modm:target">atmega8-16au</option>
     <option name="modm:platform:clock:f_cpu">1000000</option>
     <option name="modm:build:build.path">../../../../build/avr/uart/basic_mega8</option>
   </options>

--- a/examples/avr/uart/extended/project.xml
+++ b/examples/avr/uart/extended/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/uart/extended</option>
   </options>

--- a/examples/avr/xpcc/receiver/project.xml
+++ b/examples/avr/xpcc/receiver/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/xpcc/receiver</option>
     <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>

--- a/examples/avr/xpcc/sender/project.xml
+++ b/examples/avr/xpcc/sender/project.xml
@@ -1,6 +1,6 @@
 <library>
   <options>
-    <option name="modm:target">atmega644</option>
+    <option name="modm:target">atmega644-20au</option>
     <option name="modm:platform:clock:f_cpu">14745600</option>
     <option name="modm:build:build.path">../../../../build/avr/xpcc/sender</option>
     <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>

--- a/examples/generic/i2c_multiplex/project.xml
+++ b/examples/generic/i2c_multiplex/project.xml
@@ -2,8 +2,8 @@
 <library>
   <extends>../../../src/modm/board/nucleo_f303k8/board.xml</extends>
   <options>
-    <option name=":target">stm32f303k8t</option>
-    <!-- <option name=":target">stm32f103c8t</option> -->
+    <option name=":target">stm32f303k8t6</option>
+    <!-- <option name=":target">stm32f103c8t6</option> -->
     <option name=":platform:uart:2:buffer.tx">2048</option>
     <option name=":platform:uart:2:buffer.rx">2048</option>
     <option name=":build:build.path">../../../build/generic/i2c_multiplex</option>

--- a/examples/nucleo_f103rb/undefined_irq/main.cpp
+++ b/examples/nucleo_f103rb/undefined_irq/main.cpp
@@ -27,6 +27,7 @@ MODM_ISR(EXTI3)
 // MODM_ISR(EXTI4)
 // { MODM_LOG_DEBUG << "EXTI4 called!" << modm::endl; }
 
+[[maybe_unused]]
 static modm::Abandonment
 core_assertion_handler(const char * module,
 					   const char * /*location*/,

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -29,13 +29,16 @@ class CmsisDspModule(Module):
     def prepare(self, module, options):
         dependencies = {
             "basic_math": [],
+            "bayes": [":cmsis:dsp:statistics"],
             "complex_math": [":cmsis:dsp:fast_math"],
             "controller": [":cmsis:dsp:tables"],
+            "distance": [":cmsis:dsp:basic_math", ":cmsis:dsp:statistics"],
             "fast_math": [":cmsis:dsp:tables"],
             "filtering": [":cmsis:dsp:tables", ":cmsis:dsp:support"],
             "matrix": [],
             "statistics": [":cmsis:dsp:fast_math"],
             "support": [],
+            "svm": [],
             "tables": [],
             "transform": [":cmsis:dsp:tables"],
         }

--- a/repo.lb
+++ b/repo.lb
@@ -159,7 +159,34 @@ class DevicesCache(dict):
             return self[item]
         return value
 
+# =============================================================================
+class TargetOption(EnumerationOption):
+    """
+    Allows the target string to be longer than required by selecting the best
+    fitting target string
+    """
+    def as_enumeration(self, value):
+        targets = self._enumeration.keys()
+        target = self._obj_to_str(value)
+        # check if input string is part of keys OR longer
+        while(len(target) > len("attiny4-")):
+            if target in targets:
+                return self._enumeration[target]
+            else:
+                # cut off last character and try again
+                target = target[:-1]
 
+        # check if input string yields ambiguous results
+        target = self._obj_to_str(value)
+        targets = [t for t in targets if t.startswith(target)]
+        if len(targets):
+            from lbuild.exception import _bp, _hl
+            raise ValueError(_hl("Ambiguous target!\n") + "Multiple devices found:\n\n" + _bp(targets))
+
+        # Otherwise completely unknown target
+        raise TypeError("Target is unknown!")
+
+# =============================================================================
 from lbuild.format import ansi_escape as c
 def modm_format_description(node, description):
     # Remove the HTML comments we use for describing doc tests
@@ -216,9 +243,9 @@ def init(repo):
         exit(1)
 
     repo.add_option(
-        EnumerationOption(name="target",
-                          description="Meta-HAL target device",
-                          enumeration=devices))
+        TargetOption(name="target",
+                     description="Meta-HAL target device",
+                     enumeration=devices))
 
 def prepare(repo, options):
     repo.add_modules_recursive("ext", modulefile="*.lb")

--- a/src/modm/board/al_avreb_can/board.xml
+++ b/src/modm/board/al_avreb_can/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">at90can128</option>
+    <option name="modm:target">at90can128-16au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
   </options>
   <modules>

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -20,7 +20,7 @@ https://www.alvidi.de/products/DE/AVR_Entwicklungsboards/avr_modul_avreb_can.php
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "at90can128":
+    if not options[":target"].partname.startswith("at90can128"):
         return False
 
     module.depends(

--- a/src/modm/board/arduino_nano/board.xml
+++ b/src/modm/board/arduino_nano/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">atmega328p</option>
+    <option name="modm:target">atmega328p-au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
   </options>
   <modules>

--- a/src/modm/board/arduino_nano/module.lb
+++ b/src/modm/board/arduino_nano/module.lb
@@ -16,7 +16,7 @@ def init(module):
     module.description = "Arduino NANO"
 
 def prepare(module, options):
-    if options[":target"].partname != "atmega328p":
+    if not options[":target"].partname.startswith("atmega328p"):
         return False
 
     module.depends(

--- a/src/modm/board/arduino_uno/board.xml
+++ b/src/modm/board/arduino_uno/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">atmega328p</option>
+    <option name="modm:target">atmega328p-au</option>
     <option name="modm:platform:clock:f_cpu">16000000</option>
   </options>
   <modules>

--- a/src/modm/board/arduino_uno/module.lb
+++ b/src/modm/board/arduino_uno/module.lb
@@ -16,7 +16,7 @@ def init(module):
     module.description = "Arduino UNO"
 
 def prepare(module, options):
-    if options[":target"].partname != "atmega328p":
+    if not options[":target"].partname.startswith("atmega328p"):
         return False
 
     module.depends(

--- a/src/modm/board/black_pill/board.xml
+++ b/src/modm/board/black_pill/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f103c8t</option>
+    <option name="modm:target">stm32f103c8t6</option>
   </options>
   <modules>
     <module>modm:board:black-pill</module>

--- a/src/modm/board/black_pill/module.lb
+++ b/src/modm/board/black_pill/module.lb
@@ -55,7 +55,7 @@ Then include this file in your build options like so:
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f103c8t":
+    if not options[":target"].partname.startswith("stm32f103c8t"):
         return False
 
     module.depends(

--- a/src/modm/board/blue_pill/board.xml
+++ b/src/modm/board/blue_pill/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f103c8t</option>
+    <option name="modm:target">stm32f103c8t6</option>
   </options>
   <modules>
     <module>modm:board:blue-pill</module>

--- a/src/modm/board/blue_pill/module.lb
+++ b/src/modm/board/blue_pill/module.lb
@@ -55,7 +55,7 @@ Then include this file in your build options like so:
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f103c8t":
+    if not options[":target"].partname.startswith("stm32f103c8t"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f051r8/board.xml
+++ b/src/modm/board/disco_f051r8/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f051r8t</option>
+    <option name="modm:target">stm32f051r8t6</option>
   </options>
   <modules>
     <module>modm:board:disco-f051r8</module>

--- a/src/modm/board/disco_f051r8/module.lb
+++ b/src/modm/board/disco_f051r8/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f051r8t":
+    if not options[":target"].partname.startswith("stm32f051r8t"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f072rb/board.xml
+++ b/src/modm/board/disco_f072rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f072rbt</option>
+    <option name="modm:target">stm32f072rbt6</option>
   </options>
   <modules>
     <module>modm:board:disco-f072rb</module>

--- a/src/modm/board/disco_f072rb/module.lb
+++ b/src/modm/board/disco_f072rb/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f072rbt":
+    if not options[":target"].partname.startswith("stm32f072rbt"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f100rb/board.xml
+++ b/src/modm/board/disco_f100rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f100rbt</option>
+    <option name="modm:target">stm32f100rbt6</option>
   </options>
   <modules>
     <module>modm:board:disco-f100rb</module>

--- a/src/modm/board/disco_f100rb/module.lb
+++ b/src/modm/board/disco_f100rb/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f100rbt":
+    if not options[":target"].partname.startswith("stm32f100rbt"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f303vc/board.xml
+++ b/src/modm/board/disco_f303vc/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f303vct</option>
+    <option name="modm:target">stm32f303vct6</option>
   </options>
   <modules>
     <module>modm:board:disco-f303vc</module>

--- a/src/modm/board/disco_f303vc/module.lb
+++ b/src/modm/board/disco_f303vc/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f303vct":
+    if not options[":target"].partname.startswith("stm32f303vct"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f407vg/board.xml
+++ b/src/modm/board/disco_f407vg/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f407vgt</option>
+    <option name="modm:target">stm32f407vgt6</option>
   </options>
   <modules>
     <module>modm:board:disco-f407vg</module>

--- a/src/modm/board/disco_f407vg/module.lb
+++ b/src/modm/board/disco_f407vg/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f407vgt":
+    if not options[":target"].partname.startswith("stm32f407vgt"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f429zi/board.xml
+++ b/src/modm/board/disco_f429zi/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f429zit</option>
+    <option name="modm:target">stm32f429zit6</option>
   </options>
   <modules>
     <module>modm:board:disco-f429zi</module>

--- a/src/modm/board/disco_f429zi/module.lb
+++ b/src/modm/board/disco_f429zi/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f429zit":
+    if not options[":target"].partname.startswith("stm32f429zit"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f469ni/board.xml
+++ b/src/modm/board/disco_f469ni/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f469nih</option>
+    <option name="modm:target">stm32f469nih6</option>
     <option name="modm:platform:uart:3:buffer.tx">2048</option>
     <option name="modm:platform:cortex-m:allocator">tlsf</option>
     <option name="modm:tlsf:minimum_pool_size">16777216</option>

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -16,7 +16,7 @@ def init(module):
     module.description = FileReader("module.md")
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f469nih":
+    if not options[":target"].partname.startswith("stm32f469nih"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f746ng/board.xml
+++ b/src/modm/board/disco_f746ng/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f746ngh</option>
+    <option name="modm:target">stm32f746ngh6</option>
 
     <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f746ngh":
+    if not options[":target"].partname.startswith("stm32f746ngh"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_f769ni/board.xml
+++ b/src/modm/board/disco_f769ni/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f769nih</option>
+    <option name="modm:target">stm32f769nih6</option>
 
     <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/disco_f769ni/module.lb
+++ b/src/modm/board/disco_f769ni/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f769nih":
+    if not options[":target"].partname.startswith("stm32f769nih"):
         return False
 
     module.depends(

--- a/src/modm/board/disco_l152rc/board.xml
+++ b/src/modm/board/disco_l152rc/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32l152rct</option>
+    <option name="modm:target">stm32l152rct6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/disco_l152rc/module.lb
+++ b/src/modm/board/disco_l152rc/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32l152rct":
+    if not options[":target"].partname.startswith("stm32l152rct"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":architecture:clock")

--- a/src/modm/board/disco_l476vg/board.xml
+++ b/src/modm/board/disco_l476vg/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32l476vgt</option>
+    <option name="modm:target">stm32l476vgt6</option>
   </options>
   <modules>
     <module>modm:board:disco-l476vg</module>

--- a/src/modm/board/disco_l476vg/module.lb
+++ b/src/modm/board/disco_l476vg/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32l476vgt":
+    if not options[":target"].partname.startswith("stm32l476vgt"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":architecture:clock")

--- a/src/modm/board/mini_f401/board.xml
+++ b/src/modm/board/mini_f401/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f401ccu</option>
+    <option name="modm:target">stm32f401ccu6</option>
   </options>
   <modules>
     <module>modm:board:mini-f401</module>

--- a/src/modm/board/mini_f401/module.lb
+++ b/src/modm/board/mini_f401/module.lb
@@ -56,7 +56,7 @@ Then include this file in your build options like so:
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f401ccu":
+    if not options[":target"].partname.startswith("stm32f401ccu"):
         return False
 
     module.depends(

--- a/src/modm/board/mini_f411/board.xml
+++ b/src/modm/board/mini_f411/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f411ceu</option>
+    <option name="modm:target">stm32f411ceu6</option>
   </options>
   <modules>
     <module>modm:board:mini-f411</module>

--- a/src/modm/board/mini_f411/module.lb
+++ b/src/modm/board/mini_f411/module.lb
@@ -56,7 +56,7 @@ Then include this file in your build options like so:
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f411ceu":
+    if not options[":target"].partname.startswith("stm32f411ceu"):
         return False
 
     module.depends(

--- a/src/modm/board/nucleo_f031k6/board.xml
+++ b/src/modm/board/nucleo_f031k6/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f031k6t</option>
+    <option name="modm:target">stm32f031k6t6</option>
 
     <option name="modm:platform:uart:1:buffer.tx">256</option>
     <option name="modm:platform:cortex-m:main_stack_size">992</option>

--- a/src/modm/board/nucleo_f031k6/module.lb
+++ b/src/modm/board/nucleo_f031k6/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f031k6t":
+    if not options[":target"].partname.startswith("stm32f031k6t"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:1",

--- a/src/modm/board/nucleo_f042k6/board.xml
+++ b/src/modm/board/nucleo_f042k6/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f042k6t</option>
+    <option name="modm:target">stm32f042k6t6</option>
     <option name="modm:platform:uart:2:buffer.tx">256</option>
     <option name="modm:platform:cortex-m:main_stack_size">992</option>
     <option name="modm:platform:cortex-m:allocator">block</option>

--- a/src/modm/board/nucleo_f042k6/module.lb
+++ b/src/modm/board/nucleo_f042k6/module.lb
@@ -21,7 +21,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f042k6t":
+    if not options[":target"].partname.startswith("stm32f042k6t"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_f103rb/board.xml
+++ b/src/modm/board/nucleo_f103rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f103rbt</option>
+    <option name="modm:target">stm32f103rbt6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f103rb/module.lb
+++ b/src/modm/board/nucleo_f103rb/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f103rbt":
+    if not options[":target"].partname.startswith("stm32f103rbt"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_f303k8/board.xml
+++ b/src/modm/board/nucleo_f303k8/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f303k8t</option>
+    <option name="modm:target">stm32f303k8t6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f303k8/module.lb
+++ b/src/modm/board/nucleo_f303k8/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f303k8t":
+    if not options[":target"].partname.startswith("stm32f303k8t"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_f401re/board.xml
+++ b/src/modm/board/nucleo_f401re/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f401ret</option>
+    <option name="modm:target">stm32f401ret6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f401re/module.lb
+++ b/src/modm/board/nucleo_f401re/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f401ret":
+    if not options[":target"].partname.startswith("stm32f401ret"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_f411re/board.xml
+++ b/src/modm/board/nucleo_f411re/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f411ret</option>
+    <option name="modm:target">stm32f411ret6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f411re/module.lb
+++ b/src/modm/board/nucleo_f411re/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f411ret":
+    if not options[":target"].partname.startswith("stm32f411ret"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_f429zi/board.xml
+++ b/src/modm/board/nucleo_f429zi/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f429zit</option>
+    <option name="modm:target">stm32f429zit6</option>
 
     <option name="modm:platform:uart:3:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f429zi/module.lb
+++ b/src/modm/board/nucleo_f429zi/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f429zit":
+    if not options[":target"].partname.startswith("stm32f429zit"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:3",

--- a/src/modm/board/nucleo_f446re/board.xml
+++ b/src/modm/board/nucleo_f446re/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f446ret</option>
+    <option name="modm:target">stm32f446ret6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_f446re/module.lb
+++ b/src/modm/board/nucleo_f446re/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f446ret":
+    if not options[":target"].partname.startswith("stm32f446ret"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_g071rb/board.xml
+++ b/src/modm/board/nucleo_g071rb/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32g071rbt</option>
+    <option name="modm:target">stm32g071rbt6</option>
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>
   <modules>

--- a/src/modm/board/nucleo_g071rb/module.lb
+++ b/src/modm/board/nucleo_g071rb/module.lb
@@ -19,7 +19,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32g071rbt":
+    if not options[":target"].partname.startswith("stm32g071rbt"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_g474re/board.xml
+++ b/src/modm/board/nucleo_g474re/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32g474ret</option>
+    <option name="modm:target">stm32g474ret6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_g474re/module.lb
+++ b/src/modm/board/nucleo_g474re/module.lb
@@ -19,7 +19,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32g474ret":
+    if not options[":target"].partname.startswith("stm32g474ret"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_l152re/board.xml
+++ b/src/modm/board/nucleo_l152re/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32l152ret</option>
+    <option name="modm:target">stm32l152ret6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_l152re/module.lb
+++ b/src/modm/board/nucleo_l152re/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32l152ret":
+    if not options[":target"].partname.startswith("stm32l152ret"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_l432kc/board.xml
+++ b/src/modm/board/nucleo_l432kc/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32l432kcu</option>
+    <option name="modm:target">stm32l432kcu6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_l432kc/module.lb
+++ b/src/modm/board/nucleo_l432kc/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32l432kcu":
+    if not options[":target"].partname.startswith("stm32l432kcu"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/nucleo_l476rg/board.xml
+++ b/src/modm/board/nucleo_l476rg/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32l476rgt</option>
+    <option name="modm:target">stm32l476rgt6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/nucleo_l476rg/module.lb
+++ b/src/modm/board/nucleo_l476rg/module.lb
@@ -20,7 +20,7 @@ def init(module):
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32l476rgt":
+    if not options[":target"].partname.startswith("stm32l476rgt"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",

--- a/src/modm/board/olimexino_stm32/board.xml
+++ b/src/modm/board/olimexino_stm32/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f103rbt</option>
+    <option name="modm:target">stm32f103rbt6</option>
 
     <option name="modm:platform:uart:1:buffer.tx">2048</option>
   </options>

--- a/src/modm/board/olimexino_stm32/module.lb
+++ b/src/modm/board/olimexino_stm32/module.lb
@@ -21,7 +21,7 @@ https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32/open-source-hardware
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f103rbt":
+    if not options[":target"].partname.startswith("stm32f103rbt"):
         return False
 
     module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:1",

--- a/src/modm/board/stm32f030f4p6_demo/board.xml
+++ b/src/modm/board/stm32f030f4p6_demo/board.xml
@@ -6,7 +6,7 @@
   </repositories>
 
   <options>
-    <option name="modm:target">stm32f030f4p</option>
+    <option name="modm:target">stm32f030f4p6</option>
   </options>
   <modules>
     <module>modm:board:stm32f030_demo</module>

--- a/src/modm/board/stm32f030f4p6_demo/module.lb
+++ b/src/modm/board/stm32f030f4p6_demo/module.lb
@@ -53,7 +53,7 @@ Then include this file in your build options like so:
 """
 
 def prepare(module, options):
-    if options[":target"].partname != "stm32f030f4p":
+    if not options[":target"].partname.startswith("stm32f030f4p"):
         return False
 
     module.depends(

--- a/src/modm/platform/adc/at90_tiny_mega/module.lb
+++ b/src/modm/platform/adc/at90_tiny_mega/module.lb
@@ -36,7 +36,7 @@ def build(env):
     device = env[":target"]
     driver = device.get_driver("adc")
 
-    properties = device.properties
+    properties = {}
     properties["target"] = target = device.identifier
     properties["driver"] = driver
 
@@ -66,7 +66,7 @@ def build(env):
         if target["name"] in ['8', '16', '32'] and target["type"] in ['hva', 'hvab', 'hvabrevb', 'hvb', 'hvbrevb']:
             properties["vadc"] = True
 
-        if target["name"] in ['8', '128'] and target["type"] in ['a', '']:
+        if target["name"] in ['8', '128'] and target["type"] in ['a', 'l', '']:
             properties["adfr"] = True
 
         if (target["name"] in ['16', '32'] and target["type"] in ['u4']) or \
@@ -77,11 +77,11 @@ def build(env):
         if target["name"] in ['8', '48', '88', '168', '328'] and target["type"] in ['a', '', 'p', 'pa']:
             properties["nomux4"] = True
 
-        if target["name"] in ['16', '32', '8535'] and target["type"] in ['a', '']:
+        if target["name"] in ['16', '32', '8535'] and target["type"] in ['a', 'l', '']:
             properties["sfior"] = True
 
         # ADC High Speed Mode has been removed from some chips
-        if target["name"] in ['8', '16', '32', '64'] and target["type"] in ['m1', 'u4', 'c1', 'u6']:
+        if target["name"] in ['8', '16', '32', '64'] and target["type"] in ['m1', 'u4', 'u4rc', 'c1', 'u6']:
             properties["adhsm"] = True
 
     env.substitutions = properties

--- a/src/modm/platform/gpio/at90_tiny_mega/module.lb
+++ b/src/modm/platform/gpio/at90_tiny_mega/module.lb
@@ -112,7 +112,7 @@ def validate(env):
 def build(env):
     device = env[":target"]
     driver = device.get_driver("gpio")
-    properties = device.properties
+    properties = {}
     properties["target"] = target = device.identifier
     properties["driver"] = driver
     properties.update(bprops)
@@ -134,7 +134,7 @@ def build(env):
     else:
         properties["eicra"] = "EICRA"
 
-    if target["family"] == "mega" and target["name"] in ["8", "16", "32", "8515", "8535"] and target["type"] not in ["u2", "u4"]:
+    if target["family"] == "mega" and target["name"] in ["8", "16", "32", "8515", "8535"] and target["type"] not in ["u2", "u4", "u4rc"]:
         properties["isc2"] = "MCUCSR"
     if target["family"] == "mega" and target["name"] in ["162"]:
         properties["isc2"] = "EMCUCR"

--- a/test/all/Makefile
+++ b/test/all/Makefile
@@ -13,13 +13,7 @@ run-avr:
 	python3 run_all.py at
 
 run-stm32:
-	python3 run_all.py stm32f0
-	python3 run_all.py stm32f1
-	python3 run_all.py stm32f2
-	python3 run_all.py stm32f3
-	python3 run_all.py stm32f4
-	python3 run_all.py stm32f7
-	python3 run_all.py stm32l4
+	python3 run_all.py stm32
 
 run-failed:
 	python3 run_all.py failed

--- a/test/all/ignored.txt
+++ b/test/all/ignored.txt
@@ -90,8 +90,11 @@ attiny4
 attiny40
 attiny5
 attiny9
-# FIXME: modm-devices cannot deal with -A/-X variants
-stm32l151qch
-stm32l151zct
-stm32l152qch
-stm32l152zct
+# FIXME: Missing SPI0 instance
+atmega164pa
+atmega324pa
+# FIXME: cmsis-header issues on this one
+stm32l151qch6
+stm32l151zct6
+stm32l152qch6
+stm32l152zct6

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -320,8 +320,14 @@ def common_compiler_flags(compiler, target):
         ]
 
     elif core.startswith("avr"):
+        # avr-gcc only accepts certain device strings for its -mmcu flag
+        # See https://gcc.gnu.org/onlinedocs/gcc/AVR-Options.html
+        mmcu = target.partname.split("-")[0]
+        for suffix in {"v", "f", "l", "rc"}:
+            mmcu = mmcu[:-2] + mmcu[-2:].replace(suffix, "")
+
         flags["archflags"] += [
-            "-mmcu={}".format(target.partname),
+            "-mmcu={}".format(mmcu),
         ]
         flags["cxxflags"] += [
             "-fno-exceptions",

--- a/tools/scripts/generate_module_docs.py
+++ b/tools/scripts/generate_module_docs.py
@@ -33,7 +33,28 @@ def get_modules(builder, limit=None):
     builder._load_repositories(repopath("repo.lb"))
     option = builder.parser.find_option(":target")
 
-    targets = list(set(option.values) - set(d for d in repopath("test/all/ignored.txt").read_text().strip().splitlines() if "#" not in d))
+    raw_targets = list(set(option.values) - set(d for d in repopath("test/all/ignored.txt").read_text().strip().splitlines() if "#" not in d))
+
+    # Reduce device set a little to keep RAM usage in check
+    # this should ~half the considered devices
+    short_targets = set()
+    targets = []
+    for d in raw_targets:
+        if d.startswith("stm32"):
+            # filter out temperature key
+            sd = d[:12] + d[13:]
+            if sd not in short_targets:
+                targets.append(d)
+                short_targets.add(sd)
+        elif d.startswith("at"):
+            # filter out package
+            sd = d.split("-")[0]
+            if sd not in short_targets:
+                targets.append(d)
+                short_targets.add(sd)
+        else:
+            targets.append(d)
+
     if limit is not None:
         targets = targets[:limit]
     targets = sorted(targets)


### PR DESCRIPTION
modm-devices recently upgraded it's device identifiers to untangle some more merged devices.
This requires specifying the additional identifiers of the device.
All other submodules were upgraded too, with some significant additions to CMSIS-DSP.

TODO:
- [x] Adapt for CMSIS-DSP additions.
- [x] Modify compile-all tests to not compile devices that only differ in *temperature* rating (like `stm32f407vtg6` vs `stm32f407vtg7`)
- [x] Modify `generate_module_docs.py` to ignore *temperature* key for STM32 and *package* for AVR to keep RAM usage in check for CI.
- [x] Subclass EnumerationOption to allow longer than required identifiers (`stm32f407vtg6u` vs. required `stm32f407vtg6`) to allow people to simply enter the code that's laser engraved on the actual chip. Give a better error message when input string is too short.

cc @rleh @chris-durand 
