### PR TITLE
Add enableComparePreload parameter to Timer{{ id }}::configureOutputChannel()

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.cpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.cpp.in
@@ -128,7 +128,8 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
-		OutputCompareMode_t mode, Value compareValue, PinState out)
+		OutputCompareMode_t mode, Value compareValue, PinState out,
+		bool enableComparePreload)
 {
 	channel -= 1;	// 1..4 -> 0..3
 
@@ -137,8 +138,12 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 
 	setCompareValue(channel + 1, compareValue);
 
-	// enable preload (the compare value is loaded at each update event)
-	uint32_t flags = mode.value | TIM_CCMR1_OC1PE;
+	uint32_t flags = mode.value;
+	if(enableComparePreload)
+	{
+		// enable preload (the compare value is loaded at each update event)
+		flags |= TIM_CCMR1_OC1PE;
+	}
 
 	if (channel <= 1)
 	{

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -221,7 +221,8 @@ public:
 
 	static void
 	configureOutputChannel(uint32_t channel, OutputCompareMode_t mode,
-			Value compareValue, PinState out = PinState::Enable);
+			Value compareValue, PinState out = PinState::Enable,
+			bool enableComparePreload = true);
 
 	/// Switch to Pwm Mode 2
 	///


### PR DESCRIPTION
For compatibility reasons with legacy code I need more control over the `TIMx->CCMRx` register. Thus I added an additional parameter. Default value renders the previous behaviour.

The boolean decides if the `TIM_CCMR1_OC1PE` bits are enabled on the register when configuring output compare channels. The API has no reasonable alternative - except for writing to the registers directly. But that is ugly as channel arithmetic has to be done.