### PR TITLE
[driver] ENC28J60 Ethernet MAC/PHY with SPI

### DIFF
--- a/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
@@ -124,6 +124,73 @@ enum class Register : uint8_t
 	EPAUSH		= 0x19 | BANK_3,
 };
 
+/* ENC28J60 EIE Register Bit Definitions */
+static constexpr uint8_t EIE_INTIE	= 0x80;
+static constexpr uint8_t EIE_PKTIE	= 0x40;
+static constexpr uint8_t EIE_DMAIE	= 0x20;
+static constexpr uint8_t EIE_LINKIE	= 0x10;
+static constexpr uint8_t EIE_TXIE	= 0x08;
+/* static constexpr uint8_t  EIE_WOLIE	0x04 (reserved) */
+static constexpr uint8_t EIE_TXERIE	= 0x02;
+static constexpr uint8_t EIE_RXERIE	= 0x01;
+
+/* ENC28J60 EIR Register Bit Definitions */
+static constexpr uint8_t EIR_PKTIF	= 0x40;
+static constexpr uint8_t EIR_DMAIF	= 0x20;
+static constexpr uint8_t EIR_LINKIF	= 0x10;
+static constexpr uint8_t EIR_TXIF	= 0x08;
+/* static constexpr uint8_t EIR_WOLIF	0x04 (reserved) */
+static constexpr uint8_t EIR_TXERIF	= 0x02;
+static constexpr uint8_t EIR_RXERIF	= 0x01;
+
+/* ENC28J60 ESTAT Register Bit Definitions */
+static constexpr uint8_t ESTAT_INT		= 0x80;
+static constexpr uint8_t ESTAT_LATECOL	= 0x10;
+static constexpr uint8_t ESTAT_RXBUSY	= 0x04;
+static constexpr uint8_t ESTAT_TXABRT	= 0x02;
+static constexpr uint8_t ESTAT_CLKRDY	= 0x01;
+
+/* ENC28J60 ECON2 Register Bit Definitions */
+static constexpr uint8_t ECON2_AUTOINC	= 0x80;
+static constexpr uint8_t ECON2_PKTDEC	= 0x40;
+static constexpr uint8_t ECON2_PWRSV	= 0x20;
+static constexpr uint8_t ECON2_VRPS		= 0x08;
+
+/* ENC28J60 ECON1 Register Bit Definitions */
+static constexpr uint8_t ECON1_TXRST	= 0x80;
+static constexpr uint8_t ECON1_RXRST	= 0x40;
+static constexpr uint8_t ECON1_DMAST	= 0x20;
+static constexpr uint8_t ECON1_CSUMEN	= 0x10;
+static constexpr uint8_t ECON1_TXRTS	= 0x08;
+static constexpr uint8_t ECON1_RXEN		= 0x04;
+static constexpr uint8_t ECON1_BSEL1	= 0x02;
+static constexpr uint8_t ECON1_BSEL0	= 0x01;
+
+/* ENC28J60 MACON1 Register Bit Definitions */
+static constexpr uint8_t MACON1_LOOPBK	= 0x10;
+static constexpr uint8_t MACON1_TXPAUS	= 0x08;
+static constexpr uint8_t MACON1_RXPAUS	= 0x04;
+static constexpr uint8_t MACON1_PASSALL	= 0x02;
+static constexpr uint8_t MACON1_MARXEN	= 0x01;
+
+/* ENC28J60 MACON2 Register Bit Definitions */
+static constexpr uint8_t MACON2_MARST	= 0x80;
+static constexpr uint8_t MACON2_RNDRST	= 0x40;
+static constexpr uint8_t MACON2_MARXRST	= 0x08;
+static constexpr uint8_t MACON2_RFUNRST	= 0x04;
+static constexpr uint8_t MACON2_MATXRST	= 0x02;
+static constexpr uint8_t MACON2_TFUNRST	= 0x01;
+
+/* ENC28J60 MACON3 Register Bit Definitions */
+static constexpr uint8_t MACON3_PADCFG2	= 0x80;
+static constexpr uint8_t MACON3_PADCFG1	= 0x40;
+static constexpr uint8_t MACON3_PADCFG0	= 0x20;
+static constexpr uint8_t MACON3_TXCRCEN	= 0x10;
+static constexpr uint8_t MACON3_PHDRLEN	= 0x08;
+static constexpr uint8_t MACON3_HFRMLEN	= 0x04;
+static constexpr uint8_t MACON3_FRMLNEN	= 0x02;
+static constexpr uint8_t MACON3_FULDPX	= 0x01;
+
 
 /* ENC28J60 MICMD Register Bit Definitions */
 static constexpr uint8_t MICMD_MIISCAN	= 0x02;
@@ -133,6 +200,54 @@ static constexpr uint8_t MICMD_MIIRD	= 0x01;
 static constexpr uint8_t MISTAT_NVALID	= 0x04;
 static constexpr uint8_t MISTAT_SCAN	= 0x02;
 static constexpr uint8_t MISTAT_BUSY	= 0x01;
