### PR TITLE
Miscellaneous fixes/features/tweaks

### DIFF
--- a/src/modm/communication/amnb/handler.hpp.in
+++ b/src/modm/communication/amnb/handler.hpp.in
@@ -53,6 +53,16 @@ struct Listener
 		})
 	{}
 
+	inline
+	Listener(int command, void(*listener)(uint8_t, const uint8_t*, size_t))
+	:	command(command), callback((void*)listener),
+		redirect([](const Message &msg, void* cb)
+		{
+			if (const uint8_t* arg = msg.get<uint8_t>(); arg)
+				reinterpret_cast<decltype(listener)>(cb)(msg.address(), arg, msg.length());
+		})
+	{}
+
 protected:
 	const uint8_t command;
 	void *const callback;
@@ -126,6 +136,18 @@ struct Action
 		})
 	{}
 
+	template<typename T>
+	Action(int command, Response(*action)(const uint8_t*, size_t))
+	:	command(command), callback((void*)action),
+		redirect([](const Message &msg, void* cb) -> Message
+		{
+			const uint8_t* arg = msg.get<uint8_t>();
+			if (arg == nullptr)
+				return Response(Error::ResponseAllocationFailed).msg;
+			return reinterpret_cast<decltype(action)>(cb)(arg, msg.length()).msg;
+		})
+	{}
+
 	inline
 	Action(int command, void(*action)())
 	:	command(command), callback((void*)action),
@@ -144,13 +166,25 @@ struct Action
 	:	command(command), callback((void*)action),
 		redirect([](const Message &msg, void* cb) -> Message
 		{
-
 			const T* arg = msg.get<T>();
 			if (arg == nullptr)
 				return Response(Error::ResponseAllocationFailed).msg;
 			if (msg.length() < sizeof(T))
 				return Response(Error::WrongArgumentSize).msg;
 			reinterpret_cast<decltype(action)>(cb)(*arg);
+			return Response().msg;
+		})
+	{}
+
+	template<typename T>
+	Action(int command, void(*action)(const uint8_t*, size_t))
+	:	command(command), callback((void*)action),
+		redirect([](const Message &msg, void* cb) -> Message
+		{
+			const uint8_t* arg = msg.get<uint8_t>();
+			if (arg == nullptr)
+				return Response(Error::ResponseAllocationFailed).msg;
+			reinterpret_cast<decltype(action)>(cb)(arg, msg.length());
 			return Response().msg;
 		})
 	{}

--- a/src/modm/communication/amnb/node.hpp
+++ b/src/modm/communication/amnb/node.hpp
@@ -224,7 +224,7 @@ protected:
 					const auto listener = listenerList[ii];
 					if (rx_msg.command() == listener.command) {
 						if (complete) listener.call(rx_msg);
-						return true;
+						else return true;
 					}
 				}
 				break;

--- a/src/modm/communication/amnb/node.hpp
+++ b/src/modm/communication/amnb/node.hpp
@@ -61,8 +61,11 @@ public:
 	setAddress(uint8_t address)
 	{
 		this->address = address;
-		setSeed();
 	}
+
+	void
+	setSeed(uint16_t seed)
+	{ lfsr = seed; }
 
 public:
 	bool
@@ -155,7 +158,7 @@ protected:
 		RF_BEGIN(3);
 
 		msg.setValid();
-		tx_counter = std::min(10, msg.command() >> (8 - PRIORITY_BITS));
+		tx_counter = std::min(MIN_TX_TRIES, uint8_t(msg.command() >> (8 - PRIORITY_BITS)));
 		while(1)
 		{
 			while (interface.isMediumBusy())
@@ -324,7 +327,8 @@ protected:
 	}
 	response_status{ResponseStatus::NotWaiting};
 
-	static constexpr uint8_t PRIORITY_BITS{5};
+	static constexpr uint8_t MIN_TX_TRIES{20};
+	static constexpr uint8_t PRIORITY_BITS{6};
 	static constexpr uint8_t RESCHEDULE_MASK_SHORT{7};
 	static constexpr uint8_t RESCHEDULE_MASK_LONG{11};
 };

