### PR TITLE
[rpi] Adds basic support for GPIO on Raspberry Pi boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ STM32 devices, however, there are different levels of support and testing.
 | STM32F2       | ★★★★    | STM32F3       | ★★★★★   | STM32F4       | ★★★★★   |
 | STM32F7       | ★★★★    | STM32L1       | ★★★★    | STM32L4       | ★★★★    |
 | STM32L4+      | ★★★★    | STM32G0       | ★★★★    | STM32G4       | ★★★★    |
-| SAMD21        | ★★      |               |         |               |         |
+| SAMD21        | ★★      | Raspberry Pi  | ★       |               |         |
 
 </center>
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ documentation.
 <td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
 </tr><tr>
+<td align="center">RASPBERRYPI</td>
 <td align="center">SAMD21-MINI</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>

--- a/examples/rpi/blinky/main.cpp
+++ b/examples/rpi/blinky/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/debug/logger.hpp>
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int main()
+{
+	Board::initialize();
+	GpioPin<0>::setOutput();
+	MODM_LOG_INFO << "Blink blink...";
+
+	for (int i = 0; i < 10; ++i)
+	{
+		GpioPin<0>::toggle();
+		modm::delay(500ms);
+	}
+	return 0;
+}

--- a/examples/rpi/blinky/project.xml
+++ b/examples/rpi/blinky/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:raspberrypi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/rpi/blinky</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/raspberrypi/board.hpp
+++ b/src/modm/board/raspberrypi/board.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#include <wiringPi.h>
+
+using namespace modm::platform;
+
+namespace Board
+{
+
+struct SystemClock {};
+
+inline void
+initialize()
+{
+  wiringPiSetup();
+}
+
+} // Board namespace

--- a/src/modm/board/raspberrypi/board.xml
+++ b/src/modm/board/raspberrypi/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">hosted-rpi</option>
+  </options>
+  <modules>
+    <module>modm:board:raspberrypi</module>
+  </modules>
+</library>

--- a/src/modm/board/raspberrypi/module.lb
+++ b/src/modm/board/raspberrypi/module.lb
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Erik Henriksson
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:raspberrypi"
+    module.description = """\
+# Raspberry Pi
+"""
+
+def prepare(module, options):
+    if options[":target"].partname != "hosted-rpi":
+       return False
+
+    module.depends(":platform:core", ":platform:gpio", ":debug")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.copy('.')
+

--- a/src/modm/platform/core/hosted/delay_impl.hpp.in
+++ b/src/modm/platform/core/hosted/delay_impl.hpp.in
@@ -22,7 +22,7 @@
 
 #define MODM_DELAY_NS_IS_ACCURATE 0
 
-%% if target.family in ["darwin", "linux"]
+%% if target.family in ["darwin", "linux", "rpi"]
 extern "C" {
 #include <unistd.h>
 }

--- a/src/modm/platform/gpio/rpi/base.hpp
+++ b/src/modm/platform/gpio/rpi/base.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/interface/gpio.hpp>
+
+namespace modm
+{
+
+namespace platform
+{
+
+/// @ingroup modm_platform_gpio
+enum class
+Peripheral
+{
+	BitBang,
+	// ...
+};
+
+/// @ingroup	modm_platform_gpio
+struct Gpio
+{
+	/// Each Input Pin can be configured in one of these states.
+	enum class
+	InputType : uint8_t
+	{
+		Floating,	///< The input pin is left floating
+	};
+
+	enum class
+	OutputType : uint8_t
+	{
+		PushPull	///< push-pull on output
+	};
+
+	/// Available ports on this device.
+	enum class
+	Port
+	{
+        // ...
+	};
+
+	enum class
+	Signal
+	{
+		BitBang,
+        // ...
+	};
+
+	/// @endcond
+};
+
+/// @}
+
+}	// namespace platform
+
+}	// namespace modm
+
+#endif

--- a/src/modm/platform/gpio/rpi/module.lb
+++ b/src/modm/platform/gpio/rpi/module.lb
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Erik Henriksson
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":platform:gpio"
+    module.description = "Hosted GPIO for Raspberry Pi"
+
+
+def prepare(module, options):
+    if not options[":target"].has_driver("gpio:rpi"):
+        return False
+
+    module.depends(":architecture:gpio")
+    return True
+
+
+def build(env):
+    env.substitutions = {"target": env[":target"].identifier}
+    env.outbasepath = "modm/src/modm/platform/gpio"
+
+    env.collect(":build:library", "wiringPi")
+
+    env.copy(".")
+    env.copy("../common/inverted.hpp", "inverted.hpp")
+    env.copy("../common/connector.hpp", "connector.hpp")
+    env.template("../common/connector_detail.hpp.in", "connector_detail.hpp")

