### PR TITLE
Different Clock Config for Nucleo F042K6 to fix UART timings

### DIFF
--- a/src/modm/board/nucleo_f042k6/board.hpp
+++ b/src/modm/board/nucleo_f042k6/board.hpp
@@ -55,10 +55,10 @@ struct SystemClock {
 	enable()
 	{
 		Rcc::enableInternalClock();	// 8MHz
-		// (internal clock / 1) * 6 = 48MHz
+		// (internal clock / 2) * 12 = 48MHz
 		const Rcc::PllFactors pllFactors{
-			.pllMul = 6,
-			.pllPrediv = 1
+			.pllMul = 12,
+			.pllPrediv = 2
 		};
 		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		// set flash latency for 48MHz


### PR DESCRIPTION
This is a rather small fix to setup the clock on the STM32F042 differently. The result is the same but for some weird reason, with a prediv of 1 and a multiplier of 6, the UART seems to have timing issues and only prints out garbage. With a prediv of 2 and a multiplier of 12 it works just fine.

I tried the blink demo with two different Nucleo-F042K6 and the results were the same. I'm not exactly sure why this is an issue after all. According to the datasheet the originial settings should work.