### PR TITLE
Clear ADC interrupt flags when starting a conversion

### DIFF
--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -185,7 +185,8 @@ void
 modm::platform::Adc{{ id }}::startConversion(void)
 {
 	// TODO: maybe add more interrupt flags
-	acknowledgeInterruptFlag(InterruptFlag::EndOfSampling | InterruptFlag::Overrun);
+	acknowledgeInterruptFlag(InterruptFlag::EndOfRegularConversion |
+			InterruptFlag::EndOfSampling | InterruptFlag::Overrun);
 	// starts single conversion for the regular group
 	ADC{{ id }}->CR |= ADC_CR_ADSTART;
 }


### PR DESCRIPTION
Clears the interrupt flag EndOfRegularConversion as well when a conversion is started. Thix fixes issues with wrong values read from the ADC when compiling
with optimization turned on.
Fixes #330. 