### PR TITLE
Added checks for tx and rx calls

### DIFF
--- a/src/modm/driver/radio/sx1276.hpp
+++ b/src/modm/driver/radio/sx1276.hpp
@@ -13,6 +13,7 @@
 #define MODM_SX1276_HPP
 
 #include <modm/architecture/interface/spi_device.hpp>
+#include <modm/debug/logger.hpp>
 
 #include "sx1276_definitions.hpp"
 
@@ -78,8 +79,9 @@ public:
 	 *
 	 * \param data A pointer to the payload data of the Package
 	 * \param length The length of the payload data in bytes
+	 * \return Returns true if transmission has started. False if the buffer was already sending
 	 */
-	modm::ResumableResult<void>
+	modm::ResumableResult<bool>
 	transmit(uint8_t* data, uint8_t length);
 
 	/**
@@ -150,6 +152,8 @@ private:
 
 	/// The latest irq flags
 	Interrupts_t irqFlags;
+	/// Result of the last transmission attempt
+	bool lastTransmitResult;
 	/// The payload size of the last packet
 	uint8_t lastPacketSize;
 	/// Temporary storage for RSSI values

--- a/src/modm/driver/radio/sx1276_definitions.hpp
+++ b/src/modm/driver/radio/sx1276_definitions.hpp
@@ -105,7 +105,7 @@ public:
 	};
 	typedef modm::Configuration<OpModeRegister_t, ModemMode, Bit0 | Bit1 | Bit2> ModemMode_t;
 
-	//Available interrupts with their positions in the flag and mask register
+	/// Available interrupts with their positions in the flag and mask register
 	enum class
 	Interrupts : uint8_t
 	{


### PR DESCRIPTION
Improved the checks for receiving and transmitting message for the SX1276 driver.
This prevents calling transmit and receive in the wrong modes and fixed an error in the flag handling of the IRQ registers