### PR TITLE
Github Actions: add-path command was deprecated

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup environment - Python pip
         run: |
           pip3 install --user modm scons
-          echo "::add-path::/usr/local/bin"
-          echo "::add-path::/Users/runner/Library/Python/3.8/bin"
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/Users/runner/Library/Python/3.8/bin" >> $GITHUB_PATH
           echo $PATH
 
       - name: Check out repository

--- a/.github/workflows/windows_armcortexm.yml
+++ b/.github/workflows/windows_armcortexm.yml
@@ -35,7 +35,7 @@ jobs:
           Add-Type -Assembly "System.IO.Compression.Filesystem"
           [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-arm-none-eabi-win32.zip", "C:\arm-none-eabi-gcc")
           dir C:\arm-none-eabi-gcc
-          echo "::add-path::C:\arm-none-eabi-gcc\bin"
+          echo "C:\arm-none-eabi-gcc\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm gcc-arm-none-eabi-win32.zip
 
       - name: Show lbuild and arm-none-eabi-gcc Version Information

--- a/.github/workflows/windows_hosted.yml
+++ b/.github/workflows/windows_hosted.yml
@@ -34,7 +34,7 @@ jobs:
           Add-Type -Assembly "System.IO.Compression.Filesystem"
           [System.IO.Compression.ZipFile]::ExtractToDirectory("mingw-get-0.6.3.zip", "C:\mingw-get")
           dir C:\mingw-get
-          echo "::add-path::C:\mingw-get\bin"
+          echo "C:\mingw-get\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm mingw-get-0.6.3.zip
 
       - name: Install MinGW toolchains


### PR DESCRIPTION
Now fixed.

New syntax: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
(Background: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)