### PR TITLE
STM32G4 ADC improvements

### DIFF
--- a/examples/nucleo_g474re/adc/main.cpp
+++ b/examples/nucleo_g474re/adc/main.cpp
@@ -25,7 +25,7 @@ main()
 	Adc1::initialize<
 		Board::SystemClock,
 		1_MHz, 10_pct,
-		Adc1::ClockMode::SynchronousPrescaler1,
+		Adc1::ClockMode::SynchronousPrescaler2,
 		Adc1::ClockSource::SystemClock>();
 
 	Adc1::connect<GpioA0::In1>();

--- a/examples/nucleo_g474re/adc/main.cpp
+++ b/examples/nucleo_g474re/adc/main.cpp
@@ -18,9 +18,9 @@ main()
 {
 	Board::initialize();
 	LedD13::setOutput();
-	Adc1::connect<GpioB10::In11>();
+	//Adc1::connect<GpioB10::In11>();
 
-	Adc1::initialize<Board::SystemClock, 1_MHz, 10_pct, Adc1::ClockMode::Asynchronous>();
+	Adc1::initialize<Board::SystemClock, Adc1::ClockMode::Asynchronous, 1_MHz>();
 
 	uint16_t Vref = Adc1::readInternalVoltageReference();
 	int16_t Temp = Adc1::readTemperature(Vref);

--- a/examples/nucleo_g474re/adc/project.xml
+++ b/examples/nucleo_g474re/adc/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/adc</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -26,12 +26,7 @@ main()
 	// 170 MHz AHB clock / 4 = 42.5 MHz
 	Adc1::initialize<Board::SystemClock, 0_MHz, 0_pct, Adc1::ClockMode::SynchronousPrescaler4,
 					 Adc1::ClockSource::SystemClock>();
-	// Adc1::initialize(
-	// 	Adc1::ClockMode::SynchronousPrescaler4,
-	// 	Adc1::ClockSource::SystemClock,
-	// 	Adc1::Prescaler::Disabled,
-	// 	Adc1::CalibrationMode::SingleEndedInputsMode,
-	// 	true);
+
 	Adc1::connect<GpioA0::In1>();
 	Adc1::setPinChannel<GpioA0>(Adc1::SampleTime::Cycles13);
 

--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -24,7 +24,7 @@ main()
 	MODM_LOG_INFO << "Configuring ADC ...";
 	// max. ADC clock for STM32G474: 60 MHz
 	// 170 MHz AHB clock / 4 = 42.5 MHz
-	Adc1::initialize<Board::SystemClock, 10_MHz, 10_pct, Adc1::ClockMode::SynchronousPrescaler4,
+	Adc1::initialize<Board::SystemClock, 0_MHz, 0_pct, Adc1::ClockMode::SynchronousPrescaler4,
 					 Adc1::ClockSource::SystemClock>();
 	// Adc1::initialize(
 	// 	Adc1::ClockMode::SynchronousPrescaler4,
@@ -38,7 +38,7 @@ main()
 	while (true)
 	{
 		Adc1::startConversion();
-		while(!Adc1::isConversionFinished)
+		while(!Adc1::isConversionFinished())
 			;
 		int adcValue = Adc1::getValue();
 		MODM_LOG_INFO << "adcValue=" << adcValue;

--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -24,12 +24,14 @@ main()
 	MODM_LOG_INFO << "Configuring ADC ...";
 	// max. ADC clock for STM32G474: 60 MHz
 	// 170 MHz AHB clock / 4 = 42.5 MHz
-	Adc1::initialize(
-		Adc1::ClockMode::SynchronousPrescaler4,
-		Adc1::ClockSource::SystemClock,
-		Adc1::Prescaler::Disabled,
-		Adc1::CalibrationMode::SingleEndedInputsMode,
-		true);
+	Adc1::initialize<Board::SystemClock, 10_MHz, 10_pct, Adc1::ClockMode::SynchronousPrescaler4,
+					 Adc1::ClockSource::SystemClock>();
+	// Adc1::initialize(
+	// 	Adc1::ClockMode::SynchronousPrescaler4,
+	// 	Adc1::ClockSource::SystemClock,
+	// 	Adc1::Prescaler::Disabled,
+	// 	Adc1::CalibrationMode::SingleEndedInputsMode,
+	// 	true);
 	Adc1::connect<GpioA0::In1>();
 	Adc1::setPinChannel<GpioA0>(Adc1::SampleTime::Cycles13);
 

--- a/examples/nucleo_g474re/adc_interrupt/main.cpp
+++ b/examples/nucleo_g474re/adc_interrupt/main.cpp
@@ -101,35 +101,35 @@ main()
 
 MODM_ISR(ADC1_2)
 {
-	MODM_LOG_INFO << "Entry Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
-	MODM_LOG_INFO << "Entry Adc2::getInterruptFlags() = " << modm::bin << Adc2::getInterruptFlags() << modm::ascii << "\n";
+	MODM_LOG_DEBUG << "Entry Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	MODM_LOG_DEBUG << "Entry Adc2::getInterruptFlags() = " << modm::bin << Adc2::getInterruptFlags() << modm::ascii << "\n";
 
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfSampling) {
-		MODM_LOG_INFO << "ACK EndOfSampling\n";
+		MODM_LOG_DEBUG << "ACK EndOfSampling\n";
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfSampling);
 	}
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfRegularConversion) {
-		MODM_LOG_INFO << "ACK EndOfRegularConversion\n";
+		MODM_LOG_DEBUG << "ACK EndOfRegularConversion\n";
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularConversion);
-		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
+		MODM_LOG_DEBUG << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
 	}
 
-	MODM_LOG_INFO << "Middle Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	MODM_LOG_DEBUG << "Middle Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
 
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfRegularSequenceOfConversions) {
-		MODM_LOG_INFO << "ACK EndOfRegularSequenceOfConversions\n";
+		MODM_LOG_DEBUG << "ACK EndOfRegularSequenceOfConversions\n";
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularSequenceOfConversions);
-		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
+		MODM_LOG_DEBUG << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
 	}
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedConversion) {
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedConversion);
-		MODM_LOG_INFO << "ACK EndOfInjectedConversion\n";
+		MODM_LOG_DEBUG << "ACK EndOfInjectedConversion\n";
 	}
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions) {
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions);
-		MODM_LOG_INFO << "ACK EndOfInjectedSequenceOfConversions\n";
+		MODM_LOG_DEBUG << "ACK EndOfInjectedSequenceOfConversions\n";
 	}
-	MODM_LOG_INFO << "Exit Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	MODM_LOG_DEBUG << "Exit Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
 	Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag_t{0xffff'ffff});
 	__DSB();
 }
@@ -137,7 +137,7 @@ MODM_ISR(ADC1_2)
 MODM_ISR(TIM1_CC)
 {
 	if(Timer1::getInterruptFlags() & Timer1::InterruptFlag::CaptureCompare4) {
-		MODM_LOG_INFO << "TIM1_CC interrupt CaptureCompare4 entered!\n";
+		MODM_LOG_DEBUG << "TIM1_CC interrupt CaptureCompare4 entered!\n";
 		Timer1::acknowledgeInterruptFlags(Timer1::InterruptFlag::CaptureCompare4);
 	}
 	else {
@@ -148,7 +148,7 @@ MODM_ISR(TIM1_CC)
 MODM_ISR(TIM1_UP_TIM16)
 {
 	if(Timer1::getInterruptFlags() & Timer1::InterruptFlag::Update) {
-		MODM_LOG_INFO << "TIM1_UP_TIM16 interrupt Update entered!\n";
+		MODM_LOG_DEBUG << "TIM1_UP_TIM16 interrupt Update entered!\n";
 		Timer1::acknowledgeInterruptFlags(Timer1::InterruptFlag::Update);
 	}
 	else {

--- a/examples/nucleo_g474re/adc_interrupt/main.cpp
+++ b/examples/nucleo_g474re/adc_interrupt/main.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+#include <modm/platform/adc/adc_1.hpp>
+#include <array>
+
+using namespace modm::literals;
+
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "STM32G4 ADC interrupt example" << modm::endl;
+	MODM_LOG_INFO << " running on Nucleo-G474RE" << modm::endl << modm::endl;
+	MODM_LOG_INFO << "GpioA0/Adc1Ch1 and GpioA1/Adc1Ch2 are sampled as an injected sequence." << modm::endl;
+	MODM_LOG_INFO << "This sequence is triggered by timer 1 output compare 4 event, which is generated at a freuqnency of 1Hz." << modm::endl;
+	MODM_LOG_INFO << "GpioA2/Adc1Ch3 and GpioA3/Adc1Ch4 are sampled as an regular sequence triggered by software." << modm::endl;
+	MODM_LOG_INFO << "ADC data is read in an interrupt and printed to this log." << modm::endl;
+
+	MODM_LOG_INFO << "Configuring ADC ...";
+	Adc1::initialize(
+		Adc1::ClockMode::SynchronousPrescaler1,
+		Adc1::ClockSource::SystemClock,
+		Adc1::Prescaler::Disabled,
+		Adc1::CalibrationMode::SingleEndedInputsMode,
+		true);
+
+	GpioA0::setAnalogInput(); // Adc1Ch1
+	GpioA1::setAnalogInput(); // Adc1Ch2
+	GpioA2::setAnalogInput(); // Adc1Ch3
+	GpioA3::setAnalogInput(); // Adc1Ch4
+
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel1, Adc1::SampleTime::Cycles13);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel2, Adc1::SampleTime::Cycles13);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel3, Adc1::SampleTime::Cycles13);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel4, Adc1::SampleTime::Cycles13);
+
+	Adc1::setInjectedChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel1, Adc1::Channel::Channel2});
+	Adc1::setChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel3, Adc1::Channel::Channel4});
+
+	Adc1::setInjectedTrigger(Adc1::TriggerMode::RisingEdge, Adc1::TriggerSourceInjected::Tim1Cc4);
+
+	Adc1::enableInterruptVector(5);
+	Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularConversion);
+	Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedSequenceOfConversions);
+	MODM_LOG_INFO << " finished." << modm::endl;
+
+	MODM_LOG_INFO << "Configuring Timer 1 ...";
+	Timer1::enable();
+	Timer1::setMode(Timer1::Mode::UpCounter);
+	// Timer 1 runs at 170_MHz / prescaler=17000 = 10kHz
+	Timer1::setPrescaler(17000);
+	// Timer over with 1_Hz = 10kHz / overflow=10000
+	Timer1::setOverflow(10000);
+	Timer1::setCompareValue(4, 1);
+	Timer1::start();
+	MODM_LOG_INFO << " finished." << modm::endl;
+
+	while (true)
+	{
+		MODM_LOG_INFO << "Triggering a regular conversion sequence from software." << modm::endl;
+		Adc1::startConversion();
+		modm::delayMilliseconds(500);
+	}
+
+	return 0;
+}
+
+MODM_ISR(ADC1)
+{
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfRegularConversion) {
+		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularConversion);
+		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << modm::endl;
+	}
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions) {
+		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions);
+		MODM_LOG_INFO << "Interrupt: injectedCh1=" << Adc1::getInjectedValue<1>() << modm::endl;
+		MODM_LOG_INFO << "Interrupt: injectedCh2=" << Adc1::getInjectedValue<2>() << modm::endl;
+	}
+}

