### PR TITLE
Documentation improvements

### DIFF
--- a/test/modm/architecture/driver/accessor/flash_test.hpp
+++ b/test/modm/architecture/driver/accessor/flash_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_architecture
 class FlashTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/architecture/driver/atomic/atomic_queue_test.hpp
+++ b/test/modm/architecture/driver/atomic/atomic_queue_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_architecture
 class AtomicQueueTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/architecture/driver/clock_test.hpp
+++ b/test/modm/architecture/driver/clock_test.hpp
@@ -19,6 +19,8 @@
 
 // The only purpose of the test is to ensure that MODM_CLOCK_TESTMODE is
 // set to 1 when running the other tests.
+//
+/// @ingroup modm_test_test_architecture
 class ClockTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/architecture/driver/heap/block_allocator_test.hpp
+++ b/test/modm/architecture/driver/heap/block_allocator_test.hpp
@@ -17,6 +17,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_architecture
 class BlockAllocatorTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/architecture/driver/testing_clock.hpp
+++ b/test/modm/architecture/driver/testing_clock.hpp
@@ -19,6 +19,7 @@
 /**
  * Gain full access to modm::Clock::time.
  */
+/// @ingroup modm_test_test_architecture
 class TestingClock : public modm::Clock
 {
 public:

--- a/test/modm/architecture/interface/can_message_test.hpp
+++ b/test/modm/architecture/interface/can_message_test.hpp
@@ -18,7 +18,7 @@
 #include <unittest/testsuite.hpp>
 #include <modm/architecture/interface/can_message.hpp>
 
-// @author strogly-typed
+/// @ingroup modm_test_test_architecture
 class CanMessageTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/architecture/interface/register_test.hpp
+++ b/test/modm/architecture/interface/register_test.hpp
@@ -19,6 +19,7 @@
 namespace modm
 {
 
+/// @ingroup modm_test_test_architecture
 template<typename T>
 struct testing
 {
@@ -95,6 +96,7 @@ protected:
 	typedef Flags8<> Test5_t;
 };
 
+/// @ingroup modm_test_test_architecture
 enum class
 Test4
 {
@@ -116,6 +118,7 @@ MODM_TYPE_FLAGS(Test4_t)
 }
 
 // @author Niklas Hauser
+/// @ingroup modm_test_test_architecture
 class RegisterTest : public unittest::TestSuite, public modm::testing<void>
 {
 public:

--- a/test/modm/communication/sab/fake_io_device.hpp
+++ b/test/modm/communication/sab/fake_io_device.hpp
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 
+/// @ingroup modm_test_test_communication
 class FakeIODevice
 {
 public:

--- a/test/modm/communication/sab/interface_test.hpp
+++ b/test/modm/communication/sab/interface_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_communication
 class InterfaceTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/communication/sab/slave_test.hpp
+++ b/test/modm/communication/sab/slave_test.hpp
@@ -16,6 +16,7 @@
 #include <modm/communication/sab/slave.hpp>
 #include "fake_io_device.hpp"
 
+/// @ingroup modm_test_test_communication
 class SlaveTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/communication/xpcc/backend/can/can_connector_base_test.hpp
+++ b/test/modm/communication/xpcc/backend/can/can_connector_base_test.hpp
@@ -16,6 +16,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_communication
 class CanConnectorBaseTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/communication/xpcc/backend/can/can_connector_test.hpp
+++ b/test/modm/communication/xpcc/backend/can/can_connector_test.hpp
@@ -18,6 +18,7 @@
 
 #include "testing_can_connector.hpp"
 
+/// @ingroup modm_test_test_communication
 class CanConnectorTest : public unittest::TestSuite
 {
 	void

--- a/test/modm/communication/xpcc/backend/can/fake_can_driver.hpp
+++ b/test/modm/communication/xpcc/backend/can/fake_can_driver.hpp
@@ -17,6 +17,7 @@
 #include <modm/container/linked_list.hpp>
 #include <modm/architecture/interface/can.hpp>
 
+/// @ingroup modm_test_test_communication
 class FakeCanDriver : public modm::Can
 {
 public:

--- a/test/modm/communication/xpcc/backend/can/testing_can_connector.hpp
+++ b/test/modm/communication/xpcc/backend/can/testing_can_connector.hpp
@@ -19,6 +19,7 @@
 
 #include "fake_can_driver.hpp"
 
+/// @ingroup modm_test_test_communication
 class TestingCanConnector : public xpcc::CanConnector<FakeCanDriver>
 {
 public:

--- a/test/modm/communication/xpcc/dispatcher_test.hpp
+++ b/test/modm/communication/xpcc/dispatcher_test.hpp
@@ -30,6 +30,7 @@
  * Component 1 and 2 implemented locally, Component 10 somewhere outside.
  *
  *
+ * @ingroup modm_test_test_communication
  */
 class DispatcherTest : public unittest::TestSuite
 {

--- a/test/modm/communication/xpcc/fake_backend.hpp
+++ b/test/modm/communication/xpcc/fake_backend.hpp
@@ -20,6 +20,7 @@
 
 #include "message.hpp"
 
+/// @ingroup modm_test_test_communication
 class FakeBackend : public xpcc::BackendInterface
 {
 public:

--- a/test/modm/communication/xpcc/fake_postman.hpp
+++ b/test/modm/communication/xpcc/fake_postman.hpp
@@ -23,9 +23,9 @@
 #include "message.hpp"
 
 /**
- *
- *
  * \see	DispatcherTest
+ *
+ * @ingroup modm_test_test_communication
  */
 class FakePostman : public xpcc::Postman
 {

--- a/test/modm/communication/xpcc/message.hpp
+++ b/test/modm/communication/xpcc/message.hpp
@@ -16,6 +16,7 @@
 
 #include <modm/communication/xpcc.hpp>
 
+/// @ingroup modm_test_test_communication
 struct Message
 {
 	Message(const xpcc::Header& header, const modm::SmartPointer& payload) :

--- a/test/modm/communication/xpcc/testing_component_1.hpp
+++ b/test/modm/communication/xpcc/testing_component_1.hpp
@@ -19,6 +19,7 @@
 
 #include "timeline.hpp"
 
+/// @ingroup modm_test_test_communication
 class TestingComponent1 : public xpcc::AbstractComponent
 {
 public:

--- a/test/modm/communication/xpcc/testing_component_2.hpp
+++ b/test/modm/communication/xpcc/testing_component_2.hpp
@@ -19,6 +19,7 @@
 
 #include "timeline.hpp"
 
+/// @ingroup modm_test_test_communication
 class TestingComponent2 : public xpcc::AbstractComponent
 {
 public:

--- a/test/modm/communication/xpcc/timeline.hpp
+++ b/test/modm/communication/xpcc/timeline.hpp
@@ -18,6 +18,7 @@
 #include <modm/container/linked_list.hpp>
 #include <modm/container/smart_pointer.hpp>
 
+/// @ingroup modm_test_test_communication
 class Timeline
 {
 public:

--- a/test/modm/container/bounded_deque_test.hpp
+++ b/test/modm/container/bounded_deque_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class BoundedDequeTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/bounded_queue_test.hpp
+++ b/test/modm/container/bounded_queue_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class BoundedQueueTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/bounded_stack_test.hpp
+++ b/test/modm/container/bounded_stack_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class BoundedStackTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/doubly_linked_list_test.hpp
+++ b/test/modm/container/doubly_linked_list_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class DoublyLinkedListTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/dynamic_array_test.hpp
+++ b/test/modm/container/dynamic_array_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class DynamicArrayTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/linked_list_test.hpp
+++ b/test/modm/container/linked_list_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class LinkedListTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/container/pair_test.hpp
+++ b/test/modm/container/pair_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_container
 class PairTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/adc/ad7280a_test.hpp
+++ b/test/modm/driver/adc/ad7280a_test.hpp
@@ -16,6 +16,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Ad7280aTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/adc/spi_device.hpp
+++ b/test/modm/driver/adc/spi_device.hpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <stdint.h>
 
+/// @ingroup modm_test_test_driver
 namespace test
 {
 	#ifdef ENABLE_MACRO_EXPORT
@@ -32,6 +33,8 @@ namespace test
 	 * \code
 	 *
 	 * \endcode
+	 *
+	 * @ingroup modm_test_test_driver
 	 */
 	struct Transmission
 	{
@@ -53,6 +56,8 @@ namespace test
 	 * to allow the usage with static classes.
 	 *
 	 * \author	Fabian Greif
+	 *
+	 * @ingroup modm_test_test_driver
 	 */
 	class SpiDevice
 	{

--- a/test/modm/driver/adc/spi_device_test.hpp
+++ b/test/modm/driver/adc/spi_device_test.hpp
@@ -16,6 +16,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class SpiDeviceTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/can/can_lawicel_formatter_test.hpp
+++ b/test/modm/driver/can/can_lawicel_formatter_test.hpp
@@ -16,6 +16,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class CanLawicelFormatterTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/can/mcp2515_can_bit_timings_test.hpp
+++ b/test/modm/driver/can/mcp2515_can_bit_timings_test.hpp
@@ -12,6 +12,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Mcp2515CanBitTimingsTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/motor/drv832x_spi_test.hpp
+++ b/test/modm/driver/motor/drv832x_spi_test.hpp
@@ -10,6 +10,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Drv832xSpiTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/pressure/bme280_test.hpp
+++ b/test/modm/driver/pressure/bme280_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Bme280Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/pressure/bmp085_test.hpp
+++ b/test/modm/driver/pressure/bmp085_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Bmp085Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/driver/temperature/ltc2984_test.hpp
+++ b/test/modm/driver/temperature/ltc2984_test.hpp
@@ -10,6 +10,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_driver
 class Ltc2984Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/io/io_stream_test.hpp
+++ b/test/modm/io/io_stream_test.hpp
@@ -17,6 +17,7 @@
 #include <unittest/testsuite.hpp>
 #include <modm/io/iostream.hpp>
 
+/// @ingroup modm_test_test_io
 class IoStreamTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/LUDecomposition_test.hpp
+++ b/test/modm/math/LUDecomposition_test.hpp
@@ -10,6 +10,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class LUDecompositionTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/algorithm/prescaler_test.hpp
+++ b/test/modm/math/algorithm/prescaler_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class PrescalerTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/debounce_test.hpp
+++ b/test/modm/math/filter/debounce_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class DebounceTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/fir_test.hpp
+++ b/test/modm/math/filter/fir_test.hpp
@@ -15,6 +15,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class FirTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/median_test.hpp
+++ b/test/modm/math/filter/median_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class MedianTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/moving_average_test.hpp
+++ b/test/modm/math/filter/moving_average_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class MovingAverageTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/pid_test.hpp
+++ b/test/modm/math/filter/pid_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class PidTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/ramp_test.hpp
+++ b/test/modm/math/filter/ramp_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class RampTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/s_curve_controller_test.hpp
+++ b/test/modm/math/filter/s_curve_controller_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class SCurveControllerTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/filter/s_curve_generator_test.hpp
+++ b/test/modm/math/filter/s_curve_generator_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class SCurveGeneratorTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/angle_test.hpp
+++ b/test/modm/math/geometry/angle_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class AngleTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/circle_2d_test.hpp
+++ b/test/modm/math/geometry/circle_2d_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Circle2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/line_2d_test.hpp
+++ b/test/modm/math/geometry/line_2d_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Line2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/line_segment_2d_test.hpp
+++ b/test/modm/math/geometry/line_segment_2d_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class LineSegment2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/location_2d_test.hpp
+++ b/test/modm/math/geometry/location_2d_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Location2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/point_set_2d_test.hpp
+++ b/test/modm/math/geometry/point_set_2d_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class PointSet2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/polygon_2d_test.hpp
+++ b/test/modm/math/geometry/polygon_2d_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Polygon2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/quaternion_test.hpp
+++ b/test/modm/math/geometry/quaternion_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class QuaternionTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/ray_2d_test.hpp
+++ b/test/modm/math/geometry/ray_2d_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Ray2DTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/vector1_test.hpp
+++ b/test/modm/math/geometry/vector1_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Vector1Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/vector2_test.hpp
+++ b/test/modm/math/geometry/vector2_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Vector2Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/vector3_test.hpp
+++ b/test/modm/math/geometry/vector3_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Vector3Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/vector4_test.hpp
+++ b/test/modm/math/geometry/vector4_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class Vector4Test : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/geometry/vector_test.hpp
+++ b/test/modm/math/geometry/vector_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class VectorTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/interpolation/lagrange_interpolation_test.hpp
+++ b/test/modm/math/interpolation/lagrange_interpolation_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 struct LagrangeInterpolationTest : public unittest::TestSuite
 {
 	void

--- a/test/modm/math/interpolation/linear_interpolation_test.hpp
+++ b/test/modm/math/interpolation/linear_interpolation_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 struct LinearInterpolationTest : public unittest::TestSuite
 {
 	void

--- a/test/modm/math/matrix_test.hpp
+++ b/test/modm/math/matrix_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class MatrixTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/matrix_vector_test.hpp
+++ b/test/modm/math/matrix_vector_test.hpp
@@ -15,6 +15,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class MatrixVectorTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/saturated/saturated_test.hpp
+++ b/test/modm/math/saturated/saturated_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class SaturatedTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/utils/arithmetic_traits_test.hpp
+++ b/test/modm/math/utils/arithmetic_traits_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class ArithmeticTraitsTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/utils/bit_operation_test.hpp
+++ b/test/modm/math/utils/bit_operation_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class BitOperationTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/utils/endianness_test.hpp
+++ b/test/modm/math/utils/endianness_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class EndiannessTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/math/utils/operator_test.hpp
+++ b/test/modm/math/utils/operator_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_math
 class OperatorTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/platform/can_bit_timings_test.hpp
+++ b/test/modm/platform/can_bit_timings_test.hpp
@@ -14,6 +14,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_platform
 class CanBitTimingsTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/platform/gpio/platform_gpio_test.hpp
+++ b/test/modm/platform/gpio/platform_gpio_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_platform_gpio
 class PlatformGpioTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/platform/spi/mock/spi_master.hpp
+++ b/test/modm/platform/spi/mock/spi_master.hpp
@@ -25,7 +25,8 @@ namespace platform
  * Mock serial peripheral interface for unittests.
  *
  * @author	Raphael Lehmann
- * @ingroup	test
+ *
+ * @ingroup modm_test_test_platform_spi
  */
 class SpiMasterMock : public modm::SpiMaster
 {

--- a/test/modm/processing/protothread/protothread_test.hpp
+++ b/test/modm/processing/protothread/protothread_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_processing
 class ProtothreadTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/processing/resumable/resumable_test.hpp
+++ b/test/modm/processing/resumable/resumable_test.hpp
@@ -15,6 +15,7 @@
 #include <unittest/testsuite.hpp>
 
 // @author Niklas Hauser
+/// @ingroup modm_test_test_processing
 class ResumableTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/processing/scheduler/scheduler_test.hpp
+++ b/test/modm/processing/scheduler/scheduler_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_processing
 class SchedulerTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/processing/timer/clock_dummy.hpp
+++ b/test/modm/processing/timer/clock_dummy.hpp
@@ -21,7 +21,7 @@ namespace modm
 /**
  * Dummy clock implementation for testing.
  *
- * @ingroup	clock
+ * @ingroup modm_test_test_processing
  */
 class ClockDummy
 {

--- a/test/modm/processing/timer/periodic_timer_test.hpp
+++ b/test/modm/processing/timer/periodic_timer_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_processing
 class PeriodicTimerTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/processing/timer/timeout_test.hpp
+++ b/test/modm/processing/timer/timeout_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_processing
 class TimeoutTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/processing/timer/timestamp_test.hpp
+++ b/test/modm/processing/timer/timestamp_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_processing
 class TimestampTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/ui/button_group_test.hpp
+++ b/test/modm/ui/button_group_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_ui
 class ButtonGroupTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/ui/button_test.hpp
+++ b/test/modm/ui/button_test.hpp
@@ -13,6 +13,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_ui
 class ButtonTest : public unittest::TestSuite
 {
 public:

--- a/test/modm/ui/time/time_test.hpp
+++ b/test/modm/ui/time/time_test.hpp
@@ -16,6 +16,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_ui
 class TimeTest : public unittest::TestSuite
 {
 public:

--- a/test/stdc++/vector/vector_test.hpp
+++ b/test/stdc++/vector/vector_test.hpp
@@ -11,6 +11,7 @@
 
 #include <unittest/testsuite.hpp>
 
+/// @ingroup modm_test_test_stdc++
 class VectorTest : public unittest::TestSuite
 {
 public:

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -142,7 +142,7 @@ def create_target(argument):
         if device.startswith("at"):
             options.append("modm:platform:clock:f_cpu=16000000")
         builder = lbuild.api.Builder(options=options)
-        builder.load(Path(modm_path) / "repo.lb")
+        builder.load([Path(modm_path) / "repo.lb", Path(modm_path) / "test/repo.lb"])
         modules = sorted(builder.parser.modules.keys())
         # Only allow the first board module to be built (they overwrite each others files)
         first_board = next((m for m in modules if ":board:" in m), None)

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -77,7 +77,9 @@ def get_targets():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--test", "-t", action='store_true', help="Test mode: generate only a few targets")
+    test_group = parser.add_mutually_exclusive_group()
+    test_group.add_argument("--test", "-t", action='store_true', help="Test mode: generate only a few targets. List includes targets with multiple board modules.")
+    test_group.add_argument("--test2", "-t2", action='store_true', help="Test mode: generate only a few targets. List has targets from the real target list.")
     parser.add_argument("--jobs", "-j", type=int, default=2, help="Number of parallel doxygen processes")
     parser.add_argument("--local-temp", "-l", action='store_true', help="Create temporary directory inside current working directory")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -90,6 +92,8 @@ def main():
     if args.test:
         # test list
         device_list = ["hosted-linux", "atmega328p-au", "stm32f103c8t6", "stm32g474cet6"]
+    elif args.test2:
+        device_list = ["hosted-linux", "atmega328p-pu", "stm32f103zgt7", "stm32g474vet7"]
     else:
         device_list = get_targets()
 

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -177,7 +177,7 @@ def template_overview(output_dir, device_list, template_path):
     with open(str(output_dir) + "/index.html","w+") as f:
         f.write(html)
     with open(str(output_dir) + "/robots.txt","w+") as f:
-        robots_txt = "User-agent: *\nDisallow: /\n"""
+        robots_txt = "User-agent: *\n"
         f.write(robots_txt)
 
 

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -148,9 +148,15 @@ def create_target(argument):
         builder = lbuild.api.Builder(options=options)
         builder.load([Path(modm_path) / "repo.lb", Path(modm_path) / "test/repo.lb"])
         modules = sorted(builder.parser.modules.keys())
+
         # Only allow the first board module to be built (they overwrite each others files)
         first_board = next((m for m in modules if ":board:" in m), None)
         modules = [m for m in modules if ":board" not in m or m == first_board]
+
+        # Remove :architecture modules. Only the :architecture modules for which actual implementations
+        #  exist are include as dependencies of the :platform modules.
+        modules = [m for m in modules if ":architecture" not in m]
+
         builder.build(device, modules)
 
         print('Executing: (cd {}/modm/docs/ && doxypress doxypress.json)'.format(device))


### PR DESCRIPTION
- [x] Test mode with targets from real target list (e.g. stm32f103zgt7 instead of stm32f103c8t6)
- [x] Exclude unused architecture modules, see https://github.com/modm-io/modm/issues/353#issuecomment-599826924
- [x] Build documentation for test (include `test/repo.lb` lbuild repo)
- [x] Allow search crawlers on docs.modm.io

Fixes #349 