--- a/src/modm/math/algorithm/enumerate.hpp
+++ b/src/modm/math/algorithm/enumerate.hpp
@@ -29,15 +29,15 @@ constexpr auto enumerate(T && iterable)
     {
         size_t i;
         TIter iter;
-        bool operator != (const iterator & other) const { return iter != other.iter; }
-        void operator ++ () { ++i; ++iter; }
-        auto operator * () const { return std::tie(i, *iter); }
+        constexpr bool operator != (const iterator & other) const { return iter != other.iter; }
+        constexpr void operator ++ () { ++i; ++iter; }
+        constexpr auto operator * () const { return std::tie(i, *iter); }
     };
     struct iterable_wrapper
     {
         T iterable;
-        auto begin() { return iterator{ 0, std::begin(iterable) }; }
-        auto end() { return iterator{ 0, std::end(iterable) }; }
+        constexpr auto begin() { return iterator{ 0, std::begin(iterable) }; }
+        constexpr auto end() { return iterator{ 0, std::end(iterable) }; }
     };
     return iterable_wrapper{ std::forward<T>(iterable) };
 }

--- a/src/modm/math/utils/bit_constants.hpp
+++ b/src/modm/math/utils/bit_constants.hpp
@@ -21,38 +21,73 @@ namespace modm
 /// @ingroup modm_utils
 /// @{
 
