### PR TITLE
Add Nucleo446ZE + various fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,23 +150,24 @@ documentation.
 <td align="center">NUCLEO-F411RE</td>
 <td align="center">NUCLEO-F429ZI</td>
 <td align="center">NUCLEO-F446RE</td>
-<td align="center">NUCLEO-F746ZG</td>
+<td align="center">NUCLEO-F446ZE</td>
 </tr><tr>
+<td align="center">NUCLEO-F746ZG</td>
 <td align="center">NUCLEO-G071RB</td>
 <td align="center">NUCLEO-G431KB</td>
 <td align="center">NUCLEO-G431RB</td>
-<td align="center">NUCLEO-G474RE</td>
 </tr><tr>
+<td align="center">NUCLEO-G474RE</td>
 <td align="center">NUCLEO-L152RE</td>
 <td align="center">NUCLEO-L432KC</td>
 <td align="center">NUCLEO-L476RG</td>
-<td align="center">OLIMEXINO-STM32</td>
 </tr><tr>
+<td align="center">OLIMEXINO-STM32</td>
 <td align="center">RASPBERRYPI</td>
 <td align="center">SAMD21-MINI</td>
 <td align="center">STM32-F4VE</td>
-<td align="center">STM32F030F4P6-DEMO</td>
 </tr><tr>
+<td align="center">STM32F030F4P6-DEMO</td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/nucleo_f446ze/blink/main.cpp
+++ b/examples/nucleo_f446ze/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Leds::write(1 << (counter % (Leds::width+1) ));
+		modm::delay(Button::read() ? 100ms : 500ms);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f446ze/blink/project.xml
+++ b/examples/nucleo_f446ze/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f446ze</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f446ze/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_f446ze/usbserial/main.cpp
+++ b/examples/nucleo_f446ze/usbserial/main.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <tusb.h>
+
+#include <modm/board.hpp>
+#include <modm/io.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+modm::IODeviceWrapper<UsbUart0, modm::IOBuffer::BlockIfFull> usb_io_device;
+modm::IOStream usb_stream(usb_io_device);
+
+modm::PeriodicTimer tmr{2.5s};
+
+// Invoked when device is mounted
+void tud_mount_cb() { tmr.restart(1s); }
+// Invoked when device is unmounted
+void tud_umount_cb() { tmr.restart(250ms); }
+// Invoked when usb bus is suspended
+// remote_wakeup_en : if host allow us  to perform remote wakeup
+// Within 7ms, device must draw an average of current less than 2.5 mA from bus
+void tud_suspend_cb(bool) { tmr.restart(2.5s); }
+// Invoked when usb bus is resumed
+void tud_resume_cb() { tmr.restart(1s); }
+
+int main()
+{
+	Board::initialize();
+	Board::initializeUsbFs();
+
+	tusb_init();
+
+	uint8_t counter{0};
+	while (true)
+	{
+		tud_task();
+
+		if (tmr.execute())
+		{
+			Leds::toggle();
+			usb_stream << "Hello World from USB: " << (counter++) << modm::endl;
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f446ze/usbserial/project.xml
+++ b/examples/nucleo_f446ze/usbserial/project.xml
@@ -1,0 +1,13 @@
+<library>
+   <extends>modm:nucleo-f446ze</extends>
+   <options>
+     <option name="modm:build:build.path">../../../build/nucleo_f446ze/usbserial</option>
+     <option name="modm:tinyusb:config">device.cdc</option>
+   </options>
+   <modules>
+     <module>modm:build:scons</module>
+     <module>modm:tinyusb</module>
+     <module>modm:processing:timer</module>
+     <module>modm:io</module>
+   </modules>
+ </library>

--- a/src/modm/board/disco_f429zi/board.hpp
+++ b/src/modm/board/disco_f429zi/board.hpp
@@ -83,8 +83,8 @@ struct SystemClock
 			.pllP = 2		// 360MHz / P=2 -> 180MHz = F_cpu
 		};
 		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
-		PWR->CR |= PWR_CR_ODEN; // Enable overdrive mode
-		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
+		// Required for 180 MHz clock
+		Rcc::enableOverdriveMode();
 		Rcc::setFlashLatency<Frequency>();
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div4);

--- a/src/modm/board/disco_f469ni/board.hpp
+++ b/src/modm/board/disco_f469ni/board.hpp
@@ -91,8 +91,8 @@ struct SystemClock
 			.pllP = 2,		// 360MHz / P=2 -> 180MHz = F_cpu
 		};
 		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
