### PR TITLE
Rename unittest.py to unit_test.py

### DIFF
--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -25,7 +25,7 @@ class BuildModuleDocs:
         if self._content is None:
             self._content = Path(localpath("module.md")).read_text(encoding="utf-8").strip()
             tools = ["avrdude", "openocd", "bmp", "gdb", "size",
-                     "unittest", "log", "build_id", "bitmap"]
+                     "unit_test", "log", "build_id", "bitmap"]
 
             for tool in tools:
                 tpath = Path(repopath("tools/modm_tools/{}.py".format(tool)))
@@ -171,7 +171,7 @@ def build(env):
         "bitmap",
         "find_files",
         "info",
-        "unittest",
+        "unit_test",
         "utils",
     }
     if is_cortex_m:

--- a/tools/build_script_generator/scons/site_tools/info.c.in
+++ b/tools/build_script_generator/scons/site_tools/info.c.in
@@ -15,6 +15,6 @@
 %% if value is number
 const int16_t {{ name | upper }} = {{ value }};
 %% else
-const char *{{ name | upper }} = "{{ value }}";
+const char *{{ name | upper }} = "{{ value | replace('"', '\\"') }}";
 %% endif
 %% endfor

--- a/tools/build_script_generator/scons/site_tools/unittestm.py
+++ b/tools/build_script_generator/scons/site_tools/unittestm.py
@@ -21,11 +21,11 @@ import re
 import string
 import datetime
 
-from modm_tools import unittest
+from modm_tools import unit_test
 
 # -----------------------------------------------------------------------------
 def unittest_action(target, source, env):
-	unittest.render_runner(headers=(str(s) for s in source),
+	unit_test.render_runner(headers=(str(s) for s in source),
 	                       destination=target[0].abspath)
 	return 0
 

--- a/tools/modm_tools/unit_test.py
+++ b/tools/modm_tools/unit_test.py
@@ -17,7 +17,7 @@ This tools scans a directory for files ending in `_test.hpp`, extracts their
 test cases and generates a source file containing the test runner.
 
 ```sh
-python3 modm/modm_tools/unittest.py path/containing/tests \\
+python3 modm/modm_tools/unit_test.py path/containing/tests \\
                                     path/to/generated_runner.cpp
 ```
 


### PR DESCRIPTION
The unittest.py module overrides the python standard package when executing scripts in the same directory (e.g. `gdb.py`).
This addresses #492. 