### PR TITLE
Added TimerX::isChannelConfiguredAsInput.

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.cpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.cpp.in
@@ -179,3 +179,31 @@ modm::platform::Timer{{ id }}::enableInterruptVector(bool enable, uint32_t prior
 	}
 %% endfor
 }
+
+// ----------------------------------------------------------------------------
+%% if ((id <= 5) or (id in [8, 9, 12]))
+bool
+modm::platform::Timer{{ id }}::isChannelConfiguredAsInput(uint32_t channel)
+{
+	bool isInput = false;
+	switch (channel) {
+		case 1:
+			isInput = TIM{{ id }}->CCMR1 & TIM_CCMR1_CC1S;
+			break;
+		case 2:
+			isInput = TIM{{ id }}->CCMR1 & TIM_CCMR1_CC2S;
+			break;
+%% if (id <= 5)
+		case 3:
+			isInput = TIM{{ id }}->CCMR2 & TIM_CCMR2_CC3S;
+			break;
+		case 4:
+			isInput = TIM{{ id }}->CCMR2 & TIM_CCMR2_CC4S;
+			break;
+%% endif
+		default:
+			break;
+	}
+	return isInput;
+}
+%% endif

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -349,7 +349,29 @@ public:
 		}
 	}
 
+	%% if (id !=6 and id != 7)
+	/// Returns if the capture/compare channel of the timer is configured as input.
+	///
+	%% if (id <= 5)
+	/// @param channel may be [1..4]
+	%% elif (id in [8, 9, 12])
+	/// @param channel may be [1..2]
+	%% endif
+	/// @return `false` if configured as *output*; `true` if configured as *input*
+	%% if (id in [10, 11, 13, 14])
+	static inline bool
+	isChannelConfiguredAsInput()
+	{
+		return TIM{{ id }}->CCMR1 & TIM_CCMR1_CC1S;
+	}
 
+	%% else
+	static bool
+	isChannelConfiguredAsInput(uint32_t channel);
+
+	%% endif
+
+	%% endif
 	static inline void
 	setCompareValue(uint32_t channel, Value value)
 	{


### PR DESCRIPTION
This function is especially useful in the ISR in order to check the interrupt source.

#### To do:
- [x] squash all commits into one
- [x] do a spot-check of a few different families RMs