### PR TITLE
Fix the method isConversionFinished() to wait on EndOfConversion instead of EndOfSampling.

### DIFF
--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -194,7 +194,7 @@ modm::platform::Adc{{ id }}::startConversion(void)
 bool
 modm::platform::Adc{{ id }}::isConversionFinished(void)
 {
-	return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfSampling);
+	return static_cast<bool>(getInterruptFlags() & InterruptFlag::EndOfRegularConversion);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
For some reason the ADC of the F3 implementation was waiting on EndOfSampling instead of EndOfConversion. This causes invalid data as the ADC DR doesn't contain the converted data yet, but still holds the data of the previous conversion.