### PR TITLE
Patches for arm32v7

### DIFF
--- a/src/modm/io/iostream.hpp.in
+++ b/src/modm/io/iostream.hpp.in
@@ -150,6 +150,13 @@ public:
 	{ writeIntegerMode(v); return *this; }
 
 %% if options["with_long_long"]
+#ifdef __arm__
+#ifdef __linux__
+	// This overload is used on arm32v7. See issue with OSX below
+	inline IOStream& operator << (const long unsigned int& v)
+	{ writeIntegerMode(static_cast<uint32_t>(v)); return *this; }
+#endif
+#endif
 	inline IOStream& operator << (const int64_t& v)
 	{ writeIntegerMode(v); return *this; }
 	inline IOStream& operator << (const uint64_t& v)

--- a/src/modm/platform/core/cortex/assert.cpp.in
+++ b/src/modm/platform/core/cortex/assert.cpp.in
@@ -12,6 +12,7 @@
 
 %% if target.platform in ["hosted"]
 #include <stdlib.h>
+#include <cstdint>
 #include <modm/debug/logger.hpp>
 %% elif core.startswith("avr")
 #include <avr/pgmspace.h>
@@ -84,7 +85,7 @@ void modm_abandon(const modm::AssertionInfo &info)
 {
 %% if target.platform in ["hosted"]
 	MODM_LOG_ERROR.printf("Assertion '%s'", info.name);
-	if (info.context != uintptr_t(-1)) { MODM_LOG_ERROR.printf(" @ %p (%lu)", (void *)info.context, info.context); }
+	if (info.context != uintptr_t(-1)) { MODM_LOG_ERROR.printf(" @ %p (%" PRIuPTR ")", (void *)info.context, info.context); }
 	%% if options.get(":architecture:assert:with_description", False)
 	MODM_LOG_ERROR.printf(" failed!\n  %s\nAbandoning...\n", info.description) << modm::flush;
 	%% else

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -214,7 +214,6 @@ def common_compiler_flags(compiler, target):
 
         "-fdata-sections",
         "-ffunction-sections",
-        "-fshort-wchar",
         "-funsigned-char",
         "-fwrapv",
         # "-fmerge-all-constants",
@@ -222,6 +221,8 @@ def common_compiler_flags(compiler, target):
         "-g3",
         "-gdwarf",
     ]
+    if target.identifier["platform"] not in ["hosted"]:
+        flags["ccflags"].append("-fshort-wchar")
     if compiler.startswith("gcc"):
         flags["ccflags"] += [
             "-finline-limit=10000",


### PR DESCRIPTION
This fixes #424 

Changes in `src/modm/platform/core/cortex/assert.cpp.in` are only needed because of `-Wformat`:
```cpp
modm/src/modm/platform/core/assert.cpp: In function 'void modm_abandon(const modm::AssertionInfo&)':
modm/src/modm/platform/core/assert.cpp:58:71: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'uintptr_t' {aka 'unsigned int'} [-Werror=format=]
   58 |  if (info.context != uintptr_t(-1)) { MODM_LOG_ERROR.printf(" @ %p (%lu)", (void *)info.context, info.context); }
      |                                                                     ~~^                          ~~~~~~~~~~~~
      |                                                                       |                               |
      |                                                                       long unsigned int               uintptr_t {aka unsigned int}
      |                                                                     %u

```
For even more future-proof solution, we should add `static_assert(sizeof(long unsigned int) >= sizeof(uintptr_t));` just to be sure.

The other two files were discussed in the issue.