### PR TITLE
Added dummy parameter to Timer::isChannelConfiguredAsInput for 1 channel

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -357,11 +357,13 @@ public:
 	/// @param channel may be [1..4]
 	%% elif (id in [8, 9, 12])
 	/// @param channel may be [1..2]
+	%% else
+	/// @param channel is not used
 	%% endif
 	/// @return `false` if configured as *output*; `true` if configured as *input*
 	%% if (id in [10, 11, 13, 14])
 	static inline bool
-	isChannelConfiguredAsInput()
+	isChannelConfiguredAsInput([[maybe_unused]] uint32_t channel = 1)
 	{
 		return TIM{{ id }}->CCMR1 & TIM_CCMR1_CC1S;
 	}


### PR DESCRIPTION
Added dummy parameter to `Timer::isChannelConfiguredAsInput` for timers which have only one channel.

This allows a unified interface for all general purpose timers, independent of the number of available channels. As a default argument is given, it is backwards compatible.