### PR TITLE
[freertos-plus-tcp] Add includes

### DIFF
--- a/examples/nucleo_f429zi/freertos_plus_tcp/main.cpp
+++ b/examples/nucleo_f429zi/freertos_plus_tcp/main.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014, Georgi Grinshpun
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2015-2017, 2019 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing/rtos.hpp>
+
+using namespace modm::platform;
+
+/**
+ * This example uses four threads to check if task switching works correctly.
+ *
+ * It also check if the FreeRTOS TCP stack can be compiled.
+ * No TCP functionality in this example (yet).
+ *
+ * What to expect?
+ * ---------------
+ * - All our LEDs blinking at different rates, about 3 to 4 Hz
+ * - A string at 115200 baud
+ *
+ *  0aA!1bB"2cC#3dD$4eE%5fF&6gG'7hH(8iI9)jJ0*aA1!bB2"cC
+ *
+ * Each thread prints out a sequence
+ *    0123456789
+ *    abcdefghij
+ *    ABCDEFGHIJ
+ *    !"#$%&'()*
+ * respectivly.
+ */
+
+// ----------------------------------------------------------------------------
+template <typename Gpio, int SleepTime>
+class P: modm::rtos::Thread
+{
+	char c;
+	uint8_t i = 0;
+	volatile float a = 10.f;
+public:
+	P(char c): Thread(2,1<<10), c(c) {}
+
+	void run()
+	{
+		Gpio::setOutput();
+		while (true)
+		{
+			sleep(SleepTime * MILLISECONDS);
+
+			Gpio::toggle();
+			{
+				static modm::rtos::Mutex lm;
+				modm::rtos::MutexGuard m(lm);
+				MODM_LOG_INFO << char(i + c);
+			}
+			i = (i+1)%10;
+			a *= 3.141f;
+		}
+	}
+};
+
+P< Board::LedRed,   260      > p1('0');
+P< Board::LedGreen, 260 + 10 > p2('a');
+P< Board::LedBlue,  260 + 20 > p3('A');
+
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	modm::rtos::Scheduler::schedule();
+	return 0;
+}

--- a/examples/nucleo_f429zi/freertos_plus_tcp/project.xml
+++ b/examples/nucleo_f429zi/freertos_plus_tcp/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f429zi/freertos_plus_tcp</option>
+  </options>
+  <modules>
+    <module>modm:processing:rtos</module>
+    <module>modm:freertos:tcp</module>
+    <module>modm:platform:heap</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/aws/modm_port.cpp
+++ b/ext/aws/modm_port.cpp
@@ -1,12 +1,66 @@
-
+/*
+ * Copyright (c) 2019-2020 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <modm/architecture/interface/assert.hpp>
+#include <cstdlib>
 
 extern "C" void vApplicationStackOverflowHook(TaskHandle_t, char *);
-
 void vApplicationStackOverflowHook(TaskHandle_t /*pxTask*/, char *pcTaskName)
 {
 	modm_assert(false, "freertos.stack", "FreeRTOS detected a stack overflow!", pcTaskName);
+}
+
+// ----------------------------------------------------------------------------
+// Make the Newlib heap thread-safe with FreeRTOS
+
+extern "C" void __malloc_lock(struct _reent *);
+void __malloc_lock(struct _reent *)
+{
+	vTaskSuspendAll();
+}
+
+extern "C" void __malloc_unlock(struct _reent *);
+void __malloc_unlock(struct _reent *)
+{
+	xTaskResumeAll();
+}
+
+// ----------------------------------------------------------------------------
+// Make the FreeRTOS heap use Newlib heap
+
+extern "C" void *pvPortMalloc(size_t xWantedSize);
+void *pvPortMalloc(size_t xWantedSize)
+{
+	void *pvReturn = malloc(xWantedSize);
+	traceMALLOC(pvReturn, xWantedSize);
+
+#if configUSE_MALLOC_FAILED_HOOK == 1
+	if(pvReturn == nullptr)
+	{
+		extern "C" void vApplicationMallocFailedHook(void);
+		vApplicationMallocFailedHook();
+	}
+#endif
+
+	return pvReturn;
+}
+
+extern "C" void vPortFree(void *pv);
+void vPortFree(void *pv)
+{
+	if(pv)
+	{
+		free(pv);
+		traceFREE(pv, 0);
+	}
 }

--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -34,7 +34,11 @@ the config macros, then redefine them with your options, for example:
     def build(self, env):
         env.outbasepath = "modm/ext"
         env.copy("freertos/FreeRTOS-Plus-TCP", "freertos_plus_tcp",
-            ignore=env.ignore_files("BufferAllocation_1.c"))
+            ignore=env.ignore_files("BufferAllocation_1.c", "portable"))
+        # Copy the compiler support files
+        env.copy("freertos/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_start.h", "freertos_plus_tcp/include/pack_struct_start.h")
+        env.copy("freertos/FreeRTOS-Plus-TCP/portable/Compiler/GCC/pack_struct_end.h", "freertos_plus_tcp/include/pack_struct_end.h")
+
         env.collect(":build:path.include", "modm/ext/freertos_plus_tcp/include")
         env.template("FreeRTOSIPConfig.h.in", "freertos_plus_tcp/include/FreeRTOSIPConfig.h")
 # -----------------------------------------------------------------------------

--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -104,8 +104,6 @@ def build(env):
     env.copy("{}/port.c".format(path), "freertos/port.c")
     # Copy the portmacro.h file
     env.copy("{}/portmacro.h".format(path), "freertos/inc/freertos/portmacro.h")
-    # Copy the head_3.c file that just wraps the libc malloc
-    env.copy("freertos/FreeRTOS/Source/portable/MemMang/heap_3.c", "freertos/heap_3.c")
 
     # Generate the FreeRTOSConfig.h file
     env.template("FreeRTOSConfig.h.in", "freertos/inc/freertos/FreeRTOSConfig.h")


### PR DESCRIPTION
There is no FreeRTOS plus TCP project yet in there so the code is not covered by the CI.
When adding `<module>modm:freertos:tcp</module>` the includes are missing

```
In file included from modm/ext/freertos_plus_tcp/FreeRTOS_DHCP.c:35:
modm/ext/freertos_plus_tcp/include/FreeRTOS_IP.h:138:10: fatal error: pack_struct_start.h: No such file or directory
  138 | #include "pack_struct_start.h"
```

What would be more elegant way to add the includes? Shall it depend on the compiler (GCC vs clang?) But only GCC is imported from the original source.

By the way, let's bump FreeRTOS module in modm to the current version.