### PR TITLE
[docs] Explicitly declare the lbuild module in docs

### DIFF
--- a/docs/module.md.in
+++ b/docs/module.md.in
@@ -1,4 +1,6 @@
-# {{module.name}}{% if module.title %}: {{module.title}}{% endif %}
+# {{ module.title if module.title else module.name }}
+
+lbuild module: `{{module.name}}`
 
 {{module.description}}
 

--- a/tools/doc_generator/group.dox.in
+++ b/tools/doc_generator/group.dox.in
@@ -5,8 +5,9 @@
 %% endif
 @defgroup {{ module.ref }} {{ module.title if module.title else module.name }}
 
-{{ module.description | doxify }}
+lbuild module: `{{module.name}}`
 
+{{ module.description | doxify }}
 
 %% if module.options | length
 ## Module Options


### PR DESCRIPTION
Closes #312 

I originally wanted to use:

> lbuild module: `<module>name</module>`

but that was too much `module` for me. ;-P

Any better ideas? cc @rleh 