### PR TITLE
[stm32] fix adc clock source configured incorrectly on stm32g4

### DIFF
--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "STM32G4 ADC basic example" << modm::endl;
+	MODM_LOG_INFO << " running on Nucleo-G474RE" << modm::endl << modm::endl;
+
+	MODM_LOG_INFO << "Configuring ADC ...";
+	Adc1::initialize(
+		Adc1::ClockMode::SynchronousPrescaler1,
+		Adc1::ClockSource::SystemClock,
+		Adc1::Prescaler::Disabled,
+		Adc1::CalibrationMode::SingleEndedInputsMode,
+		true);
+	Adc1::connect<GpioA0::In1>();
+	Adc1::setPinChannel<GpioA0>(Adc1::SampleTime::Cycles13);
+
+	while (true)
+	{
+		Adc1::startConversion();
+		while(!Adc1::isConversionFinished)
+			;
+		int adcValue = Adc1::getValue();
+		MODM_LOG_INFO << "adcValue=" << adcValue;
+		float voltage = adcValue * 3.3 / 0xfff;
+		MODM_LOG_INFO << " voltage=";
+		MODM_LOG_INFO.printf("%.3f\n", voltage);
+		modm::delay(500ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g474re/adc_basic/project.xml
+++ b/examples/nucleo_g474re/adc_basic/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/adc_basic</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -103,13 +103,11 @@ public:
 		NoClock = 0, // No clock selected.
 %% if target["family"] in ["g4"]
 %% if id in [1, 2]
-		PllSai1 = RCC_CCIPR_ADC12SEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
-		PllSai2 = RCC_CCIPR_ADC12SEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
-		SystemClock = RCC_CCIPR_ADC12SEL_1 | RCC_CCIPR_ADC12SEL_0, // System clock selected as ADCs clock
+		Pll = RCC_CCIPR_ADC12SEL_0, // PLL “P” clock selected as ADC clock
+		SystemClock = RCC_CCIPR_ADC12SEL_1 , // System clock selected as ADCs clock
 %% elif id in [3, 4, 5]
-		PllSai1 = RCC_CCIPR_ADC345SEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
-		PllSai2 = RCC_CCIPR_ADC345SEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
-		SystemClock = RCC_CCIPR_ADC345SEL_1 | RCC_CCIPR_ADC345SEL_0, // System clock selected as ADCs clock
+		Pll = RCC_CCIPR_ADC345SEL_0, // PLL “P” clock selected as ADC clock
+		SystemClock = RCC_CCIPR_ADC345SEL_1 , // System clock selected as ADCs clock
 %% endif
 %% else
 		PllSai1 = RCC_CCIPR_ADCSEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock


### PR DESCRIPTION
The adc clock select was configured incorrectly for stm32g4. According to the reference manual it should be as follows:
![image](https://user-images.githubusercontent.com/17313824/104620560-6a613680-568f-11eb-9a23-b8b5693939e6.png)