--- a/examples/nucleo_g474re/adc_interrupt/main.cpp
+++ b/examples/nucleo_g474re/adc_interrupt/main.cpp
@@ -40,54 +40,118 @@ main()
 
 	GpioA0::setAnalogInput(); // Adc1Ch1
 	GpioA1::setAnalogInput(); // Adc1Ch2
-	GpioA2::setAnalogInput(); // Adc1Ch3
-	GpioA3::setAnalogInput(); // Adc1Ch4
+	//GpioA2::setAnalogInput(); // Adc1Ch3
+	//GpioA3::setAnalogInput(); // Adc1Ch4
 
-	Adc1::setChannelSampleTime(Adc1::Channel::Channel1, Adc1::SampleTime::Cycles13);
-	Adc1::setChannelSampleTime(Adc1::Channel::Channel2, Adc1::SampleTime::Cycles13);
-	Adc1::setChannelSampleTime(Adc1::Channel::Channel3, Adc1::SampleTime::Cycles13);
-	Adc1::setChannelSampleTime(Adc1::Channel::Channel4, Adc1::SampleTime::Cycles13);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel1, Adc1::SampleTime::Cycles641);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel2, Adc1::SampleTime::Cycles641);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel3, Adc1::SampleTime::Cycles641);
+	Adc1::setChannelSampleTime(Adc1::Channel::Channel4, Adc1::SampleTime::Cycles641);
 
 	Adc1::setInjectedChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel1, Adc1::Channel::Channel2});
 	Adc1::setChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel3, Adc1::Channel::Channel4});
 
-	Adc1::setInjectedTrigger(Adc1::TriggerMode::RisingEdge, Adc1::TriggerSourceInjected::Tim1Cc4);
+	Adc1::setInjectedTrigger(Adc1::TriggerMode::BothEdges, Adc1::TriggerSourceInjected::Tim1Trgo2);
 
 	Adc1::enableInterruptVector(5);
 	Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularConversion);
+	Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularSequenceOfConversions);
+	Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedConversion);
 	Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedSequenceOfConversions);
 	MODM_LOG_INFO << " finished." << modm::endl;
 
 	MODM_LOG_INFO << "Configuring Timer 1 ...";
 	Timer1::enable();
+	Timer1::pause();
 	Timer1::setMode(Timer1::Mode::UpCounter);
 	// Timer 1 runs at 170_MHz / prescaler=17000 = 10kHz
 	Timer1::setPrescaler(17000);
 	// Timer over with 1_Hz = 10kHz / overflow=10000
 	Timer1::setOverflow(10000);
-	Timer1::setCompareValue(4, 1);
+	Timer1::setCompareValue(4, 100);
+	//Timer1::enableInterrupt(Timer1::Interrupt::CaptureCompare4);
+	//Timer1::enableInterruptVector(Timer1::Interrupt::CaptureCompare4, true, 10);
+	//Timer1::enableInterrupt(Timer1::Interrupt::Update);
+	//Timer1::enableInterruptVector(Timer1::Interrupt::Update, true, 10);
+
+	// Trigger output for ADC
+	TIM1->CR2 |= (0b1100 << TIM_CR2_MMS2_Pos);
+	//TIM1->CR2 |= (0b??? << TIM_CR2_MMS_Pos);
+	
+	Timer1::applyAndReset();
 	Timer1::start();
+	Timer1::enableOutput();
+
 	MODM_LOG_INFO << " finished." << modm::endl;
 
+	modm::delayMilliseconds(500);
+
+	MODM_LOG_INFO << "Starting while(true) loop." << modm::endl;
 	while (true)
 	{
 		MODM_LOG_INFO << "Triggering a regular conversion sequence from software." << modm::endl;
 		Adc1::startConversion();
+		Adc1::startInjectedConversion();
 		modm::delayMilliseconds(500);
+		MODM_LOG_INFO << "ADC1->JSQR=" << modm::bin << static_cast<uint32_t>(ADC1->JSQR) << modm::ascii << "\n";
 	}
 
 	return 0;
 }
 
-MODM_ISR(ADC1)
+MODM_ISR(ADC1_2)
 {
+	MODM_LOG_INFO << "Entry Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	MODM_LOG_INFO << "Entry Adc2::getInterruptFlags() = " << modm::bin << Adc2::getInterruptFlags() << modm::ascii << "\n";
+
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfSampling) {
+		MODM_LOG_INFO << "ACK EndOfSampling\n";
+		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfSampling);
+	}
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfRegularConversion) {
+		MODM_LOG_INFO << "ACK EndOfRegularConversion\n";
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularConversion);
-		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << modm::endl;
+		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
+	}
+
+	MODM_LOG_INFO << "Middle Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfRegularSequenceOfConversions) {
+		MODM_LOG_INFO << "ACK EndOfRegularSequenceOfConversions\n";
+		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularSequenceOfConversions);
+		MODM_LOG_INFO << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
+	}
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedConversion) {
+		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedConversion);
+		MODM_LOG_INFO << "ACK EndOfInjectedConversion\n";
 	}
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions) {
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions);
-		MODM_LOG_INFO << "Interrupt: injectedCh1=" << Adc1::getInjectedValue<1>() << modm::endl;
-		MODM_LOG_INFO << "Interrupt: injectedCh2=" << Adc1::getInjectedValue<2>() << modm::endl;
+		MODM_LOG_INFO << "ACK EndOfInjectedSequenceOfConversions\n";
+	}
+	MODM_LOG_INFO << "Exit Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag_t{0xffff'ffff});
+	__DSB();
+}
+
+MODM_ISR(TIM1_CC)
+{
+	if(Timer1::getInterruptFlags() & Timer1::InterruptFlag::CaptureCompare4) {
+		MODM_LOG_INFO << "TIM1_CC interrupt CaptureCompare4 entered!\n";
+		Timer1::acknowledgeInterruptFlags(Timer1::InterruptFlag::CaptureCompare4);
+	}
+	else {
+		MODM_LOG_ERROR << "Unknown TIM1_CC interrupt\n";
+	}
+}
+
+MODM_ISR(TIM1_UP_TIM16)
+{
+	if(Timer1::getInterruptFlags() & Timer1::InterruptFlag::Update) {
+		MODM_LOG_INFO << "TIM1_UP_TIM16 interrupt Update entered!\n";
+		Timer1::acknowledgeInterruptFlags(Timer1::InterruptFlag::Update);
+	}
+	else {
+		MODM_LOG_ERROR << "Unknown TIM1_UP_TIM16 interrupt\n";
 	}
 }

--- a/examples/nucleo_g474re/adc_interrupt/main.cpp
+++ b/examples/nucleo_g474re/adc_interrupt/main.cpp
@@ -16,7 +16,7 @@
 using namespace modm::literals;
 
 #undef	MODM_LOG_LEVEL
-#define	MODM_LOG_LEVEL modm::log::INFO
+#define	MODM_LOG_LEVEL modm::log::DEBUG
 
 int
 main()
@@ -33,12 +33,11 @@ main()
 	MODM_LOG_INFO << "ADC data is read in an interrupt and printed to this log." << modm::endl;
 
 	MODM_LOG_INFO << "Configuring ADC ...";
-	Adc1::initialize(
-		Adc1::ClockMode::SynchronousPrescaler1,
-		Adc1::ClockSource::SystemClock,
-		Adc1::Prescaler::Disabled,
-		Adc1::CalibrationMode::SingleEndedInputsMode,
-		true);
+	Adc1::initialize<
+		Board::SystemClock,
+		0_MHz, 0_pct,
+		Adc1::ClockMode::SynchronousPrescaler4,
+		Adc1::ClockSource::SystemClock>();
 
 	GpioA0::setAnalogInput(); // Adc1Ch1
 	GpioA1::setAnalogInput(); // Adc1Ch2
@@ -51,16 +50,16 @@ main()
 	Adc1::setChannelSampleTime(Adc1::Channel::Channel4, Adc1::SampleTime::Cycles641);
 
 	//Adc1::setInjectedChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel1, Adc1::Channel::Channel2});
-	Adc1::setChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel3, Adc1::Channel::Channel4});
+	Adc1::setChannel(std::array<Adc1::Channel, 2>{Adc1::Channel::Channel1, Adc1::Channel::Channel2});
 
 	//Adc1::setInjectedTrigger(Adc1::TriggerMode::BothEdges, Adc1::TriggerSourceInjected::Tim1Trgo2);
 
-	Adc1::enableInterruptVector(5);
+	Adc1::enableInterruptVector(2);
 	Adc1::enableInterrupt(Adc1::Interrupt::EndOfSampling);
