### PR TITLE
[stm32] Fix address of F0 temperature calibration values

### DIFF
--- a/examples/nucleo_f042k6/adc/main.cpp
+++ b/examples/nucleo_f042k6/adc/main.cpp
@@ -30,9 +30,9 @@ main()
 	MODM_LOG_INFO << "Vref=" << Vref << modm::endl;
 	MODM_LOG_INFO << "Temp=" << Temp << modm::endl;
 
-	MODM_LOG_INFO << "TS_CAL1=" << uint16_t(*((volatile uint16_t *)0x1FFF77B8)) << modm::endl;
-	MODM_LOG_INFO << "TS_CAL2=" << uint16_t(*((volatile uint16_t *)0x1FFF77C2)) << modm::endl;
-	MODM_LOG_INFO << "VREFINT_CAL=" << uint16_t(*((volatile uint16_t *)0x1FFFF7BA)) << modm::endl;
+	MODM_LOG_INFO << "TS_CAL1=" << *Adc::TS_CAL1 << modm::endl;
+	MODM_LOG_INFO << "TS_CAL2=" << *Adc::TS_CAL2 << modm::endl;
+	MODM_LOG_INFO << "VREFINT_CAL=" << *Adc::VREFINT_CAL << modm::endl;
 
 	Adc::setPinChannel<AdcIn1>();
 	Adc::setResolution(Adc::Resolution::Bits12);

--- a/examples/stm32f030f4p6_demo_board/adc/main.cpp
+++ b/examples/stm32f030f4p6_demo_board/adc/main.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+
+	Adc::initialize<Board::SystemClock, Adc::ClockMode::Synchronous, 12_MHz>();
+	const uint16_t Vref = Adc::readInternalVoltageReference();
+
+	while (true)
+	{
+		int16_t Temp = Adc::readTemperature(Vref);
+		LedOrange::set(Temp > 30);
+		modm::delay(1s);
+	}
+
+	return 0;
+}

--- a/examples/stm32f030f4p6_demo_board/adc/openocd.cfg
+++ b/examples/stm32f030f4p6_demo_board/adc/openocd.cfg
@@ -1,0 +1,2 @@
+# Replace this with your custom programmer
+source [find interface/stlink-v2.cfg]

--- a/examples/stm32f030f4p6_demo_board/adc/project.xml
+++ b/examples/stm32f030f4p6_demo_board/adc/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:stm32f030_demo</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f030f4p6_demo/adc</option>
+    <option name="modm:build:openocd.cfg">openocd.cfg</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:adc</module>
+  </modules>
+</library>

--- a/src/modm/board/stm32f030f4p6_demo/board.hpp
+++ b/src/modm/board/stm32f030f4p6_demo/board.hpp
@@ -80,7 +80,7 @@ struct SystemClock {
 };
 
 // User LED
-using LedOrange = GpioOutputA4;
+using LedOrange = GpioInverted< GpioOutputA4 >;
 using Leds = SoftwareGpioPort< LedOrange >;
 
 using Button = GpioUnused;

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -316,11 +316,16 @@ public:
 public:
 	static constexpr uint8_t TS_CAL1_TEMP{30};
 %% if target.family in ["f0"]
-	static constexpr uint8_t TS_CAL2_TEMP{110};
 	static constexpr uint16_t VDDA_CAL{3300};
 	static inline volatile uint16_t *const VREFINT_CAL{(volatile uint16_t *)0x1FFF'F7BA};
 	static inline volatile uint16_t *const TS_CAL1{(volatile uint16_t *)0x1FFF'F7B8};
+%% if target.name in ["30", "70"]
+	// defined in F030 reference manual
+	static constexpr uint16_t TS_AVG_SLOPE{5336};
+%% else
+	static constexpr uint8_t TS_CAL2_TEMP{110};
 	static inline volatile uint16_t *const TS_CAL2{(volatile uint16_t *)0x1FFF'F7C2};
+%% endif
 %% else
 	static constexpr uint8_t TS_CAL2_TEMP{130};
 	static constexpr uint16_t VDDA_CAL{3000};

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -318,9 +318,9 @@ public:
 %% if target.family in ["f0"]
 	static constexpr uint8_t TS_CAL2_TEMP{110};
 	static constexpr uint16_t VDDA_CAL{3300};
-	static inline volatile uint16_t *const VREFINT_CAL{(volatile uint16_t *)0x1FFFF7BA};
-	static inline volatile uint16_t *const TS_CAL1{(volatile uint16_t *)0x1FFF77B8};
-	static inline volatile uint16_t *const TS_CAL2{(volatile uint16_t *)0x1FFF77C2};
+	static inline volatile uint16_t *const VREFINT_CAL{(volatile uint16_t *)0x1FFF'F7BA};
+	static inline volatile uint16_t *const TS_CAL1{(volatile uint16_t *)0x1FFF'F7B8};
+	static inline volatile uint16_t *const TS_CAL2{(volatile uint16_t *)0x1FFF'F7C2};
 %% else
 	static constexpr uint8_t TS_CAL2_TEMP{130};
 	static constexpr uint16_t VDDA_CAL{3000};

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -245,8 +245,13 @@ modm::platform::Adc{{ id }}::readTemperature(uint16_t Vref)
 	// Sample time must be at least 5us!!!
 	const int32_t TS_DATA = readChannel(Channel::Temperature);
 
+%% if target.family == "f0" and target.name in ["30", "70"]
+	const int32_t value = (int32_t(*TS_CAL1) - (TS_DATA * Vref / VDDA_CAL)) * 1000;
+	return value / TS_AVG_SLOPE + TS_CAL1_TEMP;
+%% else
 	const int32_t value = int32_t(TS_CAL2_TEMP - TS_CAL1_TEMP) * (TS_DATA * Vref / VDDA_CAL - *TS_CAL1);
 	return value / (*TS_CAL2 - *TS_CAL1) + TS_CAL1_TEMP;
+%% endif
 }
 
 uint16_t


### PR DESCRIPTION
The addresses for the temperature sensor calibration values are wrong in modm. ST manual:
![image](https://user-images.githubusercontent.com/25187160/102694697-0b8cd680-4223-11eb-9d49-0b1ddc2fdd49.png)

When first trying to use the ADC temperature sensor on a custom board with an F042K6 I ended up in the hardfault handler. I am wondering how the nucleo f042k6 adc example could have ever worked. This change is tested on real hardware.

I'll also fix the example which has these addresses hardcoded for demonstration purposes.

- [x]  change constants in F0 ADC driver
- [x] fix values in example
- [x] make temperature sensor code compatible with F030/F070