### PR TITLE
Fixes __wrap__free_r() to ignore freeing null pointers.

### DIFF
--- a/src/modm/platform/heap/cortex/heap_tlsf.cpp
+++ b/src/modm/platform/heap/cortex/heap_tlsf.cpp
@@ -148,6 +148,8 @@ void *__wrap__realloc_r(struct _reent *, void *p, size_t size)
 
 void __wrap__free_r(struct _reent *, void *p)
 {
+	// do nothing if NULL pointer
+	if (!p) return;
 	tlsf_t pool = get_tlsf_for_ptr(p);
 	// if pointer belongs to no pool, exit.
 	if (!pool) return;


### PR DESCRIPTION
Moving the heap into its own module also changed the default allocator from newlib to tlsf, which fails to "delete" null pointers.

This fix adds the missing check for null pointer as it can be found in ext/tlsf.