### PR TITLE
[timer] Fix time_point cast for short versions

### DIFF
--- a/src/modm/processing/timer/periodic_timer.hpp
+++ b/src/modm/processing/timer/periodic_timer.hpp
@@ -54,7 +54,7 @@ public:
 			size_t count{0};
 			if (this->_interval.count())
 			{
-				const typename Clock::time_point now = Clock::now();
+				const auto now = this->now();
 				while(1)
 				{
 					this->_start += this->_interval;
@@ -64,7 +64,7 @@ public:
 				}
 			}
 			else {
-				this->_start = Clock::now();
+				this->_start = this->now();
 				count = 1;
 			}
 			this->_state = this->ARMED;

--- a/src/modm/processing/timer/timeout.hpp
+++ b/src/modm/processing/timer/timeout.hpp
@@ -123,6 +123,9 @@ protected:
 	bool
 	checkExpiration() const;
 
+	time_point
+	now() const;
+
 	enum
 	InternalState : uint8_t
 	{

--- a/src/modm/processing/timer/timeout_impl.hpp
+++ b/src/modm/processing/timer/timeout_impl.hpp
@@ -38,7 +38,7 @@ modm::GenericTimeout<Clock, Duration>::restart(std::chrono::duration<Rep, Period
 		modm_assert_continue_fail_debug(interval.count() <= duration::max().count(), "tmr.size",
 				"Timer interval must be smaller than the maximal duration!", interval.count());
 
-		_start = std::chrono::time_point_cast<duration>(Clock::now());
+		_start = now();
 		_interval = cast_interval;
 		_state = ARMED;
 	}
@@ -83,7 +83,7 @@ modm::GenericTimeout<Clock, Duration>::remaining() const
 		return wide_signed_duration{0};
 	return  std::chrono::duration_cast<wide_signed_duration>(_interval) +
 			std::chrono::time_point_cast<wide_signed_duration>(_start) -
-			std::chrono::time_point_cast<wide_signed_duration>(Clock::now());
+			std::chrono::time_point_cast<wide_signed_duration>(now());
 }
 
 // ----------------------------------------------------------------------------
@@ -124,5 +124,12 @@ template< class Clock, class Duration >
 bool
 modm::GenericTimeout<Clock, Duration>::checkExpiration() const
 {
-	return (_state & ARMED) and (Clock::now() - _start) >= _interval;
+	return (_state & ARMED) and (now() - _start) >= _interval;
+}
+
+template< class Clock, class Duration >
+typename modm::GenericTimeout<Clock, Duration>::time_point
+modm::GenericTimeout<Clock, Duration>::now() const
+{
+	return std::chrono::time_point_cast<duration>(Clock::now());
 }

--- a/test/modm/processing/timer/timeout_test.cpp
+++ b/test/modm/processing/timer/timeout_test.cpp
@@ -236,6 +236,11 @@ TimeoutTest::testTimeOverflow()
 	timeoutShort.restart(time+1ms);
 	TEST_ASSERT_EQUALS(timeoutShort.remaining(), 0ms);
 	TEST_ASSERT_TRUE(timeoutShort.execute());
+
+	test_clock::setTime(-1000);
+	timeoutShort.restart(500ms);
+	TEST_ASSERT_EQUALS(timeoutShort.remaining(), 500ms);
+	TEST_ASSERT_FALSE(timeoutShort.execute());
 }
 
 void


### PR DESCRIPTION
Whoops, implicit casting during comparisons is quite horrible.

Fixes #387.