+
+/* ENC28J60 ERXFCON Register Bit Definitions */
+static constexpr uint8_t ERXFCON_UCEN	= 0x80;
+static constexpr uint8_t ERXFCON_ANDOR	= 0x40;
+static constexpr uint8_t ERXFCON_CRCEN	= 0x20;
+static constexpr uint8_t ERXFCON_PMEN	= 0x10;
+static constexpr uint8_t ERXFCON_MPEN	= 0x08;
+static constexpr uint8_t ERXFCON_HTEN	= 0x04;
+static constexpr uint8_t ERXFCON_MCEN	= 0x02;
+static constexpr uint8_t ERXFCON_BCEN	= 0x01;
+
+/* ENC28J60 PHY PHCON1 Register Bit Definitions */
+static constexpr uint16_t PHCON1_PRST		= 0x8000;
+static constexpr uint16_t PHCON1_PLOOPBK	= 0x4000;
+static constexpr uint16_t PHCON1_PPWRSV		= 0x0800;
+static constexpr uint16_t PHCON1_PDPXMD		= 0x0100;
+
+/* ENC28J60 PHY PHSTAT1 Register Bit Definitions */
+static constexpr uint16_t PHSTAT1_PFDPX		= 0x1000;
+static constexpr uint16_t PHSTAT1_PHDPX		= 0x0800;
+static constexpr uint16_t PHSTAT1_LLSTAT	= 0x0004;
+static constexpr uint16_t PHSTAT1_JBSTAT	= 0x0002;
+
+/* ENC28J60 PHY PHSTAT2 Register Bit Definitions */
+static constexpr uint16_t PHSTAT2_TXSTAT	= (1 << 13);
+static constexpr uint16_t PHSTAT2_RXSTAT	= (1 << 12);
+static constexpr uint16_t PHSTAT2_COLSTAT	= (1 << 11);
+static constexpr uint16_t PHSTAT2_LSTAT		= (1 << 10);
+static constexpr uint16_t PHSTAT2_DPXSTAT	= (1 << 9);
+static constexpr uint16_t PHSTAT2_PLRITY	= (1 << 5);
+
+/* ENC28J60 PHY PHCON2 Register Bit Definitions */
+static constexpr uint16_t PHCON2_FRCLINK	= 0x4000;
+static constexpr uint16_t PHCON2_TXDIS	= 0x2000;
+static constexpr uint16_t PHCON2_JABBER	= 0x0400;
+static constexpr uint16_t PHCON2_HDLDIS	= 0x0100;
+
+/* ENC28J60 PHY PHIE Register Bit Definitions */
+static constexpr uint8_t PHIE_PLNKIE	= (1 << 4);
+static constexpr uint8_t PHIE_PGEIE		= (1 << 1);
+
+/* ENC28J60 PHY PHIR Register Bit Definitions */
+static constexpr uint8_t PHIR_PLNKIF	= (1 << 4);
+static constexpr uint8_t PHIR_PGEIF		= (1 << 1);
+
+/* Preferred half duplex: LEDA: Link status LEDB: Rx/Tx activity */
+static constexpr uint16_t ENC28J60_LAMPS_MODE	= 0x3476;
+
 
 
 

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
@@ -1,0 +1,185 @@
+#ifndef MODM_ENC28J60_BANK
+#define MODM_ENC28J60_BANK
+
+static constexpr uint8_t BANK_0 = 0 << 5;
+static constexpr uint8_t BANK_1 = 1 << 5;
+static constexpr uint8_t BANK_2 = 2 << 5;
+static constexpr uint8_t BANK_3 = 3 << 5;
+
+static constexpr uint8_t ADDR_MASK = 0x1F;
+static constexpr uint8_t BANK_MASK = 0x60;
+static constexpr uint8_t SPRD_MASK = 0x80;
+
+enum class RegisterBank : uint8_t
+{
+	BANK_0 = BANK_0,
+	BANK_1 = BANK_1,
+	BANK_2 = BANK_2,
+	BANK_3 = BANK_3,
+	BANK_ALL = 0xff
+};
+
+/* ENC28J60 register definitions.
+   Blindly copied from enc28j60_hw.h from the Linux kernel
+ */
+
+enum class Register : uint8_t
+{
+	/* All-bank registers */
+	EIE			= 0x1B,
+	EIR			= 0x1C,
+	ESTAT		= 0x1D,
+	ECON2		= 0x1E,
+	ECON1		= 0x1F,
+
+	/* Bank 0 registers */
+	ERDPTL		= 0x00 | BANK_0,
+	ERDPTH		= 0x01 | BANK_0,
+	EWRPTL		= 0x02 | BANK_0,
+	EWRPTH		= 0x03 | BANK_0,
+	ETXSTL		= 0x04 | BANK_0,
+	ETXSTH		= 0x05 | BANK_0,
+	ETXNDL		= 0x06 | BANK_0,
+	ETXNDH		= 0x07 | BANK_0,
+	ERXSTL		= 0x08 | BANK_0,
+	ERXSTH		= 0x09 | BANK_0,
+	ERXNDL		= 0x0A | BANK_0,
+	ERXNDH		= 0x0B | BANK_0,
+	ERXRDPTL	= 0x0C | BANK_0,
+	ERXRDPTH	= 0x0D | BANK_0,
+	ERXWRPTL	= 0x0E | BANK_0,
+	ERXWRPTH	= 0x0F | BANK_0,
+	EDMASTL		= 0x10 | BANK_0,
+	EDMASTH		= 0x11 | BANK_0,
+	EDMANDL		= 0x12 | BANK_0,
+	EDMANDH		= 0x13 | BANK_0,
+	EDMADSTL	= 0x14 | BANK_0,
+	EDMADSTH	= 0x15 | BANK_0,
+	EDMACSL		= 0x16 | BANK_0,
+	EDMACSH		= 0x17 | BANK_0,
+
+	/* Bank 1 registers */
+	EHT0		= 0x00 | BANK_1,
+	EHT1		= 0x01 | BANK_1,
+	EHT2		= 0x02 | BANK_1,
+	EHT3		= 0x03 | BANK_1,
+	EHT4		= 0x04 | BANK_1,
+	EHT5		= 0x05 | BANK_1,
+	EHT6		= 0x06 | BANK_1,
+	EHT7		= 0x07 | BANK_1,
+	EPMM0		= 0x08 | BANK_1,
+	EPMM1		= 0x09 | BANK_1,
+	EPMM2		= 0x0A | BANK_1,
+	EPMM3		= 0x0B | BANK_1,
+	EPMM4		= 0x0C | BANK_1,
+	EPMM5		= 0x0D | BANK_1,
+	EPMM6		= 0x0E | BANK_1,
+	EPMM7		= 0x0F | BANK_1,
+	EPMCSL		= 0x10 | BANK_1,
+	EPMCSH		= 0x11 | BANK_1,
+	EPMOL		= 0x14 | BANK_1,
+	EPMOH		= 0x15 | BANK_1,
+	EWOLIE		= 0x16 | BANK_1,
+	EWOLIR		= 0x17 | BANK_1,
+	ERXFCON		= 0x18 | BANK_1,
+	EPKTCNT		= 0x19 | BANK_1,
+
+	/* Bank 2 registers */
+	MACON1		= 0x00 | BANK_2 | SPRD_MASK,
+	// MACON2	= 0x01 | BANK_2 | SPRD_MASK,
+	MACON3		= 0x02 | BANK_2 | SPRD_MASK,
+	MACON4		= 0x03 | BANK_2 | SPRD_MASK,
+	MABBIPG		= 0x04 | BANK_2 | SPRD_MASK,
+	MAIPGL		= 0x06 | BANK_2 | SPRD_MASK,
+	MAIPGH		= 0x07 | BANK_2 | SPRD_MASK,
+	MACLCON1	= 0x08 | BANK_2 | SPRD_MASK,
+	MACLCON2	= 0x09 | BANK_2 | SPRD_MASK,
+	MAMXFLL		= 0x0A | BANK_2 | SPRD_MASK,
+	MAMXFLH		= 0x0B | BANK_2 | SPRD_MASK,
+	MAPHSUP		= 0x0D | BANK_2 | SPRD_MASK,
+	MICON		= 0x11 | BANK_2 | SPRD_MASK,
+	MICMD		= 0x12 | BANK_2 | SPRD_MASK,
+	MIREGADR	= 0x14 | BANK_2 | SPRD_MASK,
+	MIWRL		= 0x16 | BANK_2 | SPRD_MASK,
+	MIWRH		= 0x17 | BANK_2 | SPRD_MASK,
+	MIRDL		= 0x18 | BANK_2 | SPRD_MASK,
+	MIRDH		= 0x19 | BANK_2 | SPRD_MASK,
+
+	/* Bank 3 registers */
+	MAADR1		= 0x00 | BANK_3 | SPRD_MASK,
+	MAADR0		= 0x01 | BANK_3 | SPRD_MASK,
+	MAADR3		= 0x02 | BANK_3 | SPRD_MASK,
+	MAADR2		= 0x03 | BANK_3 | SPRD_MASK,
+	MAADR5		= 0x04 | BANK_3 | SPRD_MASK,
+	MAADR4		= 0x05 | BANK_3 | SPRD_MASK,
+	EBSTSD		= 0x06 | BANK_3,
+	EBSTCON		= 0x07 | BANK_3,
+	EBSTCSL		= 0x08 | BANK_3,
+	EBSTCSH		= 0x09 | BANK_3,
+	MISTAT		= 0x0A | BANK_3 | SPRD_MASK,
+	EREVID		= 0x12 | BANK_3,
+	ECOCON		= 0x15 | BANK_3,
+	EFLOCON		= 0x17 | BANK_3,
+	EPAUSL		= 0x18 | BANK_3,
+	EPAUSH		= 0x19 | BANK_3,
+};
+
+
+/* ENC28J60 MICMD Register Bit Definitions */
+static constexpr uint8_t MICMD_MIISCAN	= 0x02;
+static constexpr uint8_t MICMD_MIIRD	= 0x01;
+
+/* ENC28J60 MISTAT Register Bit Definitions */
+static constexpr uint8_t MISTAT_NVALID	= 0x04;
+static constexpr uint8_t MISTAT_SCAN	= 0x02;
+static constexpr uint8_t MISTAT_BUSY	= 0x01;
+
+
+
+
+static uint8_t get_bank(const Register address) {
+	return (static_cast<uint8_t>(address) & BANK_MASK) >> 5;
+}
+
+static uint8_t get_address(const Register address) {
+	return (static_cast<uint8_t>(address) & ADDR_MASK);
+}
+
+static bool is_mii_mac(const Register address) {
+	return (static_cast<uint8_t>(address) & SPRD_MASK);
+}
+
+Register operator+ (const Register& lhs, const int& rhs) {
+	return static_cast<Register>( static_cast<uint8_t>(lhs) + rhs );
+}
+
+bool operator== (const Register& lhs, const RegisterBank& rhs)
+{
+	switch (rhs) {
+		case RegisterBank::BANK_ALL:
+			switch (lhs) {
+				case Register::EIE:
+				case Register::EIR:
+				case Register::ESTAT:
+				case Register::ECON2:
+				case Register::ECON1:
+					return true;
+
+				default:
+					return false;
+			}
+
+		case RegisterBank::BANK_0:
+		case RegisterBank::BANK_1:
+		case RegisterBank::BANK_2:
+		case RegisterBank::BANK_3:
+			return (static_cast<uint8_t>(lhs) | BANK_MASK) == static_cast<uint8_t>(rhs);
+	}
+
+	// In case of wrong enums
+	return false;
+}
+
+
+
+#endif // MODM_ENC28J60_BANK

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/enc28j60_bank.hpp
@@ -248,6 +248,57 @@ static constexpr uint8_t PHIR_PGEIF		= (1 << 1);
 /* Preferred half duplex: LEDA: Link status LEDB: Rx/Tx activity */
 static constexpr uint16_t ENC28J60_LAMPS_MODE	= 0x3476;
 
