### PR TITLE
[build] Add gdbgui support

### DIFF
--- a/tools/build_script_generator/cmake/module.md
+++ b/tools/build_script_generator/cmake/module.md
@@ -103,16 +103,20 @@ shutdown command invoked
 ```
 
 
-#### make gdb
-#### make gdb-release
+#### make gdbtui
+#### make gdbtui-release
+#### make gdbgui
+#### make gdbgui-release
 
-Launches GDB with the debug or release executable.
+Launches GDB with the text-based or with the [web-based GDBGUI](gdbgui) UI.
 This is just a convenience wrapper for the debug functionality defined in the
 `modm:build` module.
 (\* *only ARM Cortex-M targets*)
 
 **OpenOCD must already be running in the background**. Launch it by manually
 calling `make openocd` in another terminal.
+
+To use GDBGUI you must have it installed via `pip install gdbgui`.
 
 
 #### make openocd
@@ -132,3 +136,4 @@ being able to build again.
 
 
 [cmake]: http://cmake.org
+[gdbgui]: https://www.gdbgui.com

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -52,18 +52,42 @@ upload-release: build-release
 
 %% elif core.startswith("cortex-m")
 upload-debug: build-debug
-	@openocd -f modm/openocd.cfg -c "modm_program $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf"
+	@openocd -f modm/openocd.cfg -c "modm_program $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf"
 
 upload-release: build-release
 	@openocd -f modm/openocd.cfg -c "modm_program $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf"
 
-gdb: build-debug
-	@arm-none-eabi-gdb -x modm/gdbinit -x modm/openocd_gdbinit $(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
-	@killall openocd || true
+gdbtui: build-debug
+	@python modm/modm_tools/openocd_gdb.py \
+				--config-openocd modm/openocd.cfg \
+				--config-gdb modm/gdbinit \
+				--config-gdb modm/openocd_gdbinit \
+				--mode=tui \
+				$(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
 
-gdb-release: build-release
-	@arm-none-eabi-gdb -x modm/gdbinit -x modm/openocd_gdbinit $(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
-	@killall openocd || true
+gdbtui-release: build-release
+	@python modm/modm_tools/openocd_gdb.py \
+				--config-openocd modm/openocd.cfg \
+				--config-gdb modm/gdbinit \
+				--config-gdb modm/openocd_gdbinit \
+				--mode=tui \
+				$(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
+
+gdbgui: build-debug
+	@python modm/modm_tools/openocd_gdb.py \
+				--config-openocd modm/openocd.cfg \
+				--config-gdb modm/gdbinit \
+				--config-gdb modm/openocd_gdbinit \
+				--mode=gui \
+				$(BUILD_DIR)/cmake-build-debug/{{ project_name }}.elf
+
+gdbgui-release: build-release
+	@python modm/modm_tools/openocd_gdb.py \
+				--config-openocd modm/openocd.cfg \
+				--config-gdb modm/gdbinit \
+				--config-gdb modm/openocd_gdbinit \
+				--mode=gui \
+				$(BUILD_DIR)/cmake-build-release/{{ project_name }}.elf
 
 openocd:
 	@openocd -f modm/openocd.cfg

--- a/tools/build_script_generator/gdbinit
+++ b/tools/build_script_generator/gdbinit
@@ -1,6 +1,6 @@
-layout split
-focus cmd
 set print pretty
 set print asm-demangle on
 set mem inaccessible-by-default off
-refresh
+set pagination off
+compare-sections
+b main

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -133,6 +133,10 @@ def build(env):
     for flag, values in common_compiler_flags("gcc", env[":target"]).items():
         env.collect(flag, *values)
 
+    # Copy python tools folder
+    env.outbasepath = "modm/"
+    env.copy("../modm_tools", "modm_tools")
+
 def post_build(env):
     if env.buildlog._buildlog._metadata:
         env.log.error("'env.add_metadata(key, *values)' is not supported anymore!\n\n"

--- a/tools/build_script_generator/module.md
+++ b/tools/build_script_generator/module.md
@@ -109,10 +109,10 @@ Program received signal SIGINT, Interrupt.
 ```
 
 !!! warning "Be careful attaching to a running target"
