### PR TITLE
[board] Fix Nucleo F042 I2C clock

### DIFF
--- a/src/modm/board/nucleo_f042k6/board.hpp
+++ b/src/modm/board/nucleo_f042k6/board.hpp
@@ -31,6 +31,7 @@ namespace Board
 // Dummy clock for devices
 struct SystemClock {
 	static constexpr uint32_t Frequency = 48_MHz;
+	static constexpr uint32_t Hsi = 8_MHz;
 	static constexpr uint32_t Ahb = Frequency;
 	static constexpr uint32_t Apb = Frequency;
 
@@ -41,7 +42,7 @@ struct SystemClock {
 	static constexpr uint32_t Usart1 = Apb;
 	static constexpr uint32_t Usart2 = Apb;
 
-	static constexpr uint32_t I2c1   = Apb;
+	static constexpr uint32_t I2c1   = Hsi;
 
 	static constexpr uint32_t Timer1  = Apb;
 	static constexpr uint32_t Timer2  = Apb;


### PR DESCRIPTION
The default clock for I2C1 in F0x2 controllers is the HSI clock, not the APB clock as defined in the board header. From the reference manual:

![image](https://user-images.githubusercontent.com/25187160/77240114-7ea8e400-6be2-11ea-9849-882ff286e0ad.png)
