### PR TITLE
Miscellaneous small fixes

### DIFF
--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -29,7 +29,6 @@ def build(env):
     env.copy("cmsis/CMSIS/Core/Include/cmsis_gcc.h", "cmsis_gcc.h")
     if core != "0": # 0+ has MPU support though!
         env.copy("cmsis/CMSIS/Core/Include/mpu_armv7.h", "mpu_armv7.h")
-    print(core)
     if core == "7":
         env.copy("cmsis/CMSIS/Core/Include/cachel1_armv7.h", "cachel1_armv7.h")
 

--- a/src/modm/platform/core/avr/delay_impl.hpp.in
+++ b/src/modm/platform/core/avr/delay_impl.hpp.in
@@ -44,7 +44,7 @@ delay_us(uint32_t us)
 		const uint32_t cycles = uint32_t(ceil(fabs((F_CPU * double(us)) / 1e6)));
 		__builtin_avr_delay_cycles(cycles);
 	}) : ({
-%% if f_cpu <= 6e6
+%% if f_cpu <= 6000000
 		constexpr int32_t cycles = (F_CPU / 1e6);
 		for (int16_t _us = us; _us > 0; _us -= cycles)
 			__builtin_avr_delay_cycles(1);

--- a/src/modm/platform/gpio/hosted/module.lb
+++ b/src/modm/platform/gpio/hosted/module.lb
@@ -32,3 +32,5 @@ def build(env):
     env.template("base.hpp.in")
     env.template("unused.hpp.in")
     env.copy("../common/inverted.hpp", "inverted.hpp")
+    env.copy("../common/connector.hpp", "connector.hpp")
+    env.template("../common/connector_detail.hpp.in", "connector_detail.hpp")

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -11,11 +11,6 @@
 from os.path import join, abspath
 Import("env")
 
-%% if is_modm
-import sys
-sys.path.append(join(env.Dir("#").abspath, "modm"))
-%% endif
-
 profile = env["CONFIG_PROFILE"]
 %% if is_modm
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -33,7 +33,7 @@ def build_target(env, sources):
 	env.Alias("all", ["build", "run"])
 %% else
 	# The executable depends on the linkerscript
-	env.Depends(target=program, dependency=abspath("modm/link/linkerscript.ld"))
+	env.Depends(target=program, dependency="$BASEPATH/link/linkerscript.ld")
 	env.Alias("size", env.Size(program))
 	%% if core.startswith("cortex-m")
 	env.Alias("log-itm", env.LogItmOpenOcd())


### PR DESCRIPTION
- Removing stray debug print() in :cmsis:core.
- Fixing some path issues when calling `modm/SConscript` not from `../modm/SConscript`
- Removing redundant `sys.path.append` for modm_tools.
- Fixing Jinja2 template issue in AVR delay code
- Missing GPIO connector files for hosted

cc @mfp20