### PR TITLE
[stm32] Fixed TIM2 and TIM5 generated as 32 bit timer on stm32g4

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -108,7 +108,7 @@ public:
 	};
 
 	// This type is the internal size of the counter.
-%% if id in [2, 5] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4"])
+%% if id in [2, 5] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4", "g4"])
 	// Timer 2 and 5 are the only one which have the size of 32 bit
 	typedef uint32_t Value;
 


### PR DESCRIPTION
TIM2 and TIM5 are generated as 16 bit timers on stm32g4. They are 32 bit timers.
![image](https://user-images.githubusercontent.com/17313824/104622746-f1171300-5691-11eb-9769-fd066dcb3539.png)
