### PR TITLE
Fix FreeRTOS stack overflow hook

### DIFF
--- a/ext/aws/modm_port.cpp
+++ b/ext/aws/modm_port.cpp
@@ -4,9 +4,9 @@
 #include <freertos/task.h>
 #include <modm/architecture/interface/assert.hpp>
 
-extern "C" void vApplicationStackOverflowHook(TaskHandle_t, const char *);
+extern "C" void vApplicationStackOverflowHook(TaskHandle_t, char *);
 
-void vApplicationStackOverflowHook(TaskHandle_t /*pxTask*/, const char *pcTaskName)
+void vApplicationStackOverflowHook(TaskHandle_t /*pxTask*/, char *pcTaskName)
 {
 	modm_assert(false, "freertos.stack", "FreeRTOS detected a stack overflow!", pcTaskName);
 }


### PR DESCRIPTION
Latest version of FreeRTOS in modm declares the stack overflow hook function now in task.h, so fix the conflicting declaration and function.