-	Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularConversion);
-	Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularSequenceOfConversions);
-	Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedConversion);
-	Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedSequenceOfConversions);
+	// Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularConversion);
+	// Adc1::enableInterrupt(Adc1::Interrupt::EndOfRegularSequenceOfConversions);
+	// Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedConversion);
+	// Adc1::enableInterrupt(Adc1::Interrupt::EndOfInjectedSequenceOfConversions);
 	MODM_LOG_INFO << " finished." << modm::endl;
 
 	/*
@@ -82,16 +81,26 @@ main()
 
 	MODM_LOG_INFO << " finished." << modm::endl;
 
-	modm::delayMilliseconds(500);
+	modm::delay_ms(500);
+
+	// Adc1::connect<GpioA0::In1>();
+	// Adc1::setPinChannel<GpioA0>(Adc1::SampleTime::Cycles13);
+
+	Board::LedD13::setOutput();
+	Board::LedD13::reset();
+
 
 	MODM_LOG_INFO << "Starting while(true) loop." << modm::endl;
 	while (true)
 	{
 		MODM_LOG_INFO << "Triggering a regular conversion sequence from software." << modm::endl;
+		Board::LedD13::reset();
+		modm::delay_ms(1000);
 		Adc1::startConversion();
-		Adc1::startInjectedConversion();
-		modm::delayMilliseconds(5000);
-		//MODM_LOG_INFO << "ADC1->JSQR=" << modm::bin << static_cast<uint32_t>(ADC1->JSQR) << modm::ascii << "\n";
+		//Adc1::startInjectedConversion();
+		modm::delay_ms(1000);
+		// MODM_LOG_INFO << "ADC1->SQR1=" << modm::bin << static_cast<uint32_t>(ADC1->SQR1) << modm::ascii << "\n";
+		// MODM_LOG_INFO << "ADC1->JSQR=" << modm::bin << static_cast<uint32_t>(ADC1->JSQR) << modm::ascii << "\n";
 	}
 
 	return 0;
@@ -99,7 +108,11 @@ main()
 
 MODM_ISR(ADC1_2)
 {
-	//MODM_LOG_DEBUG << "Entry Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	Board::LedD13::set();
+
+	modm::delay_ms(1);
+
+	MODM_LOG_DEBUG << "Entry Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
 	//MODM_LOG_DEBUG << "Entry Adc2::getInterruptFlags() = " << modm::bin << Adc2::getInterruptFlags() << modm::ascii << "\n";
 
 	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfSampling) {
@@ -116,17 +129,16 @@ MODM_ISR(ADC1_2)
 		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfRegularSequenceOfConversions);
 		//MODM_LOG_DEBUG << "Interrupt: regularValue=" << Adc1::getValue() << "\n";
 	}
-	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedConversion) {
-		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedConversion);
-		MODM_LOG_DEBUG << "ADC: EndOfInjectedConversion\n";
-	}
-	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions) {
-		Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions);
-		MODM_LOG_DEBUG << "ADC: EndOfInjectedSequenceOfConversions\n";
-	}
-	MODM_LOG_DEBUG << "MODM_ISR(ADC1_2) exit Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
+	// if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedConversion) {
+	// 	Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedConversion);
+	// 	MODM_LOG_DEBUG << "ADC: EndOfInjectedConversion\n";
+	// }
+	// if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions) {
+	// 	Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag::EndOfInjectedSequenceOfConversions);
+	// 	MODM_LOG_DEBUG << "ADC: EndOfInjectedSequenceOfConversions\n";
+	// }
+	//MODM_LOG_DEBUG << "MODM_ISR(ADC1_2) exit Adc1::getInterruptFlags() = " << modm::bin << Adc1::getInterruptFlags() << modm::ascii << "\n";
 	//Adc1::acknowledgeInterruptFlag(Adc1::InterruptFlag_t{0xffff'ffff});
-	__DSB();
 }
 
 MODM_ISR(TIM1_CC)

--- a/examples/nucleo_g474re/adc_interrupt/project.xml
+++ b/examples/nucleo_g474re/adc_interrupt/project.xml
@@ -2,10 +2,12 @@
   <extends>modm:nucleo-g474re</extends>
   <options>
     <option name="modm:build:build.path">../../../build/nucleo_g474re/adc_interrupt</option>
+    <option name="modm:platform:uart:2:buffer.tx">8192</option>
   </options>
   <modules>
     <module>modm:debug</module>
     <module>modm:platform:adc:1</module>
+    <module>modm:platform:adc:2</module>
     <module>modm:platform:timer:1</module>
     <module>modm:platform:gpio</module>
     <module>modm:build:scons</module>

--- a/examples/nucleo_g474re/adc_interrupt/project.xml
+++ b/examples/nucleo_g474re/adc_interrupt/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/adc_interrupt</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:platform:timer:1</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_g474re/timer_interrupt/main.cpp
+++ b/examples/nucleo_g474re/timer_interrupt/main.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/platform/timer/timer_1.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	using namespace modm::platform;
+
+	Timer1::enable();
+	Timer1::setMode(Timer1::Mode::UpCounter);
+
+	Timer1::setPeriod<Board::SystemClock>(1'500'000);
+	Timer1::enableInterruptVector(Timer1::Interrupt::Update, true, 10);
+	Timer1::enableInterrupt(Timer1::Interrupt::Update);
+
+	Timer1::applyAndReset();
+	Timer1::start();
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delay(Button::read() ? 100ms : 500ms);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}
+
+MODM_ISR(TIM1_UP_TIM16)
+{
+	Timer1::acknowledgeInterruptFlags(Timer1::InterruptFlag::Update);
+	MODM_LOG_DEBUG << "Timer1 update interrupt\n";
+}

--- a/examples/nucleo_g474re/timer_interrupt/project.xml
+++ b/examples/nucleo_g474re/timer_interrupt/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/timer_interrupt</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:timer:1</module>
+  </modules>
+</library>

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -24,7 +24,7 @@
 namespace modm::platform
 {
 /**
- * Analog/Digital-Converter module (ADC1).
+ * Analog/Digital-Converter module (ADC{{ id }}).
  *
  * The 12-bit ADC is a successive approximation analog-to-digital
  * converter. It has up to 19 multiplexed channels allowing it measure
@@ -163,8 +163,8 @@ public:
 	 * 		want to leave this setting untouched.
 	 *
 	 */
-	template< class SystemClock, ClockMode mode,
-			  frequency_t frequency=MHz(1), percent_t tolerance=pct(10) >
+	template< class SystemClock, frequency_t frequency=MHz(1),
+	          percent_t tolerance=pct(10), ClockMode mode = ClockMode::Synchronous >
 	static void
 	initialize();
 

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -21,8 +21,8 @@
 #include <modm/math/algorithm/prescaler.hpp>
 
 
-template< class SystemClock, modm::platform::Adc{{ id }}::ClockMode mode,
-		  modm::frequency_t frequency, modm::percent_t tolerance >
+template< class SystemClock, modm::frequency_t frequency, modm::percent_t tolerance,
+          modm::platform::Adc{{ id }}::ClockMode mode >
 void
 modm::platform::Adc{{ id }}::initialize()
 {

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2014, Kevin Läufer
  * Copyright (c) 2014, 2016-2018, Niklas Hauser
  * Copyright (c) 2017, Sascha Schade
+ * Copyright (c) 2020, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -15,6 +16,8 @@
 #define MODM_STM32F3_ADC{{ id }}_HPP
 
 #include <stdint.h>
+#include <nonstd/span.hpp>
+#include <array>
 #include "../device.hpp"
 #include <modm/architecture/interface/register.hpp>
 #include <modm/platform/gpio/connector.hpp>
@@ -220,6 +223,227 @@ public:
 %% endif
 	};
 
