### PR TITLE
Add nucleo-g431kb board

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
           name: Examples STM32G4 Series
           when: always
           command: |
-            (cd examples && ../tools/scripts/examples_compile.py nucleo_g474re)
+            (cd examples && ../tools/scripts/examples_compile.py nucleo_g431kb nucleo_g474re)
 
   stm32f4-examples:
     docker:

--- a/README.md
+++ b/README.md
@@ -153,15 +153,16 @@ documentation.
 <td align="center">NUCLEO-F746ZG</td>
 </tr><tr>
 <td align="center">NUCLEO-G071RB</td>
+<td align="center">NUCLEO-G431KB</td>
 <td align="center">NUCLEO-G474RE</td>
 <td align="center">NUCLEO-L152RE</td>
-<td align="center">NUCLEO-L432KC</td>
 </tr><tr>
+<td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
 <td align="center">OLIMEXINO-STM32</td>
 <td align="center">RASPBERRYPI</td>
-<td align="center">SAMD21-MINI</td>
 </tr><tr>
+<td align="center">SAMD21-MINI</td>
 <td align="center">STM32-F4VE</td>
 <td align="center">STM32F030F4P6-DEMO</td>
 </tr>

--- a/examples/nucleo_g431kb/blink/main.cpp
+++ b/examples/nucleo_g431kb/blink/main.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		LedUser::toggle();
+		modm::delay(500ms);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g431kb/blink/project.xml
+++ b/examples/nucleo_g431kb/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-g431kb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g431kb/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_g431kb/board.hpp
+++ b/src/modm/board/nucleo_g431kb/board.hpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2020, Jeff McBride
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef MODM_STM32_NUCLEO_G431KB_HPP
+#define MODM_STM32_NUCLEO_G431KB_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_g431kb
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_g431kb
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32G431KB running at 170MHz generated from the internal 16MHz crystal
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 170_MHz;
+	static constexpr uint32_t Ahb1      = Frequency;
+	static constexpr uint32_t Ahb2      = Frequency;
+	static constexpr uint32_t Apb1      = Frequency;
+	static constexpr uint32_t Apb2      = Frequency;
+
+	static constexpr uint32_t Cordic    = Ahb1;
+	static constexpr uint32_t Crc       = Ahb1;
+	static constexpr uint32_t Dma       = Ahb1;
+	static constexpr uint32_t Dma1      = Dma;
+	static constexpr uint32_t Dma2      = Dma;
+	static constexpr uint32_t DmaMux    = Dma;
+	static constexpr uint32_t Fmac      = Ahb1;
+
+	static constexpr uint32_t Adc       = Ahb2;
+	static constexpr uint32_t Adc1      = Adc;
+	static constexpr uint32_t Adc2      = Adc;
+	static constexpr uint32_t Dac       = Ahb2;
+	static constexpr uint32_t Dac1      = Dac;
+	static constexpr uint32_t Dac3      = Dac;
+	static constexpr uint32_t Rng       = Ahb2;
+
+	static constexpr uint32_t Can       = Apb1;
+	static constexpr uint32_t Fdcan1    = Can;
+	static constexpr uint32_t I2c       = Apb1;
+	static constexpr uint32_t I2c1      = I2c;
+	static constexpr uint32_t I2c2      = I2c;
+	static constexpr uint32_t I2c3      = I2c;
+	static constexpr uint32_t I2c4      = I2c;
+	static constexpr uint32_t Lptim     = Apb1;
+	static constexpr uint32_t Lpuart    = Apb1;
+	static constexpr uint32_t Rtc       = Apb1;
+	static constexpr uint32_t Spi2      = Apb1;
+	static constexpr uint32_t Spi3      = Apb1;
+	static constexpr uint32_t Uart4     = Apb1;
+	static constexpr uint32_t Uart5     = Apb1;
+	static constexpr uint32_t Usart2    = Apb1;
+	static constexpr uint32_t Usb       = Apb1;
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Timer2    = Apb1Timer;
+	static constexpr uint32_t Timer3    = Apb1Timer;
+	static constexpr uint32_t Timer4    = Apb1Timer;
+	static constexpr uint32_t Timer5    = Apb1Timer;
+	static constexpr uint32_t Timer6    = Apb1Timer;
+	static constexpr uint32_t Timer7    = Apb1Timer;
+
+	static constexpr uint32_t Sai1      = Apb2;
+	static constexpr uint32_t Spi1      = Apb2;
+	static constexpr uint32_t Usart1    = Apb2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1    = Apb2Timer;
+	static constexpr uint32_t Timer8    = Apb2Timer;
+	static constexpr uint32_t Timer15   = Apb2Timer;
+	static constexpr uint32_t Timer16   = Apb2Timer;
+	static constexpr uint32_t Timer17   = Apb2Timer;
+	static constexpr uint32_t Timer20   = Apb2Timer;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableInternalClock();	// 16MHz
+		Rcc::PllFactors pllFactors{
+			.pllM = 4,	//  16MHz / M= 4 ->   4MHz
+			.pllN = 85,	//   4MHz * N=85 -> 340MHz
+			.pllR = 2,	// 336MHz / R= 2 -> 170MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		// APB1 has max. 170MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA3;
+using A3 = GpioA4;
+using A4 = GpioA5;
+using A5 = GpioA6;
+using A6 = GpioA7;
+using A7 = GpioA2;
+
+using D0  = GpioA10;
+using D1  = GpioA9;
+using D2  = GpioA12;
+using D3  = GpioB0;
+using D4  = GpioB7;
+using D5  = GpioA15;
+using D6  = GpioB6;
+using D7  = GpioF0;
+using D8  = GpioF1;
+using D9  = GpioA8;
+using D10 = GpioA11;
+using D11 = GpioB5;
+using D12 = GpioB4;
+using D13 = GpioB3;
+
+using Button = GpioUnused;
+using LedUser = GpioOutputB8;
+using Leds = SoftwareGpioPort< LedUser >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedUser::setOutput(modm::Gpio::Low);
+}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_G431KB_HPP

--- a/src/modm/board/nucleo_g431kb/board.xml
+++ b/src/modm/board/nucleo_g431kb/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32g431kbt6</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-g431kb</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_g431kb/module.lb
+++ b/src/modm/board/nucleo_g431kb/module.lb
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Jeff McBride
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-g431kb"
+    module.description = """\
+# NUCLEO-G431KB
+
+[Nucleo kit for STM32G431KB](https://www.st.com/en/evaluation-tools/nucleo-g431kb.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32g431kb"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/st_nucleo_g4.cfg"), "st_nucleo_g4.cfg")
+    env.collect(":build:openocd.source", "modm/board/st_nucleo_g4.cfg")


### PR DESCRIPTION
I needed a board definition for the nucleo-32 g431kb development board. 

If you are interested in expanding the BSP collection, feel free to merge. If not, feel free to reject and I can just include into my project. 

There are a couple pins that differ from the usual nucleo-32 pinouts (as defined in `nucleo32_arduino.hpp`) on this board