### PR TITLE
Explicitly set the stack pointer in the reset handler.

### DIFF
--- a/src/modm/platform/core/cortex/reset_handler.sx
+++ b/src/modm/platform/core/cortex/reset_handler.sx
@@ -16,6 +16,8 @@
 	.type	Reset_Handler, %function
 	.func   Reset_Handler
 Reset_Handler:
+	ldr r0,=__main_stack_top
+	mov sp,r0
 	bl __modm_initialize_platform
 	b __modm_startup
 	.endfunc


### PR DESCRIPTION
It turned out that running from debugger the stack pointer might be wrong
(initialized to the value of the system flash).