+	enum class TriggerMode : uint8_t
+	{
+		Disabled		= 0b00,
+		SoftwareTrigger	= Disabled,
+		RisingEdge		= 0b01,
+		FallingEdge		= 0b10,
+		BothEdges		= 0b11,
+	};
+
+	enum class TriggerSourceRegular : uint8_t
+	{
+%% if target["family"] in ["g4"]
+%% if id in [1, 2]
+		Tim1Cc1			= 0b00000,
+		Tim1Cc2			= 0b00001,
+		Tim1Cc3			= 0b00010,
+		Tim2Cc2			= 0b00011,
+		Tim3Trgo		= 0b00100,
+		Tim4Cc4			= 0b00101,
+		ExtiLine11		= 0b00110,
+		Tim8Trgo		= 0b00111,
+		Tim8Trgo2		= 0b01000,
+		Tim1Trgo		= 0b01001,
+		Tim1Trgo2		= 0b01010,
+		Tim2Trgo		= 0b01011,
+		Tim4Trgo		= 0b01100,
+		Tim6Trgo		= 0b01101,
+		Tim15Trgo		= 0b01110,
+		Tim3Cc4			= 0b01111,
+		Tim20Trgo		= 0b10000,
+		Tim20Trgo2		= 0b10001,
+		Tim20Cc1		= 0b10010,
+		Tim20Cc2		= 0b10011,
+		Tim20Cc3		= 0b10100,
+		HrtimAdcTrg1	= 0b10101,
+		HrtimAdcTrg3	= 0b10110,
+		HrtimAdcTrg5	= 0b10111,
+		HrtimAdcTrg6	= 0b11000,
+		HrtimAdcTrg7	= 0b11001,
+		HrtimAdcTrg8	= 0b11010,
+		HrtimAdcTrg9	= 0b11011,
+		HrtimAdcTrg10	= 0b11100,
+		Lptimout		= 0b11101,
+		Tim7Trgo		= 0b11110,
+		//Reserved		= 0b11111,
+%% elif id in [3, 4, 5]
+		Tim3Cc1			= 0b00000,
+		Tim2Cc3			= 0b00001,
+		Tim1Cc3			= 0b00010,
+		Tim8Cc1			= 0b00011,
+		Tim3Trgo		= 0b00100,
+		ExtiLine2		= 0b00101,
+		Tim4Cc1			= 0b00110,
+		Tim8Trgo		= 0b00111,
+		Tim8Trgo2		= 0b01000,
+		Tim1Trgo		= 0b01001,
+		Tim1Trgo2		= 0b01010,
+		Tim2Trgo		= 0b01011,
+		Tim4Trgo		= 0b01100,
+		Tim6Trgo		= 0b01101,
+		Tim15Trgo		= 0b01110,
+		Tim2Cc1			= 0b01111,
+		Tim20Trgo		= 0b10000,
+		Tim20Trgo2		= 0b10001,
+		Tim20Cc1		= 0b10010,
+		HrtimAdcTrg2	= 0b10011,
+		HrtimAdcTrg4	= 0b10100,
+		HrtimAdcTrg1	= 0b10101,
+		HrtimAdcTrg3	= 0b10110,
+		HrtimAdcTrg5	= 0b10111,
+		HrtimAdcTrg6	= 0b11000,
+		HrtimAdcTrg7	= 0b11001,
+		HrtimAdcTrg8	= 0b11010,
+		HrtimAdcTrg9	= 0b11011,
+		HrtimAdcTrg10	= 0b11100,
+		Lptimout		= 0b11101,
+		Tim7Trgo		= 0b11110,
+		//Reserved		= 0b11111,
+%% endif
+%% else
+		ExtTrigger0		= 0b0,
+		ExtTrigger1		= 0b1,
+		ExtTrigger2		= 0b10,
+		ExtTrigger3		= 0b11,
+		ExtTrigger4		= 0b100,
+		ExtTrigger5		= 0b101,
+		ExtTrigger6		= 0b110,
+		ExtTrigger7		= 0b111,
+		ExtTrigger8		= 0b1000,
+		ExtTrigger9		= 0b1001,
+		ExtTrigger10	= 0b1010,
+		ExtTrigger11	= 0b1011,
+		ExtTrigger12	= 0b1100,
+		ExtTrigger13	= 0b1101,
+		ExtTrigger14	= 0b1110,
+		ExtTrigger15	= 0b1111,
+		ExtTrigger16	= 0b10000,
+		ExtTrigger17	= 0b10001,
+		ExtTrigger18	= 0b10010,
+		ExtTrigger19	= 0b10011,
+		ExtTrigger20	= 0b10100,
+		ExtTrigger21	= 0b10101,
+		ExtTrigger22	= 0b10110,
+		ExtTrigger23	= 0b10111,
+		ExtTrigger24	= 0b11000,
+		ExtTrigger25	= 0b11001,
+		ExtTrigger26	= 0b11010,
+		ExtTrigger27	= 0b11011,
+		ExtTrigger28	= 0b11100,
+		ExtTrigger29	= 0b11101,
+		ExtTrigger30	= 0b11110,
+		ExtTrigger31	= 0b11111,
+%% endif
+	};
+
+	enum class TriggerSourceInjected : uint8_t
+	{
+%% if target["family"] in ["g4"]
+%% if id in [1, 2]
+		Tim1Trgo		= 0b00000,
+		Tim1Cc4			= 0b00001,
+		Tim2Trgo		= 0b00010,
+		Tim2Cc1			= 0b00011,
+		Tim3Cc4			= 0b00100,
+		Tim4Trgo		= 0b00101,
+		ExtiLine15		= 0b00110,
+		Tim8Cc4			= 0b00111,
+		Tim1Trgo2		= 0b01000,
+		Tim8Trgo		= 0b01001,
+		Tim8Trgo2		= 0b01010,
+		Tim3Cc3			= 0b01011,
+		Tim3Trgo		= 0b01100,
+		Tim3Cc1			= 0b01101,
+		Tim6Trgo		= 0b01110,
+		Tim15Trgo		= 0b01111,
+		Tim20Trgo		= 0b10000,
+		Tim20Trgo2		= 0b10001,
+		Tim20Cc4		= 0b10010,
+		HrtimAdcTrg2	= 0b10011,
+		HrtimAdcTrg4	= 0b10100,
+		HrtimAdcTrg5	= 0b10101,
+		HrtimAdcTrg6	= 0b10110,
+		HrtimAdcTrg7	= 0b10111,
+		HrtimAdcTrg8	= 0b11000,
+		HrtimAdcTrg9	= 0b11001,
+		HrtimAdcTrg10	= 0b11010,
+		Tim16Cc1		= 0b11011,
+		//Reserved		= 0b11100,
+		Lptimout		= 0b11101,
+		Tim7Trgo		= 0b11110,
+		//Reserved		= 0b11111,
+%% elif id in [3, 4, 5]
+		Tim1Trgo		= 0b00000,
+		Tim1Cc4			= 0b00001,
+		Tim2Trgo		= 0b00010,
+		Tim8Cc2			= 0b00011,
+		Tim4Cc3			= 0b00100,
+		Tim4Trgo		= 0b00101,
+		Tim4Cc4			= 0b00110,
+		Tim8Cc4			= 0b00111,
+		Tim1Trgo2		= 0b01000,
+		Tim8Trgo		= 0b01001,
+		Tim8Trgo2		= 0b01010,
+		Tim1Cc3			= 0b01011,
+		Tim3Trgo		= 0b01100,
+		ExtiLine3		= 0b01101,
+		Tim6Trgo		= 0b01110,
+		Tim15Trgo		= 0b01111,
+		Tim20Trgo		= 0b10000,
+		Tim20Trgo2		= 0b10001,
+		Tim20Cc2		= 0b10010,
+		HrtimAdcTrg2	= 0b10011,
+		HrtimAdcTrg4	= 0b10100,
+		HrtimAdcTrg5	= 0b10101,
+		HrtimAdcTrg6	= 0b10110,
+		HrtimAdcTrg7	= 0b10111,
+		HrtimAdcTrg8	= 0b11000,
+		HrtimAdcTrg9	= 0b11001,
+		HrtimAdcTrg10	= 0b11010,
+		HrtimAdcTrg1	= 0b11011,
+		HrtimAdcTrg3	= 0b11100,
+		Lptimout		= 0b11101,
+		Tim7Trgo		= 0b11110,
+		//Reserved		= 0b11111,
+%% endif
+%% else
+		ExtTrigger0		= 0b0,
+		ExtTrigger1		= 0b1,
+		ExtTrigger2		= 0b10,
+		ExtTrigger3		= 0b11,
+		ExtTrigger4		= 0b100,
+		ExtTrigger5		= 0b101,
+		ExtTrigger6		= 0b110,
+		ExtTrigger7		= 0b111,
+		ExtTrigger8		= 0b1000,
+		ExtTrigger9		= 0b1001,
+		ExtTrigger10	= 0b1010,
+		ExtTrigger11	= 0b1011,
+		ExtTrigger12	= 0b1100,
+		ExtTrigger13	= 0b1101,
+		ExtTrigger14	= 0b1110,
+		ExtTrigger15	= 0b1111,
+		ExtTrigger16	= 0b10000,
+		ExtTrigger17	= 0b10001,
+		ExtTrigger18	= 0b10010,
+		ExtTrigger19	= 0b10011,
+		ExtTrigger20	= 0b10100,
+		ExtTrigger21	= 0b10101,
+		ExtTrigger22	= 0b10110,
+		ExtTrigger23	= 0b10111,
+		ExtTrigger24	= 0b11000,
+		ExtTrigger25	= 0b11001,
+		ExtTrigger26	= 0b11010,
+		ExtTrigger27	= 0b11011,
+		ExtTrigger28	= 0b11100,
+		ExtTrigger29	= 0b11101,
+		ExtTrigger30	= 0b11110,
+		ExtTrigger31	= 0b11111,
+%% endif
+	};
+
 	enum class Interrupt : uint32_t
 	{
 		Ready 								= ADC_IER_ADRDYIE,
@@ -251,6 +475,18 @@ public:
 		InjectedContextQueueOverflow 		= ADC_ISR_JQOVF,
 	};
 	MODM_FLAGS32(InterruptFlag);
+
+	static constexpr uint8_t maxSequenceLength = 16;
+	static constexpr uint8_t maxInjectedSequenceLength = 4;
+
+private:
+	static inline bool
+	setSequenceChannel(const int index, const Channel channel);
+
+	static uint32_t sqr1;
+	static uint32_t sqr2;
+	static uint32_t sqr3;
+	static uint32_t sqr4;
 
 public:
 	template< template<Peripheral _> class... Signals >
@@ -345,15 +581,77 @@ public:
 	 */
 	static inline bool
 	setChannel(const Channel channel,
-			const SampleTime sampleTime=static_cast<SampleTime>(0b000));
+			const SampleTime sampleTime=static_cast<SampleTime>(0b000))
+	{
+		return setSequenceChannel(0, channel)
+			&& setChannelSampleTime(channel, sampleTime);
+	}
 
-	/// Setting the channel for a Pin
+	/**
+	 * Analog channel selection.
+	 *
+	 * Up to @see maxSequenceLength channels con be configured to be read
+	 * in a sequence.
+	 *
+	 * @param channels		List (std::span) of up to @see maxSequenceLength
+							channels which shall be read.
+	 * @param sampleTime	The sample time to sample the input voltage.
+	 *
+	 * @pre The ADC clock must be started and the ADC switched on with
+	 * 		initialize()
+	 */
+	static inline bool
+	setChannel(const nonstd::span<const Channel> channels);
+
+	/**
+	 * Analog injected channel selection.
+	 *
+	 * @see setChannel()
+	 *
+	 * @param channel		The channel which shall be read.
+	 * @param sampleTime	The sample time to sample the input voltage.
+	 */
+	static inline bool
+	setInjectedChannel(const Channel channel,
+			const SampleTime sampleTime=static_cast<SampleTime>(0b000))
+	{
+		return setInjectedChannel(std::array <Channel, 1>{ channel, })
+			&& setChannelSampleTime(channel, sampleTime);
+	}
+
+	/**
+	 * Analog injected channel selection.
+	 *
+	 * Up to @see maxInjectedSequenceLength channels con be configured to
+	 * be read in a sequence.
+	 *
+	 * @param channels		List (std::span) of up to @see
+							maxInjectedSequenceLength channels which shall
+							be read.
+	 * @param sampleTime	The sample time to sample the input voltage.
+	 *
+	 * @pre The ADC clock must be started and the ADC switched on with
+	 * 		initialize()
+	 */
+	static inline bool
+	setInjectedChannel(const nonstd::span<const Channel> channels);
+
+	/// Setting the channel by Gpio pin
 	template< class Gpio >
 	static inline bool
 	setPinChannel(SampleTime sampleTime = static_cast<SampleTime>(0b000))
 	{
 		return setChannel(getPinChannel<Gpio>(), sampleTime);
 	}
