### PR TITLE
Added timestamps to CAN messages when receiving

### DIFF
--- a/src/modm/architecture/interface/can_message.hpp
+++ b/src/modm/architecture/interface/can_message.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, 2016, Niklas Hauser
  * Copyright (c) 2015-2016, Sascha Schade
+ * Copyright (c) 2019, Benjamin Weps
  *
  * This file is part of the modm project.
  *
@@ -16,6 +17,7 @@
 #include <stdint.h>
 #include <modm/io/iostream.hpp>
 #include <modm/architecture/utils.hpp>
+#include <modm/processing/timer/timestamp.hpp>
 
 namespace modm
 {
@@ -80,6 +82,18 @@ struct Message
 		length = len;
 	}
 
+	inline Timestamp
+	getTimestamp()
+	{
+		return timestamp;
+	}
+
+	inline void
+	setTimestamp(Timestamp ts)
+	{
+		timestamp = ts;
+	}
+
 public:
 	uint32_t identifier;
 	uint8_t modm_aligned(4) data[8];
@@ -94,6 +108,7 @@ public:
 		bool extended : 1;
 	} flags;
 	uint8_t length;
+	Timestamp timestamp;
 
 public:
 	bool

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -20,6 +20,7 @@
 #include <modm/architecture/interface/assert.hpp>
 #include <modm/architecture/interface/interrupt.hpp>
 #include <modm/architecture/interface/delay.hpp>
+#include <modm/architecture/interface/clock.hpp>
 #include <modm/platform/clock/rcc.hpp>
 
 %% if id == ""
@@ -264,6 +265,7 @@ MODM_ISR({{ reg }}_RX0)
 
 %% if options["buffer.rx"] > 0
 	RxMessage rxMessage;
+	rxMessage.message.setTimestamp(modm::Clock::now());
 	readMailbox(rxMessage.message, 0, &(rxMessage.filter_id));
 
 	// Release FIFO (access the next message)
@@ -291,6 +293,7 @@ MODM_ISR({{ reg }}_RX1)
 
 %% if options["buffer.rx"] > 0
 	RxMessage rxMessage;
+	rxMessage.message.setTimestamp(modm::Clock::now());
 	readMailbox(rxMessage.message, 1, &(rxMessage.filter_id));
 
 	// Release FIFO (access the next message)


### PR DESCRIPTION
To implement a time-synchronization mechanism for a CAN network I added a timestamp feature to the CAN driver.
This feature will append the current timestamp to all incoming messages, such that one can read the time of arrival when processing the message.

I'm not sure if this featured is needed or desired in the modm mainline code, but I thought I'd offer it.