### PR TITLE
Derive iterators from std::iterator

### DIFF
--- a/src/modm/container/deque.hpp
+++ b/src/modm/container/deque.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+#include <iterator>
 
 namespace modm
 {
@@ -189,7 +190,7 @@ namespace modm
 		 *
 		 * \todo	check if a simpler implementation is possible
 		 */
-		class const_iterator
+		class const_iterator : public std::iterator<std::bidirectional_iterator_tag, T>
 		{
 			friend class BoundedDeque;
 

--- a/src/modm/container/doubly_linked_list.hpp
+++ b/src/modm/container/doubly_linked_list.hpp
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <modm/utils/allocator.hpp>
+#include <iterator>
 
 namespace modm
 {
@@ -103,7 +104,7 @@ namespace modm
 		 *
 		 * \todo	decrement operator doesn't work correctly
 		 */
-		class iterator
+		class iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class DoublyLinkedList;
 			friend class const_iterator;
@@ -132,7 +133,7 @@ namespace modm
 		 *
 		 * \todo	decrement operator doesn't work correctly
 		 */
-		class const_iterator
+		class const_iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class DoublyLinkedList;
 

--- a/src/modm/container/dynamic_array.hpp
+++ b/src/modm/container/dynamic_array.hpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <modm/utils/allocator.hpp>
 #include <initializer_list>
+#include <iterator>
 
 namespace modm
 {
@@ -258,7 +259,7 @@ namespace modm
 		/**
 		 * \brief	Forward iterator
 		 */
-		class iterator
+		class iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class DynamicArray;
 			friend class const_iterator;
@@ -288,7 +289,7 @@ namespace modm
 		/**
 		 * \brief	forward const iterator
 		 */
-		class const_iterator
+		class const_iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class DynamicArray;
 

--- a/src/modm/container/linked_list.hpp
+++ b/src/modm/container/linked_list.hpp
@@ -17,6 +17,7 @@
 #define	MODM_LINKED_LIST_HPP
 
 #include <stdint.h>
+#include <iterator>
 #include <modm/utils/allocator.hpp>
 
 namespace modm
@@ -116,7 +117,7 @@ namespace modm
 		/**
 		 * \brief	Forward iterator
 		 */
-		class iterator
+		class iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class LinkedList;
 			friend class const_iterator;
@@ -142,7 +143,7 @@ namespace modm
 		/**
 		 * \brief	forward const iterator
 		 */
-		class const_iterator
+		class const_iterator : public std::iterator<std::forward_iterator_tag, T>
 		{
 			friend class LinkedList;
 


### PR DESCRIPTION
...to make the containers work with algorithms from STL.
Currently modm containers won't work with algorithms like _std::remove_if()_. This fix resolves it.
