### PR TITLE
Add fastcode attribute to delay_ns

### DIFF
--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -31,7 +31,7 @@ extern uint16_t delay_ns_per_loop;
 extern uint16_t delay_fcpu_MHz;
 }
 
-inline void delay_ns(uint32_t ns)
+inline void modm_fastcode delay_ns(uint32_t ns)
 {
 	volatile uint32_t overhead_cycles;
 	// ns_per_loop = nanoseconds per cycle times cycles per loop ({{loop}} cycles)

--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -33,14 +33,15 @@ extern uint16_t delay_fcpu_MHz;
 
 inline void delay_ns(uint32_t ns)
 {
+	volatile uint32_t overhead_cycles;
 	// ns_per_loop = nanoseconds per cycle times cycles per loop ({{loop}} cycles)
 	asm volatile (
 		".syntax unified"       "\n\t"
-		"muls.n	%2, %2, %1"     "\n\t"  // multiply the overhead cycles with the ns per cycle:  1-2 cycles on cm3, up to 32 cycles on cm0
-		"subs.n	%0, %0, %2"     "\n\t"  // subtract the overhead in ns from the input:          1 cycle
-	"1:  subs.n	%0, %0, %1"     "\n\t"  // subtract the ns per loop from the input:             1 cycle
+		"muls.n	%0, %0, %2"     "\n\t"  // multiply the overhead cycles with the ns per cycle:  1-2 cycles on cm3, up to 32 cycles on cm0
+		"subs.n	%1, %1, %0"     "\n\t"  // subtract the overhead in ns from the input:          1 cycle
+	"1:  subs.n	%1, %1, %2"     "\n\t"  // subtract the ns per loop from the input:             1 cycle
 		"bpl.n	1b"             "\n\t"  // keep doing that while result is still positive:      2 cycles (when taken)
-	:: "r" (ns), "r" (platform::delay_ns_per_loop), "r" ({{ (overhead / loop) | int}}));
+	: "=r" (overhead_cycles) : "r" (ns), "r" (platform::delay_ns_per_loop), "0" ({{ (overhead / loop) | int}}));
 	// => loop is {{loop}} cycles long
 }
 void delay_us(uint32_t us);


### PR DESCRIPTION
See issue #495. 

I found the delay_ns to be off by scale factor of 2 on stm32f303. Putting the code into fast code section fixes this, at least for this part. 