### PR TITLE
Add modm:platform:cortex-m:linkerscript.override option

### DIFF
--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -35,7 +35,7 @@ def build(env):
 
     env.outbasepath = "modm/link"
     env.copy("linkerscript/linkerscript.ld", "linkerscript.ld")
-    env.collect(":build:linkflags", "-L{linkdir}", "-Tlinkerscript.ld")
+    env.collect(":build:linkflags", "-L{project_source_dir}", "-Tmodm/link/linkerscript.ld")
 
     env.substitutions = {
         "target": target.identifier,

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -190,6 +190,15 @@ def prepare(module, options):
             maximum=hex(flash_size),
             default=0))
 
+    module.add_option(
+        PathOption(
+            name="linkerscript.override",
+            description="Path to project provided linkerscript",
+            default="",
+            empty_ok=True,
+            absolute=False,
+        ))
+
     module.add_collector(
         StringCollector(
             name="linkerscript.memory",
@@ -315,9 +324,13 @@ def build(env):
     if env.has_module(":architecture:unaligned"):
         env.template("unaligned_impl.hpp.in")
 
+    env.collect(":build:linkflags", "-Wl,--no-wchar-size-warning", "-L{project_source_dir}")
     # Linkerscript
-    env.collect(":build:linkflags", "-L{linkdir}", "-Tlinkerscript.ld",
-                                    "-Wl,--no-wchar-size-warning")
+    linkerscript_override_option = env["linkerscript.override"]
+    if linkerscript_override_option:
+        env.collect(":build:linkflags", "-T{}".format(linkerscript_override_option))
+    else:
+        env.collect(":build:linkflags", "-Tmodm/link/linkerscript.ld")
 
     # Compilation for FPU
     core = env[":target"].get_driver("core")["type"]
@@ -337,4 +350,3 @@ def build(env):
     if single_precision:
         env.collect(":build:ccflags", "-fsingle-precision-constant",
                                       "-Wdouble-promotion")
-

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -45,7 +45,7 @@ def build(env):
     def flag_format(flag):
         subs = {
             "target_base": "${CMAKE_PROJECT_NAME}",
-            "linkdir": "${CMAKE_CURRENT_LIST_DIR}/link",
+            "project_source_dir": "${CMAKE_CURRENT_SOURCE_DIR}",
         }
         if "{" in flag:
             return flag.format(**subs)

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -66,7 +66,7 @@ def build(env):
     def flag_format(flag):
         subs = {
             "target_base": "\"${TARGET.base}\"",
-            "linkdir": "abspath(\"link\")"
+            "linkdir": "abspath(\"..\")"
         }
         flag = '"{}"'.format(flag)
         vals = ["{}={}".format(t, r) for t, r in subs.items() if "{{{}}}".format(t) in flag]


### PR DESCRIPTION
Allow a project to provide its own linkerscript, by setting the `modm:platform:cortex-m:linkerscript.override` option to a path relative to the top-level project directory. 

Closes #411 

