### PR TITLE
fix SConstruct generation on Windows

### DIFF
--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -13,10 +13,10 @@ from os.path import join, abspath
 
 # User Configurable Options
 project_name = "{{ options[":build:project.name"] }}"
-build_path = "{{ build_path }}"
+build_path = "{{ build_path | modm.windowsify(escape_level=1)}}"
 generated_paths = {{ generated_paths }}
 %% if cache_dir | length
-CacheDir("{{ cache_dir }}")
+CacheDir("{{ cache_dir | modm.windowsify(escape_level=1)}}")
 %% endif
 
 # SCons environment with all tools


### PR DESCRIPTION
I got the following error message *before*:

```bash
(modm) C:\Users\hebbeker.ST\Documents\modm_tests\modm\examples\stm32f4_discovery\timer>scons
scons: Reading SConscript files ...
OSError: [WinError 123] Die Syntax für den Dateinamen, Verzeichnisnamen oder die Datenträgerbezeichnung ist falsch: 'C:\\Users\\hebbeker.ST\\Documents\\modm_tests\\modm\\examples\\..\x08uild':
  File "C:\Users\hebbeker.ST\Documents\modm_tests\modm\examples\stm32f4_discovery\timer\SConstruct", line 26:
    env.SConscript(dirs=generated_paths, exports="env")
```

Fixes #299.