### PR TITLE
[stm32] Fix [[nodiscard]] for Can::initialize()

### DIFF
--- a/src/modm/platform/can/stm32/can.hpp.in
+++ b/src/modm/platform/can/stm32/can.hpp.in
@@ -106,9 +106,9 @@ public:
 	 * 			other function from this class!
 	 */
 	template< class SystemClock, bitrate_t bitrate=kbps(125), percent_t tolerance=pct(1) >
-	static inline bool
+	[[nodiscard]] static inline bool
 	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
-				bool overwriteOnOverrun = true) [[nodiscard]]
+				bool overwriteOnOverrun = true)
 	{
 		using Timings = CanBitTiming<SystemClock::Can{{ id }}, bitrate>;
 


### PR DESCRIPTION
Put the [[nodiscard]] attribute in the right location.