### PR TITLE
Add basic IS31FL3733 matrix driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,46 +206,47 @@ can easily configure them for you specific needs.
 </tr><tr>
 <td align="center">HX711</td>
 <td align="center">I2C-EEPROM</td>
+<td align="center">IS31FL3733</td>
 <td align="center">ITG3200</td>
 <td align="center">L3GD20</td>
 <td align="center">LAWICEL</td>
-<td align="center">LIS302DL</td>
 </tr><tr>
+<td align="center">LIS302DL</td>
 <td align="center">LIS3DSH</td>
 <td align="center">LIS3MDL</td>
 <td align="center">LM75</td>
 <td align="center">LP503X</td>
 <td align="center">LSM303A</td>
-<td align="center">LSM6DS33</td>
 </tr><tr>
+<td align="center">LSM6DS33</td>
 <td align="center">LTC2984</td>
 <td align="center">MAX6966</td>
 <td align="center">MAX7219</td>
 <td align="center">MCP23X17</td>
 <td align="center">MCP2515</td>
-<td align="center">NOKIA5110</td>
 </tr><tr>
+<td align="center">NOKIA5110</td>
 <td align="center">NRF24</td>
 <td align="center">TFT-DISPLAY</td>
 <td align="center">PAT9125EL</td>
 <td align="center">PCA8574</td>
 <td align="center">PCA9535</td>
-<td align="center">PCA9548A</td>
 </tr><tr>
+<td align="center">PCA9548A</td>
 <td align="center">PCA9685</td>
 <td align="center">SIEMENS-S65</td>
 <td align="center">SIEMENS-S75</td>
 <td align="center">SK6812</td>
 <td align="center">SK9822</td>
-<td align="center">SSD1306</td>
 </tr><tr>
+<td align="center">SSD1306</td>
 <td align="center">SX1276</td>
 <td align="center">TCS3414</td>
 <td align="center">TCS3472</td>
 <td align="center">TLC594X</td>
 <td align="center">TMP102</td>
-<td align="center">TMP175</td>
 </tr><tr>
+<td align="center">TMP175</td>
 <td align="center">VL53L0</td>
 <td align="center">VL6180</td>
 <td align="center">WS2812</td>

