### PR TITLE
Add getters for basic timer period settings

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -164,6 +164,12 @@ public:
 		TIM{{ id }}->PSC = prescaler - 1;
 	}
 
+	static uint16_t
+	getPrescaler()
+	{
+		return (TIM{{ id }}->PSC + 1);
+	}
+
 	static inline void
 	setOverflow(Value overflow)
 	{
@@ -191,6 +197,14 @@ public:
 		}
 
 		return overflow;
+	}
+
+	/* Returns the frequency of the timer */
+	template<class SystemClock>
+	static uint32_t
+	getTickFrequency()
+	{
+		return SystemClock::Timer{{ id }} / (TIM{{ id }}->PSC + 1);
 	}
 
 	static inline void


### PR DESCRIPTION
After configuring the timer, I needed to set a period in real units, but I did not see any way to determine the frequency after the timer configuration code picks the best settings from the target frequency. This adds accessors to allow that. 