### PR TITLE
Feature/bsp for nucleo f303re

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Examples STM32F3 Series
           command: |
-            (cd examples && ../tools/scripts/examples_compile.py stm32f3_discovery nucleo_f303k8)
+            (cd examples && ../tools/scripts/examples_compile.py stm32f3_discovery nucleo_f303k8 nucleo_f303re)
       - run:
           name: Examples STM32F7 Series
           command: |

--- a/README.md
+++ b/README.md
@@ -137,19 +137,20 @@ documentation.
 </tr><tr>
 <td align="center">NUCLEO-F103RB</td>
 <td align="center">NUCLEO-F303K8</td>
+<td align="center">NUCLEO-F303RE</td>
 <td align="center">NUCLEO-F401RE</td>
-<td align="center">NUCLEO-F411RE</td>
 </tr><tr>
+<td align="center">NUCLEO-F411RE</td>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
 <td align="center">NUCLEO-G071RB</td>
-<td align="center">NUCLEO-G474RE</td>
 </tr><tr>
+<td align="center">NUCLEO-G474RE</td>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
-<td align="center">OLIMEXINO-STM32</td>
 </tr><tr>
+<td align="center">OLIMEXINO-STM32</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>

--- a/examples/nucleo_f303re/blink/main.cpp
+++ b/examples/nucleo_f303re/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delay_ms(Button::read() ? 100 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f303re/blink/project.xml
+++ b/examples/nucleo_f303re/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f303re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f303re/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_f303re/itm/main.cpp
+++ b/examples/nucleo_f303re/itm/main.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+modm::IODeviceWrapper<Itm, modm::IOBuffer::DiscardIfFull> itm_device;
+modm::IOStream stream(itm_device);
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Done by OpenOCD: scons itm fcpu=64000000
+	// Itm::initialize<Board::SystemClock, 500_kHz>();
+	// Itm::connect<GpioB3::Traceswo>();
+
+	stream << "Hello from the SWO." << modm::endl;
+	stream << "debug"   << modm::endl;
+	stream << "info"    << modm::endl;
+	stream << "warning" << modm::endl;
+	stream << "error"   << modm::endl;
+
+
+	while (true)
+	{
+		static modm::PeriodicTimer tmr{500ms};
+		if (tmr.execute())
+		{
+			tmr.restart(Button::read() ? 100ms : 500ms);
+			LedD13::toggle();
+
+			static uint32_t counter{0};
+			stream << "loop: " << counter++ << modm::endl;
+		}
+		Itm::update();
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f303re/itm/project.xml
+++ b/examples/nucleo_f303re/itm/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f303re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f303re/itm</option>
+    <option name="modm:platform:itm:buffer.tx">250</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:itm</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/examples/nucleo_f303re/rtos/main.cpp
+++ b/examples/nucleo_f303re/rtos/main.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2014, Georgi Grinshpun
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2015-2017, 2019 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing/rtos.hpp>
+
+using namespace modm::platform;
+using namespace modm::literals;
+
+/**
+ * This example uses four threads to check if task switching works correctly.
+ *
+ * What to expect?
+ * ---------------
+ * - All our LEDs blinking at different rates, about 3 to 4 Hz
+ * - A string at 115200 baud
+ *
+ *  0aA!1bB"2cC#3dD$4eE%5fF&6gG'7hH(8iI9)jJ0*aA1!bB2"cC
+ *
+ * Each thread prints out a sequence
+ *    0123456789
+ *    abcdefghij
+ *    ABCDEFGHIJ
+ *    !"#$%&'()*
+ * respectivly.
+ */
+
+// ----------------------------------------------------------------------------
+template <typename Gpio, int SleepTime>
+class P: modm::rtos::Thread
+{
+	char c;
+	uint8_t i = 0;
+	volatile float a = 10.f;
+public:
+	P(char c): Thread(2,1<<10), c(c) {}
+
+	void run()
+	{
+		Gpio::setOutput();
+		while (true)
+		{
+			sleep(SleepTime * MILLISECONDS);
+
+			Gpio::toggle();
+			{
+				static modm::rtos::Mutex lm;
+				modm::rtos::MutexGuard m(lm);
+				MODM_LOG_INFO << char(i + c);
+			}
+			i = (i+1)%10;
+			a *= 3.141f;
+		}
+	}
+};
+
+P< Board::LedD13, 260      > p1('0');
+P< Board::LedD13, 260 + 10 > p2('a');
+P< Board::LedD13, 260 + 20 > p3('A');
+P< Board::LedD13, 260 + 30 > p4('!');
+
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	modm::rtos::Scheduler::schedule();
+	return 0;
+}

--- a/examples/nucleo_f303re/rtos/project.xml
+++ b/examples/nucleo_f303re/rtos/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f303re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f303re/rtos</option>
+  </options>
+  <modules>
+    <module>modm:processing:rtos</module>
+    <module>modm:platform:heap</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f303re/board.hpp
+++ b/src/modm/board/nucleo_f303re/board.hpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2016-2018, Niklas Hauser
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_F303RE_HPP
+#define MODM_STM32_NUCLEO_F303RE_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_f303re
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_f303re
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32F303RE running at 64MHz generated from the internal 8MHz clock
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 64_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb2;
+	static constexpr uint32_t Adc2   = Apb2;
+
+	static constexpr uint32_t Can    = Apb1;
+
+	static constexpr uint32_t Spi1   = Apb2;
+
+	// USART1 is on APB2 bus, but default clock is PCLK1
+	static constexpr uint32_t Usart1 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+
+	// I2C1 clock source is HSI per default
+	static constexpr uint32_t I2c1   = 8_MHz;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableInternalClock();	// 8MHz
+		// 8MHz / 2 * 16 = 64MHz
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 16,
+			.pllPrediv = 2,
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		// set flash latency for 64MHz
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		// APB1 has max. 36MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div2);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo64_arduino.hpp"
+
+using Button = GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA15;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_F303RE_HPP

--- a/src/modm/board/nucleo_f303re/board.xml
+++ b/src/modm/board/nucleo_f303re/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f303ret6</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f303re</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f303re/module.lb
+++ b/src/modm/board/nucleo_f303re/module.lb
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2020, Philipp Graf
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-f303re"
+    module.description = """\
+# NUCLEO-F303RE
+
+[Nucleo kit for STM32F303RE](https://www.st.com/en/evaluation-tools/nucleo-f303re.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f303ret"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_f3.cfg");


### PR DESCRIPTION
I would like to use a Nucleo F303RE with modm and therefore added board support for this development board.

This pull request contains nothing major, the board support files are slightly modified copies of the very similar Nucloe F303K8, corrected for the different form factor.

The examples are slightly modified copies from the examples for the aforementioned Nucleo F303K8 and the Nucleo F103RB.

I verified that the examples are running on the Nucleo F303RE Board that is available to me.

What else needs to be done to make this Pull Request mergeable?