### PR TITLE
[stm32] RCC: Fix wrong PLL HSI source selection

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,7 +9,7 @@ repo_url: 'https://github.com/modm-io/modm'
 edit_uri: ""
 # dev_addr: 192.168.1.2:8000
 
-copyright: 'Copyright &copy 2009-2019 Niklas Hauser & modm authors'
+copyright: 'Copyright &copy 2009-2020 Niklas Hauser & modm authors'
 
 # Turn around for GitHub Hosting in /docs
 docs_dir: 'src'
@@ -33,10 +33,10 @@ theme:
 
 extra:
   social:
-    - type: github-alt
+    - icon: fontawesome/brands/github-alt
       link: https://github.com/modm-io
-    - type: twitter
-      link: https://twitter.com/RCA_eV
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/modm_embedded
 
 markdown_extensions:
   - markdown.extensions.admonition

--- a/src/modm/board/disco_f051r8/board.hpp
+++ b/src/modm/board/disco_f051r8/board.hpp
@@ -37,12 +37,12 @@ struct SystemClock
 	{
 		// enable internal 8 MHz HSI RC clock
 		Rcc::enableInternalClock();
-		// (internal clock / 2) / 1 * 12 = 48MHz
+		// (internal clock / 2) * 12 = 48MHz
 		const Rcc::PllFactors pllFactors{
 			.pllMul = 12,
-			.pllPrediv = 1
+			.pllPrediv = 1  // only used with Hse
 		};
-		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::enablePll(Rcc::PllSource::HsiDiv2, pllFactors);
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f031k6/board.hpp
+++ b/src/modm/board/nucleo_f031k6/board.hpp
@@ -55,9 +55,9 @@ struct SystemClock {
 		// (internal clock / 2) * 12 = 48MHz
 		const Rcc::PllFactors pllFactors{
 			.pllMul = 12,
-			.pllPrediv = 1
+			.pllPrediv = 1  // only used with Hse
 		};
-		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::enablePll(Rcc::PllSource::HsiDiv2, pllFactors);
 		// set flash latency for 48MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f303k8/board.hpp
+++ b/src/modm/board/nucleo_f303k8/board.hpp
@@ -67,9 +67,9 @@ struct SystemClock {
 		// 8MHz / 2 * 16 = 64MHz
 		const Rcc::PllFactors pllFactors{
 			.pllMul = 16,
-			.pllPrediv = 2,
+			.pllPrediv = 2,  // only used with Hse
 		};
-		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::enablePll(Rcc::PllSource::HsiDiv2, pllFactors);
 		// set flash latency for 64MHz
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -43,20 +43,26 @@ public:
 %% if target["family"] in ["f2", "f4", "f7", "l4", "g0", "g4"]
 		/// High speed internal clock (16 MHz)
 		Hsi = RCC_PLLCFGR_PLLSRC_HSI,
+		InternalClock = Hsi,
 		/// High speed external clock (see HseConfig)
 		Hse = RCC_PLLCFGR_PLLSRC_HSE,
 %% elif target["family"] in ["f0", "f3"]
 		/// High speed internal clock (8 MHz)
-	%% if target["family"] == "f3" and target["name"] in ["02", "03", "98"] and target["size"] in ["d", "e"]
-		Hsi = 0,
-	%% else
-		Hsi = RCC_CFGR_PLLSRC_HSI_DIV2,
+		// On STM32F0 and STM32F3 some devices have a fixed /2 pre-divider, some have a configurable
+		// pre-divider and some have both, selectable via pll source mux
+	%% if (target["family"] == "f0" and (target["name"] in ["42", "48", "70", "71", "72", "78", "91", "98"] or (target["name"] in ["30"] and target["size"] in ["c"]))) or (target["family"] == "f3" and target["name"] in ["02", "03", "98"] and target["size"] in ["d", "e"])
+		Hsi = RCC_CFGR_PLLSRC_HSI_PREDIV,
+		InternalClock = Hsi,
+	%% endif
+	%% if (target["family"] == "f0") or (target["family"] == "f3" and target["size"] in ["8", "c"])
+		HsiDiv2 = RCC_CFGR_PLLSRC_HSI_DIV2,
 	%% endif
 		/// High speed external clock (see HseConfig)
 		Hse = RCC_CFGR_PLLSRC_HSE_PREDIV,
 %% elif target["family"] in ["f1", "l1"]
 		/// High speed internal clock (8 MHz)
 		Hsi = 0,
+		InternalClock = Hsi,
 		/// High speed external clock (see HseConfig)
 		Hse = RCC_CFGR_PLLSRC,
 %% endif
@@ -69,8 +75,6 @@ public:
 		Msi = RCC_PLLCFGR_PLLSRC_MSI,
 		MultiSpeedInternalClock = Msi,
 %% endif
-
-		InternalClock = Hsi,
 		ExternalClock = Hse,
 		ExternalCrystal = Hse,
 	};


### PR DESCRIPTION
On STM32F042 (and other STM32F0/STM32F3) `Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors)` selects the Hsi clock divided by 2 (and not divided by `PllFactors::pllPrediv`) as pll source.

```c++
enum class PllSource : uint32_t {
  /// High speed internal clock (8 MHz)
  Hsi = RCC_CFGR_PLLSRC_HSI_DIV2,
  InternalClock = Hsi,
  // [...]
}
```
```c++
#define RCC_CFGR_PLLSRC_HSI_DIV2 (0x00000000U) /*!< HSI clock divided by 2 selected as PLL entry clock source */
```

![grafik](https://user-images.githubusercontent.com/2820734/84021626-3f8a6380-a985-11ea-9933-0acb7552bf37.png)

---

Related to #413 