### PR TITLE
[c++] Add static initialization guards for Cortex-M

### DIFF
--- a/examples/stm32f469_discovery/threadsafe_statics/main.cpp
+++ b/examples/stm32f469_discovery/threadsafe_statics/main.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+void constructDummy();
+class Dummy
+{
+public:
+	Dummy()
+	{
+		MODM_LOG_INFO << "Dummy class constructed" << modm::endl;
+		constructDummy(); // recursive initialization
+	}
+};
+
+void
+constructDummy()
+{
+	static Dummy dummy;
+	MODM_LOG_INFO << "constructDummy() called" << modm::endl;
+}
+
+int
+main()
+{
+	Board::initialize();
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Board::LedGreen::toggle();
+		modm::delayMilliseconds(Board::Button::read() ? 125 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+		constructDummy();
+	}
+
+	return 0;
+}

--- a/examples/stm32f469_discovery/threadsafe_statics/project.xml
+++ b/examples/stm32f469_discovery/threadsafe_statics/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:disco-f469ni</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f469_discovery/threadsafe_statics</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/gcc/assert.cpp.in
+++ b/ext/gcc/assert.cpp.in
@@ -13,7 +13,7 @@
 #include <bits/functexcept.h>
 #include <modm/math/utils/bit_constants.hpp>
 
-%% if options["use_modm_assert"]
+%% if options["assert_on_exception"]
 #include <modm/architecture/interface/assert.hpp>
 
 #define __modm_stdcpp_failure(failure) modm_assert(false, "stdc++", "stdc++", failure);__builtin_abort();