+
+	/// Setting injected channel by Gpio pin
+	template< class Gpio >
+	static inline bool
+	setInjectedPinChannel(SampleTime sampleTime = static_cast<SampleTime>(0b000))
+	{
+		return setInjectedChannel(getPinChannel<Gpio>(), sampleTime);
+	}
+
 	/// Get the channel for a Pin
 	template< class Gpio >
 	static inline constexpr Channel
@@ -363,6 +661,9 @@ public:
 		static_assert(channel >= 0, "Adc{{id}} does not have a channel for this pin!");
 		return Channel(channel);
 	}
+
+	static inline bool
+	setChannelSampleTime(const Channel channel, const SampleTime sampleTime);
 
 	/**
 	 * Enables free running mode
@@ -377,6 +678,30 @@ public:
 	setFreeRunningMode(const bool enable);
 
 	/**
+	 * Enables the trigger for a regular conversion sequence.
+	 *
+	 * @param mode		Selects the trigger mode or disables the trigger
+	 * @param source	Selects one of the (up to 32) trigger sources
+	 *
+	 * @pre No ADC conversion must be ongoing when changing the
+	 *      trigger configuration.
+	 */
+	static inline void
+	setTrigger(const TriggerMode mode, const TriggerSourceRegular source);
+
+	/**
+	 * Enables the trigger for a injected conversion sequence.
+	 *
+	 * @param mode		Selects the trigger mode or disables the trigger
+	 * @param source	Selects one of the (up to 32) trigger sources
+	 *
+	 * @pre No ADC conversion must be ongoing when changing the
+	 *      trigger configuration.
+	 */
+	static inline void
+	setInjectedTrigger(const TriggerMode mode, const TriggerSourceInjected source);
+
+	/**
 	 * Start a new conversion or continuous conversions.
 	 *
 	 * @pre A ADC channel must be selected with setChannel().
@@ -386,14 +711,32 @@ public:
 	 * TODO: is there any limitation to when is can be called??
 	 */
 	static inline void
-	startConversion(void);
+	startConversion();
+
+	/**
+	 * Start a new injected conversion or continuous conversions.
+	 *
+	 * @pre A ADC channel must be selected with setChannel().
+	 *
+	 * @post The result can be fetched with getValue()
+	 */
+	static inline void
+	startInjectedConversion();
 
 	/**
 	 * @return If the conversion is finished.
 	 * @pre A conversion should have been stared with startConversion()
 	 */
 	static inline bool
-	isConversionFinished(void);
+	isConversionFinished();
+
+	/**
+	 * @return If the injected conversion is finished.
+	 * @pre A injected conversion should have been stared
+	 *   with startInjectedConversion()
+	 */
+	//static inline bool
+	//isInjectedConversionFinished();
 
 	/**
 	 * @return The most recent 16bit result of the ADC conversion.
@@ -408,10 +751,29 @@ public:
 		@endcode
 	 */
 	static inline uint16_t
-	getValue(void)
+	getValue()
 	{
 		return ADC{{ id }}->DR;
 	}
+
+	/**
+	 * @return The most recent 16bit result of the injected conversion
+	 * at the index of the sequence.
+	 * @pre A injected conversion should have been stared
+	 * with startInjectedConversion()
+	 */
+	static inline uint16_t
+	getInjectedValue(uint8_t index);
+
+	/**
+	 * @return The most recent 16bit result of the injected conversion
+	 * at the index of the sequence.
+	 * @pre A injected conversion should have been stared
+	 * with startInjectedConversion()
+	 */
+	template<uint8_t index>
+	static inline uint16_t
+	getInjectedValue();
 
 	static inline void
 	enableInterruptVector(const uint32_t priority, const bool enable = true);

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -483,10 +483,10 @@ private:
 	static inline bool
 	setSequenceChannel(const int index, const Channel channel);
 
-	static uint32_t sqr1;
-	static uint32_t sqr2;
-	static uint32_t sqr3;
-	static uint32_t sqr4;
+	static inline uint32_t sqr1 = 0;
+	static inline uint32_t sqr2 = 0;
+	static inline uint32_t sqr3 = 0;
+	static inline uint32_t sqr4 = 0;
 
 public:
 	template< template<Peripheral _> class... Signals >

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -142,7 +142,7 @@ public:
 		PllSai2 = RCC_CCIPR_ADCSEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
 		SystemClock = RCC_CCIPR_ADCSEL_1 | RCC_CCIPR_ADCSEL_0, // System clock selected as ADCs clock
  %% endif
-%%elif
+%% else
 		Default, // F3 has no clock_mux
 %% endif
 	};

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -16,7 +16,7 @@
 #define MODM_STM32F3_ADC{{ id }}_HPP
 
 #include <stdint.h>
-#include <nonstd/span.hpp>
+#include <span>
 #include <array>
 #include "../device.hpp"
 #include <modm/architecture/interface/register.hpp>
@@ -624,7 +624,7 @@ public:
 	 * 		initialize()
 	 */
 	static inline bool
-	setChannel(const nonstd::span<const Channel> channels);
+	setChannel(const std::span<const Channel> channels);
 
 	/**
 	 * Analog injected channel selection.
@@ -657,7 +657,7 @@ public:
 	 * 		initialize()
 	 */
 	static inline bool
-	setInjectedChannel(const nonstd::span<const Channel> channels);
+	setInjectedChannel(const std::span<const Channel> channels);
 
 	/// Setting the channel by Gpio pin
 	template< class Gpio >

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -586,11 +586,7 @@ FIXME!!!!!!
 	 */
 	static inline bool
 	setChannel(const Channel channel,
-			const SampleTime sampleTime=static_cast<SampleTime>(0b000))
-	{
-		return setSequenceChannel(0, channel)
-			&& setChannelSampleTime(channel, sampleTime);
-	}
+			const SampleTime sampleTime=static_cast<SampleTime>(0b000));
 
 	/**
 	 * Analog channel selection.

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -54,34 +54,57 @@ public:
 		VTS       = 16,
 		BatDiv2   = 17,
 		InternalReference = 18,
-		// TODO: Add internal connections
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4"]
 		Temperature = 17,
 		BatDiv3     = 18,
+%% elif target["family"] in ["g4"]
+		Opamp1 = 13,
+		Temperature = 16,
+		BatDiv3     = 17,
+		InternalReference = 18,
 %% endif
 %% elif id == 2
 %% if target["family"] in ["f3"]
 		Opamp2 = 17,
 		InternalReference = 18,
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4"]
 		Dac1 = 17,
 		Dac2 = 18,
+%% elif target["family"] in ["g4"]
+		Opamp2 = 16,
+		Opamp3 = 18,
 %% endif
 %% elif id == 3
 %% if target["family"] in ["f3"]
 		Vss    =  4,	// ADC3_IN4 not bonded and connected to VSS
 		Opamp3 = 17,
 		InternalReference = 18,
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4"]
 		Dac1 = 14,
 		Dac2 = 15,
 		Vss  = 16,
 		Temperature = 17,
 		BatDiv3 = 18,
+%% elif target["family"] in ["g4"]
+		Opamp3 = 13,
+		BatDiv3 = 17,
+		InternalReference  = 18,
 %% endif
 %% elif id == 4
+%% if target["family"] in ["f3"]
 		Opamp3 = 17,
+%% elif target["family"] in ["l4", "g4"]
+		Opamp6 = 17,
+%% endif
 		InternalReference = 18,
+%% elif id == 5
+%% if target["family"] in ["g4"]
+		Opamp5 = 3,
+		Temperature = 4,
+		Opamp4 = 5,
+		BatDiv3 = 17,
+		InternalReference = 18,
+%% endif
 %% endif
 	};
 

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -527,7 +527,7 @@ FIXME!!!!!!
 			, modm::platform::Adc{{ id }}::ClockSource clk_src = modm::platform::Adc{{ id }}::ClockSource::SystemClock
 			>
 	static void
-	initialize();
+	initialize(bool blocking = true);
 
 	static inline void
 	disable(const bool blocking = true);

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -122,27 +122,33 @@ public:
 		SynchronousPrescaler4 = {{ adc_ccr }}_CKMODE_1 | {{ adc_ccr }}_CKMODE_0,
 	};
 
-%% if clock_mux
 	// ADCs clock source selection
 	// Warning: One clock MUX is shared between ADCs 1 and 2,
 	//  another mux sharded between ADCs 3, 4 and 5
 	enum class ClockSource : uint32_t
 	{
+%% if clock_mux
 		NoClock = 0, // No clock selected.
-%% if target["family"] in ["g4"]
-%% if id in [1, 2]
+ %% if target["family"] in ["g4"]
+ %% if id in [1, 2]
 		Pll = RCC_CCIPR_ADC12SEL_0, // PLL “P” clock selected as ADC clock
 		SystemClock = RCC_CCIPR_ADC12SEL_1 , // System clock selected as ADCs clock
-%% elif id in [3, 4, 5]
+ %% elif id in [3, 4, 5]
 		Pll = RCC_CCIPR_ADC345SEL_0, // PLL “P” clock selected as ADC clock
 		SystemClock = RCC_CCIPR_ADC345SEL_1 , // System clock selected as ADCs clock
-%% endif
-%% else
+ %% endif
+ %% else
 		PllSai1 = RCC_CCIPR_ADCSEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
 		PllSai2 = RCC_CCIPR_ADCSEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
 		SystemClock = RCC_CCIPR_ADCSEL_1 | RCC_CCIPR_ADCSEL_0, // System clock selected as ADCs clock
+ %% endif
+%%elif
+		Default, // F3 has no clock_mux
 %% endif
 	};
+
+%% if clock_mux
+private:
 %% if target["family"] in ["g4"]
 %% if id in [1, 2]
 	static constexpr uint32_t ClockSourceMsk = RCC_CCIPR_ADC12SEL_Msk;
@@ -152,6 +158,7 @@ public:
 %% else
 	static constexpr uint32_t ClockSourceMsk = RCC_CCIPR_ADCSEL_Msk;
 %% endif
+public:
 %% endif
 
 	// Prescaler of the Asynchronous ADC clock
@@ -511,38 +518,13 @@ public:
 	/**
 	 * Initialize and enable the A/D converter.
 	 *
-	 * Enables the ADC clock and switches on the ADC. The ADC clock
-	 * prescaler will be set as well.
-	 *
-	 * The ADC can be clocked
-	 *
-	 * @param clk
-	 * 		Clock Mode for ADC1/ADC2 or ADC3/ADC4.
-	 * 		Set to ClockMode::DoNotChange or leave blank if you
-	 * 		want to leave this setting untouched.
-	 *
-	 * @param pre
-	 * 		The prescaler for the asynchronous ADC clock.
-	 * 		This parameter is only taken into account
-	 * 		if clk == ClockMode::Asynchronous.
+FIXME!!!!!!
 	 */
