### PR TITLE
Stm32 tim gp en out

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -213,7 +213,7 @@ public:
 	}
 
 
-%% if target.family not in ["l1"] and id not in [14]
+%% if target.family not in ["l1"]
 	static inline void
 	enableOutput()
 	{


### PR DESCRIPTION
Hi !
Proposing a fix for the PR: #405 , where it looks like, that the TIM14 actually has a BDTR reg.
Providing the fix where the template doesn't filter out the tim14