### PR TITLE
[usb] Fix USB version in descriptors

### DIFF
--- a/ext/hathach/tusb_descriptors.c.in
+++ b/ext/hathach/tusb_descriptors.c.in
@@ -44,7 +44,7 @@ const tusb_desc_device_t desc_device =
 {
 	.bLength            = sizeof(tusb_desc_device_t),
 	.bDescriptorType    = TUSB_DESC_DEVICE,
-	.bcdUSB             = 0x0210,
+	.bcdUSB             = 0x0200,
 
 %% if with_cdc
 	// Use Interface Association Descriptor (IAD) for CDC


### PR DESCRIPTION
The modm usb device descriptor incorrectly advertises devices as USB 2.1 which requires a BOS (Binary Device Object Store) descriptor. That is not provided and it creates a kernel error message on Linux when enumerating the device:

```
[82867.842177] usb 1-2: new full-speed USB device number 8 using xhci_hcd
[82867.991261] usb 1-2: unable to get BOS descriptor or descriptor too short
[82867.992796] usb 1-2: New USB device found, idVendor=cafe, idProduct=4001
[82867.992801] usb 1-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[82867.992804] usb 1-2: Product: TinyUSB Device
[82867.992807] usb 1-2: Manufacturer: TinyUSB
[82867.992809] usb 1-2: SerialNumber: 0022003B3137510837373438C000FCC0
[82867.993965] cdc_acm 1-2:1.0: ttyACM1: USB ACM device
```

The correct fix is to set the USB version to 2.0 which is basically the same as 2.1 without the BOS descriptor. We do not support any of the features that make use of this descriptor (LPM power management, some proprietary thing for Windows to download drivers, WebUSB ...) and I am not sure all implementations would accept an empty one. The Nucleo programmer itself also uses version 2.0.