### PR TITLE
Driver for Sx1276 LoRa modem

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,12 @@ can easily configure them for you specific needs.
 </tr><tr>
 <td align="center">SK9822</td>
 <td align="center">SSD1306</td>
+<td align="center">SX1276</td>
 <td align="center">TCS3414</td>
 <td align="center">TCS3472</td>
 <td align="center">TLC594X</td>
-<td align="center">TMP102</td>
 </tr><tr>
+<td align="center">TMP102</td>
 <td align="center">TMP175</td>
 <td align="center">VL53L0</td>
 <td align="center">VL6180</td>

--- a/examples/nucleo_f411re/sx1276_rx/main.cpp
+++ b/examples/nucleo_f411re/sx1276_rx/main.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Benjamin Carrick
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/driver/radio/sx1276.hpp>
+
+using namespace Board;
+using namespace modm;
+
+int
+main()
+{
+	Board::initialize();
+
+	//RxTx selection on the mbed shield
+	using RxTx = Board::A4;
+
+	using SpiMosi = Board::D11;
+	using SpiMiso = Board::D12;
+	using SpiSck = Board::D13;
+	using SpiCs = Board::D10;
+
+	//Set the RF switch to Receive
+	RxTx::setOutput();
+	RxTx::reset();
+
+	//Initialize the SPI
+	SpiCs::setOutput();
+	SpiCs::set();
+
+	SpiMaster1::connect<SpiSck::Sck, SpiMosi::Mosi, SpiMiso::Miso>();
+	SpiMaster1::initialize<Board::SystemClock, 1500_kHz>();
+
+	MODM_LOG_DEBUG << "Starting the modem" << modm::endl;
+
+	// Create an instance of the driver
+	Sx1276<SpiMaster1,SpiCs> loraModem;
+
+	// Initialize the modem
+	RF_CALL_BLOCKING(loraModem.initialize());
+
+	// Set Modulation Parameters
+	RF_CALL_BLOCKING(loraModem.setModemParams(sx1276::Bandwidth::BW_7,
+											  sx1276::SpreadingFactor::SF_8,
+											  sx1276::CodingRate::CR_4_8,
+											  false,
+											  false));
+	// Set Carrier Frequency
+	RF_CALL_BLOCKING(loraModem.setCarrierFrequency(433.920_MHz));
+
+	// Enable the continous listening mode
+	RF_CALL_BLOCKING(loraModem.enableListening());
+
+	//the variable to hold the counter transmitted by the tx example
+	uint32_t rxCounter(0);
+
+	while (true)
+	{
+		//check the modem if new data is available and read it
+		uint8_t bytesReceived = RF_CALL_BLOCKING(loraModem.readPacket(reinterpret_cast<uint8_t*>(&rxCounter),4));
+		if(bytesReceived > 0)
+		{
+			int8_t snr = RF_CALL_BLOCKING(loraModem.getPacketSnr());
+
+			//dirty fixed point numbers
+			uint8_t snr_dec = (snr & 0x03) * 25;
+			snr = snr >> 2;
+
+			int16_t rssi = RF_CALL_BLOCKING(loraModem.getPacketRssi());
+
+			MODM_LOG_DEBUG << "Received Message" << modm::endl;
+			MODM_LOG_DEBUG << "Counter Value: " << rxCounter << modm::endl;
+			MODM_LOG_DEBUG << "SNR: "<< snr <<"."<< snr_dec << " dB" << modm::endl;
+			MODM_LOG_DEBUG << "RSSI: "<< rssi << " dBm" << modm::endl;
+			MODM_LOG_DEBUG << modm::endl;
+		}
+		//check for new data every 100ms
+		modm::delay(100ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f411re/sx1276_rx/project.xml
+++ b/examples/nucleo_f411re/sx1276_rx/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f411re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f411re/sx1276_rx</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:driver:sx1276</module>
+  </modules>
+</library>

--- a/examples/nucleo_f411re/sx1276_tx/main.cpp
+++ b/examples/nucleo_f411re/sx1276_tx/main.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Benjamin Carrick
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/driver/radio/sx1276.hpp>
+
+using namespace Board;
+using namespace modm;
+
+int
+main()
+{
+	Board::initialize();
+
+	//RxTx selection on the mbed shield
+	using RxTx = Board::A4;
+
+	using SpiMosi = Board::D11;
+	using SpiMiso = Board::D12;
+	using SpiSck = Board::D13;
+	using SpiCs = Board::D10;
+
+	//Set the RF switch to Transmit
+	RxTx::setOutput();
+	RxTx::set();
+
+	//Initialize the SPI
+	SpiCs::setOutput();
+	SpiCs::set();
+
+	SpiMaster1::connect<SpiSck::Sck, SpiMosi::Mosi, SpiMiso::Miso>();
+	SpiMaster1::initialize<Board::SystemClock, 1500_kHz>();
+
+	// Create an instance of the driver
+	Sx1276<SpiMaster1,SpiCs> loraModem;
+
+	// Initialize the modem
+	RF_CALL_BLOCKING(loraModem.initialize());
+
+	// Set Modulation Parameters
+	RF_CALL_BLOCKING(loraModem.setModemParams(sx1276::Bandwidth::BW_7,
+											  sx1276::SpreadingFactor::SF_8,
+											  sx1276::CodingRate::CR_4_8,
+											  false,
+											  false));
+	// Set Carrier Frequency
+	RF_CALL_BLOCKING(loraModem.setCarrierFrequency(433.920_MHz));
+
+	//The message to be sent
+	uint32_t counter(0);
+
+	while (true)
+	{
+		MODM_LOG_INFO << "Trasmitting Message " << counter << modm::endl;
+		RF_CALL_BLOCKING(loraModem.transmit(reinterpret_cast<uint8_t*>(&counter),4));
+		counter++;
+		modm::delay(1000ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f411re/sx1276_tx/project.xml
+++ b/examples/nucleo_f411re/sx1276_tx/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-f411re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f411re/sx1276_tx</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:driver:sx1276</module>
+  </modules>
+</library>

--- a/src/modm/driver/radio/sx1276.hpp
+++ b/src/modm/driver/radio/sx1276.hpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2020, Benjamin Carrick
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SX1276_HPP
+#define MODM_SX1276_HPP
+
+#include <modm/architecture/interface/spi_device.hpp>
+
+#include "sx1276_definitions.hpp"
+
+namespace modm
+{
+
+/**
+ * @tparam    SpiMaster    SpiMaster interface
+ * @tparam    Cs           Chip-select pin
+ *
+ * @author    Benjamin Carrick
+ * @ingroup   modm_driver_sx1276
+ */
+template <typename SpiMaster, typename Cs>
+class Sx1276 : public sx1276, public modm::SpiDevice<SpiMaster>, protected modm::NestedResumable<6>
+{
+public:
+	/**
+	 * \brief Construct a new Sx1276 Driver
+	 */
+	Sx1276();
+
+	/**
+	 * \brief Initialize the modem into Lora mode
+	 */
+	modm::ResumableResult<void>
+	initialize();
+
+	/**
+	 * \brief Setup the modem parameters
+	 *
+	 * \param bw    The Bandwidth of the LoRa Transmission
+	 * \param sf    The Spreading factor for each symbol
+	 * \param cr    The Coding rate for the symbols
+	 * \param implicitHeader Run the modem in implicit header mode
+	 * \param payloadCrc Append CRC checksums to validate the packages
+	 */
+	modm::ResumableResult<void>
+	setModemParams( Bandwidth bw,
+					SpreadingFactor sf,
+					CodingRate cr,
+					bool implicitHeader,
+					bool payloadCrc);
+
+	/**
+	 * \brief Set the carrier frequency of the Modem
+	 *
+	 * \param freq The Carrier frequency the modem will be tuned to
+	 */
+	modm::ResumableResult<void>
+	setCarrierFrequency(frequency_t freq);
+
+	/**
+	 * \brief Set the sync word for the LoRa packages
+	 *
+	 * \param syncWord The new sync word of upcoming lora packages
+	 */
+	modm::ResumableResult<void>
+	setSyncWord(uint8_t syncWord);
+
+	/**
+	 * \brief Transmit a single package
+	 *
+	 * \param data A pointer to the payload data of the Package
+	 * \param length The length of the payload data in bytes
+	 */
+	modm::ResumableResult<void>
+	transmit(uint8_t* data, uint8_t length);
+
+	/**
+	 * \brief Enable the Rx mode and start listening for packages
+	 */
+	modm::ResumableResult<void>
+	enableListening();
+
+	/**
+	 * \brief Disable Rx mode
+	 */
+	modm::ResumableResult<void>
+	disableListening();
+
+	/**
+	 * \brief Reads a package from the modem if one is available.
+	 * The return value indicates how many bytes have been read from the last received package.
+	 * If the return value is 0 no package has been received, is it larger than the max length
+	 * parameter, the package was bigger than the buffer provided and got discarded
+	 *
+	 * \param data A pointer to a buffer where received data will be stored
+	 * \param maxLength The maximum amount of bytes that can be read
+	 * \return The amount of bytes in the last package
+	 */
+	modm::ResumableResult<uint8_t>
+	readPacket(uint8_t* data, uint8_t maxLength);
+
+	/**
+	 * \brief Get the signal to noise ratio for the last received packet
+	 *
+	 * \return The raw signal to noise ratio in dB (has to be divided by 4 for the actual value)
+	 */
+	modm::ResumableResult<int8_t>
+	getPacketSnr();
+
+	/**
+	 * \brief Get the recieved signal strength indicator (RSSI) of the last received packet
+	 *
+	 * \return The RSSI value of the last received packet
+	 */
+	modm::ResumableResult<int16_t>
+	getPacketRssi();
+
+	/**
+	 * \brief Get the current recieved signal strength indicator (RSSI)
+	 *
+	 * \return The RSSI value of the last received packet
+	 */
+	modm::ResumableResult<int16_t>
+	getCurrentRssi();
+
+private:
+
+	/// The frequency of the connected oscillator
+	static constexpr frequency_t osc_freq = 32_MHz;
+
+	/// The internal buffer for spi transfers
+	uint8_t buffer[4];
+
+	// Shadow registers of the chip registers
+
+	OpModeRegister_t opModeShadow;
+	ModemConfig1_t modemConf1Shadow;
+	ModemConfig2_t modemConf2Shadow;
+	ModemConfig3_t modemConf3Shadow;
+	int32_t frfShadow;
+	Interrupts_t irqMaskShadow;
+
+	/// The latest irq flags
+	Interrupts_t irqFlags;
+	/// The payload size of the last packet
+	uint8_t lastPacketSize;
+	/// Temporary storage for RSSI values
+	int16_t tempRssi;
+
+	/// Reads a single register
+	modm::ResumableResult<uint8_t>
+	readRegister(Sx1276Register reg);
+
+	/// Writes a single register with a given value
+	modm::ResumableResult<void>
+	writeRegister(Sx1276Register reg, uint8_t value);
+
+	/// Transfers the buffer to the SPI bus
+	modm::ResumableResult<void>
+	transferBuffer(uint8_t length);
+
+	/// change the operation mode of the modem
+	modm::ResumableResult<void>
+	changeMode(ModemMode mode);
+
+};
+
+}
+
+#include "sx1276_impl.hpp"
+
+#endif

--- a/src/modm/driver/radio/sx1276.lb
+++ b/src/modm/driver/radio/sx1276.lb
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:sx1276"
+    module.description = "Semtech SX1276 Driver"
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:delay",
+        ":architecture:register",
+        ":architecture:spi",
+        ":architecture:spi.device",
+        ":architecture:clock",
+        ":debug",
+        ":processing:timer")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/radio"
+    env.copy("sx1276.hpp")
+    env.copy("sx1276_impl.hpp")
+    env.copy("sx1276_definitions.hpp")

--- a/src/modm/driver/radio/sx1276_definitions.hpp
+++ b/src/modm/driver/radio/sx1276_definitions.hpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2020, Benjamin Carrick
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SX1276_DEFINITIONS_HPP
+#define MODM_SX1276_DEFINITIONS_HPP
+
+#include <stdint.h>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/math/utils/bit_constants.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_sx1276
+struct sx1276
+{
+public:
+
+	///Definitions of all the Registers of the modem in LoRa mode
+	enum class
+	Sx1276Register : uint8_t
+	{
+		Fifo = 0x00,                ///< Fifo I/O for the transceiver
+		OpMode = 0x01,              ///< Operation Mode Register
+		FrMsb  = 0x06,              ///< MSB of the Carrier Frequency Register
+		FrMid  = 0x07,              ///< Middle Byte of the Carrier Frequency Register
+		FrLsb  = 0x08,              ///< LSB of the Carrier Frequency Register
+		PaConfig = 0x09,            ///< Power output control
+		PaRamp = 0x0A,              ///< Power ramp steepness
+		Ocp = 0x0B,                 ///< Overload current protection
+		Lna = 0x0C,                 ///< Low Noise Amplifier Control
+		FifoAddrPtr = 0x0D,         ///< Address Pointer in Fifo Buffer
+		FifoTxBaseAddr = 0x0E,      ///< Base Write Address for Tx Fifo
+		FifoRxBaseAddr = 0x0F,      ///< Base Read Address for Rx Fifo
+		FifoRxCurrentAddr = 0x10,   ///< Fifo Address of the last received packet
+		IrqFlagsMask =  0x11,       ///< Interrupt Masks
+		IrqFlags = 0x12,            ///< Interrupt Flags
+		RxNbBytes = 0x13,           ///< Amount of payload bytes in last received message
+		RxHeaderCntValueMsb = 0x14, ///< MSB of valid header counter since last transition to rx mode
+		RxHeaderCntValueLsb = 0x15, ///< LSB of valid header counter since last transition to rx mode
+		RxPacketCntValueMsb = 0x16, ///< MSB of valid packet counter since last transition to rx mode
+		RxPacketCntValueLsb = 0x17, ///< LSB of valid packet counter since last transition to rx mode
+		ModemStat = 0x18,           ///< Modem status
+		PktSnrValue = 0x19,         ///< Estimation of the signal-to-noise ration of the last packet received
+		PktRssiValue = 0x1A,        ///< RSSI value of the last packet received
+		RssiValue = 0x1B,           ///< Current RSSI value
+		HopChannel = 0x1C,          ///< Configuration of the frequency hopping
+		ModemConfig1 = 0x1D,        ///< Lora PHY configuration register 1
+		ModemConfig2 = 0x1E,        ///< Lora PHY configuration register 2
+		SymbTimeoutLsb = 0x1F,      ///< LSB symbol timeout (MSB is in ModemConfig 2 Register)
+		PreambleMsb = 0x20,         ///< MSB of the preamble length
+		PreambleLsb = 0x21,         ///< LSB of the preamble length
+		PayloadLength = 0x22,       ///< Payload length
+		MaxPayloadLength = 0x23,    ///< Maximum payload length
+		HopPeriod = 0x24,           ///< Frequency Hopping Period
+		FifoRxByteAddr = 0x25,      ///< Current Rx Fifo Pointer
+		ModemConfig3 = 0x26,        ///< Lora PHY configuration register 3
+		PpmCorrection = 0x27,       ///< Data rate offset control
+		FeiMsb = 0x28,              ///< MSB of the estimated Frequency Error
+		FeiMid = 0x29,              ///< Middle byte of the estimated Frequency error
+		FeiLsb = 0x2A,              ///< LSB of the estimated frequency error
+		RssiWideband = 0x2C,        ///< Wideband RSSI measurement
+		DetectOptimize = 0x31,      ///< Lora Detection Optimize
+		InvertIQ = 0x33,            ///< Invert I and Q
+		HighBWOptimize1 = 0x36,     ///< High bandwidth optimization register 1
+		DetectionThreshold = 0x37,  ///< Lora detection threshold
+		SyncWord = 0x39,            ///< Lora syncword (0x34 for LoraWAN)
+		HighBWOptimize2 = 0x3A,     ///< High bandwidth optimization 2
+		InvertIQ2 = 0x3B            ///< Set to 0x19 for inverted IQ
+	};
+
+	/// Operation mode register
+	enum class
+	OpModeRegister : uint8_t
+	{
+		LoraMode = Bit7,            ///< Enables the Lora Mode - if zero the FSK mode is active
+		AccessSharedReg = Bit6,     ///< Enables shared access to FSK register in Lora mode
+		// Bit 5 : reserved
+		// Bit 4 : reserved
+		LowFrequencyMode = Bit3    ///<Enables the Low Frequency Mode
+		//Bit 2 - 0 Mode of the Modem - See ModemMode
+	};
+	MODM_FLAGS8(OpModeRegister);
+
+	/// Modem operation modes
+	enum class
+	ModemMode : uint8_t
+	{
+		SLEEP = 0b000,          ///< Sleep Mode
+		STDBY = 0b001,          ///< Standby Mode (default)
+		FSTX =  0b010,          ///< Frequency Synthesis Mode for Transmission
+		TX = 0b011,             ///< Transmit Mode
+		FSRX = 0b100,           ///< Frequency Synthesis Mode for Reception
+		RXCONTINOUS = 0b101,    ///< Continous Receive Mode
+		RXSINGLE = 0b110,       ///< Single Receive Mode
+		CAD =   0b111,          ///< Channel Activity Detection
+	};
+	typedef modm::Configuration<OpModeRegister_t, ModemMode, Bit0 | Bit1 | Bit2> ModemMode_t;
+
+	//Available interrupts with their positions in the flag and mask register
+	enum class
+	Interrupts : uint8_t
+	{
+		CAD_DETECED         = 1,
+		FHSS_CHANGE_CHANNEL = 2,
+		CAD_DONE            = 4,
+		TX_DONE             = 8,
+		VALID_HEADER        = 16,
+		PAYLOAD_CRC_ERROR   = 32,
+		RX_DONE             = 64,
+		RX_TIMEOUT          = 128
+	};
+	MODM_FLAGS8(Interrupts);
+
+	//Modem Config
+
+	/// Operation mode register
+	enum class
+	ModemConfig1 : uint8_t
+	{
+		//Bit 7 - 4: Bandwidth
+		//Bit 3 - 1: Error Coding Rate
+		ImplicitHeaderModeOn = Bit0    ///< Headers will not transmitted
+	};
+	MODM_FLAGS8(ModemConfig1);
+
+	/// LoRa Bandwidth Modes
+	enum class
+	Bandwidth : uint8_t
+	{
+		BW_0 = 0x00,  ///< 7.8 kHz
+		BW_1 = 0x10,  ///< 10.4 kHZ
+		BW_2 = 0x20,  ///< 15.6 kHz
+		BW_3 = 0x30,  ///< 20.8 kHz
+		BW_4 = 0x40,  ///< 31.25 kHz
+		BW_5 = 0x50,  ///< 41.7 kHz
+		BW_6 = 0x60,  ///< 62.5 kHz
+		BW_7 = 0x70,  ///< 125 kHz
+		BW_8 = 0x80,  ///< 250 kHz
+		BW_9 = 0x90,  ///< 500 kHz
+	};
+	typedef modm::Configuration<ModemConfig1_t, Bandwidth, Bit7 | Bit6 | Bit5 | Bit4> Bandwidth_t;
+
+	///LoRa Coding Rate
+	enum class
+	CodingRate : uint8_t
+	{
+		CR_4_5  = 0b0010,  ///< Error Coding Rate 4/5
+		CR_4_6  = 0b0100,  ///< Error Coding Rate 4/6
+		CR_4_7  = 0b0110,  ///< Error Coding Rate 4/7
+		CR_4_8  = 0b1000,  ///< Error Coding Rate 4/8
+	};
+	typedef modm::Configuration<ModemConfig1_t, CodingRate, Bit3 | Bit2 | Bit1 >CodingRate_t;
+
+	// Flag definitions for configuration registers
+	enum class
+	ModemConfig2 : uint8_t
+	{
+		//Bit 7 - 4: Spreading Factor
+		TxContinousMode = Bit3, ///< Continously Transmit Data
+		RxPayloadCrc = Bit2     ///< Messages will be transmitted along with a CRC
+	};
+	MODM_FLAGS8(ModemConfig2);
+
+	enum class
+	ModemConfig3 : uint8_t
+	{
+		//Bit 7 - 4: Unused
+		LowDataRateOptimize = Bit3,  ///< Optimize the modem for symbol times larger than 16ms
+		AgcAutoOn = Bit2             ///< Turn on the Automatic Gain Control
+	};
+	MODM_FLAGS8(ModemConfig3);
+
+	///Available Spreading Factors
+	enum class
+	SpreadingFactor : uint8_t
+	{
+		SF_6 = 0x60,    ///< 64 chips/symbol
+		SF_7 = 0x70,    ///< 128 chips/symbol
+		SF_8 = 0x80,    ///< 256 chips/symbol
+		SF_9 = 0x90,    ///< 512 chips/symbol
+		SF_10 = 0xA0,   ///< 1024 chips/symbol
+		SF_11 = 0xB0,   ///< 2048 chips/symbol
+		SF_12 = 0xC0,   ///< 4096 chips/symbol
+
+	};
+	typedef modm::Configuration<ModemConfig2_t, SpreadingFactor, Bit7 | Bit6 | Bit5 | Bit4 >SpreadingFactor_t;
+
+	static constexpr int16_t rssiOffsetLF = -164;
+
+}; // struct sx1276
+
+}
+#endif

--- a/src/modm/driver/radio/sx1276_impl.hpp
+++ b/src/modm/driver/radio/sx1276_impl.hpp
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2020, Benjamin Carrick
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SX1276_HPP
+#   error "Don't include this file directly, use 'sx1276.hpp' instead!"
+#endif
+
+#include "sx1276.hpp"
+#include <string.h>
+#include <stdint.h>
+
+namespace modm
+{
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+Sx1276<SpiMaster, Cs>::Sx1276()
+{
+	//init the config shadow registers with the default values
+	opModeShadow.value = 0x09;
+	modemConf1Shadow.value = 0x72;
+	modemConf2Shadow.value = 0x70;
+	modemConf3Shadow.value = 0x00;
+	irqMaskShadow.value = 0x00;
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+ResumableResult<void>
+Sx1276<SpiMaster, Cs>::initialize()
+{
+	RF_BEGIN();
+
+	// set the mode to sleep
+	RF_CALL(changeMode(ModemMode::SLEEP));
+
+	// change to the Lora mode
+	opModeShadow.set(OpModeRegister::LoraMode);
+	opModeShadow.reset(OpModeRegister::AccessSharedReg);
+	opModeShadow.set(OpModeRegister::LowFrequencyMode);
+
+	RF_CALL(writeRegister(Sx1276Register::OpMode,opModeShadow.value));
+
+	//mask out all interrupts
+	irqMaskShadow.value = 0xFF;
+	RF_CALL(writeRegister(Sx1276Register::IrqFlagsMask,irqMaskShadow.value));
+
+	// set the mode back to standby
+	RF_CALL(changeMode(ModemMode::STDBY));
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::setCarrierFrequency(frequency_t freq)
+{
+	RF_BEGIN();
+
+	frfShadow = static_cast<uint32_t>(freq * (static_cast<float>(1<<19) / static_cast<float>(osc_freq)));
+
+	// do a burst write to the three frequency registers instead of seperate register write calls
+	buffer[0] = 0x80 | static_cast<uint8_t>(Sx1276Register::FrMsb);
+	buffer[1] = static_cast<uint8_t>((frfShadow >> 16) & 0xFF);
+	buffer[2] = static_cast<uint8_t>((frfShadow >> 8) & 0xFF);
+	buffer[3] = static_cast<uint8_t>(frfShadow & 0xFF);
+
+	RF_CALL(transferBuffer(4));
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::setModemParams(  Bandwidth bw,
+										SpreadingFactor sf,
+										CodingRate cr,
+										bool implicitHeader,
+										bool payloadCrc)
+{
+	RF_BEGIN();
+	//configure the modem config shadow registers
+	Bandwidth_t::set(modemConf1Shadow,bw);
+	CodingRate_t::set(modemConf1Shadow,cr);
+	modemConf1Shadow.update(ModemConfig1::ImplicitHeaderModeOn,implicitHeader);
+
+	SpreadingFactor_t::set(modemConf2Shadow,sf);
+	modemConf2Shadow.reset(ModemConfig2::TxContinousMode);
+	modemConf2Shadow.update(ModemConfig2::RxPayloadCrc,payloadCrc);
+
+	//determine if the low bandwith optimization flag needs to be set
+	if( (sf == SpreadingFactor::SF_7 && bw < Bandwidth::BW_1) ||
+		(sf == SpreadingFactor::SF_8 && bw < Bandwidth::BW_3)  ||
+		(sf == SpreadingFactor::SF_9 && bw < Bandwidth::BW_5)  ||
+		(sf == SpreadingFactor::SF_10 && bw < Bandwidth::BW_7) ||
+		(sf == SpreadingFactor::SF_11 && bw < Bandwidth::BW_8) ||
+		(sf == SpreadingFactor::SF_12 && bw < Bandwidth::BW_9)
+	  )
+	{
+		modemConf3Shadow.set(ModemConfig3::LowDataRateOptimize);
+	}
+	else
+	{
+		modemConf3Shadow.reset(ModemConfig3::LowDataRateOptimize);
+	}
+
+	// Write out the config registers
+	RF_CALL(writeRegister(Sx1276Register::ModemConfig1,modemConf1Shadow.value));
+	RF_CALL(writeRegister(Sx1276Register::ModemConfig2,modemConf2Shadow.value));
+	RF_CALL(writeRegister(Sx1276Register::ModemConfig3,modemConf3Shadow.value));
+
+	//Configure the optimizations
+	if(sf == SpreadingFactor::SF_6)
+	{
+		RF_CALL(writeRegister(Sx1276Register::DetectOptimize,0x05));
+		RF_CALL(writeRegister(Sx1276Register::DetectionThreshold,0x0C));
+	}
+	else
+	{
+		RF_CALL(writeRegister(Sx1276Register::DetectOptimize,0x03));
+		RF_CALL(writeRegister(Sx1276Register::DetectionThreshold,0x0A));
+	}
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template<typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::setSyncWord(uint8_t syncWord)
+{
+	RF_BEGIN();
+	RF_CALL(writeRegister(Sx1276Register::SyncWord,syncWord));
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::transmit(uint8_t* data, uint8_t length)
+{
+	RF_BEGIN();
+
+	RF_CALL(changeMode(ModemMode::STDBY));
+
+	RF_CALL(writeRegister(Sx1276Register::PayloadLength,length));
+	RF_CALL(writeRegister(Sx1276Register::FifoTxBaseAddr,0x00));
+	RF_CALL(writeRegister(Sx1276Register::FifoAddrPtr,0x00));
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+
+	buffer[0] = 0x80 | static_cast<uint8_t>(Sx1276Register::Fifo);
+
+	Cs::reset();
+
+	RF_CALL(SpiMaster::transfer(buffer,nullptr,1));
+	RF_CALL(SpiMaster::transfer(data,nullptr,length));
+
+	if(this->releaseMaster())
+	{
+		Cs::set();
+	}
+
+	RF_CALL(changeMode(ModemMode::TX));
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::enableListening()
+{
+	RF_BEGIN();
+	//enable the rx interrupts
+	irqMaskShadow.reset(Interrupts::RX_DONE);
+
+	RF_CALL(writeRegister(Sx1276Register::FifoAddrPtr,0x00));
+	RF_CALL(writeRegister(Sx1276Register::FifoRxBaseAddr,0x00));
+
+	RF_CALL(writeRegister(Sx1276Register::IrqFlagsMask,irqMaskShadow.value));
+	RF_CALL(writeRegister(Sx1276Register::IrqFlags, 0xFF));
+
+	RF_CALL(changeMode(ModemMode::RXCONTINOUS));
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::disableListening()
+{
+	RF_BEGIN();
+
+	irqMaskShadow.set(Interrupts::RX_DONE);
+	RF_CALL(writeRegister(Sx1276Register::IrqFlagsMask,irqMaskShadow.value));
+
+	RF_CALL(changeMode(ModemMode::SLEEP));
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<uint8_t>
+Sx1276<SpiMaster, Cs>::readPacket(uint8_t* data, uint8_t maxLength)
+{
+	RF_BEGIN();
+
+	irqFlags.value = RF_CALL(readRegister(Sx1276Register::IrqFlags));
+	RF_CALL(writeRegister(Sx1276Register::IrqFlags, 0xFF));
+
+	lastPacketSize = 0;
+
+	if(irqFlags & Interrupts::RX_DONE)
+	{
+		lastPacketSize = RF_CALL(readRegister(Sx1276Register::RxNbBytes));
+		RF_WAIT_UNTIL(this->acquireMaster());
+
+		buffer[0] = static_cast<uint8_t>(Sx1276Register::Fifo);
+
+		Cs::reset();
+
+		RF_CALL(SpiMaster::transfer(buffer,nullptr,1));
+		if(lastPacketSize > maxLength)
+		{
+			MODM_LOG_ERROR<<"Read buffer is too small, packet discarded!"<<modm::endl;
+			//read it out anyway to clean the fifo
+			RF_CALL(SpiMaster::transfer(nullptr,nullptr,lastPacketSize));
+		}
+		else
+		{
+			RF_CALL(SpiMaster::transfer(nullptr,data,lastPacketSize));
+		}
+
+		if(this->releaseMaster())
+		{
+			Cs::set();
+		}
+
+	}
+
+	RF_END_RETURN(lastPacketSize);
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<int8_t>
+Sx1276<SpiMaster, Cs>::getPacketSnr()
+{
+	RF_BEGIN();
+	RF_CALL(readRegister(Sx1276Register::PktSnrValue));
+	RF_END_RETURN(static_cast<int8_t>(buffer[1]));
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<int16_t>
+Sx1276<SpiMaster, Cs>::getPacketRssi()
+{
+	RF_BEGIN();
+	tempRssi = static_cast<int16_t>(RF_CALL(readRegister(Sx1276Register::PktRssiValue)));
+	tempRssi += rssiOffsetLF;
+	RF_END_RETURN(tempRssi);
+}
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<int16_t>
+Sx1276<SpiMaster, Cs>::getCurrentRssi()
+{
+	RF_BEGIN();
+	tempRssi = static_cast<int16_t>(RF_CALL(readRegister(Sx1276Register::RssiValue)));
+	tempRssi += rssiOffsetLF;
+	RF_END_RETURN(tempRssi);
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::transferBuffer(uint8_t length)
+{
+	RF_BEGIN();
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+	Cs::reset();
+
+	RF_CALL(SpiMaster::transfer(buffer,buffer,length));
+
+	if(this->releaseMaster())
+	{
+		Cs::set();
+	}
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::writeRegister(Sx1276Register reg, uint8_t value)
+{
+	RF_BEGIN();
+
+	buffer[0] = 0x80 | static_cast<uint8_t>(reg);
+	buffer[1] = value;
+
+	RF_CALL(transferBuffer(2));
+
+	RF_END();
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<uint8_t>
+Sx1276<SpiMaster, Cs>::readRegister(Sx1276Register reg)
+{
+	RF_BEGIN();
+
+	buffer[0] = static_cast<uint8_t>(reg);
+	buffer[1] = 0x00;
+
+	RF_CALL(transferBuffer(2));
+
+	RF_END_RETURN(buffer[1]);
+}
+
+// -----------------------------------------------------------------------------
+
+template <typename SpiMaster, typename Cs>
+modm::ResumableResult<void>
+Sx1276<SpiMaster, Cs>::changeMode(ModemMode mode)
+{
+	RF_BEGIN();
+
+	ModemMode_t::set(opModeShadow,mode);
+	RF_CALL(writeRegister(Sx1276Register::OpMode,opModeShadow.value));
+
+	RF_END();
+}
+
+}


### PR DESCRIPTION
This is a basic driver for the Semtech Sx1276 LoRa modem chip.

The datasheet can be found here: https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/2R0000001OKs/Bs97dmPXeatnbdoJNVMIDaKDlQz8q1N_gxDcgqi7g2o

Currently it only supports the LoRa modulation of the chip (the chip itself got a FSK modulation mode as well), and only the 443Mhz Band can be used.

I added two examples to the driver demonstrating the TX and RX mode of the driver. The example runs on two Nucleo F411 with the SX1276 mbed shield (https://os.mbed.com/components/SX1276MB1xAS/)