### PR TITLE
[math] Add modm::range() inspired by Python

### DIFF
--- a/src/modm/math/algorithm/range.hpp
+++ b/src/modm/math/algorithm/range.hpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2015, Huu Nguyen
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MPL was not distributed with this file, you can obtain
+ * one at https://opensource.org/licenses/MIT.
+ */
+// Adapted for constexpr from https://github.com/whoshuu/cpp_range
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <iterator>
+#include <type_traits>
+// #include <modm/architecture/interface/assert.hpp> // TODO
+
+namespace modm
+{
+
+/// @cond
+namespace detail
+{
+
+template <typename T>
+class Range
+{
+public:
+	constexpr Range(const T& start, const T& stop, const T& step) :
+		start_{start},
+		stop_{validate(start,stop,step) ? stop : start},
+		step_{validate(start,stop,step) ? step : 1}
+	{}
+
+	class iterator
+	{
+	public:
+		typedef std::forward_iterator_tag iterator_category;
+		typedef T value_type;
+		typedef T& reference;
+		typedef T* pointer;
+
+		constexpr iterator(value_type value, T step, value_type boundary) :
+			value_{value}, step_{step}, boundary_{boundary}, positive_step_(step_ > 0)
+		{}
+		constexpr iterator operator++() { value_ += step_; return *this; }
+		constexpr reference operator*() { return value_; }
+		constexpr pointer operator->() { return &value_; }
+		constexpr bool operator==(const iterator& rhs)
+		{
+			if (positive_step_)
+				return (value_ >= rhs.value_ and value_ > boundary_);
+			return (value_ <= rhs.value_ and value_ < boundary_);
+		}
+		constexpr bool operator!=(const iterator& rhs)
+		{
+			if (positive_step_)
+				return (value_ < rhs.value_ and value_ >= boundary_);
+			return (value_ > rhs.value_ and value_ <= boundary_);
+		}
+
+	private:
+		value_type value_;
+		const T step_;
+		const T boundary_;
+		const bool positive_step_;
+	};
+
+	constexpr iterator begin() const { return iterator(start_, step_, start_); }
+	constexpr iterator end()   const { return iterator(stop_,  step_, start_); }
+
+private:
+	constexpr bool
+	validate(const T& start, const T& stop, const T& step)
+	{
+		bool step_ok = (step != 0);
+		bool order_ok = not ((start > stop and step > 0) or (start < stop and step < 0));
+
+		// TODO: Use std::is_constant_evaluated() to make modm_assert redirect to static_assert!
+		// throw std::invalid_argument("Range step argument must not be zero");
+		// modm_assert_debug(step_ok, "algorithm", "range", "step");
+		// throw std::invalid_argument("Range arguments must result in termination");
+		// modm_assert_debug(order_ok, "algorithm", "range", "termination");
+
+		return step_ok and order_ok;
+	}
+
+	const T start_;
+	const T stop_;
+	const T step_;
+};
+
+} // namespace detail
+/// @endcond
+
+/**
+ * Returns an iterable range [0, stop) of step 1.
+ * @warning Returns an empty range if stop <= 0!
+ *
+ * @ingroup	modm_math_algorithm
+ */
+template <typename T>
+constexpr detail::Range<T>
+range(const T& stop)
+{
+	return detail::Range<T>(T{0}, stop, T{1});
+}
+
+/**
+ * Returns an iterable range [start, stop) of step 1.
+ * @warning Returns an empty range if start >= stop!
+ *
+ * @ingroup	modm_math_algorithm
+ */
+template <typename T>
+constexpr detail::Range<T>
+range(const T& start, const T& stop)
+{
+	return detail::Range<T>(start, stop, T{1});
+}
+
+/**
+ * Returns an iterable range [start, stop) of step != 0.
+ * @warning Returns an empty range if
+ *          (start >= stop and step >= 0) or (start <= stop and step <= 0)!
+ *
+ * @ingroup	modm_math_algorithm
+ */
+template <typename T>
+constexpr detail::Range<T>
+range(const T& start, const T& stop, const T& step)
+{
+	return detail::Range<T>(start, stop, step);
+}
+
+} // namespace modm

--- a/test/modm/math/algorithm/range_test.cpp
+++ b/test/modm/math/algorithm/range_test.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/math/algorithm/range.hpp>
+#include "range_test.hpp"
+
+void
+RangeTest::testRange()
+{
+	// Positive step
+	{
+		int counter{0};
+		for (auto ii : modm::range(10))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter++;
+		}
+		TEST_ASSERT_EQUALS(10, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(0, 10, 2))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter += 2;
+		}
+		TEST_ASSERT_EQUALS(10, counter);
+	}
+	{
+		int counter{5};
+		for (auto ii : modm::range(5, 15))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter++;
+		}
+		TEST_ASSERT_EQUALS(15, counter);
+	}
+	{
+		int counter{5};
+		for (auto ii : modm::range(5, 15, 2))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter += 2;
+		}
+		TEST_ASSERT_EQUALS(15, counter);
+	}
+	// Negative step
+	{
+		int counter{10};
+		for (auto ii : modm::range(10, 0, -1))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter--;
+		}
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{10};
+		for (auto ii : modm::range(10, 0, -2))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter -= 2;
+		}
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{15};
+		for (auto ii : modm::range(15, 5, -1))
+		{
+			TEST_ASSERT_EQUALS(ii, counter);
+			counter--;
+		}
+		TEST_ASSERT_EQUALS(5, counter);
+	}
+	// constexpr calls
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(10))
+				counter += ii;
+			return counter;
+		};
+		static_assert(45 == get_counter());
+	}
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(5, 10, 2))
+				counter += ii;
+			return counter;
+		};
+		static_assert(21 == get_counter());
+	}
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(10, 5, -2))
+				counter += ii;
+			return counter;
+		};
+		static_assert(24 == get_counter());
+	}
+}
+
+
+void
+RangeTest::testInvalidRange()
+{
+	// Invalid ranges should be empty!
+	{
+		int counter{0};
+		for (auto ii : modm::range(0))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(1, 1))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(1, 1, -1))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(-10))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(10, 0))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(0, 10, -1))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(0, 10, 0))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	{
+		int counter{0};
+		for (auto ii : modm::range(10, 0, 0))
+			counter += ii;
+		TEST_ASSERT_EQUALS(0, counter);
+	}
+	// constexpr
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(0))
+				counter += ii;
+			return counter;
+		};
+		static_assert(0 == get_counter());
+	}
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(10, 0))
+				counter += ii;
+			return counter;
+		};
+		static_assert(0 == get_counter());
+	}
+	{
+		auto get_counter = []() constexpr
+		{
+			int counter{0};
+			for (auto ii : modm::range(0, 10, -1))
+				counter += ii;
+			return counter;
+		};
+		static_assert(0 == get_counter());
+	}
+}

--- a/test/modm/math/algorithm/range_test.hpp
+++ b/test/modm/math/algorithm/range_test.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+class RangeTest : public unittest::TestSuite
+{
+public:
+	void
+	testRange();
+
+	void
+	testInvalidRange();
+};


### PR DESCRIPTION
This adds another convenience iterator to emulate Python's `range()` function.
It's also constexpr and has been tested. #LetMeThoughImSolvingImportantIssuesHere