--- a/ext/gcc/atomics_c11_cortex.cpp.in
+++ b/ext/gcc/atomics_c11_cortex.cpp.in
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+
+#include <cstring>
+#include <modm/platform/core/atomic_lock.hpp>
+
+/* Cortex-M0 does not have hardware support for true atomics, like STREX/LDREX.
+ * The toolchain does not implement the intrinsics, instead linking to them, so
+ * that an external library can implement them as they wish.
+ * Here we wrap all operations into an atomic lock, which globally disables
+ * interrupts. This isn't high performance, but we have no other choice here.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
+ */
+
+using _a8 = uint8_t;
+using _a16 = uint16_t;
+using _a32 = unsigned int;
+using _a64 = uint64_t;
+
+// =========================== atomics for >64 bits ===========================
+%% macro atomic_load(len)
+extern "C" _a{{len}}
+__atomic_load_{{len//8}}(const volatile void *ptr, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    return *reinterpret_cast<const volatile _a{{len}}*>(ptr);
+}
+%% endmacro
+
+extern "C" void
+__atomic_load_c(size_t size, const void *src, void *dest, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    std::memcpy(dest, src, size);
+}
+
+
+%% macro atomic_store(len)
+extern "C" void
+__atomic_store_{{len//8}}(volatile void *ptr, _a{{len}} value, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    *reinterpret_cast<volatile _a{{len}}*>(ptr) = value;
+}
+%% endmacro
+
+extern "C" void
+__atomic_store_c(size_t size, void *dest, const void *src, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    std::memcpy(dest, src, size);
+}
+
+
+%% macro atomic_exchange(len)
+extern "C" _a{{len}}
+__atomic_exchange_{{len//8}}(volatile void *ptr, _a{{len}} desired, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    const _a{{len}} previous = *reinterpret_cast<const volatile _a{{len}}*>(ptr);
+    *reinterpret_cast<volatile _a{{len}}*>(ptr) = desired;
+    return previous;
+}
+%% endmacro
+
+extern "C" void
+__atomic_exchange_c(size_t size, void *ptr, void *val, void *ret, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    std::memcpy(ret, ptr, size);
+    std::memcpy(ptr, val, size);
+}
+
+
+%% macro atomic_compare_exchange(len)
+extern "C" bool
+__atomic_compare_exchange_{{len//8}}(volatile void *ptr, void *expected, _a{{len}} desired,
+                                    bool /*weak*/, int /*success_memorder*/, int /*failure_memorder*/)
+{
+    modm::atomic::Lock _;
+    const _a{{len}} current = *reinterpret_cast<const volatile _a{{len}}*>(ptr);
+    if (current != *reinterpret_cast<_a{{len}}*>(expected))
+    {
+        *reinterpret_cast<_a{{len}}*>(expected) = current;
+        return false;
+    }
+    *reinterpret_cast<volatile _a{{len}}*>(ptr) = desired;
+    return true;
+}
+%% endmacro
+
+extern "C" bool
+__atomic_compare_exchange_c(size_t len, void *ptr, void *expected, void *desired,
+                            bool /*weak*/, int /*success_memorder*/, int /*failure_memorder*/)
+{
+    modm::atomic::Lock _;
+    if (std::memcmp(ptr, expected, len) == 0)
+    {
+        std::memcpy(ptr, desired, len);
+        return true;
+    }
+    std::memcpy(expected, ptr, len);
+    return false;
+}
+
+
+%% macro atomic_fetch(len)
+    %% for name, op in [("add", "+"), ("sub", "-"), ("and", "&"), ("or", "|"), ("xor", "^"), ("nand", "&")]
+        %% set prefix = "~" if name == "nand" else ""
+extern "C" _a{{len}}
+__atomic_fetch_{{name}}_{{len//8}}(volatile void *ptr, _a{{len}} value, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    const _a{{len}} previous = *reinterpret_cast<const volatile _a{{len}}*>(ptr);
+    *reinterpret_cast<volatile _a{{len}}*>(ptr) = {{prefix}}(previous {{op}} value);
+    return previous;
+}
+extern "C" _a{{len}}
+__atomic_{{name}}_fetch_{{len//8}}(volatile void *ptr, _a{{len}} value, int /*memorder*/)
+{
+    modm::atomic::Lock _;
+    const _a{{len}} current = {{prefix}}(*reinterpret_cast<const volatile _a{{len}}*>(ptr) {{op}} value);
+    *reinterpret_cast<volatile _a{{len}}*>(ptr) = current;
+    return current;
+}
+    %% endfor
+%% endmacro
+
+%% for length in [8, 16, 32, 64]
+// ============================ atomics for {{length}} bits ============================
+{{ atomic_load(length) }}
+
+{{ atomic_store(length) }}
+
+{{ atomic_exchange(length) }}
+
+{{ atomic_compare_exchange(length) }}
+
+{{ atomic_fetch(length) }}
+%% endfor

--- a/ext/gcc/cabi_cortex.c
+++ b/ext/gcc/cabi_cortex.c
@@ -9,16 +9,13 @@
  */
 // ----------------------------------------------------------------------------
 
-#include <modm/architecture/interface/assert.hpp>
+#include <modm/architecture/interface/assert.h>
 
 // ------------------------------------------------------------------------
-extern "C"
-{
 
 extern void _exit(int);
 void _exit(int status)
 {
 	modm_assert(false, "libc", "libc", "exit", status);
-}
-
+	__builtin_trap();
 }

--- a/ext/gcc/cxxabi.cpp.in
+++ b/ext/gcc/cxxabi.cpp.in
@@ -17,18 +17,12 @@
 extern "C"
 {
 
-/**
- * \brief Pure-virtual workaround.
- *
- * The libc does not support a default implementation for handling
- * possible pure-virtual calls. This is a short and empty workaround for this.
- */
-void
-__cxa_pure_virtual()
-{
-	modm_assert_debug(0, "cxa", "virtual", "pure");
-}
+void __cxa_pure_virtual()
+{ modm_assert_debug(0, "cxa", "virtual", "pure"); __builtin_trap(); }
+void __cxa_deleted_virtual()
+{ modm_assert_debug(0, "cxa", "virtual", "deleted"); __builtin_trap(); }
 
+void* __dso_handle = (void*) &__dso_handle;
 %% if core.startswith("avr")
 int __cxa_atexit(void (*)(void *), void *, void *)
 %% else
@@ -38,7 +32,46 @@ int __aeabi_atexit(void (*)(void *), void *, void *)
 {
 	return 0;
 }
-
-void* __dso_handle = (void*) &__dso_handle;
-
 }
+
+%% if with_threadsafe_statics
+#include <atomic>
+/* One-time construction API, see ARM IHI0041D section 3.2.3.
+ * The ARM C++ ABI mandates the guard to be 32-bit aligned, 32-bit values.
+ */
+enum
+{
+	UNINITIALIZED = 0,
+	INITIALIZED = 1,
+	INITIALIZING = 0x100,
+};
+
+// This function is only called when `(guard & 1) != 1`!
+extern "C" int __cxa_guard_acquire(int *guard)
+{
+	std::atomic_int *atomic_guard = reinterpret_cast<std::atomic_int *>(guard);
+	if (atomic_guard->exchange(INITIALIZING) == INITIALIZING)
+	{
+		modm_assert_debug(0, "cxa", "guard", "recursion", guard);
+		return 0;
+	}
+	return 1;
+}
+
+// After this function the compiler expects `(guard & 1) == 1`!
+extern "C" void __cxa_guard_release(int *guard) noexcept
+{
+	std::atomic_int *atomic_guard = reinterpret_cast<std::atomic_int *>(guard);
+	atomic_guard->store(INITIALIZED);
+}
+
+// Called if the initialization terminates by throwing an exception.
+// After this function the compiler expects `(guard & 3) == 0`!
+extern "C" void __cxa_guard_abort([[maybe_unused]] int *guard) noexcept
+{
+%% if with_exceptions
+	std::atomic_int *atomic_guard = reinterpret_cast<std::atomic_int *>(guard);
+	atomic_guard->store(UNINITIALIZED);
+%% endif
+}
+%% endif

--- a/ext/gcc/cxxabi.cpp.in
+++ b/ext/gcc/cxxabi.cpp.in
@@ -29,7 +29,7 @@ __cxa_pure_virtual()
 	modm_assert_debug(0, "cxa", "virtual", "pure");
 }
 
-%% if target.platform in ["avr"]
+%% if core.startswith("avr")
 int __cxa_atexit(void (*)(void *), void *, void *)
 %% else
 // ARM EABI specifies __aeabi_atexit instead of __cxa_atexit

--- a/ext/gcc/module_c++.lb
+++ b/ext/gcc/module_c++.lb
@@ -33,12 +33,6 @@ or:
 
 A partial port of GCC 8 libstdc++ is provided:
 See https://github.com/modm-io/avr-libstdcpp.
-
-## ARM Cortex-M
-
-Additional compiler options:
-
-- `-fno-threadsafe-statics`: No thread-safe static initialization provided.
 """
 
 
@@ -52,7 +46,7 @@ def prepare(module, options):
     if is_avr:
         module.add_option(
             BooleanOption(
-                name="use_modm_assert", default=True,
+                name="assert_on_exception", default=True,
                 description="Assert on exception in stdlib. Set to False to save flash."))
 
     elif is_cortex_m:
@@ -64,6 +58,10 @@ def prepare(module, options):
             BooleanOption(
                 name="rtti", default=False,
                 description=descr_rtti))
+        module.add_option(
+            BooleanOption(
+                name="safe_statics", default=True,
+                description=descr_safe_statics))
 
     module.depends(":architecture:assert", ":architecture:memory", ":stdc")
     return True
@@ -73,8 +71,14 @@ def build(env):
     core = env[":target"].get_driver("core")["type"]
     is_avr = core.startswith("avr")
     is_cortex_m = core.startswith("cortex-m")
+    with_exceptions = env.get("exceptions", False)
+    with_threadsafe_statics = env.get("safe_statics", False)
 
-    env.substitutions = {"core": core}
+    env.substitutions = {
+        "core": core,
+        "with_exceptions": with_exceptions,
+        "with_threadsafe_statics": with_threadsafe_statics
+    }
     env.outbasepath = "modm/ext/gcc"
     env.template("cxxabi.cpp.in")
 
@@ -87,12 +91,16 @@ def build(env):
     elif is_cortex_m:
         env.copy("newdelete_cortex.cpp", "newdelete.cpp")
 
-    # Compilation flags
-    env.collect(":build:cxxflags", "-fuse-cxa-atexit", "-fno-threadsafe-statics")
-    if env.get("exceptions", False):
+    env.collect(":build:cxxflags", "-fuse-cxa-atexit")
+    # Threadsafe statics
+    if not with_threadsafe_statics:
+        env.collect(":build:cxxflags", "-fno-threadsafe-statics")
+    # Compiler options for C++ Exceptions
+    if with_exceptions:
         env.collect(":build:cxxflags", "-fexceptions", "-funwind-tables")
     else:
         env.collect(":build:cxxflags", "-fno-exceptions", "-fno-unwind-tables")
+    # Compiler options for C++ RTTI
     if env.get("rtti", False):
         env.collect(":build:cxxflags", "-frtti")
     else:
@@ -117,4 +125,16 @@ Enables the full use of C++ runtime type information.
 !!! warning "Check your code size"
     The inclusion of the RTTI information will increase your code size quite a
     bit. Check whether your target has enough memory for this!
+"""
+
+descr_safe_statics = """# C++ Safe Statics Initialization
+
+Enables safe initialization of statics inside functions and interrupts.
+In case of recursive initialization the debug assertion `cxa.guard.recursion`
+is raised.
+
+Further reading on this topic:
+- [C++ ABI for the ARM Architecture](https://static.docs.arm.com/ihi0041/d/IHI0041D_cppabi.pdf)
+- https://manishearth.github.io/blog/2015/06/26/adventures-in-systems-programming-c-plus-plus-local-statics/
+- https://iamroman.org/blog/2017/04/cpp11-static-init/
 """

--- a/ext/gcc/module_c++.lb
+++ b/ext/gcc/module_c++.lb
@@ -39,14 +39,13 @@ See https://github.com/modm-io/avr-libstdcpp.
 Additional compiler options:
 
 - `-fno-threadsafe-statics`: No thread-safe static initialization provided.
-- `--specs=nano.specs`: use Newlib Nano (when not using exceptions).
-- `--specs=nosys.specs`: No additional C library features are implemented.
 """
 
 
 def prepare(module, options):
-    is_avr = options[":target"].identifier.platform == "avr"
-    is_cortex_m = options[":target"].has_driver("core:cortex-m*")
+    core = options[":target"].get_driver("core")["type"]
+    is_avr = core.startswith("avr")
+    is_cortex_m = core.startswith("cortex-m")
     if not (is_avr or is_cortex_m):
         return False
 
@@ -66,16 +65,16 @@ def prepare(module, options):
                 name="rtti", default=False,
                 description=descr_rtti))
 
-    module.depends(":architecture:assert",
-                   ":architecture:memory")
-
+    module.depends(":architecture:assert", ":architecture:memory", ":stdc")
     return True
 
 
 def build(env):
-    is_avr = env[":target"].identifier.platform == "avr"
-    is_cortex_m = env[":target"].has_driver("core:cortex-m*")
-    env.substitutions = {"target": env[":target"].identifier}
+    core = env[":target"].get_driver("core")["type"]
+    is_avr = core.startswith("avr")
+    is_cortex_m = core.startswith("cortex-m")
+
+    env.substitutions = {"core": core}
     env.outbasepath = "modm/ext/gcc"
     env.template("cxxabi.cpp.in")
 
@@ -83,11 +82,9 @@ def build(env):
         env.collect(":build:path.include", "modm/ext/gcc/libstdc++/include")
         env.copy("libstdc++", ignore=env.ignore_files("*.lb", "*.md", "*.in", "examples"))
         env.template("assert.cpp.in", "assert.cpp")
-
         env.copy("newdelete_avr.cpp", "newdelete.cpp")
 
     elif is_cortex_m:
-        env.copy("libcabi_cortex.cpp", "libcabi.cpp")
         env.copy("newdelete_cortex.cpp", "newdelete.cpp")
 
     # Compilation flags
@@ -101,11 +98,6 @@ def build(env):
     else:
         env.collect(":build:cxxflags", "-fno-rtti")
 
-    if is_cortex_m:
-        env.collect(":build:linkflags", "--specs=nosys.specs")
-        if not env.get("exceptions", False):
-            # Newlib Nano does not support C++ exceptions at all
-            env.collect(":build:linkflags", "--specs=nano.specs")
 
 # ============================ Option Descriptions ============================
 

--- a/ext/gcc/module_c.lb
+++ b/ext/gcc/module_c.lb
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2017, Niklas Hauser
+# Copyright (c) 2017-2018, Fabian Greif
+# Copyright (c) 2018, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":stdc"
+    module.description = """\
+# C Standard Environment
+
+Refines the C language to make it easier to use on embedded targets.
+
+## ARM Cortex-M
+
+Additional compiler options:
+
+- `--specs=nano.specs`: use Newlib Nano (when not using exceptions).
+- `--specs=nosys.specs`: No additional C library features are implemented.
+"""
+
+def prepare(module, options):
+    core = options[":target"].get_driver("core")["type"]
+    if not (core.startswith("avr") or core.startswith("cortex-m")):
+        return False
+    module.depends(":architecture:assert")
+    return True
+
+def build(env):
+    core = env[":target"].get_driver("core")["type"]
+    env.outbasepath = "modm/ext/gcc"
+
+    if core.startswith("cortex-m"):
+        env.copy("cabi_cortex.c", "cabi.c")
+
+        # Compiler options for targets
+        env.collect(":build:linkflags", "--specs=nosys.specs")
+        if not env.get(":stdc++:exceptions", False):
+            # Newlib Nano does not support C++ exceptions at all
+            env.collect(":build:linkflags", "--specs=nano.specs")

--- a/ext/gcc/module_c.lb
+++ b/ext/gcc/module_c.lb
@@ -22,6 +22,8 @@ Refines the C language to make it easier to use on embedded targets.
 
 ## ARM Cortex-M
 
+For ARMv6-M, C11 atomics are implemented via atomic lock.
+
 Additional compiler options:
 
 - `--specs=nano.specs`: use Newlib Nano (when not using exceptions).
@@ -32,7 +34,11 @@ def prepare(module, options):
     core = options[":target"].get_driver("core")["type"]
     if not (core.startswith("avr") or core.startswith("cortex-m")):
         return False
+
     module.depends(":architecture:assert")
+    if core.startswith("cortex-m0"):
+        module.depends(":architecture:atomic")
+
     return True
 
 def build(env):
@@ -41,6 +47,8 @@ def build(env):
 
     if core.startswith("cortex-m"):
         env.copy("cabi_cortex.c", "cabi.c")
+        if core.startswith("cortex-m0"):
+            env.template("atomics_c11_cortex.cpp.in")
 
         # Compiler options for targets
         env.collect(":build:linkflags", "--specs=nosys.specs")


### PR DESCRIPTION
This adds a hopefully atomic statics initialization guard implementation to implement #345.
In case of recursive initialization, a debug assertion `cxa.guard.recursion` is raised.
For AVRs, the threadsafe statics are not implemented at all to save code space.

Should the guard implementation be optional for ARM Cortex-M? The guard itself takes 4 bytes per function static, and the guards a little bit of code. I don't think this is too much size, but for very small targets it may be useful to have this as an option. I'm also not aware of this not being atomic being an issue in the past.

Not sure how to overwrite this for FreeRTOS use, I'll fix it when it becomes an issue.

cc @chris-durand @rleh @dergraaf 