-constexpr uint8_t  Bit0  = (1ul <<  0);
-constexpr uint8_t  Bit1  = (1ul <<  1);
-constexpr uint8_t  Bit2  = (1ul <<  2);
-constexpr uint8_t  Bit3  = (1ul <<  3);
-constexpr uint8_t  Bit4  = (1ul <<  4);
-constexpr uint8_t  Bit5  = (1ul <<  5);
-constexpr uint8_t  Bit6  = (1ul <<  6);
-constexpr uint8_t  Bit7  = (1ul <<  7);
-constexpr uint16_t Bit8  = (1ul <<  8);
-constexpr uint16_t Bit9  = (1ul <<  9);
-constexpr uint16_t Bit10 = (1ul << 10);
-constexpr uint16_t Bit11 = (1ul << 11);
-constexpr uint16_t Bit12 = (1ul << 12);
-constexpr uint16_t Bit13 = (1ul << 13);
-constexpr uint16_t Bit14 = (1ul << 14);
-constexpr uint16_t Bit15 = (1ul << 15);
-constexpr uint32_t Bit16 = (1ul << 16);
-constexpr uint32_t Bit17 = (1ul << 17);
-constexpr uint32_t Bit18 = (1ul << 18);
-constexpr uint32_t Bit19 = (1ul << 19);
-constexpr uint32_t Bit20 = (1ul << 20);
-constexpr uint32_t Bit21 = (1ul << 21);
-constexpr uint32_t Bit22 = (1ul << 22);
-constexpr uint32_t Bit23 = (1ul << 23);
-constexpr uint32_t Bit24 = (1ul << 24);
-constexpr uint32_t Bit25 = (1ul << 25);
-constexpr uint32_t Bit26 = (1ul << 26);
-constexpr uint32_t Bit27 = (1ul << 27);
-constexpr uint32_t Bit28 = (1ul << 28);
-constexpr uint32_t Bit29 = (1ul << 29);
-constexpr uint32_t Bit30 = (1ul << 30);
-constexpr uint32_t Bit31 = (1ul << 31);
+constexpr uint8_t  Bit0  = uint8_t(1) << 0;
+constexpr uint8_t  Bit1  = uint8_t(1) << 1;
+constexpr uint8_t  Bit2  = uint8_t(1) << 2;
+constexpr uint8_t  Bit3  = uint8_t(1) << 3;
+constexpr uint8_t  Bit4  = uint8_t(1) << 4;
+constexpr uint8_t  Bit5  = uint8_t(1) << 5;
+constexpr uint8_t  Bit6  = uint8_t(1) << 6;
+constexpr uint8_t  Bit7  = uint8_t(1) << 7;
+
+constexpr uint16_t Bit8  = uint16_t(1) <<  8;
+constexpr uint16_t Bit9  = uint16_t(1) <<  9;
+constexpr uint16_t Bit10 = uint16_t(1) << 10;
+constexpr uint16_t Bit11 = uint16_t(1) << 11;
+constexpr uint16_t Bit12 = uint16_t(1) << 12;
+constexpr uint16_t Bit13 = uint16_t(1) << 13;
+constexpr uint16_t Bit14 = uint16_t(1) << 14;
+constexpr uint16_t Bit15 = uint16_t(1) << 15;
+
+constexpr uint32_t Bit16 = uint32_t(1) << 16;
+constexpr uint32_t Bit17 = uint32_t(1) << 17;
+constexpr uint32_t Bit18 = uint32_t(1) << 18;
+constexpr uint32_t Bit19 = uint32_t(1) << 19;
+constexpr uint32_t Bit20 = uint32_t(1) << 20;
+constexpr uint32_t Bit21 = uint32_t(1) << 21;
+constexpr uint32_t Bit22 = uint32_t(1) << 22;
+constexpr uint32_t Bit23 = uint32_t(1) << 23;
+constexpr uint32_t Bit24 = uint32_t(1) << 24;
+constexpr uint32_t Bit25 = uint32_t(1) << 25;
+constexpr uint32_t Bit26 = uint32_t(1) << 26;
+constexpr uint32_t Bit27 = uint32_t(1) << 27;
+constexpr uint32_t Bit28 = uint32_t(1) << 28;
+constexpr uint32_t Bit29 = uint32_t(1) << 29;
+constexpr uint32_t Bit30 = uint32_t(1) << 30;
+constexpr uint32_t Bit31 = uint32_t(1) << 31;
+
+constexpr uint64_t Bit32 = uint64_t(1) << 32;
+constexpr uint64_t Bit33 = uint64_t(1) << 33;
+constexpr uint64_t Bit34 = uint64_t(1) << 34;
+constexpr uint64_t Bit35 = uint64_t(1) << 35;
+constexpr uint64_t Bit36 = uint64_t(1) << 36;
+constexpr uint64_t Bit37 = uint64_t(1) << 37;
+constexpr uint64_t Bit38 = uint64_t(1) << 38;
+constexpr uint64_t Bit39 = uint64_t(1) << 39;
+constexpr uint64_t Bit40 = uint64_t(1) << 40;
+constexpr uint64_t Bit41 = uint64_t(1) << 41;
+constexpr uint64_t Bit42 = uint64_t(1) << 42;
+constexpr uint64_t Bit43 = uint64_t(1) << 43;
+constexpr uint64_t Bit44 = uint64_t(1) << 44;
+constexpr uint64_t Bit45 = uint64_t(1) << 45;
+constexpr uint64_t Bit46 = uint64_t(1) << 46;
+constexpr uint64_t Bit47 = uint64_t(1) << 47;
+constexpr uint64_t Bit48 = uint64_t(1) << 48;
+constexpr uint64_t Bit49 = uint64_t(1) << 49;
+constexpr uint64_t Bit50 = uint64_t(1) << 50;
+constexpr uint64_t Bit51 = uint64_t(1) << 51;
+constexpr uint64_t Bit52 = uint64_t(1) << 52;
+constexpr uint64_t Bit53 = uint64_t(1) << 53;
+constexpr uint64_t Bit54 = uint64_t(1) << 54;
+constexpr uint64_t Bit55 = uint64_t(1) << 55;
+constexpr uint64_t Bit56 = uint64_t(1) << 56;
+constexpr uint64_t Bit57 = uint64_t(1) << 57;
+constexpr uint64_t Bit58 = uint64_t(1) << 58;
+constexpr uint64_t Bit59 = uint64_t(1) << 59;
+constexpr uint64_t Bit60 = uint64_t(1) << 60;
+constexpr uint64_t Bit61 = uint64_t(1) << 61;
+constexpr uint64_t Bit62 = uint64_t(1) << 62;
+constexpr uint64_t Bit63 = uint64_t(1) << 63;
 
 /// @}
 

--- a/src/modm/platform/gpio/stm32/pin.hpp.in
+++ b/src/modm/platform/gpio/stm32/pin.hpp.in
@@ -93,9 +93,9 @@ public:
 	inline static void set() { PinSet::set(); }
 	inline static void set(bool status) { PinSet::set(status); }
 	inline static void reset() { PinSet::reset(); }
