### PR TITLE
[hosted] Generate .exe rather than .elf on Windows

### DIFF
--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -139,6 +139,7 @@ def build(env):
     env.substitutions = env.query("::device")
     env.substitutions["upload_with_artifact"] = env.has_module(":crashcatcher")
     env.substitutions["with_compilation_db"] = env.has_module(":build:compilation_db")
+    env.substitutions["program_extension"] = ".exe" if env[":target"].identifier.family == "windows" else ".elf"
     env.outbasepath = "modm/scons/site_tools"
     env.template("resources/build_target.py.in", "build_target.py")
 

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -14,7 +14,7 @@ from os.path import abspath, relpath
 
 def build_target(env, sources):
 	# Building application
-	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+".elf", source=sources)
+	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+"{{ program_extension }}", source=sources)
 
 %% if with_compilation_db
 	env.Command("compile_commands.json", sources,


### PR DESCRIPTION
Currently, the hosted-windows target generates a PE executable with an ELF extension. Instead, special-case based on the target system family.