### PR TITLE
Avoid fail of CAN init when the bus isn't ready.

### DIFF
--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -102,8 +102,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 		// The CAN hardware waits until the current CAN activity (transmission
 		// or reception) is completed before entering the initialization mode.
 	}
-	if (not modm_assert_continue_fail_debug(deadlockPreventer > 0, "can.init",
-			"CAN::initialize() timed out on entering initialization!", {{ 0 if id == '' else id }}))
+	if (deadlockPreventer == 0)
 		return false;
 
 	// Enable Interrupts:
@@ -154,8 +153,7 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	while ((({{ reg }}->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) and (deadlockPreventer-- > 0))  {
 		// wait for the normal mode
 	}
-	return modm_assert_continue_fail_debug(deadlockPreventer > 0, "can.init2",
-		"CAN::initialize() timed out on leaving initialization!", {{ 0 if id == '' else id }});
+	return deadlockPreventer > 0;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/platform/can/stm32/can.hpp.in
+++ b/src/modm/platform/can/stm32/can.hpp.in
@@ -108,7 +108,7 @@ public:
 	template< class SystemClock, bitrate_t bitrate=kbps(125), percent_t tolerance=pct(1) >
 	static inline bool
 	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
-				bool overwriteOnOverrun = true)
+				bool overwriteOnOverrun = true) [[nodiscard]]
 	{
 		using Timings = CanBitTiming<SystemClock::Can{{ id }}, bitrate>;
 


### PR DESCRIPTION
Return a bool instead and let the user handle the situation.

Fixes #472.