### PR TITLE
[freertos] Make malloc/free thread-safe

### DIFF
--- a/ext/aws/modm_port.cpp
+++ b/ext/aws/modm_port.cpp
@@ -1,12 +1,66 @@
-
+/*
+ * Copyright (c) 2019-2020 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <modm/architecture/interface/assert.hpp>
+#include <cstdlib>
 
 extern "C" void vApplicationStackOverflowHook(TaskHandle_t, char *);
-
 void vApplicationStackOverflowHook(TaskHandle_t /*pxTask*/, char *pcTaskName)
 {
 	modm_assert(false, "freertos.stack", "FreeRTOS detected a stack overflow!", pcTaskName);
+}
+
+// ----------------------------------------------------------------------------
+// Make the Newlib heap thread-safe with FreeRTOS
+
+extern "C" void __malloc_lock(struct _reent *);
+void __malloc_lock(struct _reent *)
+{
+	vTaskSuspendAll();
+}
+
+extern "C" void __malloc_unlock(struct _reent *);
+void __malloc_unlock(struct _reent *)
+{
+	xTaskResumeAll();
+}
+
+// ----------------------------------------------------------------------------
+// Make the FreeRTOS heap use Newlib heap
+
+extern "C" void *pvPortMalloc(size_t xWantedSize);
+void *pvPortMalloc(size_t xWantedSize)
+{
+	void *pvReturn = malloc(xWantedSize);
+	traceMALLOC(pvReturn, xWantedSize);
+
+#if configUSE_MALLOC_FAILED_HOOK == 1
+	if(pvReturn == nullptr)
+	{
+		extern "C" void vApplicationMallocFailedHook(void);
+		vApplicationMallocFailedHook();
+	}
+#endif
+
+	return pvReturn;
+}
+
+extern "C" void vPortFree(void *pv);
+void vPortFree(void *pv)
+{
+	if(pv)
+	{
+		free(pv);
+		traceFREE(pv, 0);
+	}
 }

--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -100,8 +100,6 @@ def build(env):
     env.copy("{}/port.c".format(path), "freertos/port.c")
     # Copy the portmacro.h file
     env.copy("{}/portmacro.h".format(path), "freertos/inc/freertos/portmacro.h")
-    # Copy the head_3.c file that just wraps the libc malloc
-    env.copy("freertos/FreeRTOS/Source/portable/MemMang/heap_3.c", "freertos/heap_3.c")
 
     # Generate the FreeRTOSConfig.h file
     env.template("FreeRTOSConfig.h.in", "freertos/inc/freertos/FreeRTOSConfig.h")


### PR DESCRIPTION
Partial fix for #447 making all calls to malloc thread-safe, not just the ones from within FreeRTOS.

TODO:
- [ ] Make example to test this thread-safety

cc @mikewolfram 