--- a/src/modm/platform/gpio/rpi/pin.hpp
+++ b/src/modm/platform/gpio/rpi/pin.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2018, Fabian Greif
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/interface/gpio.hpp>
+#include <wiringPi.h>
+
+#include "base.hpp"
+
+
+namespace modm
+{
+
+namespace platform
+{
+
+template< int Pin >
+class GpioPin : public Gpio, public modm::GpioIO
+{
+	static Gpio::InputType inputType;
+public:
+	using Output = GpioPin<Pin>;
+	using Input = GpioPin<Pin>;
+	using IO = GpioPin<Pin>;
+	using Type = GpioPin<Pin>;
+
+public:
+	inline static void configure(Gpio::InputType type) {}
+	modm_always_inline static void setInput() {
+    pinMode(Pin, INPUT);
+  }
+	inline static void setInput(Gpio::InputType type) {
+    setInput();
+  }
+	modm_always_inline static void setOutput() {
+    pinMode(Pin, OUTPUT);
+  }
+	modm_always_inline static void setOutput(OutputType) {
+    setOutput();
+  }
+	modm_always_inline static void setOutput(bool status) {
+    setOutput();
+		set(status);
+	}
+	inline static void set() {
+    digitalWrite(Pin, HIGH);
+	}
+	modm_always_inline static void reset() {
+    digitalWrite(Pin, LOW);
+	}
+	inline static void set(bool status) {
+    digitalWrite(Pin, status);
+	}
+	inline static bool isSet() {
+    return digitalRead(Pin);
+	}
+  inline static void toggle() {
+		if (isSet()) { set(); }
+		else { reset(); }
+  }
+	modm_always_inline static modm::Gpio::Direction getDirection() {
+		return modm::Gpio::Direction::Out;
+	}
+};
+
+/// @}
+
+}	// namespace platform
+
+}	// namespace modm
+

--- a/src/modm/platform/gpio/rpi/unused.hpp
+++ b/src/modm/platform/gpio/rpi/unused.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2018, Fabian Greif
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_HOSTED_GPIO_PIN_UNUSED_HPP
+#define MODM_HOSTED_GPIO_PIN_UNUSED_HPP
+
+#include "base.hpp"
+#include <modm/architecture/interface/gpio.hpp>
+
+namespace modm
+{
+
+namespace platform
+{
+
+/**
+ * Dummy implementation of an I/O pin.
+ *
+ * This class can be used when a pin is not required. All functions
+ * are dummy functions which do nothing. `read()` will always
+ * return `false`.
+ *
+ * For example when creating a software SPI with the modm::SoftwareSimpleSpi
+ * class and the return channel (MISO - Master In Slave Out) is not needed,
+ * a good way is to use this class as a parameter when defining the
+ * SPI class.
+ *
+ * Example:
+ * @code
+ * #include <modm/architecture/platform.hpp>
+ *
+ * namespace pin
+ * {
+ *     typedef GpioOutputD7 Clk;
+ *     typedef GpioOutputD5 Mosi;
+ * }
+ *
+ * modm::SoftwareSpiMaster< pin::Clk, pin::Mosi, GpioUnused > Spi;
+ *
+ * ...
+ * Spi::write(0xaa);
+ * @endcode
+ *
+ * @author	Fabian Greif
+ * @author	Niklas Hauser
+ * @ingroup	modm_platform_gpio
+ */
+class GpioUnused : public Gpio, public ::modm::GpioIO
+{
+public:
+	using Output = GpioUnused;
+	using Input = GpioUnused;
+	using IO = GpioUnused;
+	using Type = GpioUnused;
+
+public:
+	// GpioOutput
+	// start documentation inherited
+	static void setOutput() {}
+	static void setOutput(bool) {}
+	static void set() {}
+	static void set(bool) {}
+	static void reset() {}
+	static void toggle() {}
+	static bool isSet() { return false; }
+	// stop documentation inherited
+
+	// GpioInput
+	// start documentation inherited
+	static void setInput() {}
+	static bool read() { return false; }
+	// end documentation inherited
+
+	// GpioIO
+	// start documentation inherited
+	static Direction getDirection() { return Direction::Special; }
+	// end documentation inherited
+};
+
+} // namespace platform
+
+} // namespace modm
+
+#endif

--- a/tools/devices/hosted/rpi.xml
+++ b/tools/devices/hosted/rpi.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE rca SYSTEM "../devicefile.dtd">
+<modm version="1.0">
+  <device platform="hosted" family="rpi">
+    <naming-schema>{platform}-{family}</naming-schema>
+
+    <driver name="core" type="rpi"/>
+    <driver name="gpio" type="rpi"/>
+    <driver name="uart" type="hosted"/>
+  </device>
+</modm>


### PR DESCRIPTION
The purpose of this is to simplify driver development, using bitbang SPI&I2C on the RPi.

It is essentially just a wrapper around WiringPi.