### PR TITLE
ADS7843: Use pressure measurement for touch detection and different filtering

### DIFF
--- a/src/modm/driver/touch/ads7843.hpp
+++ b/src/modm/driver/touch/ads7843.hpp
@@ -44,7 +44,7 @@ namespace modm
 		 * 			stable enough to provide a reading, otherwise `false`.
 		 */
 		static bool
-		read(modm::glcd::Point * point);
+		read(modm::glcd::Point * point, uint16_t pressure_threshold=defaultThreshold);
 
 		static inline uint16_t
 		readX()
@@ -58,13 +58,33 @@ namespace modm
 			return readData(CHY);
 		}
 
+		static inline uint16_t
+		readZ1()
+		{
+			return readData(CHZ1);
+		}
+
+		static inline uint16_t
+		readZ2()
+		{
+			return readData(CHZ2);
+		}
+
+		static inline uint16_t
+		readPressure()
+		{
+			uint16_t z1 = readZ1();
+			uint16_t z2 = readZ2();
+			return z1 + 4095 - z2;
+		}
+
 	private:
 		static const uint8_t CHX = 0x90;
 		static const uint8_t CHY = 0xd0;
 		static const uint8_t CHZ1 = 0xb0;
 		static const uint8_t CHZ2 = 0xc0;
 
-		static const uint16_t threshold = 72;
+		static const uint16_t defaultThreshold = 72;
 
 		static uint16_t
 		getBestTwo(uint16_t *temp);

--- a/src/modm/driver/touch/ads7843.hpp
+++ b/src/modm/driver/touch/ads7843.hpp
@@ -19,6 +19,8 @@
 #include <modm/ui/display/graphic_display.hpp>
 #include <modm/architecture/interface/delay.hpp>
 
+
+
 namespace modm
 {
 	/**
@@ -59,11 +61,13 @@ namespace modm
 	private:
 		static const uint8_t CHX = 0x90;
 		static const uint8_t CHY = 0xd0;
+		static const uint8_t CHZ1 = 0xb0;
+		static const uint8_t CHZ2 = 0xc0;
 
-		static const uint16_t threshold = 2;
+		static const uint16_t threshold = 72;
 
-		static bool
-		getAverage(uint16_t * buffer, int16_t & value);
+		static uint16_t
+		getBestTwo(uint16_t *temp);
 
 		static uint16_t
 		readData(uint8_t command);

--- a/src/modm/driver/touch/ads7843_impl.hpp
+++ b/src/modm/driver/touch/ads7843_impl.hpp
@@ -58,15 +58,13 @@ modm::Ads7843<Spi, Cs, Int>::getBestTwo(uint16_t *buf)
 // ----------------------------------------------------------------------------
 template <typename Spi, typename Cs, typename Int>
 bool
-modm::Ads7843<Spi, Cs, Int>::read(glcd::Point * point)
+modm::Ads7843<Spi, Cs, Int>::read(glcd::Point * point, uint16_t pressure_threshold)
 {
-	uint16_t z1 = readData(CHZ1);
-	uint16_t z2 = readData(CHZ2);
-	uint16_t z = z1 + 4095 - z2;
+	uint16_t z = readPressure();
 	uint16_t xbuf[3];
 	uint16_t ybuf[3];
 
-	if(z > threshold) {
+	if(z > pressure_threshold) {
 		xbuf[0] = readData(CHX);
 		ybuf[0] = readData(CHY);
 		xbuf[1] = readData(CHX);


### PR DESCRIPTION
I tried using the ADS7843 driver with this display: http://hiletgo.com/ProductDetail/2157216.html. I found the touch detection to not be very good; if I held my finger firmly on the display it would go back and forth between pressed or not. 

With a little reading, it seems that the recommended approach is to use the Z registers for a pressure calculation, and this seems to work much better at identifying when the screen is touched, at least for this display. 

I'm hesitant to recommend this, because even though this works much better for me, it is changing the driver behavior in ways that may affect other projects. At the same time, I found this driver to be essentially unusable as-is. I'm interested in feedback on how best to proceed from anyone interested. 

