### PR TITLE
[spi] Fix writing SPI data size into correct register

### DIFF
--- a/src/modm/platform/spi/stm32/spi_hal_impl.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_hal_impl.hpp.in
@@ -80,8 +80,8 @@ modm::platform::SpiHal{{ id }}::setDataOrder(DataOrder dataOrder)
 void inline
 modm::platform::SpiHal{{ id }}::setDataSize(DataSize dataSize)
 {
-%% if "data-size" in features
 	// TODO: implement as set/reset bit
+%% if "data-size" not in features
 	SPI{{ id }}->CR1 = (SPI{{ id }}->CR1 & ~static_cast<uint32_t>(DataSize::All))
 										 | static_cast<uint32_t>(dataSize);
 %% else

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -64,6 +64,8 @@ public:
 		LsbFirst = SPI_CR1_LSBFIRST
 	};
 
+	using DataSize = Hal::DataSize;
+
 public:
 	template< template<Peripheral _> class... Signals >
 	static void
@@ -107,6 +109,11 @@ public:
 	setDataOrder(DataOrder order)
 	{
 		SpiHal{{ id }}::setDataOrder(static_cast<SpiHal{{ id }}::DataOrder>(order));
+	}
+	static modm_always_inline void
+	setDataSize(DataSize size)
+	{
+		SpiHal{{ id }}::setDataSize(static_cast<SpiHal{{ id }}::DataSize>(size));
 	}
 
 


### PR DESCRIPTION
Also adds the missing method to the SPI master class.
Fixes #406.