### PR TITLE
[freertos] Add enter/exit critical section functions

### DIFF
--- a/src/modm/processing/rtos/freertos/thread.cpp
+++ b/src/modm/processing/rtos/freertos/thread.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2009-2012, Fabian Greif
  * Copyright (c) 2012, 2018, Niklas Hauser
+ * Copyright (c) 2020, Ayoub SOUSSI
  *
  * This file is part of the modm project.
  *
@@ -69,6 +70,21 @@ modm::rtos::Thread::setPriority(uint32_t priority)
 }
 
 // ----------------------------------------------------------------------------
+
+void
+modm::rtos::Thread::enterCritical()
+{
+	taskENTER_CRITICAL();
+}
+
+void
+modm::rtos::Thread::exitCritical()
+{
+	taskEXIT_CRITICAL();
+}
+
+// ----------------------------------------------------------------------------
+
 /*void
 modm::rtos::Thread::suspend()
 {

--- a/src/modm/processing/rtos/freertos/thread.hpp
+++ b/src/modm/processing/rtos/freertos/thread.hpp
@@ -142,7 +142,7 @@ namespace modm
 			 */
 			void
 			setPriority(uint32_t priority);
-                        
+
 			/**
 			 * \brief Enter critical section
 			 *
@@ -151,7 +151,7 @@ namespace modm
 			 */
 			void
 			enterCritical();
-			
+
 			/**
 			 * \brief Exit critical section
 			 *
@@ -160,7 +160,7 @@ namespace modm
 			 */
 			void
 			exitCritical();
-			
+
 			/**
 			 * \brief	When created suspends all real time kernel activity
 			 * 			while keeping interrupts (including the kernel tick)

--- a/src/modm/processing/rtos/freertos/thread.hpp
+++ b/src/modm/processing/rtos/freertos/thread.hpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2010, Martin Rosekeit
  * Copyright (c) 2012, 2018, Niklas Hauser
  * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2020, Ayoub SOUSSI
  *
  * This file is part of the modm project.
  *
@@ -141,7 +142,25 @@ namespace modm
 			 */
 			void
 			setPriority(uint32_t priority);
-
+                        
+			/**
+			 * \brief Enter critical section
+			 *
+			 * It simply disables all interrupts
+			 *
+			 */
+			void
+			enterCritical();
+			
+			/**
+			 * \brief Exit critical section
+			 *
+			 * By re-enabling interrupts
+			 *
+			 */
+			void
+			exitCritical();
+			
 			/**
 			 * \brief	When created suspends all real time kernel activity
 			 * 			while keeping interrupts (including the kernel tick)


### PR DESCRIPTION
Wrapping taskENTER_CRITICAL and taskEXIT_CRITICAL of FreeRTOS to deal with critical sections.

I tested it on an STM32F4 discovery board.