+/* ENC28J60 Packet Control Byte Bit Definitions */
+#define PKTCTRL_PHUGEEN		0x08
+#define PKTCTRL_PPADEN		0x04
+#define PKTCTRL_PCRCEN		0x02
+#define PKTCTRL_POVERRIDE	0x01
+
+/* ENC28J60 Transmit Status Vector */
+static constexpr uint8_t TSV_TXBYTECNT			= 0;
+static constexpr uint8_t TSV_TXCOLLISIONCNT		= 16;
+static constexpr uint8_t TSV_TXCRCERROR			= 20;
+static constexpr uint8_t TSV_TXLENCHKERROR		= 21;
+static constexpr uint8_t TSV_TXLENOUTOFRANGE	= 22;
+static constexpr uint8_t TSV_TXDONE				= 23;
+static constexpr uint8_t TSV_TXMULTICAST		= 24;
+static constexpr uint8_t TSV_TXBROADCAST		= 25;
+static constexpr uint8_t TSV_TXPACKETDEFER		= 26;
+static constexpr uint8_t TSV_TXEXDEFER			= 27;
+static constexpr uint8_t TSV_TXEXCOLLISION		= 28;
+static constexpr uint8_t TSV_TXLATECOLLISION	= 29;
+static constexpr uint8_t TSV_TXGIANT			= 30;
+static constexpr uint8_t TSV_TXUNDERRUN			= 31;
+static constexpr uint8_t TSV_TOTBYTETXONWIRE	= 32;
+static constexpr uint8_t TSV_TXCONTROLFRAME		= 48;
+static constexpr uint8_t TSV_TXPAUSEFRAME		= 49;
+static constexpr uint8_t TSV_BACKPRESSUREAPP	= 50;
+static constexpr uint8_t TSV_TXVLANTAGFRAME		= 51;
+
+static constexpr uint8_t TSV_SIZE		= 7;
+#define TSV_BYTEOF(x)		((x) / 8)
+#define TSV_BITMASK(x)		(1 << ((x) % 8))
+#define TSV_GETBIT(x, y)	(((x)[TSV_BYTEOF(y)] & TSV_BITMASK(y)) ? 1 : 0)
+
+/* ENC28J60 Receive Status Vector */
+static constexpr uint8_t RSV_RXLONGEVDROPEV		= 16;
+static constexpr uint8_t RSV_CARRIEREV			= 18;
+static constexpr uint8_t RSV_CRCERROR			= 20;
+static constexpr uint8_t RSV_LENCHECKERR		= 21;
+static constexpr uint8_t RSV_LENOUTOFRANGE		= 22;
+static constexpr uint8_t RSV_RXOK				= 23;
+static constexpr uint8_t RSV_RXMULTICAST		= 24;
+static constexpr uint8_t RSV_RXBROADCAST		= 25;
+static constexpr uint8_t RSV_DRIBBLENIBBLE		= 26;
+static constexpr uint8_t RSV_RXCONTROLFRAME		= 27;
+static constexpr uint8_t RSV_RXPAUSEFRAME		= 28;
+static constexpr uint8_t RSV_RXUNKNOWNOPCODE	= 29;
+static constexpr uint8_t RSV_RXTYPEVLAN			= 30;
+
+static constexpr uint8_t RSV_SIZE		= 6;
+#define RSV_BITMASK(x)		(1 << ((x) - 16))
+#define RSV_GETBIT(x, y)	(((x) & RSV_BITMASK(y)) ? 1 : 0)
+
 
 
 

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
@@ -44,217 +44,450 @@ namespace enc28j60
 	using SpiMaster = SpiMaster2;
 }
 
-static constexpr uint8_t BANK_0 = 0x00;
-static constexpr uint8_t BANK_1 = 0x20;
-static constexpr uint8_t BANK_2 = 0x40;
-static constexpr uint8_t BANK_3 = 0x60;
-
-static constexpr uint8_t MAC_MII = 0x80;
+#include "enc28j60_bank.hpp"
 
 
-enum class Register : uint8_t
-{
-	ERDPTL = 0x00 | BANK_0,
-	ERDPTH = 0x01 | BANK_0,
-
-	MICMD = 0x12 | BANK_2,
-
-	MIREGADR = 0x14 | BANK_2,
-
-	MIRDL = 0x18 | BANK_2,
-	MIRDH = 0x19 | BANK_2,
+/// Length of standard SPI operation,
+static constexpr uint8_t SPI_OPLEN = 2;
 
 
-	MISTAT = 0x0a | BANK_3 | MAC_MII,
 
-	ECON1 = 0x1F
-};
+/* ENC28J60 ECON1 Register Bit Definitions */
+static constexpr uint8_t ECON1_TXRST	= 0x80;
+static constexpr uint8_t ECON1_RXRST	= 0x40;
+static constexpr uint8_t ECON1_DMAST	= 0x20;
+static constexpr uint8_t ECON1_CSUMEN	= 0x10;
+static constexpr uint8_t ECON1_TXRTS	= 0x08;
+static constexpr uint8_t ECON1_RXEN		= 0x04;
+static constexpr uint8_t ECON1_BSEL1	= 0x02;
+static constexpr uint8_t ECON1_BSEL0	= 0x01;
+
 
 
 enum class PhyRegister : uint8_t
 {
-	PHLCON = 0x14
+	PHCON1		= 0x00,
+	PHSTAT1		= 0x01,
+	PHHID1		= 0x02,
+	PHHID2		= 0x03,
+	PHCON2		= 0x10,
+	PHSTAT2		= 0x11,
+	PHIE		= 0x12,
+	PHIR		= 0x13,
+	PHLCON		= 0x14
 };