-    Due to the OpenOCD implementation, the target is halted for a very short
-    period of time, while the device's debug peripheral is initialized.
-    This time is dependent on the debug adapter and may range from just a few
-    milliseconds to hundreds. Make sure your hardware can handle that!
+    The OpenOCD implementation halts the target at least while the device's
+    debug peripheral is initialized. Only connect to systems that cannot create
+    any damage while being halted! For example halting motor controllers may
+    result in literal burning motors!!
 
 
 ## Using AvrDude

--- a/tools/build_script_generator/openocd_gdbinit.in
+++ b/tools/build_script_generator/openocd_gdbinit.in
@@ -16,5 +16,3 @@ end
 
 mon init
 mon poll on
-refresh
-c

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -50,7 +50,7 @@ module documentation.
 !!! tip "Debug Profile"
     When working with the debug profile, make sure to add `profile=debug` to all
     commands, especially `scons program profile=debug` and
-    `scons gdb profile=debug`!
+    `scons gdbtui profile=debug`!
 
 
 #### scons build
@@ -241,23 +241,27 @@ Executes your project on your computer.
 (\* *only Hosted targets*)
 
 
-#### scons gdb
+#### scons gdbtui
+#### scons gdbgui
 
 Launches OpenOCD in the background, then launches GDB in foreground with the
-correct executable. When GDB exits, it stops the OpenOCD process.
+correct executable with text-based or [web-based GDBGUI](gdbgui) UI. When GDB
+exits, it stops the OpenOCD process.
 (\* *only ARM Cortex-M targets*)
 
 This is just a convenience wrapper for the debug functionality defined in the
 `modm:build` module.
 
+To use GDBGUI you must have it installed via `pip install gdbgui`.
+
 !!! tip "Choose the correct profile"
