### PR TITLE
Add Mega 2560 PRO AVR board to run almost all unittests on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
             (cd test && make compile-al-avreb-can)
             (cd test && make compile-arduino-uno)
             (cd test && make compile-arduino-nano)
+            (cd test && make compile-mega-2560-pro)
       - run:
           name: Linux Examples
           command: |

--- a/README.md
+++ b/README.md
@@ -130,26 +130,27 @@ documentation.
 <td align="center">DISCO-L152RC</td>
 <td align="center">DISCO-L476VG</td>
 </tr><tr>
+<td align="center">MEGA-2560-PRO</td>
 <td align="center">MINI-F401</td>
 <td align="center">MINI-F411</td>
 <td align="center">NUCLEO-F031K6</td>
-<td align="center">NUCLEO-F042K6</td>
 </tr><tr>
+<td align="center">NUCLEO-F042K6</td>
 <td align="center">NUCLEO-F103RB</td>
 <td align="center">NUCLEO-F303K8</td>
 <td align="center">NUCLEO-F303RE</td>
-<td align="center">NUCLEO-F401RE</td>
 </tr><tr>
+<td align="center">NUCLEO-F401RE</td>
 <td align="center">NUCLEO-F411RE</td>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
-<td align="center">NUCLEO-G071RB</td>
 </tr><tr>
+<td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-G474RE</td>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
-<td align="center">NUCLEO-L476RG</td>
 </tr><tr>
+<td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>

--- a/examples/avr/mega_pro/main.cpp
+++ b/examples/avr/mega_pro/main.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011, Fabian Greif
+ * Copyright (c) 2013-2014, 2017-2018, Niklas Hauser
+ * Copyright (c) 2014, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+using namespace std::chrono_literals;
+#include <math.h>
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::DEBUG
+
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint8_t counter{0};
+	while (true)
+	{
+		MODM_LOG_INFO << "Loop " << counter++ << modm::endl;
+		Board::LedD13::toggle();
+
+		MODM_LOG_INFO << "sin " << (int)sinf(counter) << modm::endl;
+		modm::delay(1s);
+	}
+}

--- a/examples/avr/mega_pro/project.xml
+++ b/examples/avr/mega_pro/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:mega-2560-pro</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/avr/mega_pro</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/mega_2560_pro/board.hpp
+++ b/src/modm/board/mega_2560_pro/board.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016-2018, Niklas Hauser
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_mega_2560_pro
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_mega_2560_pro
+namespace Board
+{
+using namespace modm::literals;
+using SystemClock = modm::platform::SystemClock;
+
+using D0  = GpioE0;
+using D1  = GpioE1;
+using D2  = GpioE4;
+using D3  = GpioE5;
+using D4  = GpioG5;
+using D5  = GpioE3;
+using D6  = GpioH3;
+using D7  = GpioH4;
+using D8  = GpioH5;
+using D9  = GpioH6;
+using D10 = GpioB4;
+using D11 = GpioB5;
+using D12 = GpioB6;
+using D13 = GpioB7;
+using D14 = GpioJ1;
+using D15 = GpioJ0;
+using D16 = GpioH1;
+using D17 = GpioH0;
+using D18 = GpioD3;
+using D19 = GpioD2;
+using D20 = GpioD1;
+using D21 = GpioD0;
+using D22 = GpioA0;
+using D23 = GpioA1;
+using D24 = GpioA2;
+using D25 = GpioA3;
+using D26 = GpioA4;
+using D27 = GpioA5;
+using D28 = GpioA6;
+using D29 = GpioA7;
+using D30 = GpioC7;
+using D31 = GpioC6;
+
+using A0 = GpioF0;
+using A1 = GpioF1;
+using A2 = GpioF2;
+using A3 = GpioF3;
+using A4 = GpioF4;
+using A5 = GpioF5;
+using A6 = GpioF6;
+using A7 = GpioF7;
+using A8 = GpioK0;
+using A9 = GpioK1;
+using A10 = GpioK2;
+using A11 = GpioK3;
+using A12 = GpioK4;
+using A13 = GpioK5;
+using A14 = GpioK6;
+using A15 = GpioK7;
+
+using D32 = GpioC5;
+using D33 = GpioC4;
+using D34 = GpioC3;
+using D35 = GpioC2;
+using D36 = GpioC1;
+using D37 = GpioC0;
+using D38 = GpioD7;
+using D39 = GpioG2;
+using D40 = GpioG1;
+using D41 = GpioG0;
+using D42 = GpioL7;
+using D43 = GpioL6;
+using D44 = GpioL5;
+using D45 = GpioL4;
+using D46 = GpioL3;
+using D47 = GpioL2;
+using D48 = GpioL1;
+using D49 = GpioL0;
+using D50 = GpioB3;
+using D51 = GpioB2;
+using D52 = GpioB1;
+using D53 = GpioB0;
+
+using Button = GpioUnused;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+using LoggerDevice = modm::IODeviceWrapper< Uart0, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+
+	// Uart0 is connected to onboard USB bridge
+	Uart0::connect<D1::Txd, D0::Rxd>();
+	Uart0::initialize<SystemClock, 38'400_Bd>();
+
+	enableInterrupts();
+}
+
+}
+
+using namespace Board;
+extern modm::IOStream serialStream;

