### PR TITLE
Fix Rcc:PllSource for some STM32F3 devices and add Nucleo-F334R8 board

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Examples STM32F3 Series
           when: always
           command: |
-            (cd examples && ../tools/scripts/examples_compile.py stm32f3_discovery nucleo_f303k8 nucleo_f303re)
+            (cd examples && ../tools/scripts/examples_compile.py stm32f3_discovery nucleo_f303k8 nucleo_f303re nucleo_f334r8)
       - run:
           name: Examples STM32F7 Series
           when: always

--- a/README.md
+++ b/README.md
@@ -144,24 +144,25 @@ documentation.
 </tr><tr>
 <td align="center">NUCLEO-F303K8</td>
 <td align="center">NUCLEO-F303RE</td>
+<td align="center">NUCLEO-F334R8</td>
 <td align="center">NUCLEO-F401RE</td>
-<td align="center">NUCLEO-F411RE</td>
 </tr><tr>
+<td align="center">NUCLEO-F411RE</td>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
 <td align="center">NUCLEO-F746ZG</td>
-<td align="center">NUCLEO-G071RB</td>
 </tr><tr>
+<td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-G474RE</td>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
-<td align="center">NUCLEO-L476RG</td>
 </tr><tr>
+<td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
 <td align="center">RASPBERRYPI</td>
 <td align="center">SAMD21-MINI</td>
-<td align="center">STM32-F4VE</td>
 </tr><tr>
+<td align="center">STM32-F4VE</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>

--- a/examples/nucleo_f334r8/blink/main.cpp
+++ b/examples/nucleo_f334r8/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delay_ms(Button::read() ? 100 : 500);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f334r8/blink/project.xml
+++ b/examples/nucleo_f334r8/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f334r8</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f334r8/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f334r8/board.hpp
+++ b/src/modm/board/nucleo_f334r8/board.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_F334R8_HPP
+#define MODM_STM32_NUCLEO_F334R8_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_f334r8
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_f334r8
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32F334R8 running at 64MHz generated from the internal 8MHz clock
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 64_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 2;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1   = Apb2;
+	static constexpr uint32_t Adc2   = Apb2;
+
+	static constexpr uint32_t Can    = Apb1;
+
+	static constexpr uint32_t Spi1   = Apb2;
+
+	// USART1 is on APB2 bus, but default clock is PCLK1
+	static constexpr uint32_t Usart1 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+
+	// I2C1 clock source is HSI per default
+	static constexpr uint32_t I2c1   = 8_MHz;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableInternalClock();	// 8MHz
+		// 8MHz / 2 * 16 = 64MHz
+		const Rcc::PllFactors pllFactors{
+			.pllMul = 16,
+			.pllPrediv = 2, // fixed (/2) for Hsi
+		};
+		Rcc::enablePll(Rcc::PllSource::HsiDiv2, pllFactors);
+		// set flash latency for 64MHz
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		// APB1 has max. 36MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div2);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo64_arduino.hpp"
+
+using Button = GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA15;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_F334R8_HPP

--- a/src/modm/board/nucleo_f334r8/board.xml
+++ b/src/modm/board/nucleo_f334r8/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f334r8t6</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f334r8</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f334r8/module.lb
+++ b/src/modm/board/nucleo_f334r8/module.lb
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-f334r8"
+    module.description = """\
+# NUCLEO-F334R8
+
+[Nucleo kit for STM32F334R8](https://www.st.com/en/evaluation-tools/nucleo-f334r8.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f334r8t"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_f3.cfg");

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -54,7 +54,7 @@ public:
 		Hsi = RCC_CFGR_PLLSRC_HSI_PREDIV,
 		InternalClock = Hsi,
 	%% endif
-	%% if (target["family"] == "f0") or (target["family"] == "f3" and target["size"] in ["8", "c"])
+	%% if (target["family"] == "f0") or (target["family"] == "f3" and target["name"] in ["18", "28", "58", "73", "78"]) or (target["family"] == "f3" and target["size"] in ["8", "c"])
 		HsiDiv2 = RCC_CFGR_PLLSRC_HSI_DIV2,
 	%% endif
 		/// High speed external clock (see HseConfig)


### PR DESCRIPTION
@hshose [discovered](https://github.com/modm-io/modm/pull/414#commitcomment-42985517) that there is no `Hsi` element in `Rcc::PllSource` on STM32F373 devices, d89c06e should fix it.

Sadly there is no STM32F373 Nucleo or Discovery board, but I found a Nucleo-F334R8 board in my dev-board box, so I added it to modm.