### PR TITLE
FreeRTOS example on stm32f4_discovery board

### DIFF
--- a/examples/stm32f4_discovery/freertos_display/main.cpp
+++ b/examples/stm32f4_discovery/freertos_display/main.cpp
@@ -22,7 +22,7 @@ using namespace modm::platform;
  * What to expect?
  * ---------------
  * - All 3  LEDs blinking at different rates, about 3 to 4 Hz
- * - SSD1306 LCD screen displaying a counter.
+ * - SSD1306 LCD screen displaying a counter (coming).
  */
 
 // ----------------------------------------------------------------------------

--- a/examples/stm32f4_discovery/freertos_display/main.cpp
+++ b/examples/stm32f4_discovery/freertos_display/main.cpp
@@ -43,10 +43,7 @@ public:
 			sleep(SleepTime * MILLISECONDS);
 
 			Gpio::toggle();
-			{
-				static modm::rtos::Mutex lm;
-				modm::rtos::MutexGuard m(lm);
-			}
+
 			i = (i+1)%10;
 			a *= 3.141f;
 		}

--- a/examples/stm32f4_discovery/freertos_display/main.cpp
+++ b/examples/stm32f4_discovery/freertos_display/main.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2014, Georgi Grinshpun
+ * Copyright (c) 2015-2017, 2019 Niklas Hauser
+ * Copyright (c) 2020, Ayoub SOUSSI
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing/rtos.hpp>
+
+using namespace modm::platform;
+
+/**
+ * This example can be used as a template for FreeRtos + display implementation.
+ *
+ * What to expect?
+ * ---------------
+ * - All 3  LEDs blinking at different rates, about 3 to 4 Hz
+ * - SSD1306 LCD screen displaying a counter.
+ */
+
+// ----------------------------------------------------------------------------
+template <typename Gpio, int SleepTime>
+class LedThread: modm::rtos::Thread
+{
+	char c;
+	uint8_t i = 0;
+	volatile float a = 10.f;
+public:
+	LedThread(char c): Thread(2,1<<10), c(c) {}
+
+	void run()
+	{
+		Gpio::setOutput();
+		while (true)
+		{
+			sleep(SleepTime * MILLISECONDS);
+
+			Gpio::toggle();
+			{
+				static modm::rtos::Mutex lm;
+				modm::rtos::MutexGuard m(lm);
+			}
+			i = (i+1)%10;
+			a *= 3.141f;
+		}
+	}
+};
+
+LedThread< Board::LedRed,   260      > p1('0');
+LedThread< Board::LedGreen, 260 + 10 > p2('a');
+LedThread< Board::LedBlue,  260 + 20 > p3('A');
+
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	modm::rtos::Scheduler::schedule();
+	return 0;
+}

--- a/examples/stm32f4_discovery/freertos_display/project.xml
+++ b/examples/stm32f4_discovery/freertos_display/project.xml
@@ -5,7 +5,6 @@
   </options>
   <modules>
     <module>modm:processing:rtos</module>
-     <module>modm:freertos:tcp</module>
     <module>modm:platform:heap</module>
     <module>modm:build:scons</module>
   </modules>

--- a/examples/stm32f4_discovery/freertos_display/project.xml
+++ b/examples/stm32f4_discovery/freertos_display/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:disco-f407vg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f4_discovery/freertos_display</option>
+  </options>
+  <modules>
+    <module>modm:processing:rtos</module>
+     <module>modm:freertos:tcp</module>
+    <module>modm:platform:heap</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>


### PR DESCRIPTION
Basic example of using FreeRTOS on an STM32F407VG board similar to the one that exists in the NUCLEO-F429zi examples.
It uses 3 threads to make 3 LEDs blink at different rates.
The plan is to add later another thread for an SSD1306 LCD screen (still working on it).