+
+/* buffer boundaries applied to internal 8K ram
+ * entire available packet buffer space is allocated.
+ * Give TX buffer space for one full ethernet frame (~1500 bytes)
+ * receive buffer gets the rest */
+static constexpr uint16_t TXSTART_INIT	= 0x1A00;
+static constexpr uint16_t TXEND_INIT	= 0x1FFF;
+
+/* Put RX buffer at 0 as suggested by the Errata datasheet */
+static constexpr uint16_t RXSTART_INIT	= 0x0000;
+static constexpr uint16_t RXEND_INIT	= 0x19FF;
+
+/// Maximum Ethernet frame length
+static constexpr uint16_t MAX_FRAMELEN = 1518;
+
+/// Buffer size required for the largest SPI transfer (i.e., reading a frame).
+static constexpr uint16_t SPI_TRANSFER_BUF_LEN = (4 + MAX_FRAMELEN);
+
+
+uint8_t spi_transfer_buf[SPI_TRANSFER_BUF_LEN];
 
 class Enc28j60
 {
 public:
-	static uint16_t
-	read_phy(PhyRegister address)
-	{
-		// 1. Write MIREGADR
-		write_control_register(Register::MIREGADR, static_cast<uint8_t>(address));
 
-		// 2. Set MICMD.MIIRD bit
-		bfs_eth(0x12, 0x01);
-
-		// 3. Wait 10.24us. Poll MISTAT.BUSY
-		modm::delay(11us);
-		uint8_t busy;
-		do {
-			busy = read_control_register(Register::MISTAT) & 0x01;
-		} while (busy);
-
-		// 4. Clear MICMD.MIIRD (in bank 2)
-		wcr_eth(0x1f, 2); // ECON1
-		bfc_eth(0x12, 0x01); // MICMD
-
-		// 5. Read MIRDL and MIRDH
-		uint16_t phy_data = (rcr_mac_mii(0x19) << 8) | rcr_mac_mii(0x18);
-
-		MODM_LOG_DEBUG.printf("PhyRegister 0x%02x=0x%04x\n", static_cast<uint8_t>(address), phy_data);
-		return phy_data;
-	}
-
+	/// Soft reset of chip
 	static void
-	write_phy(PhyRegister address, uint16_t data)
+	enc28j60_soft_reset() {
+		spi_write_op(SpiOperation::SOFT_RESET, Register::ERDPTL /* 0 */, 0xff);
+		/* Errata workaround #1, CLKRDY check is unreliable,
+		 * delay at least 1 ms instead */
+		modm::delay(2ms);
+}
+
+	/// Debug routine to dump useful register contents
+	static void
+	enc28j60_dump_regs(const char *msg)
 	{
-		// 1. Write MIREGADR
-		write_control_register(Register::MIREGADR, static_cast<uint8_t>(address));
+		MODM_LOG_DEBUG.printf(
+			" %s\n"
+			"HwRevID: 0x%02x\n"
+			"Cntrl: ECON1 ECON2 ESTAT EIR   EIE\n"
+			"       0x%02x  0x%02x  0x%02x  0x%02x  0x%02x\n"
+			"MAC  : MACON1 MACON3 MACON4\n"
+			"       0x%02x   0x%02x   0x%02x\n"
+			"Rx   : ERXST  ERXND  ERXWRPT ERXRDPT ERXFCON EPKTCNT MAMXFL\n"
+			"       0x%04x 0x%04x 0x%04x  0x%04x  "
+			"0x%02x    0x%02x    0x%04x\n"
+			"Tx   : ETXST  ETXND  MACLCON1 MACLCON2 MAPHSUP\n"
+			"       0x%04x 0x%04x 0x%02x     0x%02x     0x%02x\n",
 
-		// 2. Write MIWRL
-		uint8_t data_low = data & 0x00ff;
-		wcr_eth(0x16, data_low); // MIWRL
-
-		// 3. Write MIWRH
-		uint8_t data_high = data >> 8;
-		wcr_eth(0x17, data_high); // MIWRH
-
-		// 4. Wait 10.24 usec
-		modm::delay(11us);
-
-		// 5. Wait for MISTAT.BUSY == 0
-		uint8_t busy;
-		do {
-			busy = read_control_register(Register::MISTAT) & 0x01;
-		} while (busy);
-
-		MODM_LOG_DEBUG.printf("PhyRegister 0x%02x:=0x%04x\n", static_cast<uint8_t>(address), data);
+			msg, nolock_regb_read(Register::EREVID),
+			nolock_regb_read(Register::ECON1), nolock_regb_read(Register::ECON2),
+			nolock_regb_read(Register::ESTAT), nolock_regb_read(Register::EIR),
+			nolock_regb_read(Register::EIE), nolock_regb_read(Register::MACON1),
+			nolock_regb_read(Register::MACON3), nolock_regb_read(Register::MACON4),
+			nolock_regw_read(Register::ERXSTL), nolock_regw_read(Register::ERXNDL),
+			nolock_regw_read(Register::ERXWRPTL),
+			nolock_regw_read(Register::ERXRDPTL),
+			nolock_regb_read(Register::ERXFCON),
+			nolock_regb_read(Register::EPKTCNT),
+			nolock_regw_read(Register::MAMXFLL), nolock_regw_read(Register::ETXSTL),
+			nolock_regw_read(Register::ETXNDL),
+			nolock_regb_read(Register::MACLCON1),
+			nolock_regb_read(Register::MACLCON2),
+			nolock_regb_read(Register::MAPHSUP));
 	}
 
 
-
-	// ------------------------------------------------------------------------
-	static uint8_t
-	read_control_register(Register reg)
+	/// PHY register read
+	static uint16_t
+	enc28j60_phy_read(const PhyRegister address)
 	{
-		// Select Bank
-		uint8_t bank = (static_cast<uint8_t>(reg) & 0x60) >> 5;
-		uint8_t addr = static_cast<uint8_t>(reg) & 0x1f;
-		bool mac_mii = static_cast<uint8_t>(reg) & 0x80;
-		MODM_LOG_DEBUG.printf(" - read_control_register %02x in bank %1x\n", addr, bank);
+		// mutex_lock
 
-		// Select bank
-		wcr_eth(0x1f, bank); // ECON1
+		/* set the PHY register address */
+		nolock_regb_write(Register::MIREGADR, address);
+		/* start the register read operation */
+		nolock_regb_write(Register::MICMD, MICMD_MIIRD);
+		/* wait until the PHY read completes */
+		wait_phy_ready();
+		/* quit reading */
+		nolock_regb_write(Register::MICMD, 0x00);
+		/* return the data */
+		uint16_t ret = nolock_regw_read(Register::MIRDL);
+		// mutex_unlock
 
-		uint8_t data;
-		if (mac_mii) {
-			data = rcr_mac_mii(addr);
-		} else {
-			data = rcr_eth(addr);
+		return ret;
+	}
+
+
+	/// PHY register write
+	static int8_t
+	enc28j60_phy_write(const PhyRegister address, const uint16_t data)
+	{
+		// mutex_lock
+
+		/* set the PHY register address */
+		nolock_regb_write(Register::MIREGADR, address);
+		/* write the PHY data */
+		nolock_regw_write(Register::MIWRL, data);
+		/* wait until the PHY write completes and return */
+		int8_t ret = wait_phy_ready();
+
+		// mutex_unlock
+		return ret;
+	}
+
+
+private:
+	/// Wait until the PHY operation is complete.
+	static int8_t wait_phy_ready()
+	{
+		return poll_ready(Register::MISTAT, MISTAT_BUSY, 0) ? 0 : 1;
+	}
+
+	static int8_t poll_ready(const Register address, uint8_t bitmask, uint8_t value)
+	{
+		/* 20 msec timeout read */
+		uint8_t tt = 20;
+		while ((nolock_regb_read(address) & bitmask) != value) {
+			// ToDo modm::Timeout
+			if (--tt == 0) {
+				MODM_LOG_ERROR.printf("Timeout poll_read 0x%02x, 0x%02x, 0x%02x\n",
+					static_cast<uint8_t>(address), bitmask, value);
+				return -1;
+			}
 		}
 
-		return data;
+		return 0;
 	}
 
-	static void
-	write_control_register(Register reg, uint8_t data)
-	{
-		// Select Bank
-		uint8_t bank = (static_cast<uint8_t>(reg) & 0x60) >> 5;
-		uint8_t addr = static_cast<uint8_t>(reg) & 0x1f;
-		MODM_LOG_DEBUG.printf(" - write_control_register %02x in bank %1x\n", addr, bank);
+	
+	/*
+	 * Register access routines through the SPI bus.
+	 * Every register access comes in two flavours:
+	 * - nolock_xxx: caller needs to invoke mutex_lock, usually to access
+	 *   atomically more than one register
+	 * - locked_xxx: caller doesn't need to invoke mutex_lock, single access
+	 *
+	 * Some registers can be accessed through the bit field clear and
+	 * bit field set to avoid a read modify write cycle.
+	 */
 
-		wcr_eth(0x1f, bank); // ECON1
+	/// Register bit field Set
+	static void nolock_reg_bfset(const Register address, const uint8_t bitmask) {
+		enc28j60_set_bank(address);
+		spi_write_op(SpiOperation::BIT_FIELD_SET, address, bitmask);
+	}
 
-		// Write data
-		wcr_eth(addr, data);
+	static void locked_reg_bfset(const Register address, const uint8_t bitmask) {
+		// mutex_lock
+		nolock_reg_bfset(address, bitmask);
+		// mutex_unlock
+	}
+
+	/// Register bit field Clear
+	static void nolock_reg_bfclr(const Register address, const uint8_t bitmask) {
+		enc28j60_set_bank(address);
+		spi_write_op(SpiOperation::BIT_FIELD_CLR, address, bitmask);
+	}
+
+	static void locked_reg_bfclr(const Register address, const uint8_t bitmask) {
+		// mutex_lock
+		nolock_reg_bfclr(address, bitmask);
+		// mutex_unlock
 	}
 
 
-	// ------------------------------------------------------------------------
-	static void
-	bfs_eth(uint8_t address, uint8_t bitmask)
+	/// Register byte read
+	static uint8_t nolock_regb_read(const Register address) {
+		enc28j60_set_bank(address);
+		return spi_read_op(SpiOperation::READ_CTRL_REG, address);
+	}
+
+	static uint8_t locked_regb_read(const Register address) {
+		// mutex_lock
+		auto ret = nolock_regb_read(address);
+		// mutex_unlock
+
+		return ret;
+	}
+
+
+	/// Register word read
+	static uint16_t nolock_regw_read(const Register address) {
+		// assert address is even
+		// assert address is word address (register with L and H)
+
+		enc28j60_set_bank(address);
+		uint8_t rl = spi_read_op(SpiOperation::READ_CTRL_REG, address);
+		uint8_t rh = spi_read_op(SpiOperation::READ_CTRL_REG, address + 1);
+
+		return (rh << 8) | rl;
+	}
+
+	static uint16_t locked_regw_read(const Register address) {
+		// mutex_lock
+		auto ret = nolock_regw_read(address);
+		// mutex_unlock
+
+		return ret;
+	}
+
+
+	/// Register byte write
+	static void nolock_regb_write(const Register address, const uint8_t data) {
+		enc28j60_set_bank(address);
+		spi_write_op(SpiOperation::WRITE_CTRL_REG, address, data);
+	}
+
+	static void nolock_regb_write(const Register address, const PhyRegister phy_register) {
+		nolock_regb_write(address, static_cast<uint8_t>(phy_register));
+	}
+
+	static void locked_regb_write(const Register address, const uint8_t data) {
+		// mutex_lock
+		nolock_regb_write(address, data);
+		// mutex_unlock
+	}
+
+
+	/// Register word write
+	static void nolock_regw_write(const Register address, const uint16_t data) {
+		// assert address is even
+		// assert address is word address (register with L and H)
+
+		enc28j60_set_bank(address);
+		spi_write_op(SpiOperation::WRITE_CTRL_REG, address, data);
+		spi_write_op(SpiOperation::WRITE_CTRL_REG, address + 1, data >> 8);
+	}
+
+	static void locked_regw_write(const Register address, const uint16_t data) {
+		// mutex_lock
+		nolock_regw_write(address, data);
+		// mutex_unlock
+	}
+
+
+	/// Buffer memory read
+	static void enc28j60_mem_read(const uint16_t address, std::size_t len, uint8_t *data) {
+		// mutex_lock
+		nolock_regw_write(Register::ERDPTL, address);
+
+		if (true) {
+			uint16_t reg = nolock_regw_read(Register::ERDPTL);
+			if (reg != address) {
+				MODM_LOG_ERROR.printf("Error writing ERDPT (0x%04x - 0x%04x)\n",
+					reg, address);
+			}
+		}
+
+		spi_read_buf(len, data);
+		// mutex_unlock
+	}
+
+
+	/// Buffer memory write
+	static void enc28j60_packet_write(const std::size_t len, const uint8_t *data)
 	{
-		uint8_t opcode = 0b100;
+		// mutex_lock
+
+		/* Set the write pointer to start of transmit buffer area */
+		nolock_regw_write(Register::EWRPTL, TXSTART_INIT);
+
+		if (true) {
+			uint16_t reg = nolock_regw_read(Register::EWRPTL);
+			if (reg != TXSTART_INIT) {
+				MODM_LOG_ERROR.printf("ERWPT:0x%04x != 0x%04x\n", reg, TXSTART_INIT);
+			}
+		}
+
+		/* Set the TXND pointer to correspond to the packet size given */
+		nolock_regw_write(Register::ETXNDL, TXSTART_INIT + len);
+		/* write per-packet control byte */
+		spi_write_op(SpiOperation::WRITE_BUF_MEM, Register::ERDPTL/* 0 */, 0x00);
+		MODM_LOG_DEBUG.printf("after control byte ERWPT:0x%04x\n", nolock_regw_read(Register::EWRPTL));
+
+		/* copy the packet into the transmit buffer */
+		spi_write_buf(len, data);
+		MODM_LOG_DEBUG.printf("after write packet ERWPT:0x%04x, len=%d\n", nolock_regw_read(Register::EWRPTL), len);
+
+		// mutex_unlock
+	}
+
+
+	static void
+	enc28j60_set_bank(const Register address)
+	{
+		/* These registers (EIE, EIR, ESTAT, ECON2, ECON1)
+		 * are present in all banks, no need to switch bank.
+		 */
+		if (address == RegisterBank::BANK_ALL) {
+			return;
+		}
+
+		uint8_t new_bank = get_bank(address);
+
+		/* Clear or set each bank selection bit as needed */
+		if ((new_bank & ECON1_BSEL0) != (bank & ECON1_BSEL0)) {
+			if (new_bank & ECON1_BSEL0) {
+				spi_write_op(SpiOperation::BIT_FIELD_SET, Register::ECON1, ECON1_BSEL0);
+			} else {
+				spi_write_op(SpiOperation::BIT_FIELD_CLR, Register::ECON1, ECON1_BSEL0);
+			}
+		}
+		if ((new_bank & ECON1_BSEL1) != (bank & ECON1_BSEL1)) {
+			if (new_bank & ECON1_BSEL1) {
+				spi_write_op(SpiOperation::BIT_FIELD_SET, Register::ECON1, ECON1_BSEL1);
+			} else {
+				spi_write_op(SpiOperation::BIT_FIELD_CLR, Register::ECON1, ECON1_BSEL1);
+			}
+		}
+
+		// Bank change successful, so store
+		bank = new_bank;
+	}
+
+
+	enum class SpiOperation : uint8_t
+	{
+		READ_CTRL_REG	= 0b000 << 5, // RCR
+		READ_BUF_MEM	= 0b001 << 5 | 0x1a, // RBM
+		WRITE_CTRL_REG	= 0b010 << 5, // WCR
+		WRITE_BUF_MEM	= 0b011 << 5 | 0x1a, // WBM
+		BIT_FIELD_SET	= 0b100 << 5, // BFS
+		BIT_FIELD_CLR	= 0b101 << 5, // BFC
+		SOFT_RESET		= 0b111 << 5  // SRC
+	};
+
+
+	/// SPI read buffer
+	static void
+	spi_read_buf(const std::size_t len, uint8_t *data)
+	{
+		uint8_t *tx_buf = spi_transfer_buf;
+
+		tx_buf[0] = static_cast<uint8_t>(SpiOperation::READ_BUF_MEM);
+
+		// assert len <= SPI_TRANSFER_BUF_LEN
 		enc28j60::Cs::reset();
-
-		MODM_LOG_DEBUG.printf("   - bfs_eth: address=%02x, bitmask=%02x\n", address, bitmask);
-
-		uint8_t write = (opcode << 5) | (address & 0x1f);
-		enc28j60::SpiMaster::transferBlocking(write);
-		enc28j60::SpiMaster::transferBlocking(bitmask);
-
+		enc28j60::SpiMaster::transferBlocking(tx_buf, data, len);
 		enc28j60::Cs::set();
 	}
 
+
+	/// SPI write buffer
 	static void
-	bfc_eth(uint8_t address, uint8_t bitmask)
+	spi_write_buf(const std::size_t len, const uint8_t *data)
 	{
-		uint8_t opcode = 0b101;
-		enc28j60::Cs::reset();
+		if (len > SPI_TRANSFER_BUF_LEN - 1) {
+			MODM_LOG_ERROR.printf("len(%d) > SPI_TRANSFER_BUF_LEN - 1\n", len);
+			return;
+		} else if (len <= 0) {
+			// nothing to do
+			return;
+		} else {
+			spi_transfer_buf[0] = static_cast<uint8_t>(SpiOperation::WRITE_BUF_MEM);
+			memcpy(&spi_transfer_buf[1], data, len);
 
-		MODM_LOG_DEBUG.printf("   - bfc_eth: address=%02x, bitmask=%02x\n", address, bitmask);
-
-		uint8_t write = (opcode << 5) | (address & 0x1f);
-		enc28j60::SpiMaster::transferBlocking(write);
-		enc28j60::SpiMaster::transferBlocking(bitmask);
-
-		enc28j60::Cs::set();
-	}
-
-	static void
-	wcr_eth(uint8_t address, uint8_t data)
-	{
-		uint8_t opcode = 0b010;
-		enc28j60::Cs::reset();
-
-		MODM_LOG_DEBUG.printf("   - wcr_eth: address=%02x, data=%02x\n", address, data);
-
-		uint8_t write = (opcode << 5) | (address & 0x1f);
-		enc28j60::SpiMaster::transferBlocking(write);
-		enc28j60::SpiMaster::transferBlocking(data);
-
-		enc28j60::Cs::set();
+			enc28j60::Cs::reset();
+			enc28j60::SpiMaster::transferBlocking(spi_transfer_buf, nullptr, len + 1);
+			enc28j60::Cs::set();
+		}
 	}
 
 
+	// basic SPI read operation
 	static uint8_t
-	rcr_eth(uint8_t address) {
-		uint8_t opcode = 0b000;
+	spi_read_op(SpiOperation op, Register address)
+	{
+		// buffers account for dummy byte for MII and MAC transfers
+		uint8_t tx_buf[SPI_OPLEN + 1];
+		uint8_t rx_buf[SPI_OPLEN + 1];
+
+		uint8_t slen = SPI_OPLEN;
+
+		/* add dummy read if needed */
+		if (is_mii_mac(address)) {
+			slen++;
+		}
+
+		tx_buf[0] = static_cast<uint8_t>(op) | get_address(address);
+
 		enc28j60::Cs::reset();
-
-		uint8_t write = (opcode << 5) | (address & 0x1f);
-		enc28j60::SpiMaster::transferBlocking(write);
-		uint8_t control_register = enc28j60::SpiMaster::transferBlocking(0x00); // dummy
-
+		enc28j60::SpiMaster::transferBlocking(tx_buf, rx_buf, slen);
 		enc28j60::Cs::set();
 
-		return control_register;
-	}
-
-	static uint8_t
-	rcr_mac_mii(uint8_t address) {
-		uint8_t opcode = 0b000;
-		enc28j60::Cs::reset();
-
-		uint8_t write = (opcode << 5) | (address & 0x1f);
-		enc28j60::SpiMaster::transferBlocking(write);
-
-		enc28j60::SpiMaster::transferBlocking(0x00); // dummy
-		uint8_t control_register = enc28j60::SpiMaster::transferBlocking(0x00); // dummy
-
-		enc28j60::Cs::set();
-
-		return control_register;
+		return rx_buf[slen - 1];
 	}
 
 	static void
-	initialize()
+	spi_write_op(SpiOperation op, Register address, uint8_t value)
 	{
+		uint8_t tx_buf[2];
 
+		tx_buf[0] = static_cast<uint8_t>(op) | get_address(address);
+		tx_buf[1] = value;
+
+		enc28j60::Cs::reset();
+		enc28j60::SpiMaster::transferBlocking(tx_buf, nullptr, 2);
+		enc28j60::Cs::set();
 	}
+
+
+private:
+	static uint8_t bank;
+
+
 };
+
+uint8_t Enc28j60::bank = 0;
 
 /*
  * Blinks the green user LED with 1 Hz.
@@ -279,6 +512,23 @@ main()
 	MODM_LOG_WARNING << "warning" << modm::endl;
 	MODM_LOG_ERROR   << "error"   << modm::endl;
 
+	// Testing Register and RegisterBank class
+	if (true)
+	{
+		Register econ1 = Register::ECON1;
+
+		MODM_LOG_DEBUG.printf("cast = %02x\n", static_cast<uint8_t>(econ1));
+		MODM_LOG_DEBUG.printf("BANK_ALL = %d\n", (econ1 == RegisterBank::BANK_ALL));
+
+		MODM_LOG_DEBUG.printf("+1: %d %d\n",
+			static_cast<uint8_t>(Register::ECON1), static_cast<uint8_t>(Register::ECON1 + 1));
+
+		for (uint8_t ii = 0; ii < 80; ++ii) {
+			MODM_LOG_DEBUG.printf("*");
+		}
+		MODM_LOG_DEBUG.printf("\n");
+	}
+
 	enc28j60::Reset::setOutput(modm::Gpio::High);
 	enc28j60::Cs::setOutput(modm::Gpio::High);
 
@@ -296,17 +546,20 @@ main()
 	modm::delay(500ms);
 
 
+	// Dump registers
+	Enc28j60::enc28j60_dump_regs("Hw init");
+
 	// Access PHY for testing communication
 
-	uint16_t phlcon = Enc28j60::read_phy(PhyRegister::PHLCON);
+	uint16_t phlcon = Enc28j60::enc28j60_phy_read(PhyRegister::PHLCON);
 	MODM_LOG_DEBUG.printf("PHLCON=%04x\n", phlcon);
 
 	// blink LED B (orange) fast
 	// blink LED A (green)  slow
 	//                                         0011 LEDA LEDB 0010
-	Enc28j60::write_phy(PhyRegister::PHLCON, 0b0011'1011'1010'0010);
+	Enc28j60::enc28j60_phy_write(PhyRegister::PHLCON, 0b0011'1011'1010'0010);
 
-	phlcon = Enc28j60::read_phy(PhyRegister::PHLCON);
+	phlcon = Enc28j60::enc28j60_phy_read(PhyRegister::PHLCON);
 	MODM_LOG_DEBUG.printf("PHLCON=%04x\n", phlcon);
 
 

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2020, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::DEBUG
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+modm::IODeviceWrapper< Usart1, modm::IOBuffer::BlockIfFull > loggerDevice;
+
+// Set all four logger streams to use the UART
+modm::log::Logger modm::log::debug(loggerDevice);
+modm::log::Logger modm::log::info(loggerDevice);
+modm::log::Logger modm::log::warning(loggerDevice);
+modm::log::Logger modm::log::error(loggerDevice);
+
+namespace enc28j60
+{
+	using Cs = GpioOutputB12; 		// orange wire
+	using Sck = GpioOutputB13;		// yellow wire
+	using Miso = GpioInputB14;		// blue wire
+	using Mosi = GpioOutputB15; 	// green wire
+
+	using Wol = GpioInputA8;		// violet wire
+	using Int = GpioInputA9;		// grey wire
+	using Clk = GpioInputA10;		// white wire
+
+	using Reset = GpioOutputB8; 	// red wire
+
+	using SpiMaster = SpiMaster2;
+}
+
+static constexpr uint8_t BANK_0 = 0x00;
+static constexpr uint8_t BANK_1 = 0x20;
+static constexpr uint8_t BANK_2 = 0x40;
+static constexpr uint8_t BANK_3 = 0x60;
+
+static constexpr uint8_t MAC_MII = 0x80;
+
+
+enum class Register : uint8_t
+{
+	ERDPTL = 0x00 | BANK_0,
+	ERDPTH = 0x01 | BANK_0,
+
+	MICMD = 0x12 | BANK_2,
+
+	MIREGADR = 0x14 | BANK_2,
+
+	MIRDL = 0x18 | BANK_2,
+	MIRDH = 0x19 | BANK_2,
+
+
+	MISTAT = 0x0a | BANK_3 | MAC_MII,
+
+	ECON1 = 0x1F
+};
+
+
+enum class PhyRegister : uint8_t
+{
+	PHLCON = 0x14
+};
+
+class Enc28j60
+{
+public:
+	static uint16_t
+	read_phy(PhyRegister address)
+	{
+		// 1. Write MIREGADR
+		write_control_register(Register::MIREGADR, static_cast<uint8_t>(address));
+
+		// 2. Set MICMD.MIIRD bit
+		bfs_eth(0x12, 0x01);
+
+		// 3. Wait 10.24us. Poll MISTAT.BUSY
+		modm::delay(11us);
+		uint8_t busy;
+		do {
+			busy = read_control_register(Register::MISTAT) & 0x01;
+		} while (busy);
+
+		// 4. Clear MICMD.MIIRD (in bank 2)
+		wcr_eth(0x1f, 2); // ECON1
+		bfc_eth(0x12, 0x01); // MICMD
+
+		// 5. Read MIRDL and MIRDH
+		uint16_t phy_data = (rcr_mac_mii(0x19) << 8) | rcr_mac_mii(0x18);
+
+		MODM_LOG_DEBUG.printf("PhyRegister 0x%02x=0x%04x\n", static_cast<uint8_t>(address), phy_data);
+		return phy_data;
+	}
+
+	static void
+	write_phy(PhyRegister address, uint16_t data)
+	{
+		// 1. Write MIREGADR
+		write_control_register(Register::MIREGADR, static_cast<uint8_t>(address));
+
+		// 2. Write MIWRL
+		uint8_t data_low = data & 0x00ff;
+		wcr_eth(0x16, data_low); // MIWRL
+
+		// 3. Write MIWRH
+		uint8_t data_high = data >> 8;
+		wcr_eth(0x17, data_high); // MIWRH
+
+		// 4. Wait 10.24 usec
+		modm::delay(11us);
+
+		// 5. Wait for MISTAT.BUSY == 0
+		uint8_t busy;
+		do {
+			busy = read_control_register(Register::MISTAT) & 0x01;
+		} while (busy);
+
+		MODM_LOG_DEBUG.printf("PhyRegister 0x%02x:=0x%04x\n", static_cast<uint8_t>(address), data);
+	}
+
+
+
+	// ------------------------------------------------------------------------
+	static uint8_t
+	read_control_register(Register reg)
+	{
+		// Select Bank
+		uint8_t bank = (static_cast<uint8_t>(reg) & 0x60) >> 5;
+		uint8_t addr = static_cast<uint8_t>(reg) & 0x1f;
+		bool mac_mii = static_cast<uint8_t>(reg) & 0x80;
+		MODM_LOG_DEBUG.printf(" - read_control_register %02x in bank %1x\n", addr, bank);
+
+		// Select bank
+		wcr_eth(0x1f, bank); // ECON1
+
+		uint8_t data;
+		if (mac_mii) {
+			data = rcr_mac_mii(addr);
+		} else {
+			data = rcr_eth(addr);
+		}
+
+		return data;
+	}
+
+	static void
+	write_control_register(Register reg, uint8_t data)
+	{
+		// Select Bank
+		uint8_t bank = (static_cast<uint8_t>(reg) & 0x60) >> 5;
+		uint8_t addr = static_cast<uint8_t>(reg) & 0x1f;
+		MODM_LOG_DEBUG.printf(" - write_control_register %02x in bank %1x\n", addr, bank);
+
+		wcr_eth(0x1f, bank); // ECON1
+
+		// Write data
+		wcr_eth(addr, data);
+	}
+
+
+	// ------------------------------------------------------------------------
+	static void
+	bfs_eth(uint8_t address, uint8_t bitmask)
+	{
+		uint8_t opcode = 0b100;
+		enc28j60::Cs::reset();
+
+		MODM_LOG_DEBUG.printf("   - bfs_eth: address=%02x, bitmask=%02x\n", address, bitmask);
+
+		uint8_t write = (opcode << 5) | (address & 0x1f);
+		enc28j60::SpiMaster::transferBlocking(write);
+		enc28j60::SpiMaster::transferBlocking(bitmask);
+
+		enc28j60::Cs::set();
+	}
+
+	static void
+	bfc_eth(uint8_t address, uint8_t bitmask)
+	{
+		uint8_t opcode = 0b101;
+		enc28j60::Cs::reset();
+
+		MODM_LOG_DEBUG.printf("   - bfc_eth: address=%02x, bitmask=%02x\n", address, bitmask);
+
+		uint8_t write = (opcode << 5) | (address & 0x1f);
+		enc28j60::SpiMaster::transferBlocking(write);
+		enc28j60::SpiMaster::transferBlocking(bitmask);
+
+		enc28j60::Cs::set();
+	}
+
+	static void
+	wcr_eth(uint8_t address, uint8_t data)
+	{
+		uint8_t opcode = 0b010;
+		enc28j60::Cs::reset();
+
+		MODM_LOG_DEBUG.printf("   - wcr_eth: address=%02x, data=%02x\n", address, data);
+
+		uint8_t write = (opcode << 5) | (address & 0x1f);
+		enc28j60::SpiMaster::transferBlocking(write);
+		enc28j60::SpiMaster::transferBlocking(data);
+
+		enc28j60::Cs::set();
+	}
+
+
+	static uint8_t
+	rcr_eth(uint8_t address) {
+		uint8_t opcode = 0b000;
+		enc28j60::Cs::reset();
+
+		uint8_t write = (opcode << 5) | (address & 0x1f);
+		enc28j60::SpiMaster::transferBlocking(write);
+		uint8_t control_register = enc28j60::SpiMaster::transferBlocking(0x00); // dummy
+
+		enc28j60::Cs::set();
+
+		return control_register;
+	}
+
+	static uint8_t
+	rcr_mac_mii(uint8_t address) {
+		uint8_t opcode = 0b000;
+		enc28j60::Cs::reset();
+
+		uint8_t write = (opcode << 5) | (address & 0x1f);
+		enc28j60::SpiMaster::transferBlocking(write);
+
+		enc28j60::SpiMaster::transferBlocking(0x00); // dummy
+		uint8_t control_register = enc28j60::SpiMaster::transferBlocking(0x00); // dummy
+
+		enc28j60::Cs::set();
+
+		return control_register;
+	}
+
+	static void
+	initialize()
+	{
+
+	}
+};
+
+/*
+ * Blinks the green user LED with 1 Hz.
+ * It is on for 90% of the time and off for 10% of the time.
+ */
+
+int
+main()
+{
+	Board::initialize();
+
+	LedGreen::set();
+
+	// initialize Uart1 for MODM_LOG_*
+	Usart1::connect<GpioOutputB6::Tx>();
+	Usart1::initialize<Board::SystemClock, 115200_Bd>();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	enc28j60::Reset::setOutput(modm::Gpio::High);
+	enc28j60::Cs::setOutput(modm::Gpio::High);
+
+	enc28j60::Wol::setInput(Gpio::InputType::PullUp);
+	enc28j60::Int::setInput(Gpio::InputType::PullUp);
+	enc28j60::Clk::setInput(Gpio::InputType::PullUp);
+
+	enc28j60::SpiMaster::connect<enc28j60::Sck::Sck, enc28j60::Mosi::Mosi, enc28j60::Miso::Miso>();
+	enc28j60::SpiMaster::initialize<SystemClock, 9_MHz>();
+
+	enc28j60::Reset::reset();
+	modm::delay(500ms);
+
+	enc28j60::Reset::set();
+	modm::delay(500ms);
+
+
+	// Access PHY for testing communication
+
+	uint16_t phlcon = Enc28j60::read_phy(PhyRegister::PHLCON);
+	MODM_LOG_DEBUG.printf("PHLCON=%04x\n", phlcon);
+
+	// blink LED B (orange) fast
+	// blink LED A (green)  slow
+	//                                         0011 LEDA LEDB 0010
+	Enc28j60::write_phy(PhyRegister::PHLCON, 0b0011'1011'1010'0010);
+
+	phlcon = Enc28j60::read_phy(PhyRegister::PHLCON);
+	MODM_LOG_DEBUG.printf("PHLCON=%04x\n", phlcon);
+
+
+	while (true)
+	{
+		LedGreen::set();
+		modm::delay(100ms);
+
+		LedGreen::reset();
+		modm::delay(90ms);
+	}
+
+	return 0;
+}

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/main.cpp
@@ -254,7 +254,20 @@ public:
 	}
 
 
+	static void
+	enc28j60_check_link_status()
+	{
+		uint16_t phstat2 = enc28j60_phy_read(PhyRegister::PHSTAT2);
+		uint16_t phstat1 = enc28j60_phy_read(PhyRegister::PHSTAT1);
+		MODM_LOG_DEBUG.printf("PHSTAT1: %04x, PHSTAT2: %04x\n", phstat1, phstat2);
+		bool duplex = phstat2 & PHSTAT2_DPXSTAT;
 
+		if (phstat2 & PHSTAT2_LSTAT) {
+			MODM_LOG_DEBUG.printf("link up - %s\n", duplex ? "Full duplex" : "Half duplex");
+		} else {
+			MODM_LOG_DEBUG.printf("link down\n");
+		}
+	}
 
 
 
@@ -782,10 +795,12 @@ main()
 	while (true)
 	{
 		LedGreen::set();
-		modm::delay(100ms);
+		modm::delay(1000ms);
 
 		LedGreen::reset();
-		modm::delay(90ms);
+		modm::delay(900ms);
+
+		Enc28j60::enc28j60_check_link_status();
 	}
 
 	return 0;

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/openocd.cfg
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f103c8t6_blue_pill/enc28j60/project.xml
+++ b/examples/stm32f103c8t6_blue_pill/enc28j60/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:blue-pill</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f103c8t6_blue_pill/enc28j60</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>


### PR DESCRIPTION
This is heavily WIP. Opened the PR for discussions ...

# Variable sized messages

What is the `modm` way of representing a message with variable data size, e.g. [Ethernet Frames](https://en.wikipedia.org/wiki/Ethernet_frame#Structure)? An Ethernet Frame begins with the MAC address of the  destination and then of the source. It can be between 64 and 1522 bytes long.

For the [CAN messages](https://github.com/modm-io/modm/blob/develop/src/modm/architecture/interface/can_message.hpp.in#L81), a fixed 8 bytes buffer is used.

For the [PR with FDCAN](https://github.com/rleh/modm/blob/86427ff072ba9e73a104944a3d64a713133dfde5/src/modm/architecture/interface/can_message.hpp.in#L102), the data size was not changed?! @rleh 
If it was changed to 64 bytes, it will increase memory usage for all normal CAN messages by a factor of 8 (!).

For AMNB, a mixture of fixed allocation and [dynamic allocation](https://github.com/modm-io/modm/blob/cb82eecc054b8607e80b337af7a03b4b9a6abb09/src/modm/communication/amnb/message.hpp.in#L183) is used.

What would be the best approach for Ethernet Frames?
