### PR TITLE
moving BDTR related code to GeneralPurpose

### DIFF
--- a/src/modm/platform/timer/stm32/advanced_base.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced_base.hpp.in
@@ -120,18 +120,6 @@ public:
 		ExternalClock = TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0,
 	};
 
-	enum class OffStateForRunMode : uint32_t
-	{
-		Disable = 0,
-		Enable  = TIM_BDTR_OSSR,
-	};
-
-	enum class OffStateForIdleMode : uint32_t
-	{
-		Disable = 0,
-		Enable  = TIM_BDTR_OSSI,
-	};
-
 	enum class OutputIdleState : uint32_t
 	{
 		Reset = 0,
@@ -152,12 +140,6 @@ public:
 		CaptureCompare1 			= TIM_EGR_CC1G,
 		Update 						= TIM_EGR_UG,
 	};
-
-	/**
-	 * Enable output pins
-	 */
-	static void
-	enableOutput();
 };
 
 }	// namespace platform

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -212,6 +212,96 @@ public:
 		TIM{{ id }}->CNT = value;
 	}
 
+
+%% if target.family not in ["l1"] and id not in [14]
+	static inline void
+	enableOutput()
+	{
+		TIM{{ id }}->BDTR |= TIM_BDTR_MOE;
+	}
+
+	static inline void
+	disableOutput()
+	{
+		TIM{{ id }}->BDTR &= ~(TIM_BDTR_MOE);
+	}
+
+	/*
+	 * Enable/Disable automatic set of MOE bit at the next update event
+	 */
+	static inline void
+	setAutomaticUpdate(bool enable)
+	{
+		if(enable)
+			TIM{{ id }}->BDTR |= TIM_BDTR_AOE;
+		else
+			TIM{{ id }}->BDTR &= ~TIM_BDTR_AOE;
+	}
+
+	static inline void
+	setOffState(OffStateForRunMode runMode, OffStateForIdleMode idleMode)
+	{
+		uint32_t flags = TIM{{ id }}->BDTR;
+		flags &= ~(TIM_BDTR_OSSR | TIM_BDTR_OSSI);
+		flags |= static_cast<uint32_t>(runMode);
+		flags |= static_cast<uint32_t>(idleMode);
+		TIM{{ id }}->BDTR = flags;
+	}
+
+	/*
+	 * Set Dead Time Value
+	 *
+	 * Different Resolution Depending on DeadTime[7:5]:
+	 *     0xx =>  DeadTime[6:0]            * T(DTS)
+	 *     10x => (DeadTime[5:0] + 32) *  2 * T(DTS)
+	 *     110 => (DeadTime[4:0] + 4)  *  8 * T(DTS)
+	 *     111 => (DeadTime[4:0] + 2)  * 16 * T(DTS)
+	 */
+	static inline void
+	setDeadTime(uint8_t deadTime)
+	{
+		uint32_t flags = TIM{{ id }}->BDTR;
+		flags &= ~TIM_BDTR_DTG;
+		flags |= deadTime;
+		TIM{{ id }}->BDTR = flags;
+	}
+
+	/*
+	 * Set Dead Time Value
+	 *
+	 * Different Resolution Depending on DeadTime[7:5]:
+	 *     0xx =>  DeadTime[6:0]            * T(DTS)
+	 *     10x => (DeadTime[5:0] + 32) *  2 * T(DTS)
+	 *     110 => (DeadTime[4:0] + 4)  *  8 * T(DTS)
+	 *     111 => (DeadTime[4:0] + 2)  * 16 * T(DTS)
+	 */
+	static inline void
+	setDeadTime(DeadTimeResolution resolution, uint8_t deadTime)
+	{
+		uint8_t bitmask;
+		switch(resolution){
+			case DeadTimeResolution::From0With125nsStep:
+				bitmask = 0b01111111;
+				break;
+			case DeadTimeResolution::From16usWith250nsStep:
+				bitmask = 0b00111111;
+				break;
+			case DeadTimeResolution::From32usWith1usStep:
+			case DeadTimeResolution::From64usWith2usStep:
+				bitmask = 0b00011111;
+				break;
+			default:
+				bitmask = 0x00;
+				break;
+		}
+		uint32_t flags = TIM{{ id }}->BDTR;
+		flags &= ~TIM_BDTR_DTG;
+		flags |= (deadTime & bitmask) | static_cast<uint32_t>(resolution);
+		TIM{{ id }}->BDTR = flags;
+	}
+%% endif
+
+
 public:
 	static void
 	configureInputChannel(uint32_t channel, InputCaptureMapping input,

--- a/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
@@ -201,6 +201,20 @@ public:
 	};
 %% endif
 
+%% if target.family not in ["l1"]
+	enum class OffStateForRunMode : uint32_t
+	{
+		Disable = 0,
+		Enable  = TIM_BDTR_OSSR,
+	};
+
+	enum class OffStateForIdleMode : uint32_t
+	{
+		Disable = 0,
+		Enable  = TIM_BDTR_OSSI,
+	};
+%% endif
+
 public:
 	/**
 	 * Set operation mode of the timer
@@ -211,6 +225,8 @@ public:
 	static void
 	setMode(Mode mode, SlaveMode slaveMode = SlaveMode::Disabled,
 			SlaveModeTrigger slaveModeTrigger = (SlaveModeTrigger) 0);
+
+
 
 public:
 	/**


### PR DESCRIPTION
Hi ! First PR here, on this project (I want to say, I was really pleased to find this project, I really like it !)

I noticed that, for some of the General Purpose Timers of STM32, at least F0 (namely, TIM15, 16, 17)
There is a missing feature: "enable/disableOutput",

This is related to BDTR register ofn these Timers, specifically MOE bit.
Therefore, I propose this PR that is dedicated to move all the code related to this register; from Advanced Timer to General Purpose. 

This allow to use setAutomatic Update and en/disableOutput for these timers..

I probably miss a good way to filter out the timers, I don't know enough the full architecture of St's timers.

Bests,
Vivien