--- a/src/modm/board/mega_2560_pro/board.xml
+++ b/src/modm/board/mega_2560_pro/board.xml
@@ -1,0 +1,15 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">atmega2560-16au</option>
+    <option name="modm:platform:core:f_cpu">16000000</option>
+  </options>
+  <modules>
+    <module>modm:board:mega-2560-pro</module>
+  </modules>
+</library>

--- a/src/modm/board/mega_2560_pro/board_serial.cpp
+++ b/src/modm/board/mega_2560_pro/board_serial.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2018, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "board.hpp"
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+Board::LoggerDevice loggerDevice;
+
+// Set all four logger streams to use the UART
+modm::IOStream serialStream(loggerDevice);
+modm::log::Logger modm::log::debug(loggerDevice);
+modm::log::Logger modm::log::info(loggerDevice);
+modm::log::Logger modm::log::warning(loggerDevice);
+modm::log::Logger modm::log::error(loggerDevice);

--- a/src/modm/board/mega_2560_pro/module.lb
+++ b/src/modm/board/mega_2560_pro/module.lb
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:mega-2560-pro"
+    module.description = """
+# Mega 2560 PRO (Embed) CH340G
+
+A compact breakout board similiar to the Arduino Mega 2560 board.
+You can order this for little money from well known Chinese online stores.
+
+See: https://robotdyn.com/mega-2560-pro-embed-ch340g-atmega2560-16au.html
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("atmega2560"):
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":architecture:interrupt",
+        ":debug",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:uart:0")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.copy('.')
+    env.collect(":build:default.avrdude.programmer", "stk500v2");
+    env.collect(":build:default.avrdude.baudrate", "115200");
+    # The STK500v2 bootloader of the atmega is unwilling to chip erase
+    env.collect(":build:default.avrdude.options", "-D");

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,18 +60,23 @@ run-nucleo-f103:
 
 
 compile-al-avreb-can:
-	$(call compile-test,al-avreb-can)
+	$(call compile-test,al-avreb-can,size)
 run-al-avreb-can:
-	$(call run-test,al-avreb-can)
+	$(call run-test,al-avreb-can,size)
 
 
 compile-arduino-uno:
-	$(call compile-test,arduino-uno)
+	$(call compile-test,arduino-uno,size)
 run-arduino-uno:
-	$(call run-test,arduino-uno)
+	$(call run-test,arduino-uno,size)
 
 
 compile-arduino-nano:
-	$(call compile-test,arduino-nano)
+	$(call compile-test,arduino-nano,size)
 run-arduino-nano:
-	$(call run-test,arduino-nano)
+	$(call run-test,arduino-nano,size)
+
+compile-mega-2560-pro:
+	$(call compile-test,mega-2560-pro,size)
+run-mega-2560-pro:
+	$(call run-test,mega-2560-pro,size)

--- a/test/config/mega-2560-pro.xml
+++ b/test/config/mega-2560-pro.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:mega-2560-pro</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro/</option>
+    <option name="modm:build:scons:unittest.source">../../build/generated-unittest/mega-2560-pro/modm-test</option>
+    <option name="modm:build:scons:info.git">Disabled</option>
+    <option name="modm:io:with_float">True</option>
+    <option name="modm:io:with_long_long">True</option>
+    <option name="modm:io:with_printf">True</option>
+  </options>
+
+  <modules>
+    <module>modm-test:test:architecture</module>
+    <module>modm-test:test:communication:sab</module>
+
+
+    <!-- <module>modm-test:test:communication:xpcc</module> -->
+
+
+    <module>modm-test:test:container</module>
+
+
+    <module>modm-test:test:driver</module>
+    <module>modm-test:test:stdc++</module>
+
+
+    <module>modm-test:test:io</module>
+    <module>modm-test:test:platform:**</module>
+
+
+    <module>modm-test:test:processing</module>
+
+
+    <module>modm-test:test:ui</module>
+    <module>modm-test:test:math</module>
+  </modules>
+</library>

--- a/test/stdc++/module.lb
+++ b/test/stdc++/module.lb
@@ -16,10 +16,6 @@ def init(module):
 
 
 def prepare(module, options):
-    target = options[":target"].identifier
-    if target["platform"] != "avr":
-        return False
-
     module.depends(":stdc++")
     return True
 

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -152,6 +152,8 @@ def common_avrdude_options(env):
         option_port = env.collector_values(":build:default.avrdude.port", option_port)[0]
     if not option_baudrate:
         option_baudrate = env.collector_values(":build:default.avrdude.baudrate", option_baudrate)[0]
+    if not option_options:
+        option_options = env.collector_values(":build:default.avrdude.options", option_options)[0]
     options = {
         "avrdude_programmer": option_programmer,
         "avrdude_port": option_port,

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -127,6 +127,9 @@ def prepare(module, options):
         module.add_collector(
             StringCollector(name="default.avrdude.port",
                             description="Default AvrDude port"))
+        module.add_collector(
+            StringCollector(name="default.avrdude.options",
+                            description="Default AvrDude options"))
 
     # Compile flag collectors
     def flag_validate(flag):


### PR DESCRIPTION
This adds a simple BSP for the Mega 2560 PRO board, which is one of the largest AVRs I could find, which fits almost all unittests on.

This also fixes an issue with libstdc++ regarding linking the right math functions in libm.a on AVR, see https://github.com/modm-io/avr-libstdcpp/pull/1.