### PR TITLE
Fix deprecation warning from Rcc::PllFactors, use upstream STM32G0/G4 support

### DIFF
--- a/src/modm/board/black_pill/board.hpp
+++ b/src/modm/board/black_pill/board.hpp
@@ -61,7 +61,10 @@ struct SystemClock {
 		Rcc::enableExternalCrystal();
 
 		// external clock * 9 = 72MHz, => 72/1.5 = 48 => good for USB
-		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, 9);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 9
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 
 		// set flash latency for 72MHz
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/blue_pill/board.hpp
+++ b/src/modm/board/blue_pill/board.hpp
@@ -62,7 +62,10 @@ struct SystemClock {
 		Rcc::enableExternalCrystal();
 
 		// external clock * 9 = 72MHz, => 72/1.5 = 48 => good for USB
-		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, 9);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 9
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 
 		// set flash latency for 72MHz
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/disco_f051r8/board.hpp
+++ b/src/modm/board/disco_f051r8/board.hpp
@@ -37,8 +37,12 @@ struct SystemClock
 	{
 		// enable internal 8 MHz HSI RC clock
 		Rcc::enableInternalClock();
-		// (internal clock / 2) * 12 = 48MHz
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 12, 1);
+		// (internal clock / 2) / 1 * 12 = 48MHz
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 12,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/disco_f100rb/board.hpp
+++ b/src/modm/board/disco_f100rb/board.hpp
@@ -71,11 +71,11 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableExternalCrystal();	// 8MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalCrystal,
-			3,
-			1
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 3,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 		// set flash latency for 24MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/disco_f303vc/board.hpp
+++ b/src/modm/board/disco_f303vc/board.hpp
@@ -85,11 +85,11 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableExternalClock();	// 8MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalClock,
-			9,
-			1
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 9,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
 		// set flash latency for 72MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/disco_f407vg/board.hpp
+++ b/src/modm/board/disco_f407vg/board.hpp
@@ -79,12 +79,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableExternalCrystal();	// 8MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalCrystal,
-			4,		// 8MHz / N=2 -> 2MHz
-			168,	// 2MHz * M=168 -> 336MHz
-			2		// 336MHz / P=2 -> 168MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		// 8MHz / M=4 -> 2MHz
+			.pllN = 168,	// 2MHz * N=168 -> 336MHz
+			.pllP = 2		// 336MHz / P=2 -> 168MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 		// set flash latency for 168MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/disco_f429zi/board.hpp
+++ b/src/modm/board/disco_f429zi/board.hpp
@@ -77,12 +77,12 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableExternalCrystal(); // 8 MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalCrystal,
-			4,		// 8MHz / N=4 -> 2MHz
-			180,	// 2MHz * M=180 -> 360MHz
-			2		// 360MHz / P=2 -> 180MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		// 8MHz / M=4 -> 2MHz
+			.pllN = 180,	// 2MHz * N=180 -> 360MHz
+			.pllP = 2		// 360MHz / P=2 -> 180MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 		PWR->CR |= PWR_CR_ODEN; // Enable overdrive mode
 		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/disco_f469ni/board.hpp