-    When debugging, make sure to select the correct compilation profile.
-    The firmware and the executable given to GDB have to be the some or you'll
-    see GDB translate the program counter to the wrong code locations.
-    When you suspect a bug in your firmware, consider that it was most likely
-    compiled with the release profile, since that's the default.
-    First try to `scons gdb profile=release`, and if that doesn't help, compile
-    and `scons program profile=debug` and try `scons gdb profile=debug` again.
+    When debugging, make sure to select the correct compilation profile. The
+    firmware and the executable given to GDB have to be the some or you'll see
+    GDB translate the program counter to the wrong code locations. When you
+    suspect a bug in your firmware, consider that it was most likely compiled
+    with the release profile, since that's the default. First try to `scons
+    gdbtui profile=release`, and if that doesn't help, compile and `scons
+    program profile=debug` and try `scons gdbtui profile=debug` again.
 
 
 #### scons postmortem

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -8,6 +8,11 @@
 
 #!/usr/bin/env python3
 
+%% if is_modm
+import sys
+sys.path.append("modm")
+%% endif
+
 from os.path import join, abspath
 Import("env")
 

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -37,7 +37,8 @@ def build_target(env, sources):
 	env.Alias("size", env.Size(program))
 	%% if core.startswith("cortex-m")
 	env.Alias("itm", env.OpenOcdItm())
-	env.Alias("gdb", env.OpenOcdGdb(program))
+	env.Alias("gdbtui", env.OpenOcdGdbTui(program))
+	env.Alias("gdbgui", env.OpenOcdGdbGui(program))
 	env.Alias("postmortem", env.PostMortemGdb(program))
 	env.Alias("artifact", env.CacheArtifact(program))
 

--- a/tools/modm_tools/openocd_gdb.py
+++ b/tools/modm_tools/openocd_gdb.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+import os
+import subprocess
+import signal
+
+def execute(env, mode):
+    # Build GBD config and command
+    gdb_configfiles = env.get("CONFIG_GDB", [])
+    gdb_configfiles = ' '.join(map('-x "{}"'.format, gdb_configfiles))
+    if mode == 'tui':
+        gdb_command = 'arm-none-eabi-gdb ' \
+                '-ex "layout split" ' \
+                '-ex "focus cmd" ' \
+                '{0} {1} ' \
+                '-ex "refresh"'
+    elif mode == 'gui':
+        gdb_command = 'gdbgui ' \
+                '-g arm-none-eabi-gdb ' \
+                '--gdb-args="{0} {1}" ' \
+                '{1}'
+    else:
+        print("No valid GDB mode selected: tui, gui")
+        return 1
+
+    # We have to start openocd in its own session ID, so that Ctrl-C in GDB
+    # does not kill OpenOCD. See https://github.com/RIOT-OS/RIOT/pull/3619.
+    openocd_configfiles = env.get("CONFIG_OPENOCD", [])
+    openocd_configfiles = ' '.join(map('-f "{}"'.format, openocd_configfiles))
+    openocd_command = 'openocd {} -c "log_output /dev/null"'.format(openocd_configfiles)
+    openocd = subprocess.Popen(openocd_command, preexec_fn=os.setsid,
+                               cwd=os.getcwd(), shell=True)
+
+    # This call is now blocking
+    source = env["CONFIG_SOURCES"][0]
+    subprocess.call(gdb_command.format(gdb_configfiles, source),
+                    cwd=os.getcwd(), shell=True)
+
+    # Then kill just the background OpenOCD process
+    os.killpg(os.getpgid(openocd.pid), signal.SIGTERM)
+
+    return 0
+
+
+if __name__ == "__main__":
+    import argparse, sys
+
+    parser = argparse.ArgumentParser(description='Run OpenOCD in background and GDB on top.')
+    parser.add_argument(
+            dest="elfs",
+            metavar="ELF",
+            type=str,
+            nargs="+",
+            help="The ELF files to use for debugging.")
+    parser.add_argument(
+            "--config-openocd",
+            dest="config_openocd",
+            type=str,
+            action="append",
+            default=[],
+            help="Use these OpenOCD config files.")
+    parser.add_argument(
+            "--config-gdb",
+            dest="config_gdb",
+            type=str,
+            action="append",
+            default=[],
+            help="Use these GDB init file.")
+    parser.add_argument(
+            "--mode",
+            choices=['tui', 'gui'],
+            dest="mode",
+            help="Use GDB via TUI or GDBGUI.")
+    args = parser.parse_args()
+
+    env = {
+        "CONFIG_OPENOCD": args.config_openocd,
+        "CONFIG_GDB": args.config_gdb,
+        "CONFIG_SOURCES": args.elfs,
+    }
+    exit(execute(env, args.mode))


### PR DESCRIPTION
This adds support for gdbgui.com to the build systems.
You only need to `pip install gdbgui` and then it should work out the box (in theory).
This was surprisingly easy to get to work.

~~By default *our* GDB config does not halt the CPU, but I find it confusing. Is it ok to halt the CPU on debugger connection? I felt this might perhaps be dangerous when debugging a live system, hence it continues immediately.~~ We will halt on debug, since you have to manually halt anyways to debug, and so you simply cannot debug hard real time systems using GDB.

TODO:

- [x] Integrate into SCons
- [x] Integrate into CMake
- [x] Enable for Cortex-M targets
- [x] Run tui commands only for TUI target
- [ ] Enable for Hosted targets
- [ ] Autoselect right ELF file by probing what's on the target.
- [ ] Figure out if disassembly can be forced to thumb2 instead of ARM(?)
- [x] ~~Continue on debug or halt?~~ halt.
- [ ] Update install instructions
- [x] Update module documentation

cc @rleh @se-bi