-	inline static void toggle() {
-		if (isSet()) { reset(); }
-		else         { set();   }
+	inline static bool toggle() {
+		if (isSet()) { reset(); return true; }
+		else         { set();   return false; }
 	}
 	inline static bool isSet() { return ({{reg}}->ODR & mask); }
 	// stop documentation inherited

--- a/src/modm/ui/animation/base_impl.hpp
+++ b/src/modm/ui/animation/base_impl.hpp
@@ -63,12 +63,6 @@ template< typename T >
 bool
 modm::ui::Animation<T>::animateTo(T value, TimeType time)
 {
-	if (value == currentValue)
-	{
-		setValue(value);
-		animationTime = time;
-		return false;
-	}
 	if(time == 0)
 	{
 		setValue(value);
@@ -77,8 +71,9 @@ modm::ui::Animation<T>::animateTo(T value, TimeType time)
 
 	endValue = value;
 	animationTime = time;
-	interpolation.initialize(currentValue, endValue, animationTime);
 	previous = modm::Clock::now();
+	interpolation.initialize(currentValue, endValue, animationTime);
+	if (endValue == currentValue and handler) handler(currentValue);
 	return true;
 }
 
@@ -95,7 +90,7 @@ modm::ui::Animation<T>::update()
 	{
 		// buffer the delta time
 		const modm::ShortTimestamp now = modm::Clock::now();
-		// this cast requires us to be updates once at least every 255ms
+		// this cast requires us to be updated once at least every 255ms
 		// If this method is not called every few ms, the animation does
 		// not look good anyways, so this limitation is okay.
 		uint_fast8_t delta = (now - previous).count();
@@ -120,7 +115,7 @@ modm::ui::Animation<T>::update()
 			while (delta--) interpolation.step();
 
 			// get the calculated value for this step
-			T newValue = interpolation.getValue();
+			const T newValue = interpolation.getValue();
 
 			if (currentValue != newValue)
 			{

--- a/src/modm/ui/animation/interpolation.hpp
+++ b/src/modm/ui/animation/interpolation.hpp
@@ -115,10 +115,17 @@ private:
 		initialize(Type begin, Type end, uint_fast16_t steps)
 		{
 			int_fast16_t delta = (static_cast<int_fast16_t>(end) - begin) << 7;
-			deltaValue = delta / static_cast<int_fast16_t>(steps);
-			if (deltaValue == 0)
-				deltaValue = delta > 0 ? 1 : -1;
-			accumulatedValue = (static_cast<uint_fast16_t>(begin) << 7) + deltaValue / 2;
+			if (delta)
+			{
+				deltaValue = delta / static_cast<int_fast16_t>(steps);
+				if (deltaValue == 0) deltaValue = delta > 0 ? 1 : -1;
+				accumulatedValue = (static_cast<uint_fast16_t>(begin) << 7) + deltaValue / 2;
+			}
+			else
+			{
+				deltaValue = 0;
+				accumulatedValue = end << 7;
+			}
 		}
 
 		void inline
@@ -156,10 +163,17 @@ private:
 		initialize(Type begin, Type end, uint32_t steps)
 		{
 			int32_t delta = (static_cast<int32_t>(end) - begin) << 15;
-			deltaValue = delta / static_cast<int32_t>(steps);
-			if (deltaValue == 0)
-				deltaValue = delta > 0 ? 1 : -1;
-			accumulatedValue = (static_cast<uint32_t>(begin) << 15) + deltaValue / 2;
+			if (delta)
+			{
+				deltaValue = delta / static_cast<int32_t>(steps);
+				if (deltaValue == 0) deltaValue = delta > 0 ? 1 : -1;
+				accumulatedValue = (static_cast<uint32_t>(begin) << 15) + deltaValue / 2;
+			}
+			else
+			{
+				deltaValue = 0;
+				accumulatedValue = end << 15;
+			}
 		}
 
 		void inline
@@ -204,10 +218,17 @@ private:
 		initialize(Type begin, Type end, uint32_t steps)
 		{
 			int64_t delta = (static_cast<int64_t>(end) - begin) << 16;
-			deltaValue = delta / static_cast<int32_t>(steps);
-			if (deltaValue == 0)
-				deltaValue = delta > 0 ? 1 : -1;
-			accumulatedValue = (static_cast<uint64_t>(begin) << 16) + deltaValue / 2;
+			if (delta)
+			{
+				deltaValue = delta / static_cast<int32_t>(steps);
+				if (deltaValue == 0) deltaValue = delta > 0 ? 1 : -1;
+				accumulatedValue = (static_cast<uint64_t>(begin) << 16) + deltaValue / 2;
+			}
+			else
+			{
+				deltaValue = 0;
+				accumulatedValue = end << 16;
+			}
 		}
 
 		void inline

--- a/src/modm/ui/animation/key_frame.hpp
+++ b/src/modm/ui/animation/key_frame.hpp
@@ -35,13 +35,15 @@ struct KeyFrameBase
 {
 	static constexpr std::size_t size = sizeof...(Args);
 
-	typename Animation<T>::TimeType length;
-	T value[size];
+	typename Animation<T>::TimeType length = 0;
+	T value[size] = {};
+
+	KeyFrameBase() = default;
+	KeyFrameBase(typename Animation<T>::TimeType length)
+	:	length(length) {}
 
 	KeyFrameBase(typename Animation<T>::TimeType length, Args... values)
-	:	length(length), value{values...}
-	{
-	}
+	:	length(length), value{values...} {}
 } modm_packed;
 
 template<typename T, int remaining, typename... Args>
@@ -114,6 +116,9 @@ public:
 
 	KeyFrame<T, size> *
 	getKeyFrames() const;
+
+	uint16_t
+	getCurrentKeyFrame() const;
 
 	void
 	setKeyFrames(KeyFrame<T, size> *frames, uint16_t length);
@@ -207,6 +212,10 @@ public:
 	/// @return	the pointer to the key frame array
 	KeyFrame<T, N> *
 	getKeyFrames() const;
+
+	/// @return	get the currently animating key frame index, or 0
+	uint16_t
+	getCurrentKeyFrame() const;
 
 	/// @param	frames	pointer to the keyframe array
 	/// @param	length	the number of keyframes in the array

--- a/src/modm/ui/animation/key_frame_impl.hpp
+++ b/src/modm/ui/animation/key_frame_impl.hpp
@@ -83,6 +83,13 @@ modm::ui::KeyFrameAnimationBase<T, Args...>::cancel()
 }
 
 template< typename T, class... Args >
+uint16_t
+modm::ui::KeyFrameAnimationBase<T, Args...>::getCurrentKeyFrame() const
+{
+	return currentFrame ? (currentFrame - 1) : 0;
+}
+
+template< typename T, class... Args >
 bool
 modm::ui::KeyFrameAnimationBase<T, Args...>::isAnimating() const
 {

--- a/src/modm/ui/color.hpp
+++ b/src/modm/ui/color.hpp
@@ -36,22 +36,19 @@ template<class UnderlyingType = uint8_t>
 class RgbT
 {
 public:
-	UnderlyingType red;
-	UnderlyingType green;
-	UnderlyingType blue;
+	UnderlyingType red{0};
+	UnderlyingType green{0};
+	UnderlyingType blue{0};
 
-	RgbT(UnderlyingType red, UnderlyingType green, UnderlyingType blue)
+	constexpr RgbT() = default;
+
+	constexpr RgbT(UnderlyingType red, UnderlyingType green, UnderlyingType blue)
 	:	red(red), green(green), blue(blue)
 	{
 	}
 
-	RgbT()
-	:	red(0), green(0), blue(0)
-	{
-	}
-
 	template<typename IntermediateType = float, unsigned int multiplier = 100, typename ReturnType = UnderlyingType>
-	inline ReturnType getRelative(const UnderlyingType color) const
+	ReturnType getRelative(const UnderlyingType color) const
 	{
 		return static_cast<ReturnType>(
 				(static_cast<IntermediateType>(color) *
@@ -60,25 +57,25 @@ public:
 	}
 
 	template<typename IntermediateType = float, unsigned int multiplier = 100, typename ReturnType = UnderlyingType>
-	inline ReturnType getRelativeRed() const
+	ReturnType getRelativeRed() const
 	{
 		return getRelative<IntermediateType, multiplier, ReturnType>(red);
 	}
 
 	template<typename IntermediateType = float, unsigned int multiplier = 100, typename ReturnType = UnderlyingType>
-	inline ReturnType getRelativeGreen() const
+	ReturnType getRelativeGreen() const
 	{
 		return getRelative<IntermediateType, multiplier, ReturnType>(green);
 	}
 
 	template<typename IntermediateType = float, unsigned int multiplier = 100, typename ReturnType = UnderlyingType>
-	inline ReturnType getRelativeBlue() const
+	ReturnType getRelativeBlue() const
 	{
 		return getRelative<IntermediateType, multiplier, ReturnType>(blue);
 	}
 
 	template<typename IntermediateType = float, unsigned int multiplier = 100, typename ReturnType = UnderlyingType>
-	inline RgbT<ReturnType> getRelativeColors() const
+	RgbT<ReturnType> getRelativeColors() const
 	{
 		return RgbT<ReturnType>(
 			getRelativeRed	<IntermediateType, multiplier, ReturnType>(),
@@ -89,6 +86,12 @@ public:
 
 	template<typename T> void
 	toHsv(HsvT<T>* color) const;
+
+	constexpr bool
+	operator == (const RgbT<UnderlyingType>& other) const
+	{
+		return (red == other.red and green == other.green and blue == other.blue);
+	}
 
 private:
 	template<typename T>
@@ -104,17 +107,14 @@ template<class UnderlyingType = uint8_t>
 class HsvT
 {
 public:
-	UnderlyingType hue;
-	UnderlyingType saturation;
-	UnderlyingType value;
+	UnderlyingType hue{0};
+	UnderlyingType saturation{0};
+	UnderlyingType value{0};
 
-	HsvT(UnderlyingType hue, UnderlyingType saturation, UnderlyingType value)
+	constexpr HsvT() = default;
+
+	constexpr HsvT(UnderlyingType hue, UnderlyingType saturation, UnderlyingType value)
 	:	hue(hue), saturation(saturation), value(value)
-	{
-	}
-
-	HsvT()
-	:	hue(0), saturation(0), value(0)
 	{
 	}
 

--- a/test/modm/communication/amnb/node_test.cpp
+++ b/test/modm/communication/amnb/node_test.cpp
@@ -46,7 +46,7 @@ AmnbNodeTest::testBroadcast()
 	SharedMedium::fail_tx_index = 2;
 	{
 		node.broadcast(0x70);
-		for(uint32_t ii=0; ii < 10000; ii += 10) { node.update(); micro_clock::setTime(ii); }
+		for(uint32_t ii=0; ii < 20000; ii += 10) { node.update(); micro_clock::setTime(ii); }
 		// first transmission attempt fails
 		const uint8_t raw[] = {0x7E, 0x7E, 110, 0x7E, 0x7E, 110, 0x08, 0x70, 0};
 		TEST_ASSERT_EQUALS(SharedMedium::raw_transmitted.size(), sizeof(raw));


### PR DESCRIPTION
This is a collection PR of small improvements, fixes, tweaks that accumulated over some time while working on real world projects.

- [architecture] Add binary import helper macro. Unfortunately it does declare any dependency on the the binary, so SCons will not recompile the inclusion file if the binary changed. However, this is a generic problem that's not really an issue of the binary inclusion mechanism.
- [ui] Animation should always run for the fade time, even if the value change is zero. This is necessary for RGB LEDs, where it makes sense to have one LED d
- [gpio] Gpio::toggle() returns previous output state on STM32. This is not part of the interface, since it may cost extra to read the previous state, but on STM32 it must be done, since there is no hardware toggle.o nothing.
- [amnb] Fine-tune retransmission attempts for a busier bus. Testing this with 10+ nodes requires significantly more attempts before discarding the message.
- [amnb] Allow actions and listeners with binary data (Action return types must still be fixed size though).
- [amnb] Call all compatible listeners for a command.
- [color] Make color constexpr.
- [math] Make modm::enumerate constexpr.
