### PR TITLE
Implementation of interrupt hooks

### DIFF
--- a/examples/nucleo_f042k6/hooks/main.cpp
+++ b/examples/nucleo_f042k6/hooks/main.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ * Copyright (c) 2019, Benjamin Weps
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		modm::delayMilliseconds(Button::read() ? 100 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}
+
+//This hook will be triggered, whenever an interrupt occurs on the USART
+MODM_ISR_ENTRY_HOOK(USART2)
+{
+	//Toggle the LED whenever we received a byte
+	if (modm::platform::UsartHal2::isReceiveRegisterNotEmpty())
+	{
+		LedD13::toggle();
+	}
+}

--- a/examples/nucleo_f042k6/hooks/project.xml
+++ b/examples/nucleo_f042k6/hooks/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f042k6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f042k6/can</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/interrupt.hpp
+++ b/src/modm/architecture/interface/interrupt.hpp
@@ -88,6 +88,19 @@
  */
 #define MODM_ISR(vector, ...)
 
+/**
+ * Declare an interrupt handler with enter and leave hooks.
+ *
+ *
+ * @param vector
+ *        The name of the interrupt without any suffix (neither `_vect`, nor `_IRQHandler`).
+ * @param ...
+ *        Multiple compiler attributes can be added to an interrupt. For example `modm_fastcode`.
+ *
+ * @ingroup	modm_architecture_interrupt
+ */
+#define MODM_ISR_HOOKS(vector, ...)
+
 #else
 
 #ifdef MODM_CPU_AVR
@@ -113,6 +126,23 @@
 		modm_extern_c void vector ## _IRQHandler(void) \
 			__attribute__((externally_visible)) __VA_ARGS__; \
 		void vector ## _IRQHandler(void)
+#	define MODM_ISR_HOOKS(vector, ...) \
+		modm_extern_c __attribute__((weak)) void vector ## _ISR_Entry(void){} \
+		modm_extern_c __attribute__((weak)) void vector ## _ISR_Exit(void){} \
+		void vector ## _ISR_Main(); \
+		modm_extern_c void vector ## _IRQHandler(void) \
+			__attribute__((externally_visible)) __VA_ARGS__; \
+		void vector ## _IRQHandler(void) \
+		{ \
+			vector ## _ISR_Entry(); \
+			vector ## _ISR_Main(); \
+			vector ## _ISR_Exit(); \
+		} \
+		void vector ## _ISR_Main()
+# define MODM_ISR_ENTRY_HOOK(vector) \
+		modm_extern_c void vector ## _ISR_Entry(void)
+# define MODM_ISR_EXIT_HOOK(vector) \
+		modm_extern_c void vector ## _ISR_Exit(void)
 
 #else
 

--- a/src/modm/architecture/interface/interrupt.hpp
+++ b/src/modm/architecture/interface/interrupt.hpp
@@ -127,9 +127,9 @@
 			__attribute__((externally_visible)) __VA_ARGS__; \
 		void vector ## _IRQHandler(void)
 #	define MODM_ISR_HOOKS(vector, ...) \
-		modm_extern_c __attribute__((weak)) void vector ## _ISR_Entry(void){} \
-		modm_extern_c __attribute__((weak)) void vector ## _ISR_Exit(void){} \
-		void vector ## _ISR_Main(); \
+		modm_extern_c modm_weak void vector ## _ISR_Entry(void){} \
+		modm_extern_c modm_weak void vector ## _ISR_Exit(void){} \
+		static void vector ## _ISR_Main(); \
 		modm_extern_c void vector ## _IRQHandler(void) \
 			__attribute__((externally_visible)) __VA_ARGS__; \
 		void vector ## _IRQHandler(void) \
@@ -138,7 +138,7 @@
 			vector ## _ISR_Main(); \
 			vector ## _ISR_Exit(); \
 		} \
-		void vector ## _ISR_Main()
+		static void inline vector ## _ISR_Main()
 # define MODM_ISR_ENTRY_HOOK(vector) \
 		modm_extern_c void vector ## _ISR_Entry(void)
 # define MODM_ISR_EXIT_HOOK(vector) \

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -220,7 +220,7 @@ readMailbox(modm::can::Message& message, uint32_t mailboxId, uint8_t* filter_id)
  * Generated when Transmit Mailbox 0..2 becomes empty.
  */
 
-MODM_ISR({{ reg }}_TX)
+MODM_ISR_HOOKS({{ reg }}_TX)
 {
 %% if options["buffer.tx"] > 0
 	uint32_t mailbox;
@@ -253,7 +253,7 @@ MODM_ISR({{ reg }}_TX)
  * Generated on a new received message, FIFO0 full condition and Overrun
  * Condition.
  */
-MODM_ISR({{ reg }}_RX0)
+MODM_ISR_HOOKS({{ reg }}_RX0)
 {
 	if ({{ reg }}->RF0R & CAN_RF0R_FOVR0) {
 		modm::ErrorReport::report(modm::platform::CAN{{ id }}_FIFO0_OVERFLOW);
@@ -280,7 +280,7 @@ MODM_ISR({{ reg }}_RX0)
  *
  * See FIFO0 Interrupt
  */
-MODM_ISR({{ reg }}_RX1)
+MODM_ISR_HOOKS({{ reg }}_RX1)
 {
 	if ({{ reg }}->RF1R & CAN_RF1R_FOVR1) {
 		modm::ErrorReport::report(modm::platform::CAN{{ id }}_FIFO1_OVERFLOW);
@@ -308,7 +308,7 @@ MODM_ISR({{ reg }}_RX1)
 // the interrupt source and call the correct interrupts function defined above.
 // Sources for the different interrupts are specified in the Reference Manual
 // in the "bxCAN interrupts" section.
-MODM_ISR(CEC_CAN)
+MODM_ISR_HOOKS(CEC_CAN)
 {
 	if({{ reg }}->TSR & (CAN_TSR_RQCP0 | CAN_TSR_RQCP1 | CAN_TSR_RQCP2)) {
 		MODM_ISR_CALL({{ reg }}_TX);

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -200,7 +200,7 @@ modm::platform::{{ name }}::discardReceiveBuffer()
 void
 modm::platform::{{ name }}::irq()
 %% else
-MODM_ISR({{ name | upper }})
+MODM_ISR_HOOKS({{ name | upper }})
 %% endif
 {
 	if ({{ hal }}::isReceiveRegisterNotEmpty()) {


### PR DESCRIPTION
So second try on the interrupt hooks.  :smile: 

This approach will do the interrupt handling in three steps. First it calls the entry hook, then the main method and at last the exit hook. The two hooks are defined as weak, empty functions, that can be redefined in the user code.

To enable the hook, the ISR macro in the driver just has to be changed from `MODM_ISR` to `MODM_ISR_HOOKS `. This macro will be compatible to the old interrupt handling but additionally creates the two hook methods.

To implement the hooks there are two macros: `MODM_ISR_ENTRY_HOOK`  to implement the entry hook and `MODM_ISR_EXIT_HOOK` to implement the exit hook. 

I added an example for the Nucleo-F042 that toggles the LED whenever a byte has been received via the UART.