-/*
-	static inline void
-	initialize(	const ClockMode clk = ClockMode::DoNotChange,
-%% if clock_mux
-				const ClockSource clk_src = ClockSource::SystemClock,
-%% endif
-				const Prescaler pre = Prescaler::Disabled,
-				const CalibrationMode cal = CalibrationMode::DoNotCalibrate,
-				const bool blocking = true);
-*/
 	template< class SystemClock
 			, modm::frequency_t frequency
 			, modm::percent_t tolerance = modm::pct(10)
 			, modm::platform::Adc{{ id }}::ClockMode clk = modm::platform::Adc{{ id }}::ClockMode::SynchronousPrescaler1
-	%% if clock_mux
 			, modm::platform::Adc{{ id }}::ClockSource clk_src = modm::platform::Adc{{ id }}::ClockSource::SystemClock
-	%% endif
 			>
 	static void
 	initialize();

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -538,10 +538,10 @@ public:
 */
 	template< class SystemClock
 			, modm::frequency_t frequency
-			, modm::percent_t tolerance
-			, modm::platform::Adc{{ id }}::ClockMode clk
+			, modm::percent_t tolerance = modm::pct(10)
+			, modm::platform::Adc{{ id }}::ClockMode clk = modm::platform::Adc{{ id }}::ClockMode::SynchronousPrescaler1
 	%% if clock_mux
-			, modm::platform::Adc{{ id }}::ClockSource clk_src
+			, modm::platform::Adc{{ id }}::ClockSource clk_src = modm::platform::Adc{{ id }}::ClockSource::SystemClock
 	%% endif
 			>
 	static void

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -124,6 +124,8 @@ public:
 
 %% if clock_mux
 	// ADCs clock source selection
+	// Warning: One clock MUX is shared between ADCs 1 and 2,
+	//  another mux sharded between ADCs 3, 4 and 5
 	enum class ClockSource : uint32_t
 	{
 		NoClock = 0, // No clock selected.
@@ -141,6 +143,15 @@ public:
 		SystemClock = RCC_CCIPR_ADCSEL_1 | RCC_CCIPR_ADCSEL_0, // System clock selected as ADCs clock
 %% endif
 	};
+%% if target["family"] in ["g4"]
+%% if id in [1, 2]
+	static constexpr uint32_t ClockSourceMsk = RCC_CCIPR_ADC12SEL_Msk;
+%% elif id in [3, 4, 5]
+	static constexpr uint32_t ClockSourceMsk = RCC_CCIPR_ADC345SEL_Msk;
+%% endif
+%% else
+	static constexpr uint32_t ClockSourceMsk = RCC_CCIPR_ADCSEL_Msk;
+%% endif
 %% endif
 
 	// Prescaler of the Asynchronous ADC clock
@@ -515,6 +526,7 @@ public:
 	 * 		This parameter is only taken into account
 	 * 		if clk == ClockMode::Asynchronous.
 	 */
+/*
 	static inline void
 	initialize(	const ClockMode clk = ClockMode::DoNotChange,
 %% if clock_mux
@@ -523,6 +535,17 @@ public:
 				const Prescaler pre = Prescaler::Disabled,
 				const CalibrationMode cal = CalibrationMode::DoNotCalibrate,
 				const bool blocking = true);
+*/
+	template< class SystemClock
+			, modm::frequency_t frequency
+			, modm::percent_t tolerance
+			, modm::platform::Adc{{ id }}::ClockMode clk
+	%% if clock_mux
+			, modm::platform::Adc{{ id }}::ClockSource clk_src
+	%% endif
+			>
+	static void
+	initialize();
 
 	static inline void
 	disable(const bool blocking = true);

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2014, Kevin Läufer
  * Copyright (c) 2014, Sascha Schade
  * Copyright (c) 2014, 2016-2017, Niklas Hauser
+ * Copyright (c) 2020, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -17,6 +18,7 @@
 
 #include <modm/architecture/interface/delay.hpp>	// modm::delayMicroseconds
 #include <modm/platform/clock/rcc.hpp>
+#include <modm/math/algorithm/enumerate.hpp>
 
 void
 modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
@@ -146,30 +148,104 @@ modm::platform::Adc{{ id }}::setLeftAdjustResult(const bool enable)
 }
 
 bool
-modm::platform::Adc{{ id }}::setChannel(	const Channel channel,
-										const SampleTime sampleTime)
+modm::platform::Adc{{ id }}::setChannel(const nonstd::span<const Channel> channels)
+{
+	if(channels.size() >= maxSequenceLength) {
+		return false;
+	}
+
+	// Clear temporary variables
+	sqr1 = 0;
+	sqr2 = 0;
+	sqr3 = 0;
+	sqr4 = 0;
+
+	for (auto [i, channel] : enumerate(channels))
+	{
+		if(!setSequenceChannel(i, channel)) {
+			return false;
+		}
+	}
+
+	sqr1 |= channels.size();
+
+	// Write SQRx registers
+	ADC{{ id }}->SQR1 = sqr1;
+	ADC{{ id }}->SQR2 = sqr2;
+	ADC{{ id }}->SQR3 = sqr3;
+	ADC{{ id }}->SQR4 = sqr4;
+
+	return true;
+}
+
+bool
+modm::platform::Adc{{ id }}::setInjectedChannel(const nonstd::span<const Channel> channels)
+{
+	if(channels.size() >= maxInjectedSequenceLength) {
+		return false;
+	}
+	// clear JSQR register except for JEXTEN and JEXTSEL bits
+	ADC{{ id }}->JSQR &= ADC_JSQR_JEXTEN_Msk | ADC_JSQR_JEXTSEL_Msk;
+
+	// Set channels and seqeunce length
+	uint32_t reg{0};
+	for (auto [i, channel] : enumerate(channels))
+	{
+		reg |= (static_cast<uint8_t>(channel) & 0b11111) << (9 + (6 * i));
+	}
+	ADC{{ id }}->JSQR |= reg | channels.size();
+
+	return true;
+}
+
+
+bool
+modm::platform::Adc{{ id }}::setSequenceChannel(const int index, const Channel channel)
 {
 	if(static_cast<uint8_t>(channel) > 18) {
 		return false;
 	}
 
-	uint32_t tmpreg;
-	// SQR1[10:6] contain SQ1[4:0]
-	ADC{{ id }}->SQR1 = (static_cast<uint8_t>(channel) & 0b11111) << 6;
+	// index==0 -> SQR1
+	if(index <= 4) {
+		sqr1 |= (static_cast<uint8_t>(channel) & 0b11111) << (6 * (index + 1));
+	}
+	else if(index <= 9) {
+		sqr2 |= (static_cast<uint8_t>(channel) & 0b11111) << (6 * (index - 4));
+	}
+	else if(index <= 14) {
+		sqr3 |= (static_cast<uint8_t>(channel) & 0b11111) << (6 * (index - 9));
+	}
+	else if(index <= 16) {
+		sqr4 |= (static_cast<uint8_t>(channel) & 0b11111) << (6 * (index - 14));
+	}
+	else {
+		return false;
+	}
+	return true;
+}
 
-	if (static_cast<uint8_t>(channel) < 10) {
+bool
+modm::platform::Adc{{ id }}::setChannelSampleTime(const Channel channel,
+	const SampleTime sampleTime)
+{
+	uint32_t tmpreg;
+	if (static_cast<uint8_t>(channel) <= 9) {
 		tmpreg = ADC{{ id }}->SMPR1
 			& ((~ADC_SMPR1_SMP0) << (static_cast<uint8_t>(channel) * 3));
 		tmpreg |= static_cast<uint32_t>(sampleTime) <<
 						(static_cast<uint8_t>(channel) * 3);
 		ADC{{ id }}->SMPR1 = tmpreg;
 	}
-	else {
+	else if (static_cast<uint8_t>(channel) <= 18) {
 		tmpreg = ADC{{ id }}->SMPR2
 			& ((~ADC_SMPR2_SMP10) << ((static_cast<uint8_t>(channel)-10) * 3));
 		tmpreg |= static_cast<uint32_t>(sampleTime) <<
 						((static_cast<uint8_t>(channel)-10) * 3);
 		ADC{{ id }}->SMPR2 = tmpreg;
+	}
+	else {
+		return false;
 	}
 	return true;
 }
@@ -184,6 +260,26 @@ modm::platform::Adc{{ id }}::setFreeRunningMode(const bool enable)
 	}
 }
 
