### PR TITLE
[architecture] Make operator<< for can::Message usable in namespace modm

### DIFF
--- a/src/modm/architecture/interface/can_message.cpp.in
+++ b/src/modm/architecture/interface/can_message.cpp.in
@@ -35,8 +35,11 @@ modm::can::Message::operator == (const modm::can::Message& rhs) const
 #include <inttypes.h>
 #include <modm/io/iostream.hpp>
 
+namespace modm
+{
+
 modm::IOStream&
-operator << (modm::IOStream& s, const modm::can::Message m)
+operator << (modm::IOStream& s, const modm::can::Message& m)
 {
 	s.printf("id = %04" PRIx32 ", len = ", m.identifier);
 	s << m.length;
@@ -49,5 +52,7 @@ operator << (modm::IOStream& s, const modm::can::Message m)
 		}
 	}
 	return s;
+}
+
 }
 %% endif

--- a/src/modm/architecture/interface/can_message.hpp.in
+++ b/src/modm/architecture/interface/can_message.hpp.in
@@ -101,8 +101,13 @@ public:
 %% if with_io
 #include <modm/io/iostream.hpp>
 
+namespace modm
+{
+
 modm::IOStream&
-operator << (modm::IOStream& s, const modm::can::Message m);
+operator << (modm::IOStream& s, const modm::can::Message& m);
+
+}
 %% endif
 
 #endif // MODM_CAN_MESSAGE_HPP


### PR DESCRIPTION
Fixes #509. The operator was defined in the global namespace and is not found by name lookup when used from within namespace modm.

@strongly-typed Could you please check if this works for you?