### PR TITLE
fixed issue with escaping of arguments for size script

### DIFF
--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -34,5 +34,5 @@ add_custom_target(${CMAKE_PROJECT_NAME}.lss ALL DEPENDS ${CMAKE_PROJECT_NAME} CO
 add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_SIZE} ARGS -C -d --mcu={{ partname }} ${CMAKE_PROJECT_NAME}.elf)
 %% elif core.startswith("cortex-m")
 #% FIXME: build path does not contain python tools of course
-#% add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD COMMAND python3 ./modm/modm_tools/size.py ${CMAKE_PROJECT_NAME}.elf "{{memories}}")
+#% add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD VERBATIM COMMAND python3 ./modm/modm_tools/size.py ${CMAKE_PROJECT_NAME}.elf "{{memories}}")
 %% endif


### PR DESCRIPTION
I found that the escaping of the spaces in the argument of the custom command for the "size.py" script did not work correctly. The "VERBATIM"-Option makes sure, that it works on all platforms. I came across this issue on mac OS Catalina.

for reference from [documentation](https://cmake.org/cmake/help/latest/command/add_custom_command.html "documentation")
>VERBATIM
>All arguments to the commands will be escaped properly for the build tool so that the invoked command receives each argument unchanged. Note that one level of escapes is still used by the CMake language processor before add_custom_command even sees the arguments. Use of VERBATIM is recommended as it enables correct behavior. When VERBATIM is not given the behavior is platform specific because there is no protection of tool-specific special characters.