### PR TITLE
[rpi] Remove stray #endif

### DIFF
--- a/src/modm/platform/gpio/rpi/base.hpp
+++ b/src/modm/platform/gpio/rpi/base.hpp
@@ -65,5 +65,3 @@ struct Gpio
 }	// namespace platform
 
 }	// namespace modm
-
-#endif


### PR DESCRIPTION
When cross-compiling with (my own, upgraded build of) [dockcross](https://github.com/dockcross/dockcross), I get the following error:

```
[sascha:/work/modm/examples/rpi/blinky] develop* 130 ± scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
Compiling C++·· /work/modm/build/rpi/blinky/release/main.o
In file included from modm/src/modm/platform.hpp:15,
                 from modm/src/modm/board/board.hpp:15,
                 from modm/src/modm/board.hpp:12,
                 from main.cpp:12:
modm/src/modm/platform/gpio/base.hpp:69:2: error: #endif without #if
 #endif
  ^~~~~
```

I'll rebase once my other PR is accepted.