-		PWR->CR |= PWR_CR_ODEN; // Enable overdrive mode
-		while (not (PWR->CSR & PWR_CSR_ODRDY)) ;
+		// Required for 180 MHz clock
+		Rcc::enableOverdriveMode();
 		Rcc::setFlashLatency<Frequency>();
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div4);

--- a/src/modm/board/disco_f746ng/board.hpp
+++ b/src/modm/board/disco_f746ng/board.hpp
@@ -91,8 +91,8 @@ struct SystemClock
 			.pllQ = 9		// 432MHz / Q=9 -> 48MHz = F_usb
 		};
 		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
-		PWR->CR1 |= PWR_CR1_ODEN; // Enable overdrive mode
-		while (not (PWR->CSR1 & PWR_CSR1_ODRDY)) ;
+		// Required for 216 MHz clock
+		Rcc::enableOverdriveMode();
 
 		Rcc::setFlashLatency<Frequency>();
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);

--- a/src/modm/board/disco_f769ni/board.hpp
+++ b/src/modm/board/disco_f769ni/board.hpp
@@ -88,8 +88,8 @@ struct SystemClock
 			.pllP = 2		// 432MHz / P=2 -> 216MHz = F_cpu
 		};
 		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
-		PWR->CR1 |= PWR_CR1_ODEN; // Enable overdrive mode
-		while (not (PWR->CSR1 & PWR_CSR1_ODRDY)) ;
+		// Required for 216 MHz clock
+		Rcc::enableOverdriveMode();
 		Rcc::setFlashLatency<Frequency>();
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		// APB1 is running only at 27MHz, since AHB / 4 = 54MHz > 45MHz limit!

--- a/src/modm/board/nucleo_f446re/board.hpp
+++ b/src/modm/board/nucleo_f446re/board.hpp
@@ -76,6 +76,8 @@ struct SystemClock {
 			.pllP = 2,		// 360MHz / P=  2 -> 180MHz = F_cpu
 		};
 		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		// Required for 180 MHz clock
+		Rcc::enableOverdriveMode();
 		// set flash latency
 		Rcc::setFlashLatency<Frequency>();
 		// switch system clock to PLL output

