### PR TITLE
[docs] Installation improvements

### DIFF
--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -8,7 +8,7 @@ with modm:
 - [Library Builder][lbuild]
 - AVR toolchain: [avr-gcc][] and [avrdude][]
 - ARM toolchain: [gcc-arm-toolchain][] and [OpenOCD][] (HEAD version!).
-- Optional: [Doxygen][] or [Doxypress][]
+- Optional: [Doxypress][] (preferred) or [Doxygen][]
 - Optional: [gdbgui][] for IDE-independent debugging
 
 Note that the modm examples use the SCons build system by default, however,
@@ -34,17 +34,62 @@ Please help us [keep these instructions up-to-date][contribute]!
 
 For Ubuntu 20.04LTS, these commands install the basic build system:
 
-	sudo apt-get install python3 python3-pip scons git gcc-arm-none-eabi openocd \
-	  gcc build-essential libboost-all-dev
+	sudo apt install python3 python3-pip scons cmake git doxygen
 	pip3 install modm gdbgui
+
+!!! info "Python Packages in PATH"
+	The pip3 command installs executables into `~/.local/bin`, which
+	must be added to PATH if it is not already the case.
+	Add the following line to the end of your `~/.bashrc` file:
+
+		export PATH="~/.local/bin:$PATH"
+
+For host system (x86_64/arm64) targets:
+
+	sudo apt install gcc build-essential libboost-all-dev
+
+For ARM Cortex-M targets:
+
+	sudo apt install openocd
+
+!!! warning "Ubuntus 'gcc-arm-none-eabi' package"
+	The Ubuntu package 'gcc-arm-none-eabi' causes [issues at the moment](https://github.com/modm-io/modm/issues/468).
+	We recommend using the toolchain provided by ARM:
+
+		wget -O- https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 | sudo tar xj -C /opt/
+	
+	Add it to your systems PATH variable by appending the following line to `~/.bashrc`:
+
+		export PATH="/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"
+
+For Atmel/Microchip AVR targets:
+
+	wget -O- https://github.com/modm-ext/docker-avr-gcc/releases/download/v10.2.0/avr-gcc.tar.bz2 | sudo tar xj -C /opt
+
+Add it to your systems PATH variable by appending the following line to `~/.bashrc`:
+
+	export PATH="/opt/avr-gcc/avr-gcc/bin:/opt/avr-gcc/avr-binutils/bin:$PATH"
+
+We recommend Doxypress to generate the documentation:
+Download the [binary][doxypress_binaries] for your distribution and unzip it:
+
+	sudo mkdir /opt/doxypress
+	wget -O- https://download.copperspice.com/doxypress/binary/doxypress-1.4.0-ubuntu20.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
+
+... and add the directory to your `PATH` variable by appending the following line
+to `~/.bashrc`:
+
+	export PATH="/opt/doxypress:$PATH"
 
 !!! warning "OpenOCD for recent targets"
 	The latest OpenOCD release v0.10.0 (as of May 2020) is too old for some targets
 	(STM32G0, STM32G4, STM32F7). To program these targets you need to compile the
 	[HEAD version of OpenOCD from source][openocd-source], install it and add it to
 	the beginning of your `$PATH`.
+	[Here](https://rleh.de/2019/10/08/openocd-stm32-stm32g4-stm32g0.html) is a guide
+	on how to do it.
 
-!!! warning "Python 3 on Ubuntu ≤ 19.10"
+!!! warning "Ubuntu ≤ 19.10"
 	Ubuntu ≤ 19.10 unfortunately defaults to Python 2, however, our SCons tools
 	require Python 3. For a less intrusive way to run all scons scripts with
 	Python 3 add this to your `.bashrc` or `.zshrc`:
@@ -53,17 +98,6 @@ For Ubuntu 20.04LTS, these commands install the basic build system:
 
 	If you get errors about missing `pyelftools`, check that you're really
 	running SCons with Python 3!
-
-!!! warning "arm-none-eabi-gcc on Ubuntu ≤ 19.10"
-	Ubuntu ≤ 19.10 does not provide a recent arm-none-eabi-gcc toolchain.
-	Install the ARM toochain by downloading [the pre-built version][gcc-arm-toolchain]
-	for 64-bit Linux and adding its `/bin` directory to the beginning of your `$PATH`.
-
-!!! bug "avr-gcc on Ubuntu"
-	Ubuntu does not provide an up-to-date version of avr-gcc that supports C++17.
-	For our CI we've created a [precompiled version of avr-gcc for Ubuntu][avr-gcc-latest].
-	Unfortunately its path is hardcoded to `/work/avr-gcc`,
-	[please help us fix it](https://github.com/modm-ext/docker-avr-gcc/issues/1).
 
 
 ## macOS
@@ -89,22 +123,19 @@ To program Microchip SAM devices via the bootloader, install the `bossac` tool:
 
 	brew cask install bossa
 
-We recommend the use of a graphical frontend for GDB called [gdbgui][]:
+We recommend using a graphical frontend for GDB called [gdbgui][]:
 
 	pip3 install gdbgui
 
-SCons now works with Python 3. Unfortunately, macOS still defaults to Python 2.
-For a less intrusive way to run all scons scripts with Python 3 add this to your
-`.bashrc` or `.zshrc`:
-
-	alias scons="/usr/bin/env python3 $(which scons)"
-	# or if your using scons elsewhere too:
-	alias scons3="/usr/bin/env python3 $(which scons)"
-
-To compile modm *for macOS* (and not the embedded target) you need to install
-some of these libraries as well, depending on what modm modules you use:
+To compile modm *for x86_64 macOS* you need to install these tools too:
 
 	brew install boost gcc
+
+We recommend using Doxypress to generate the API documentation:
+
+	brew tap modm-ext/modm
+	brew install doxypress
+
 
 ## Windows
 
@@ -115,19 +146,22 @@ packages:
     conda create --name modm python=3 pip
     activate modm
     conda install -c conda-forge git
-    pip install jinja2 scons future pyelftools lbuild gdbgui
+    pip install modm scons future gdbgui
 
 For ARM development install the Windows 32-bit build of the [GNU Arm Embedded
 Toolchain][gcc-arm-toolchain]. For programming and debugging ARM Cortex-M
 devices install the pre-build [OpenOCD binaries][openocd_binaries].
-You'll need to add both `/bin` paths to your `PATH` variable manually.
+You need to add both `/bin` paths to your `PATH` variable manually.
+
+We recommend using Doxypress to generate the documentation:
+Download the [Installer (*.exe)][doxypress_binaries] and run it.
 
 !!! warning "For non-English speakers"
 	For now project and build paths containing non-ASCII characters are not
 	parsed correctly.
 
 !!! warning "Windows paths"
-	Windows created maximal incompatibility with it's `\` path separator.
+	Windows created maximal incompatibility with its `\` path separator.
 	Even though we try hard to not hardcode the path separator, there may still
 	be issues related to this. [Please open an issue][newissue] in that case.
 
@@ -154,4 +188,5 @@ You'll need to add both `/bin` paths to your `PATH` variable manually.
 [openocd_binaries]: https://gnutoolchains.com/arm-eabi/openocd
 [doxygen]: http://www.doxygen.nl
 [doxypress]: https://www.copperspice.com/documentation-doxypress.html
+[doxypress_binaries]: https://download.copperspice.com/doxypress/binary/
 [gdbgui]: https://www.gdbgui.com


### PR DESCRIPTION
- [x] Doxypress installation
- [x] Ubuntu: Split installation into three apt commands (because copying the escaped newline does not work sometimes)
- [x] Pip3 install path is not included in `$PATH` on Ubuntu 20.04?!
  - According to this warning in _Github Actions_ Ubuntu 20.04 VM: `WARNING: The script lbuild is installed in '/home/runner/.local/bin' which is not on PATH.` Can someone confirm?
- [x] Test Windows installation