--- a/examples/nucleo_g071rb/matrix/main.cpp
+++ b/examples/nucleo_g071rb/matrix/main.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+#include <modm/driver/display/is31fl3733.hpp>
+
+using namespace Board;
+
+using PinReset = GpioC8;
+using PinSda = GpioA11;
+using PinScl = GpioA12;
+
+using I2cInstance = BitBangI2cMaster<PinScl, PinSda>;
+static modm::Is31fl3733<I2cInstance> driver(modm::is31fl3733::addr());
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput(modm::Gpio::Low);
+
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	// Reset the I2C interface of the chip
+	PinReset::setOutput(modm::Gpio::High);
+	modm::delay(20ms);
+	PinReset::setOutput(modm::Gpio::Low);
+
+	I2cInstance::initialize<SystemClock, 400_kHz>();
+	I2cInstance::connect<PinScl::BitBang, PinSda::BitBang>();
+
+	RF_CALL_BLOCKING(driver.reset());
+	RF_CALL_BLOCKING(driver.clearSoftwareShutdown());
+	RF_CALL_BLOCKING(driver.setGlobalCurrent(1));
+
+	driver.enableAll();
+	RF_CALL_BLOCKING(driver.writeOnOff());
+
+	uint8_t pwm{0};
+	while (true)
+	{
+		for (uint8_t y=0, pi=pwm; y<16; y++) {
+			for (uint8_t x=0; x<12; x++) {
+				driver.setPwm(x, y, pi++);
+			}
+		}
+		RF_CALL_BLOCKING(driver.writePwm());
+		modm::delay(10ms);
+		pwm++;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g071rb/matrix/project.xml
+++ b/examples/nucleo_g071rb/matrix/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-g071rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g071rb/matrix</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c.bitbang</module>
+    <module>modm:driver:is31fl3733</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/driver/display/is31fl3733.hpp
+++ b/src/modm/driver/display/is31fl3733.hpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/processing/resumable.hpp>
+#include <cstring>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_is31fl3733
+struct is31fl3733
+{
+	enum class
+	Addr : uint8_t
+	{
+		GND = 0b00,
+		SCL = 0b01,
+		SDA = 0b10,
+		VCC = 0b11
+	};
+
+	/// Available I2C addresses
+	static constexpr uint8_t
+	addr(Addr addr2 = Addr::GND, Addr addr1 = Addr::GND)
+	{
+		return 0b1010000 | (uint8_t(addr2) << 2) | uint8_t(addr1);
+	};
+
+	enum class
+	Register : uint16_t
+	{
+		// Page 0
+		LED_ON_OFF = 0x8000,
+		LED_OPEN = 0x8018,
+		LED_SHORT = 0x8030,
+
+		// Page 1
+		PWM = 0x8100,
+
+		// Page 2
+		AUTO_BREATH_MODE = 0x8200,
+
+		// Page 3
+		CONFIGURATION = 0x8300,
+		GLOBAL_CURRENT_CONTROL = 0x8301,
+		ABM_1 = 0x8302,
+		ABM_2 = 0x8306,
+		ABM_3 = 0x830A,
+		TIME_UPDATE = 0x830E,
+		SW_PULL_UP = 0x830F,
+		CS_PULL_DOWN = 0x8310,
+		RESET = 0x8311,
+
+		// Global
+		COMMAND = 0xFD,
+		COMMAND_WRITE_LOCK = 0xFE,
+		INTERRUPT_MASK = 0xF0,
+		INTERRUPT_STATUS =  0xF1
+	};
+
+protected:
+	static constexpr uint8_t LED_ON_OFF_size = 0x18;
+	static constexpr uint8_t LED_OPEN_size = LED_ON_OFF_size;
+	static constexpr uint8_t LED_SHORT_size = LED_ON_OFF_size;
+	static constexpr uint8_t PWM_size = 0xC0;
+	static constexpr uint8_t AUTO_BREATH_MODE_size = PWM_size;
+
+	static constexpr bool
+	hasPage(Register reg)
+	{ return uint16_t(reg) & 0x8000; }
+
+	static constexpr uint8_t
+	getPage(Register reg)
+	{ return ((uint16_t(reg) >> 8) & 0x0f); }
+};
+
+/**
+ * @ingroup modm_driver_is31fl3733
+ * @author  Niklas Hauser
+ */
+template < class I2cMaster >
+class Is31fl3733 : public is31fl3733, public modm::I2cDevice<I2cMaster, 4>
+{
+public:
+	Is31fl3733(uint8_t address=addr()):
+		I2cDevice<I2cMaster,4>(address)
+	{}
+
+	bool
+	enable(uint8_t x, uint8_t y)
+	{
+		if (x < 12 and y < 16)
+		{
+			data.led_on_off[x] |= (1u << y);
+			return true;
+		}
+		return false;
+	}
+	void enableAll()
+	{ std::memset(data.led_on_off, 0xff, sizeof(data.led_on_off)); }
+
+	bool
+	disable(uint8_t x, uint8_t y)
+	{
+		if (x < 12 and y < 16)
+		{
+			data.led_on_off[x] &= ~(1u << y);
+			return true;
+		}
+		return false;
+	}
+	void disableAll()
+	{ std::memset(data.led_on_off, 0, sizeof(data.led_on_off)); }
+
+	bool
+	setPwm(uint8_t x, uint8_t y, uint8_t pwm)
+	{
+		if (x < 12 and y < 16)
+		{
+			data.led_pwm[x][y] = pwm;
+			return true;
+		}
+		return false;
+	}
+	void setAllPwm(uint8_t pwm)
+	{ std::memset(data.led_pwm, pwm, sizeof(data.led_pwm)); }
+
+public:
+	modm::ResumableResult<bool>
+	reset()
+	{ return readRegister(Register::RESET, buffer); }
+
+	modm::ResumableResult<bool>
+	setGlobalCurrent(uint8_t current)
+	{ return writeRegister(Register::GLOBAL_CURRENT_CONTROL, current); }
+
+	modm::ResumableResult<bool>
+	clearSoftwareShutdown()
+	{ return writeRegister(Register::CONFIGURATION, 0x01); }
+
+	modm::ResumableResult<bool>
+	writeOnOff()
+	{
+		RF_BEGIN();
+		if (not RF_CALL(setPage(Register::LED_ON_OFF))) RF_RETURN(false);
+
+		this->transaction.configureWrite(&data.addr_led_on_off, LED_ON_OFF_size+1);
+		RF_END_RETURN_CALL(this->runTransaction());
+	}
+
+	modm::ResumableResult<bool>
+	writePwm()
+	{
+		RF_BEGIN();
+		if (not RF_CALL(setPage(Register::PWM))) RF_RETURN(false);
+
+		this->transaction.configureWrite(&data.addr_led_pwm, PWM_size+1);
+		RF_END_RETURN_CALL(this->runTransaction());
+	}
+
+public:
+	modm::ResumableResult<bool>
+	writeRegister(Register reg, uint8_t value, uint8_t offset=0)
+	{
+		RF_BEGIN();
+		if (not RF_CALL(setPage(reg))) RF_RETURN(false);
+
+		buffer[0] = uint8_t(reg) + offset;
+		buffer[1] = value;
+
+		this->transaction.configureWrite(buffer, 2);
+		RF_END_RETURN_CALL(this->runTransaction());
+	}
+
+	modm::ResumableResult<bool>
+	readRegister(Register reg, uint8_t *const value, uint8_t offset=0)
+	{
+		RF_BEGIN();
+		if (not RF_CALL( setPage(reg) )) RF_RETURN(false);
+
+		buffer[0] = uint8_t(reg) + offset;
+		this->transaction.configureWriteRead(buffer, 1, value, 1);
+
+		RF_END_RETURN_CALL(this->runTransaction());
+	}
+
+protected:
+	modm::ResumableResult<bool>
+	setPage(Register reg)
+	{
+		RF_BEGIN();
+
+		if (hasPage(reg) and (getPage(reg) != current_page))
+		{
+			buffer[0] = uint8_t(Register::COMMAND_WRITE_LOCK);
+			buffer[1] = 0xC5; // command write key
+			this->transaction.configureWrite(buffer, 2);
+			if (not RF_CALL(this->runTransaction())) RF_RETURN(false);
+
+			buffer[0] = uint8_t(Register::COMMAND);
+			buffer[1] = getPage(reg);
+			if (not RF_CALL(this->runTransaction())) RF_RETURN(false);
+			current_page = getPage(reg);
+		}
+
+		RF_END_RETURN(true);
+	}
+
+private:
+	struct LedData
+	{
+        const uint8_t addr_led_on_off{uint8_t(Register::LED_ON_OFF)};
+		uint16_t led_on_off[12];
+
+        const uint8_t addr_led_pwm{uint8_t(Register::PWM)};
+		uint8_t led_pwm[12][16];
+	} modm_packed;
+
+	LedData data;
+	uint8_t current_page{0xff};
+	uint8_t buffer[2];
+};
+
+} // namespace modm

--- a/src/modm/driver/display/is31fl3733.lb
+++ b/src/modm/driver/display/is31fl3733.lb
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:is31fl3733"
+    module.description = "IS31FL3733 Matrix Driver"
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:i2c.device",
+        ":architecture:register")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/display"
+    env.copy("is31fl3733.hpp")


### PR DESCRIPTION
This adds a basic I2C driver for the IS31FL3733 matrix driver with 12x16 LEDs.