--- a/src/modm/board/nucleo_f446ze/board.hpp
+++ b/src/modm/board/nucleo_f446ze/board.hpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2016-2017, Sascha Schade
+ * Copyright (c) 2016-2018, Niklas Hauser
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_F446ZE_HPP
+#define MODM_STM32_NUCLEO_F446ZE_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_f446ze
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_f446ze
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32F446 running at 180 MHz from external 8 MHz STLink clock
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 180_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb1 = Frequency / 4;
+	static constexpr uint32_t Apb2 = Frequency / 2;
+
+	static constexpr uint32_t Adc    = Apb2;
+
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Spi2   = Apb1;
+	static constexpr uint32_t Spi3   = Apb1;
+	static constexpr uint32_t Spi4   = Apb2;
+	static constexpr uint32_t Spi5   = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+
+	static constexpr uint32_t I2c1   = Apb1;
+	static constexpr uint32_t I2c2   = Apb1;
+	static constexpr uint32_t I2c3   = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer9  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+
+	static constexpr uint32_t Usb     = 48_MHz;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableExternalClock();	// 8MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 4,		//  8MHz / M=  4 ->   2MHz
+			.pllN = 180,	//   2MHz * N=180 -> 360MHz
+			.pllP = 2,		// 360MHz / P=  2 -> 180MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
+
+		const Rcc::PllSaiFactors pllSaiFactors{
+			.pllSaiM = 4,	//   8MHz / M=  4 ->   2MHz
+			.pllSaiN = 96,	//   2MHz * N= 96 -> 192MHz
+			.pllSaiP = 4,	// 192MHz / P=  4 ->  48MHz = F_usb
+		};
+		Rcc::enablePllSai(pllSaiFactors);
+
+		// "Overdrive" is required for guaranteed stable 180 MHz operation
+		Rcc::enableOverdriveMode();
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setClock48Source(Rcc::Clock48Source::PllSaiP);
+		// APB1 has max. 45MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div4);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div2);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo144_arduino.hpp"
+
+using Button = GpioInputC13;
+
+using LedGreen = GpioOutputB0;	// LED1 [Green]
+using LedBlue = GpioOutputB7;	// LED2 [Blue]
+using LedRed = GpioOutputB14;	// LED3 [Red]
+using Leds = SoftwareGpioPort< LedRed, LedBlue, LedGreen >;
+
+namespace usb
+{
+using Vbus = GpioA9;
+using Id = GpioA10;
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Overcurrent = GpioInputG7;	// OTG_FS_OverCurrent
+using Power = GpioOutputG6;			// OTG_FS_PowerSwitchOn
+
+using Device = UsbFs;
+}
+
+namespace stlink
+{
+using Tx = GpioOutputD8;
+using Rx = GpioInputD9;
+using Uart = Usart3;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedRed::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+	Button::enableExternalInterrupt();
+	//  Button::enableExternalInterruptVector(12);
+}
+
+inline void
+initializeUsbFs()
+{
+	usb::Device::initialize<SystemClock>();
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
+
+	usb::Overcurrent::setInput();
+	usb::Vbus::setInput();
+	// Force device mode
+	USB_OTG_FS->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
+	modm::delay_ms(25);
+	// Enable VBUS sense (B device) via pin PA9
+	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
+}
+
+}
+
+#endif  // MODM_STM32_NUCLEO_F446ZE_HPP

