### PR TITLE
[stm32] Fix F0/F1 PLL pre-divider setting

### DIFF
--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2016-2019, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2021, Christopher Durand
 #
 # This file is part of the modm project.
 #
@@ -57,6 +58,7 @@ def build(env):
     properties["pllprediv"] = \
         (target["family"] in ["f0", "f3"] or (target["family"] == "f1" and target["name"] in ["00", "05", "07"]))
     properties["pllprediv2"] = False    # FIXME: not sure what value this should have
+    properties["pll_hse_prediv2"] = target["family"] == "f1" and target["name"] in ["01", "02", "03"]
     properties["hsi48"] = \
         target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -261,6 +261,12 @@ modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, u
 	// Pll multiplication factor
 	tmp |= (static_cast<uint32_t>(pllFactors.pllMul - 2) << 18) & {{pullmul}};
 
+%% if pll_hse_prediv2
+	if(pllFactors.enableHsePllPrediv2) {
+		tmp |= RCC_CFGR_PLLXTPRE;
+	}
+%% endif
+
 	RCC->CFGR = tmp;
 
 %% if pllprediv

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -5,7 +5,7 @@
  * Copyright (c) 2012, 2016, Sascha Schade
  * Copyright (c) 2012, 2014-2019, Niklas Hauser
  * Copyright (c) 2013-2014, Kevin Läufer
- * Copyright (c) 2018, Christopher Durand
+ * Copyright (c) 2018, 2021, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -261,16 +261,13 @@ modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, u
 	// Pll multiplication factor
 	tmp |= (static_cast<uint32_t>(pllFactors.pllMul - 2) << 18) & {{pullmul}};
 
+	RCC->CFGR = tmp;
+
 %% if pllprediv
 	%% set mask = 'RCC_CFGR2_PREDIV1' if target["family"] == "f1" else 'RCC_CFGR2_PREDIV'
-#ifdef {{mask}}
 	// HSE PREDIV division factor
 	RCC->CFGR2 = (RCC->CFGR2 & ~({{mask}})) | (uint32_t(pllFactors.pllPrediv - 1) & {{mask}});
-#else
-	if (uint32_t(pllFactors.pllPrediv - 1) & 0x1) tmp |= RCC_CFGR_PLLXTPRE;
-#endif
 %% endif
-	RCC->CFGR = tmp;
 %% if pllprediv2
 	RCC->CFGR2 = (RCC->CFGR2 & ~(RCC_CFGR2_PREDIV2)) | ((uint32_t(pllFactors.pllPrediv2 - 1) << 4) & RCC_CFGR2_PREDIV2);
 %% endif

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -399,6 +399,8 @@ public:
 		const uint8_t pllPrediv2;
  %% elif pllprediv
 		const uint8_t pllPrediv;
+ %% elif pll_hse_prediv2
+		const bool enableHsePllPrediv2 = false;
  %% endif
  %% if usbprescaler
  		const UsbPrescaler usbPrediv = UsbPrescaler::Div1_5;


### PR DESCRIPTION
This PR fixes the issue of PR https://github.com/modm-io/modm/pull/99 opened by @daniel-k in 2018.
Bit 17 in register `RCC->CFGR` (`RCC_CFGR_PLLXTPRE`) aliases the LSB of the PLL pre-divider setting in `RCC->CFGR2`. They were written in such a way that the LSB of the pre-divider was always zero. This is fixed by setting `CFGR2` after `CFGR`.

Furthermore a parameter is added to set the `RCC_CFGR_PLLXTPRE` bit on  F10{1, 2, 3} devices which acts as a HSE clock /2 pre-divider. These devices don't include the /1-/16 divider.

I don't have access to any of the affected hardware right now, but I am quite confident the changes will work.