### PR TITLE
Add missing module for example in Getting Started documentation.

### DIFF
--- a/docs/getting-started.md.in
+++ b/docs/getting-started.md.in
@@ -245,6 +245,7 @@ source code.
     <module>modm:platform:clock</module>
     <module>modm:platform:core</module>
     <module>modm:platform:gpio</module>
+    <module>modm:architecture:delay</module>
   </modules>
 </library>
 ```


### PR DESCRIPTION
In Getting Started section [Custom Configuration](https://modm.io/guide/getting-started/#custom-configuration) there is a code listing for the `project.xml` and for the `main.cpp` which are supposed to work together.

Without the `modm:architecture:delay` module the corresponding `main.cpp` does not compile.