+void
+modm::platform::Adc{{ id }}::setTrigger(const TriggerMode mode,
+	const TriggerSourceRegular source)
+{
+	ADC{{ id }}->CFGR =
+		(ADC{{ id }}->CFGR & ~(ADC_CFGR_EXTSEL_Msk | ADC_CFGR_EXTEN_Msk))
+		| (static_cast<uint32_t>(mode) << ADC_CFGR_EXTEN_Pos)
+		| (static_cast<uint32_t>(source) << ADC_CFGR_EXTSEL_Pos);
+}
+
+void
+modm::platform::Adc{{ id }}::setInjectedTrigger(const TriggerMode mode,
+	const TriggerSourceInjected source)
+{
+	ADC{{ id }}->JSQR =
+		(ADC{{ id }}->JSQR & ~(ADC_JSQR_JEXTSEL_Msk | ADC_JSQR_JEXTEN_Msk))
+		| (static_cast<uint32_t>(mode) << ADC_JSQR_JEXTEN_Pos)
+		| (static_cast<uint32_t>(source) << ADC_JSQR_JEXTSEL_Pos);
+}
+
 
 void
 modm::platform::Adc{{ id }}::startConversion(void)
@@ -195,10 +291,58 @@ modm::platform::Adc{{ id }}::startConversion(void)
 	ADC{{ id }}->CR |= ADC_CR_ADSTART;
 }
 
+
+void
+modm::platform::Adc{{ id }}::startInjectedConversion(void)
+{
+	// TODO: maybe add more interrupt flags
+	acknowledgeInterruptFlag(InterruptFlag::EndOfSampling | InterruptFlag::Overrun);
+	// starts single conversion for the regular group
+	ADC{{ id }}->CR |= ADC_CR_JADSTART;
+}
+
 bool
 modm::platform::Adc{{ id }}::isConversionFinished(void)
 {
 	return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfRegularConversion);