+++ b/src/modm/board/disco_f469ni/board.hpp
@@ -83,12 +83,12 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableExternalCrystal(); // 8 MHz
-		Rcc::enablePll(
-		Rcc::PllSource::ExternalCrystal,
-			8,		// 8MHz / N=8 -> 1MHz   !!! Must be 1 MHz for PLLSAI !!!
-			360,	// 1MHz * M=360 -> 360MHz
-			2		// 360MHz / P=2 -> 180MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 8,		// 8MHz / M=8 -> 1MHz   !!! Must be 1 MHz for PLLSAI !!!
+			.pllN = 360,	// 1MHz * N=360 -> 360MHz
+			.pllP = 2		// 360MHz / P=2 -> 180MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 		PWR->CR |= PWR_CR_ODEN; // Enable overdrive mode
 		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/disco_f746ng/board.hpp
+++ b/src/modm/board/disco_f746ng/board.hpp
@@ -82,12 +82,12 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableExternalClock(); // 25 MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalClock,
-			25,		// 25MHz / N=25 -> 1MHz
-			432,	// 1MHz * M=432 -> 432MHz
-			2		// 432MHz / P=2 -> 216MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 25,		// 25MHz / M=25 -> 1MHz
+			.pllN = 432,	// 1MHz * N=432 -> 432MHz
+			.pllP = 2		// 432MHz / P=2 -> 216MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
 		PWR->CR1 |= PWR_CR1_ODEN; // Enable overdrive mode
 		while (not (PWR->CSR1 & PWR_CSR1_ODRDY)) ;
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/disco_f769ni/board.hpp
+++ b/src/modm/board/disco_f769ni/board.hpp
@@ -82,12 +82,12 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableExternalClock(); // 25 MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalClock,
-			25,		// 25MHz / N=25 -> 1MHz
-			432,	// 1MHz * M=432 -> 432MHz
-			2		// 432MHz / P=2 -> 216MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 25,		// 25MHz / M=25 -> 1MHz
+			.pllN = 432,	// 1MHz * N=432 -> 432MHz
+			.pllP = 2		// 432MHz / P=2 -> 216MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
 		PWR->CR1 |= PWR_CR1_ODEN; // Enable overdrive mode
 		while (not (PWR->CSR1 & PWR_CSR1_ODRDY)) ;
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/disco_l152rc/board.hpp
+++ b/src/modm/board/disco_l152rc/board.hpp
@@ -89,8 +89,12 @@ struct SystemClock
 		Rcc::updateCoreFrequency<16_MHz>();
 		modm::delayMicroseconds(5);
 
-		// internal clock 8MHz * 8 / 2 = 32MHz => bad for USB
-		Rcc::enablePll(Rcc::PllSource::InternalClock, Rcc::PllMultiplier::Mul4, 2);
+		// internal clock 16MHz * 4 / 2 = 32MHz => bad for USB
+		const Rcc::PllFactors pllFactors{
+			.pllMul = Rcc::PllMultiplier::Mul4,
+			.pllDiv = 2,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/mini_f411/board.hpp
+++ b/src/modm/board/mini_f411/board.hpp
@@ -62,13 +62,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableExternalCrystal();
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalCrystal,
-			25,		// 25MHz / N=25 -> 1MHz
-			336,	// 1MHz * M=336 -> 336MHz
-			4,		// 336MHz / P=4 -> 84MHz = F_cpu
-			7		// 336MHz / Q=7 -> 48MHz for USB
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 25,		// 25MHz / M=25 -> 1MHz
+			.pllN = 336,	// 1MHz * N=336 -> 336MHz
+			.pllP = 4,		// 336MHz / P=4 -> 84MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 
 		// set flash latency
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/nucleo_f031k6/board.hpp
+++ b/src/modm/board/nucleo_f031k6/board.hpp
@@ -54,7 +54,11 @@ struct SystemClock {
 	{
 		Rcc::enableInternalClock();	// 8MHz
 		// (internal clock / 2) * 12 = 48MHz
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 12, 1);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 12,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f042k6/board.hpp
+++ b/src/modm/board/nucleo_f042k6/board.hpp
@@ -54,8 +54,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 8MHz
-		// (internal clock / 2) * 12 = 48MHz
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 12, 2, 1);
+		// (internal clock / 1) * 6 = 48MHz
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 6,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f103rb/board.hpp
+++ b/src/modm/board/nucleo_f103rb/board.hpp
@@ -67,7 +67,10 @@ struct SystemClock {
 	{
 		Rcc::enableInternalClock();	// 8MHz
 		// internal clock / 2 * 16 = 64MHz, => 64/1.5 = 42.6 => bad for USB
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 16);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 16,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 64MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f303k8/board.hpp
+++ b/src/modm/board/nucleo_f303k8/board.hpp
@@ -64,8 +64,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 8MHz
-		// 4MHz * 16 = 64MHz
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 16, 2);
+		// 8MHz / 2 * 16 = 64MHz
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 16,
+			.pllPrediv = 2,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 64MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f401re/board.hpp
+++ b/src/modm/board/nucleo_f401re/board.hpp
@@ -64,13 +64,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 16MHz
-		Rcc::enablePll(
-			Rcc::PllSource::InternalClock,
-			4,	//  16MHz / N= 4 -> 4MHz
-			84,	//   4MHz * M=84 -> 336MHz
-			4	// 336MHz / P= 4 -> 84MHz = F_cpu
-		);
-		// set flash latency for 96MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		//  16MHz / M= 4 -> 4MHz
+			.pllN = 84,		//   4MHz * N=84 -> 336MHz
+			.pllP = 4,		// 336MHz / P= 4 -> 84MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/nucleo_f411re/board.hpp
+++ b/src/modm/board/nucleo_f411re/board.hpp
@@ -66,13 +66,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 16MHz
-		Rcc::enablePll(
-			Rcc::PllSource::InternalClock,
-			4,	// 16MHz / N=4 -> 4MHz
-			96,	// 4MHz * M=96 -> 384MHz
-			4	// 384MHz / P=4 -> 96MHz = F_cpu
-		);
-		// set flash latency for 96MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		//  16MHz / M= 4 ->   4MHz
+			.pllN = 96,		//   4MHz * N=96 -> 384MHz
+			.pllP = 4,		// 384MHz / P= 4 ->  96MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/nucleo_f429zi/board.hpp
+++ b/src/modm/board/nucleo_f429zi/board.hpp
@@ -79,12 +79,12 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableExternalClock(); // 8 MHz
-		Rcc::enablePll(
-			Rcc::PllSource::ExternalClock,
-			4,		// 8MHz / N=4 -> 2MHz
-			180,	// 2MHz * M=180 -> 360MHz
-			2		// 360MHz / P=2 -> 180MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		//   8MHz / M=  4 ->   2MHz
+			.pllN = 180,	//   2MHz * N=180 -> 360MHz
+			.pllP = 2,		// 360MHz / P=  2 -> 180MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
 		PWR->CR |= PWR_CR_ODEN; // Enable overdrive mode
 		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/board/nucleo_f446re/board.hpp
+++ b/src/modm/board/nucleo_f446re/board.hpp
@@ -70,13 +70,13 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 16MHz
-		Rcc::enablePll(
-			Rcc::PllSource::InternalClock,
-			8,	//  16MHz / N= 8  -> 2MHz
-			180,	//   2MHz * M=180 -> 360MHz
-			2	// 360MHz / P= 2  -> 180MHz = F_cpu
-		);
-		// set flash latency for 96MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 8,		//  16MHz / M=  8 ->   2MHz
+			.pllN = 180,	//   2MHz * N=180 -> 360MHz
+			.pllP = 2,		// 360MHz / P=  2 -> 180MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		// set flash latency
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/nucleo_g071rb/board.hpp
+++ b/src/modm/board/nucleo_g071rb/board.hpp
@@ -83,13 +83,12 @@ struct SystemClock {
 	{
 		Rcc::enableInternalClock();	// 16MHz
 		// (internal clock / 1_M) * 8_N / 2_R = 128MHz / 2 = 64MHz
-		Rcc::enablePll(
-			Rcc::PllSource::InternalClock,
-			1,	// Pll_M
-			8,	// Pll_N
-			2	// Pll_R
-		);
-		// set flash latency for 64MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 1,
+			.pllN = 8,
+			.pllR = 2,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/nucleo_g071rb/module.lb
+++ b/src/modm/board/nucleo_g071rb/module.lb
@@ -35,11 +35,6 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
 
-    # Waiting on OpenOCD to add support for STM32G0
-    env.log.warning("\nUploading firmware and debugging for STM32G0 via OpenOCD requires this patch: http://openocd.zylin.com/#/c/4807"
-                    "\nAlternatively you may copy the compiled binary onto the Nucleo USB Mass-Storage Device manually:"
-                    "\n    $ scons bin && cp path/to/build/release/project.bin /Volumes/NODE_G071RB")
-
     # The patch doesn't include board config file though
     env.outbasepath = "modm/openocd/modm/board/"
     env.copy(repopath("tools/openocd/modm/st_nucleo_g0.cfg"), "st_nucleo_g0.cfg")

--- a/src/modm/board/nucleo_g474re/board.hpp
+++ b/src/modm/board/nucleo_g474re/board.hpp
@@ -96,13 +96,12 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 16MHz
-		Rcc::enablePll(
-			Rcc::PllSource::InternalClock,
-			4,	//  16MHz / N= 4 -> 4MHz
-			85,	//   4MHz * M=85 -> 340MHz
-			2	// 336MHz / P= 2 -> 170MHz = F_cpu
-		);
-		// set flash latency for 170MHz
+		Rcc::PllFactors pllFactors{
+			.pllM = 4,	//  16MHz / M= 4 ->   4MHz
+			.pllN = 85,	//   4MHz * N=85 -> 340MHz
+			.pllR = 2,	// 336MHz / R= 2 -> 170MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/nucleo_l152re/board.hpp
+++ b/src/modm/board/nucleo_l152re/board.hpp
@@ -87,7 +87,11 @@ struct SystemClock
 		Rcc::updateCoreFrequency<8_MHz>();
 
 		// internal clock 8MHz * 8 / 2 = 32MHz => bad for USB
-		Rcc::enablePll(Rcc::PllSource::ExternalClock, Rcc::PllMultiplier::Mul8, 2);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = Rcc::PllMultiplier::Mul8,
+			.pllDiv = 2,
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
 		// set flash latency
 		Rcc::setFlashLatency<Frequency>();
 		modm::delayMicroseconds(5);

--- a/src/modm/board/nucleo_l432kc/board.hpp
+++ b/src/modm/board/nucleo_l432kc/board.hpp
@@ -43,12 +43,12 @@ struct SystemClock {
 	static bool inline
 	enable()
 	{
-		Rcc::enablePll(
-			Rcc::PllSource::MultiSpeedInternalClock,
-			1,	// 4MHz / M=1 -> 4MHz
-			40,	// 4MHz * N=40 -> 160MHz <= 344MHz = PLL VCO output max, >= 64 MHz = PLL VCO out min
-			2	// 160MHz / P=2 -> 80MHz = F_cpu
-		);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 1,	//   4MHz /  1 -> 4MHz
+			.pllN = 40,	//   4MHz * 40 -> 160MHz <= 344MHz = PLL VCO output max, >= 64 MHz = PLL VCO out min
+			.pllR = 2,	// 160MHz /  2 -> 80MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::MultiSpeedInternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
 
 		// switch system clock to PLL output

--- a/src/modm/board/olimexino_stm32/board.hpp
+++ b/src/modm/board/olimexino_stm32/board.hpp
@@ -67,7 +67,10 @@ struct SystemClock {
 	{
 		Rcc::enableInternalClock();	// 8MHz
 		// internal clock / 2 * 16 = 64MHz, => 64/1.5 = 42.6 => bad for USB
-		Rcc::enablePll(Rcc::PllSource::InternalClock, 16);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 16,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 64MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/stm32f030f4p6_demo/board.hpp
+++ b/src/modm/board/stm32f030f4p6_demo/board.hpp
@@ -51,10 +51,14 @@ struct SystemClock {
 	static bool inline
 	enable()
 	{
-		Rcc::enableExternalCrystal();
+		Rcc::enableExternalCrystal(); // 8MHz
 
 		// external clock / 1 * 6 = 48MHz
-		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, 6, 1);
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 6,
+			.pllPrediv = 1
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
 
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -368,7 +368,7 @@ public:
 		const PllMultiplier pllMul;
 		const uint8_t pllDiv;
 %% else
-		uint8_t pllMul;
+		const uint8_t pllMul;
  %% if pllprediv2
 		const uint8_t pllPrediv;
 		const uint8_t pllPrediv2;


### PR DESCRIPTION
This fixes the annoying deprecation warnings coming from the BSPs introduced in #361.
Since http://openocd.zylin.com/#/c/4807 was merged, compiling OpenOCD from source as per install instructions make our custom support unnecessary, (but the board files still need to be there).

cc @rleh 