--- a/src/modm/board/nucleo_f446ze/board.xml
+++ b/src/modm/board/nucleo_f446ze/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f446zet6</option>
+
+    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f446ze</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f446ze/module.lb
+++ b/src/modm/board/nucleo_f446ze/module.lb
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2021, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-f446ze"
+    module.description = """\
+# NUCLEO-F446ZE
+
+[Nucleo kit for STM32F446ZE](https://www.st.com/en/evaluation-tools/nucleo-f446ze.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f446zet"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:3",
+        ":platform:usb:fs")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_f4.cfg");

--- a/src/modm/board/nucleo_f746zg/board.hpp
+++ b/src/modm/board/nucleo_f746zg/board.hpp
@@ -94,8 +94,8 @@ struct SystemClock
 			//.pllQ = 9		// 432MHz / P=2 -> 48MHz (USB, etc.)
 		};
 		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
-		PWR->CR1 |= PWR_CR1_ODEN; // Enable overdrive mode
-		while (not (PWR->CSR1 & PWR_CSR1_ODRDY)) ;
+		// Required for 216 MHz clock
+		Rcc::enableOverdriveMode();
 		Rcc::setFlashLatency<Frequency>();
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		// APB1 is running at 54MHz, since AHB / 4 = 54MHz (= limit)

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -60,6 +60,8 @@ def build(env):
     properties["hsi48"] = \
         target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")
+    properties["overdrive"] = (target["family"] == "f7") or \
+        ((target["family"] == "f4") and target["name"] in ["27", "29", "37", "39", "46", "69", "79"])
 
     flash_latencies = {}
     for vcore in device.get_driver("flash")["latency"]:

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -62,6 +62,8 @@ def build(env):
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")
     properties["overdrive"] = (target["family"] == "f7") or \
         ((target["family"] == "f4") and target["name"] in ["27", "29", "37", "39", "46", "69", "79"])
+    properties["pllsai_p_usb"] = (target["family"] == "f7") or \
+        ((target["family"] == "f4") and target["name"] in ["46", "69", "79"])
 
     flash_latencies = {}
     for vcore in device.get_driver("flash")["latency"]:

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -284,6 +284,35 @@ modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, u
 %%endif
 }
 
+%% if overdrive
+bool
+modm::platform::Rcc::enableOverdriveMode(uint32_t waitCycles)
+{
+	RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+
+%% set suffix = '1' if target["family"] == "f7" else ''
+
+	PWR->CR{{suffix}} |= PWR_CR{{suffix}}_ODEN;
+	auto waitCounter = waitCycles;
+	while (!(PWR->CSR{{suffix}} & PWR_CSR{{suffix}}_ODRDY))
+	{
+		if (--waitCounter == 0)
+			return false;
+	}
+
+	PWR->CR{{suffix}} |= PWR_CR{{suffix}}_ODSWEN;
+	waitCounter = waitCycles;
+	while (!(PWR->CSR{{suffix}} & PWR_CSR{{suffix}}_ODSWRDY))
+	{
+		if (--waitCounter == 0)
+			return false;
+	}
+
+	return true;
+}
+%% endif
+
+
 // ----------------------------------------------------------------------------
 bool
 modm::platform::Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -284,6 +284,40 @@ modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, u
 %%endif
 }
 
+%% if pllsai_p_usb
+bool
+modm::platform::Rcc::enablePllSai(const PllSaiFactors& pllFactors, uint32_t waitCycles)
+{
+	// Read reserved values and clear all other values
+	uint32_t tmp = RCC->PLLSAICFGR & ~(
+%% if target["family"] == "f4" and target["name"] in "46"
+		RCC_PLLSAICFGR_PLLSAIM |
+%% endif
+		RCC_PLLSAICFGR_PLLSAIN | RCC_PLLSAICFGR_PLLSAIP);
+
+%% if target["family"] == "f4" and target["name"] in "46"
+	// PLLSAIM (0) = factor is user defined VCO input frequency must be configured to 2MHz
+	tmp |= ((uint32_t) pllFactors.pllSaiM) & RCC_PLLSAICFGR_PLLSAIM;
+%% endif
+
+	// PLLSAIN (6) = factor is user defined
+	tmp |= (((uint32_t) pllFactors.pllSaiN) << RCC_PLLSAICFGR_PLLSAIN_Pos) & RCC_PLLSAICFGR_PLLSAIN;
+
+	// PLLSAIP (16) divider for CLK48 frequency; (00: PLLP = 2, 01: PLLP = 4, etc.)
+	tmp |= (((uint32_t) (pllFactors.pllSaiP / 2) - 1) << RCC_PLLCFGR_PLLP_Pos) & RCC_PLLCFGR_PLLP;
+
+	RCC->PLLSAICFGR = tmp;
+
+	// enable pll
+	RCC->CR |= RCC_CR_PLLSAION;
+
+	while (not (tmp = (RCC->CR & RCC_CR_PLLSAIRDY)) and --waitCycles)
+		;
+
+	return tmp;
+}
+%% endif
+
 %% if overdrive
 bool
 modm::platform::Rcc::enableOverdriveMode(uint32_t waitCycles)

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2012, 2017, Fabian Greif
  * Copyright (c) 2012, 2014-2017, Niklas Hauser
  * Copyright (c) 2013-2014, Kevin Läufer
- * Copyright (c) 2018, Christopher Durand
+ * Copyright (c) 2018, 2021, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -594,6 +594,11 @@ public:
 		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE2) | uint32_t(prescaler);
 		return true;
 	}
+%% endif
+
+%% if overdrive
+	static bool
+	enableOverdriveMode(uint32_t waitCycles = 2048);
 %% endif
 
 public:

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -195,6 +195,18 @@ public:
 	};
 %% endif
 
+%% if pllsai_p_usb
+	enum class Clock48Source
+	{
+		PllQ = 0,
+%% if target["family"] == "f4" and target["name"] in ["69", "79"]
+		PllSaiP = RCC_DCKCFGR_CK48MSEL
+%% else
+		PllSaiP = RCC_DCKCFGR2_CK48MSEL
+%% endif
+	};
+%% endif
+
 %% if target["family"] in ["f2", "f4", "f7"]
 	enum class
 	ClockOutput1Source : uint32_t
@@ -394,6 +406,17 @@ public:
 %% endif
 	};
 
+%% if pllsai_p_usb
+	struct PllSaiFactors
+	{
+%% if target["family"] == "f4" and target["name"] in "46"
+		const uint8_t pllSaiM;
+%% endif
+		const uint16_t pllSaiN;
+		const uint8_t pllSaiP;
+	};
+%% endif
+
 	/**
 	 * Enable PLL.
 	 *
@@ -409,6 +432,22 @@ public:
 	 */
 	static bool
 	enablePll(PllSource source, const PllFactors& pllFactors, uint32_t waitCycles = 2048);
+
+%% if pllsai_p_usb
+	/**
+	 * Enable PLLSAI.
+	 *
+	 * \warning The PLL source must be selected first by configuring the main PLL.
+	 *
+	 * \param	factors
+	 * 		Struct with all pllsai factors. \see PllSaiFactors.
+	 *
+	 * \param	waitCycles
+	 * 		Number of cycles to wait for the pll to stabilise. Default: 2048.
+	 */
+	static bool
+	enablePllSai(const PllSaiFactors& pllFactors, uint32_t waitCycles = 2048);
+%% endif
 
 %% if target["family"] in ["f2", "f4", "f7", "l4", "g0", "g4"]
 	/**
@@ -513,6 +552,18 @@ public:
 	static inline bool
 	enableWatchdogClock(WatchdogClockSource /*src*/)
 	{ return true; }
+
+%% if pllsai_p_usb
+	static inline void
+	setClock48Source(Clock48Source source)
+	{
+%% if target["family"] == "f4" and target["name"] in ["69", "79"]
+		RCC->DCKCFGR = (RCC->DCKCFGR & ~RCC_DCKCFGR_CK48MSEL) | uint32_t(source);
+%% else
+		RCC->DCKCFGR2 = (RCC->DCKCFGR2 & ~RCC_DCKCFGR2_CK48MSEL) | uint32_t(source);
+%% endif
+	}
+%% endif
 
 %% if target["family"] in ["f2", "f4", "f7"]
 	static inline bool

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,6 +51,12 @@ run-nucleo-f446:
 	$(call run-test,nucleo-f446,size)
 
 
+compile-nucleo-f446ze:
+	$(call compile-test,nucleo-f446ze,size)
+run-nucleo-f446ze:
+	$(call run-test,nucleo-f446ze,size)
+
+
 compile-nucleo-l432:
 	$(call compile-test,nucleo-l432,size)
 run-nucleo-l432:

--- a/test/config/nucleo-f446ze.xml
+++ b/test/config/nucleo-f446ze.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-f446ze</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/nucleo-f446ze/</option>
+    <option name="modm:build:scons:unittest.source">../../build/generated-unittest/nucleo-f446ze/modm-test</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>


### PR DESCRIPTION
This PR adds the following:
- Nucleo 446ZE board
- Nucleo 446ZE USB serial example
- Function to enable overdrive mode in the clock driver
This is actually provided by the PWR peripheral but we don't have a separate driver for that and the setting is highly related to the clock configuration. For simplicity I put it into the RCC module.
- Correctly set overdrive mode for all F4 boards with a 180 MHz clock and F7 boards with a 216 MHz clock
This was done the wrong way in all boards, if done at all. The `ODEN` bit was set but not the `ODSWEN` bit to actually change the mode.
- Support for configuring the PLLSAIP clock to support USB on F4{46, 69, 79} and F7 running at maximum SYSCLK 