+}
+
+uint16_t
+modm::platform::Adc{{ id }}::getInjectedValue(uint8_t index)
+{
+	switch(index){
+		case 1:
+			return ADC{{ id }}->JDR1;
+		case 2:
+			return ADC{{ id }}->JDR2;
+		case 3:
+			return ADC{{ id }}->JDR3;
+		case 4:
+			return ADC{{ id }}->JDR4;
+		default:
+			return 0;
+	}
+}
+
+template<uint8_t index>
+uint16_t
+modm::platform::Adc{{ id }}::getInjectedValue()
+{
+	static_assert(maxInjectedSequenceLength == 4, "Invalid maxInjectedSequenceLength");
+	static_assert(index <= 4, "There are only 4 injected ADC values.");
+
+	if constexpr(index == 1) {
+		return ADC{{ id }}->JDR1;
+	}
+	else if constexpr(index == 2){
+		return ADC{{ id }}->JDR2;
+	}
+	else if constexpr(index == 3){
+		return ADC{{ id }}->JDR3;
+	}
+	else if constexpr(index == 4){
+		return ADC{{ id }}->JDR4;
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -20,26 +20,31 @@
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/math/algorithm/enumerate.hpp>
 
-void
-modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
+template< class SystemClock
+          , modm::frequency_t frequency
+          , modm::percent_t tolerance
+          , modm::platform::Adc{{ id }}::ClockMode clk
 %% if clock_mux
-		const ClockSource clk_src,
+          , modm::platform::Adc{{ id }}::ClockSource clk_src
 %% endif
-		const Prescaler pre,
-		const CalibrationMode cal, const bool blocking)
+		  >
+void
+modm::platform::Adc{{ id }}::initialize()
+//		const Prescaler pre,
+//		const CalibrationMode cal, const bool blocking)
 {
 	uint32_t tmp = 0;
 
 	// enable clock
-%% if target["family"] in ["f3", "g4"]
+%% if target["family"] in ["f3"]
 	RCC->{{ ahb }}ENR |= RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
-%% elif target["family"] in ["l4"]
+%% elif target["family"] in ["l4", "g4"]
 	Rcc::enable<Peripheral::Adc1>();
 %% endif
 
 %% if clock_mux
 	// select clock source
-	RCC->CCIPR |= static_cast<uint32_t>(clk_src);
+	RCC->CCIPR = (RCC->CCIPR & ~ClockSourceMsk) | static_cast<uint32_t>(clk_src);
 %% endif
 
 %% if target["family"] in ["l4", "g4"]
@@ -54,7 +59,7 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 	// set ADC "analog" clock source
 	if (clk != ClockMode::DoNotChange) {
 		if (clk == ClockMode::Asynchronous) {
-			setPrescaler(pre);
+			//setPrescaler(pre);
 		}
 		tmp  =  ADC{{ id_common_u }}->CCR;
 		tmp &= ~{{ adc_ccr }}_CKMODE;
@@ -68,8 +73,6 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 	modm::delay_us(10);	// FIXME: this is ugly -> find better solution
 
 	acknowledgeInterruptFlag(InterruptFlag::Ready);
-
-	calibrate(cal, true);	// blocking calibration
 
 	ADC{{ id }}->CR |= ADC_CR_ADEN;
 	if (blocking) {

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -147,7 +147,20 @@ modm::platform::Adc{{ id }}::setLeftAdjustResult(const bool enable)
 	}
 }
 
-bool
+inline bool
+modm::platform::Adc{{ id }}::setChannel(const Channel channel, const SampleTime sampleTime)
+{
+	sqr1 = 0;
+	setSequenceChannel(0, channel);
+	setChannelSampleTime(channel, sampleTime);
+
+	// Write SQRx registers
+	ADC{{ id }}->SQR1 = sqr1;
+
+	return true;
+}
+
+inline bool
 modm::platform::Adc{{ id }}::setChannel(const std::span<const Channel> channels)
 {
 	if(channels.size() >= maxSequenceLength) {
@@ -199,7 +212,7 @@ modm::platform::Adc{{ id }}::setInjectedChannel(const std::span<const Channel> c
 }
 
 
-bool
+inline bool
 modm::platform::Adc{{ id }}::setSequenceChannel(const int index, const Channel channel)
 {
 	if(static_cast<uint8_t>(channel) > 18) {

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -39,7 +39,9 @@ modm::platform::Adc{{ id }}::initialize()
 %% if target["family"] in ["f3"]
 	RCC->{{ ahb }}ENR |= RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
 %% elif target["family"] in ["l4", "g4"]
-	Rcc::enable<Peripheral::Adc1>();
+	//Rcc::enable<Peripheral::Adc1>();
+	// FIXME
+	RCC->AHB2ENR |= RCC_AHB2ENR_ADC{{ id_common }}EN;
 %% endif
 
 %% if clock_mux

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -151,7 +151,7 @@ modm::platform::Adc{{ id }}::setLeftAdjustResult(const bool enable)
 }
 
 bool
-modm::platform::Adc{{ id }}::setChannel(const nonstd::span<const Channel> channels)
+modm::platform::Adc{{ id }}::setChannel(const std::span<const Channel> channels)
 {
 	if(channels.size() >= maxSequenceLength) {
 		return false;
@@ -182,7 +182,7 @@ modm::platform::Adc{{ id }}::setChannel(const nonstd::span<const Channel> channe
 }
 
 bool
-modm::platform::Adc{{ id }}::setInjectedChannel(const nonstd::span<const Channel> channels)
+modm::platform::Adc{{ id }}::setInjectedChannel(const std::span<const Channel> channels)
 {
 	if(channels.size() >= maxInjectedSequenceLength) {
 		return false;

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -167,7 +167,7 @@ modm::platform::Adc{{ id }}::setChannel(const nonstd::span<const Channel> channe
 		}
 	}
 
-	sqr1 |= channels.size();
+	sqr1 |= (channels.size() - 1);
 
 	// Write SQRx registers
 	ADC{{ id }}->SQR1 = sqr1;
@@ -193,7 +193,7 @@ modm::platform::Adc{{ id }}::setInjectedChannel(const nonstd::span<const Channel
 	{
 		reg |= (static_cast<uint8_t>(channel) & 0b11111) << (9 + (6 * i));
 	}
-	ADC{{ id }}->JSQR |= reg | channels.size();
+	ADC{{ id }}->JSQR |= reg | (channels.size() - 1);
 
 	return true;
 }

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -19,6 +19,7 @@
 #include <modm/architecture/interface/delay.hpp>	// modm::delayMicroseconds
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/math/algorithm/enumerate.hpp>
+#include <modm/math/algorithm/prescaler.hpp>
 
 template< class SystemClock
           , modm::frequency_t frequency
@@ -54,6 +55,13 @@ modm::platform::Adc{{ id }}::initialize()
 	// FIXME: not a good idea since you can only reset both
 	// ADC1/ADC2 or ADC3/ADC4 at once ....
 
+	if constexpr (clk != ClockMode::DoNotChange) {
+		// TODO...
+		ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
+	}
+
+	/*
+	OLD INTERFACE: prescaler manually supplied as function parameter
 	// set ADC "analog" clock source
 	if (clk != ClockMode::DoNotChange) {
 		if (clk == ClockMode::Asynchronous) {
@@ -65,6 +73,7 @@ modm::platform::Adc{{ id }}::initialize()
 		ADC{{ id_common_u }}->CCR = tmp;
 		//ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
 	}
+	*/
 
 	// enable regulator
 	ADC{{ id }}->CR &= ~ADC_CR_ADVREGEN;
@@ -74,7 +83,7 @@ modm::platform::Adc{{ id }}::initialize()
 	acknowledgeInterruptFlag(InterruptFlag::Ready);
 
 	ADC{{ id }}->CR |= ADC_CR_ADEN;
-	if (blocking) {
+	if (true) {
 		// ADEN can only be set 4 ADC clock cycles after ADC_CR_ADCAL gets
 		// cleared. Setting it in a loop ensures the flag gets set for ADC
 		// clocks slower than the CPU clock.

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -24,9 +24,7 @@ template< class SystemClock
           , modm::frequency_t frequency
           , modm::percent_t tolerance
           , modm::platform::Adc{{ id }}::ClockMode clk
-%% if clock_mux
           , modm::platform::Adc{{ id }}::ClockSource clk_src
-%% endif
 		  >
 void
 modm::platform::Adc{{ id }}::initialize()
@@ -36,12 +34,10 @@ modm::platform::Adc{{ id }}::initialize()
 	uint32_t tmp = 0;
 
 	// enable clock
-%% if target["family"] in ["f3"]
+%% if target["family"] in ["f3", "g4"]
 	RCC->{{ ahb }}ENR |= RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
-%% elif target["family"] in ["l4", "g4"]
-	//Rcc::enable<Peripheral::Adc1>();
-	// FIXME
-	RCC->AHB2ENR |= RCC_AHB2ENR_ADC{{ id_common }}EN;
+%% elif target["family"] in ["l4"]
+	Rcc::enable<Peripheral::Adc{{ id }}>();
 %% endif
 
 %% if clock_mux
@@ -61,12 +57,13 @@ modm::platform::Adc{{ id }}::initialize()
 	// set ADC "analog" clock source
 	if (clk != ClockMode::DoNotChange) {
 		if (clk == ClockMode::Asynchronous) {
-			//setPrescaler(pre);
+			setPrescaler(pre);
 		}
 		tmp  =  ADC{{ id_common_u }}->CCR;
-		tmp &= ~{{ adc_ccr }}_CKMODE;
+		tmp &= ~{{ adc_ccr }}_CKMODE_Msk;
 		tmp |=  static_cast<uint32_t>(clk);
 		ADC{{ id_common_u }}->CCR = tmp;
+		//ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
 	}
 
 	// enable regulator

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -28,7 +28,7 @@ template< class SystemClock
           , modm::platform::Adc{{ id }}::ClockSource clk_src
 		  >
 void
-modm::platform::Adc{{ id }}::initialize()
+modm::platform::Adc{{ id }}::initialize(bool blocking)
 //		const Prescaler pre,
 //		const CalibrationMode cal, const bool blocking)
 {
@@ -38,7 +38,7 @@ modm::platform::Adc{{ id }}::initialize()
 %% if target["family"] in ["f3", "g4"]
 	RCC->{{ ahb }}ENR |= RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
 %% elif target["family"] in ["l4"]
-	Rcc::enable<Peripheral::Adc{{ id }}>();
+	Rcc::enable<Peripheral::Adc1>();
 %% endif
 
 %% if clock_mux
@@ -55,25 +55,14 @@ modm::platform::Adc{{ id }}::initialize()
 	// FIXME: not a good idea since you can only reset both
 	// ADC1/ADC2 or ADC3/ADC4 at once ....
 
-	if constexpr (clk != ClockMode::DoNotChange) {
-		// TODO...
-		ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
-	}
-
-	/*
-	OLD INTERFACE: prescaler manually supplied as function parameter
 	// set ADC "analog" clock source
 	if (clk != ClockMode::DoNotChange) {
 		if (clk == ClockMode::Asynchronous) {
-			setPrescaler(pre);
+			// FIXME
+			// compute and set prescaler
 		}
-		tmp  =  ADC{{ id_common_u }}->CCR;
-		tmp &= ~{{ adc_ccr }}_CKMODE_Msk;
-		tmp |=  static_cast<uint32_t>(clk);
-		ADC{{ id_common_u }}->CCR = tmp;
-		//ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
+		ADC{{ id_common_u }}->CCR = (ADC{{ id_common_u }}->CCR & ~{{ adc_ccr }}_CKMODE_Msk) | static_cast<uint32_t>(clk);
 	}
-	*/
 
 	// enable regulator
 	ADC{{ id }}->CR &= ~ADC_CR_ADVREGEN;
@@ -83,7 +72,7 @@ modm::platform::Adc{{ id }}::initialize()
 	acknowledgeInterruptFlag(InterruptFlag::Ready);
 
 	ADC{{ id }}->CR |= ADC_CR_ADEN;
-	if (true) {
+	if (blocking) {
 		// ADEN can only be set 4 ADC clock cycles after ADC_CR_ADCAL gets
 		// cleared. Setting it in a loop ensures the flag gets set for ADC
 		// clocks slower than the CPU clock.

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -147,7 +147,8 @@ def prepare(module, options):
         ":architecture:register",
         ":cmsis:device",
         ":platform:gpio",
-        ":platform:rcc")
+        ":platform:rcc",
+        ":span-lite")
 
     for instance in listify(device.get_driver("adc")["instance"]):
         module.add_submodule(Instance(int(instance)))

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -134,32 +134,32 @@ class Instance(Module):
 
 
 
-class InstanceCommon(Module):
-    def __init__(self, instance):
-        self.instance = instance
+# class InstanceCommon(Module):
+#     def __init__(self, instance):
+#         self.instance = instance
 
-    def init(self, module):
-        module.name = str(self.instance)
-        module.description = "Common configuration for ADC{}".format(self.instance)
+#     def init(self, module):
+#         module.name = str(self.instance)
+#         module.description = "Common configuration for ADC{}".format(self.instance)
 
-    def prepare(self, module, options):
-        module.depends(":platform:adc")
-        return True
+#     def prepare(self, module, options):
+#         module.depends(":platform:adc")
+#         return True
 
-    def build(self, env):
-        device = env[":target"]
-        driver = device.get_driver("adc")
+#     def build(self, env):
+#         device = env[":target"]
+#         driver = device.get_driver("adc")
 
-        properties = device.properties
-        properties["target"] = target = device.identifier
-        instance_id = int(self.instance)
-        properties["id"] = instance_id
+#         properties = device.properties
+#         properties["target"] = target = device.identifier
+#         instance_id = int(self.instance)
+#         properties["id"] = instance_id
 
-        env.substitutions = properties
-        env.outbasepath = "modm/src/modm/platform/adc"
+#         env.substitutions = properties
+#         env.outbasepath = "modm/src/modm/platform/adc"
 
-        env.template("adc.hpp.in", "adc_{}.hpp".format(self.instance))
-        env.template("adc_impl.hpp.in", "adc_{}_impl.hpp".format(self.instance))
+#         env.template("adc_common.hpp.in", "adc_common_{}.hpp".format(self.instance))
+#         env.template("adc_common_impl.hpp.in", "adc_common{}_impl.hpp".format(self.instance))
 
 
 def init(module):
@@ -180,6 +180,13 @@ def prepare(module, options):
 
     for instance in listify(device.get_driver("adc")["instance"]):
         module.add_submodule(Instance(int(instance)))
+
+    # if target["family"] in ["f3", "l4"]:
+    #     module.add_submodule(InstanceCommon(12))
+    #     module.add_submodule(InstanceCommon(34))
+    # elif target["family"] in ["g4"]:
+    #     module.add_submodule(InstanceCommon(12))
+    #     module.add_submodule(InstanceCommon(345))
 
     return True
 

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -176,8 +176,7 @@ def prepare(module, options):
         ":architecture:register",
         ":cmsis:device",
         ":platform:gpio",
-        ":platform:rcc",
-        ":span-lite")
+        ":platform:rcc")
 
     for instance in listify(device.get_driver("adc")["instance"]):
         module.add_submodule(Instance(int(instance)))

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -133,6 +133,35 @@ class Instance(Module):
         env.template("adc_impl.hpp.in", "adc_{}_impl.hpp".format(self.instance))
 
 
+
+class InstanceCommon(Module):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Common configuration for ADC{}".format(self.instance)
+
+    def prepare(self, module, options):
+        module.depends(":platform:adc")
+        return True
+
+    def build(self, env):
+        device = env[":target"]
+        driver = device.get_driver("adc")
+
+        properties = device.properties
+        properties["target"] = target = device.identifier
+        instance_id = int(self.instance)
+        properties["id"] = instance_id
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/adc"
+
+        env.template("adc.hpp.in", "adc_{}.hpp".format(self.instance))
+        env.template("adc_impl.hpp.in", "adc_{}_impl.hpp".format(self.instance))
+
+
 def init(module):
     module.name = ":platform:adc"
     module.description = "Analog-to-Digital Converter (ADC)"

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -41,7 +41,8 @@ class Instance(Module):
                 channels = range(1,17)
             elif target["family"] == "g4":
                 # ADC1 is connected to 14 external channels + 4 internal channels
-                channels = range(1,15)
+                # 13, 16-18 reserved
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,14,15]
             else:
                 # 11-14 reserved
                 channels = [1,2,3,4,5,6,7,8,9,10,15,16,17,18]
@@ -51,7 +52,8 @@ class Instance(Module):
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,17,18]
             elif target["family"] == "g4":
                 # ADC2 is connected to 16 external channels + 2 internal channels
-                channels = range(1,17)
+                # 16 and 18 reserved
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17]
             else:
                 # ADC2 is connected to 16 external channels + 2 internal channels
                 channels = range(1,17)
@@ -60,7 +62,8 @@ class Instance(Module):
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
             elif target["family"] == "g4":
                 # ADC3 is connected to 15 external channels + 3 internal channels
-                channels = range(1,16)
+                # 13, 17, 18 reserved
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,14,15,16]
             else:
                 # ADC3 is connected to 12 external channels + 4 internal channels
                 channels = [1,2,3,4,6,7,8,9,10,11,12,13]
@@ -74,7 +77,8 @@ class Instance(Module):
         elif instance_id == 5:
             if target["family"] == "g4":
                 # ADC5 is connected to 13 external channels + 5 internal channels
-                channels = range(1,14)
+                # 3-5, 17, 18 reserved
+                channels = [1,2,6,7,8,9,10,11,12,13,14,15,16]
             else:
                 raise NotImplementedError
         properties["channels"] = sorted(channels)


### PR DESCRIPTION
- [x] Fix channels
- [x] Add support for ADC conversion sequences
- [x] Add support for ADC triggers
- [x] Add an advanced adc example for Nucleo-G474RE
- [x] ~Add [`nonstd::span`](https://github.com/martinmoene/span-lite) because we are not ready for [C++20](https://en.cppreference.com/w/cpp/container/span) yet.~
- [ ] Prescaler computation: https://github.com/modm-io/modm/blob/develop/src/modm/math/algorithm/prescaler.hpp
- [ ] Test on real hardware