### PR TITLE
ADC fixes for STM32F3 series (proposal/wip)

### DIFF
--- a/examples/stm32f3_discovery/adc/interrupt/main.cpp
+++ b/examples/stm32f3_discovery/adc/interrupt/main.cpp
@@ -49,29 +49,20 @@ main()
 	// initialize Adc4
 	Adc4::initialize(Adc4::ClockMode::Asynchronous, Adc4::Prescaler::Div256,
 					Adc4::CalibrationMode::SingleEndedInputsMode, true);
+	Adc4::connect<AdcIn0::In3>();
+	Adc4::setPinChannel<AdcIn0>(Adc4::SampleTime::Cycles182);
 
 	Adc4::enableInterruptVector(5);
 	Adc4::enableInterrupt(Adc4::Interrupt::EndOfRegularConversion);
 
-	Adc4::connect<AdcIn0::In3>();
-	Adc4::setPinChannel<AdcIn0>(Adc4::SampleTime::Cycles182);
+	AdcInterrupt4::attachInterruptHandler(printAdc);
 
 	while (true)
 	{
 		Adc4::startConversion();
-		while(!Adc4::isConversionFinished);
-		printAdc();
 		modm::delay(500ms);
 	}
 
 	return 0;
 }
 
-
-MODM_ISR(ADC4)
-{
-	if (Adc4::getInterruptFlags() & Adc4::InterruptFlag::EndOfRegularConversion) {
-		Adc4::acknowledgeInterruptFlag(Adc4::InterruptFlag::EndOfRegularConversion);
-		printAdc();
-	}
-}

--- a/src/modm/driver/adc/adc_sampler_impl.hpp
+++ b/src/modm/driver/adc/adc_sampler_impl.hpp
@@ -52,6 +52,8 @@ template < class AdcInterrupt, uint8_t Channels, uint32_t Oversamples >
 void
 modm::AdcSampler<AdcInterrupt,Channels,Oversamples>::sampleAdc()
 {
+	AdcInterrupt::acknowledgeInterruptFlags(AdcInterrupt::InterruptFlag::All);
+
 	if (Oversamples > 1) {
 
 		// reset array to zero at the beginning of sampling

--- a/src/modm/platform/adc/at90_tiny_mega/adc_mega.hpp.in
+++ b/src/modm/platform/adc/at90_tiny_mega/adc_mega.hpp.in
@@ -15,6 +15,7 @@
 #define MODM_ATMEGA_ADC_HPP
 
 #include <modm/architecture/interface/adc.hpp>
+#include <modm/architecture/interface/register.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
 //#include "../device.hpp"
@@ -96,6 +97,13 @@ public:
 	%% endif
 	};
 %% endif
+
+	enum class
+	InterruptFlag : uint8_t
+	{
+		All = (1<<ADIF),
+	};
+	MODM_FLAGS8(InterruptFlag);
 
 private:
 	enum class
@@ -283,11 +291,26 @@ public:
 		return (ADCSRA & (1<<ADIF));
 	}
 
+	/// @return	`InterruptFlag::All` if the flag is set,
+	///			`0` otherwise
+	static inline InterruptFlag_t
+	getInterruptFlags()
+	{
+		return InterruptFlag(ADCSRA & (1<<ADIF));
+	}
+
 	/// Clears the interrupt flag
 	static inline void
 	acknowledgeInterruptFlag()
 	{
 		ADCSRA &= ~(1<<ADIF);
+	}
+
+	/// Clears the interrupt flag if `flags` is set to `InterruptFlag::All`
+	static inline void
+	acknowledgeInterruptFlags(const InterruptFlag_t flags)
+	{
+		ADCSRA &= ~flags.value;
 	}
 
 	/// Enables the ADC Conversion Complete Interrupt

--- a/src/modm/platform/adc/at90_tiny_mega/adc_tiny.hpp.in
+++ b/src/modm/platform/adc/at90_tiny_mega/adc_tiny.hpp.in
@@ -16,6 +16,7 @@
 #include <avr/io.h>
 
 #include <modm/architecture/interface/adc.hpp>
+#include <modm/architecture/interface/register.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
 
@@ -142,6 +143,13 @@ public:
 	%% endif
 	};
 %% endif
+
+	enum class
+	InterruptFlag : uint8_t
+	{
+		All = (1<<ADIF),
+	};
+	MODM_FLAGS8(InterruptFlag);
 
 private:
 	enum class
@@ -339,11 +347,26 @@ public:
 		return (ADCSRA & (1<<ADIF));
 	}
 
+	/// @return	`InterruptFlag::All` if the flag is set,
+	///			`0` otherwise
+	static inline InterruptFlag_t
+	getInterruptFlags()
+	{
+		return InterruptFlag(ADCSRA & (1<<ADIF));
+	}
+
 	/// Clears the interrupt flag
 	static inline void
 	acknowledgeInterruptFlag()
 	{
 		ADCSRA &= ~(1<<ADIF);
+	}
+
+	/// Clears the interrupt flag if `flags` is set to `InterruptFlag::All`
+	static inline void
+	acknowledgeInterruptFlags(const InterruptFlag_t flags)
+	{
+		ADCSRA &= ~flags.value;
 	}
 
 

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -135,7 +135,8 @@ public:
 		EndOfConversion = ADC_ISR_EOC,
 		EndOfSequence = ADC_ISR_EOS,
 		Overrun = ADC_ISR_OVR,
-		AnalogWatchdog = ADC_ISR_AWD1
+		AnalogWatchdog = ADC_ISR_AWD1,
+		All = ADC_ISR_ADRDY | ADC_ISR_EOSMP | ADC_ISR_EOC | ADC_ISR_EOS | ADC_ISR_OVR | ADC_ISR_AWD1,
 	};
 	MODM_FLAGS32(InterruptFlag);
 
@@ -311,7 +312,14 @@ public:
 	getInterruptFlags();
 
 	static inline void
-	acknowledgeInterruptFlag(InterruptFlag_t flags);
+	acknowledgeInterruptFlags(InterruptFlag_t flags);
+
+	[[deprecated("Use `acknowledgeInterruptFlags(InterruptFlag_t flags)` instead!")]]
+	static inline void
+	acknowledgeInterruptFlag(InterruptFlag_t flags)
+	{
+		acknowledgeInterruptFlags(flags);
+	}
 
 public:
 	static constexpr uint8_t TS_CAL1_TEMP{30};

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -339,7 +339,7 @@ modm::platform::Adc{{ id }}::getInterruptFlags()
 }
 
 void
-modm::platform::Adc{{ id }}::acknowledgeInterruptFlag(const InterruptFlag_t flags)
+modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t flags)
 {
 	// Flags are cleared by writing a one to the flag position.
 	// Writing a zero is ignored.

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -40,6 +40,10 @@ namespace platform
  */
 class Adc{{ id }}
 {
+
+public:
+	static constexpr uint8_t Resolution = {{ resolution }};
+
 public:
 	/// Channels, which can be used with this ADC.
 	enum class Channel : uint8_t	// TODO: What is the best type?
@@ -226,6 +230,7 @@ public:
 		AnalogWatchdog2 					= ADC_ISR_AWD2,
 		AnalogWatchdog3 					= ADC_ISR_AWD3,
 		InjectedContextQueueOverflow 		= ADC_ISR_JQOVF,
+		All									= ADC_ISR_ADRDY | ADC_ISR_EOSMP | ADC_ISR_EOC | ADC_ISR_EOS | ADC_ISR_OVR | ADC_ISR_JEOC | ADC_ISR_JEOS | ADC_ISR_AWD1 | ADC_ISR_AWD2 | ADC_ISR_AWD3 | ADC_ISR_JQOVF,
 	};
 	MODM_FLAGS32(InterruptFlag);
 
@@ -403,7 +408,7 @@ public:
 	getInterruptFlags();
 
 	static inline void
-	acknowledgeInterruptFlag(const InterruptFlag_t flags);
+	acknowledgeInterruptFlags(const InterruptFlag_t flags);
 };
 
 }

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -65,7 +65,7 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 	ADC{{ id }}->CR |= static_cast<uint32_t>(VoltageRegulatorState::Enabled);
 	modm::delay_us(10);	// FIXME: this is ugly -> find better solution
 
-	acknowledgeInterruptFlag(InterruptFlag::Ready);
+	acknowledgeInterruptFlags(InterruptFlag::Ready);
 
 	calibrate(cal, true);	// blocking calibration
 
@@ -77,7 +77,7 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 		while (not isReady()) {
 			ADC{{ id }}->CR |= ADC_CR_ADEN;
 		}
-		acknowledgeInterruptFlag(InterruptFlag::Ready);
+		acknowledgeInterruptFlags(InterruptFlag::Ready);
 	}
 }
 
@@ -189,7 +189,7 @@ void
 modm::platform::Adc{{ id }}::startConversion(void)
 {
 	// TODO: maybe add more interrupt flags
-	acknowledgeInterruptFlag(InterruptFlag::EndOfRegularConversion |
+	acknowledgeInterruptFlags(InterruptFlag::EndOfRegularConversion |
 			InterruptFlag::EndOfSampling | InterruptFlag::Overrun);
 	// starts single conversion for the regular group
 	ADC{{ id }}->CR |= ADC_CR_ADSTART;
@@ -262,7 +262,7 @@ modm::platform::Adc{{ id }}::getInterruptFlags()
 }
 
 void
-modm::platform::Adc{{ id }}::acknowledgeInterruptFlag(const InterruptFlag_t flags)
+modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t flags)
 {
 	// Flags are cleared by writing a one to the flag position.
 	// Writing a zero is ignored.

--- a/src/modm/platform/adc/stm32f3/adc_interrupt.cpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_interrupt.cpp.in
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2009-2010, Fabian Greif
+ * Copyright (c) 2009-2010, Martin Rosekeit
+ * Copyright (c) 2012, 2014-2015, 2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "adc_interrupt_{{ id }}.hpp"
+#include <modm/architecture/interface/interrupt.hpp>
+// ----------------------------------------------------------------------------
+modm::platform::AdcInterrupt{{ id }}::Handler
+modm::platform::AdcInterrupt{{ id }}::handler(modm::dummy);
+
+%% if id not in shared_irq_ids
+MODM_ISR(ADC{{ id }})
+{
+	modm::platform::AdcInterrupt{{ id }}::handler();
+}
+%% endif

--- a/src/modm/platform/adc/stm32f3/adc_interrupt.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_interrupt.hpp.in
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015-2017, Niklas Hauser
+ * Copyright (c) 2017, Fabian Greif
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_ADC_INTERRUPT_{{ id }}_HPP
+#define MODM_STM32_ADC_INTERRUPT_{{ id }}_HPP
+
+#include <modm/utils/dummy.hpp>
+#include "adc_{{ id }}.hpp"
+#include <modm/architecture/interface/adc_interrupt.hpp>
+
+
+namespace modm
+{
+
+namespace platform
+{
+
+/**
+ * ADC Interrupt module
+ *
+ * This class allows you to attach functions to the ADC Conversion
+ * Complete Interrupt via function pointers.
+ * Be aware however, that this implementation is slower and requires
+ * more resources than writing the function code directly into
+ * the interrupt service routines.
+ *
+ * @see AnalogSensors uses this implemenation.
+ *
+ * @ingroup		modm_platform_adc_{{id}}
+ * @author		Niklas Hauser
+ */
+class AdcInterrupt{{ id }} : public Adc{{ id }}, public modm::AdcInterrupt
+{
+public:
+	static inline void
+	attachInterruptHandler(Handler handler=modm::dummy)
+	{
+		AdcInterrupt{{ id }}::handler = handler;
+	}
+
+	static Handler handler;
+};
+
+}	// namespace platform
+
+}	// namespace modm
+
+#endif // MODM_STM32_ADC_INTERRUPT_HPP

--- a/src/modm/platform/adc/stm32f3/adc_shared_interrupts.cpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_shared_interrupts.cpp.in
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2009-2010, Fabian Greif
+ * Copyright (c) 2009-2010, Martin Rosekeit
+ * Copyright (c) 2012, 2014-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "../device.hpp"
+#include <modm/architecture/interface/interrupt.hpp>
+
+// this should be able to be generated instead of using Macros for this.
+%% for id in shared_irq_ids
+%% if id in instances
+#include "adc_interrupt_{{ id }}.hpp"
+%% endif
+%% endfor
+
+%% for name, irqs in shared_irqs.items()
+
+MODM_ISR({{ name }})
+{
+%% for id in irqs
+%% if id in instances
+	modm::platform::AdcInterrupt{{ id }}::handler();
+%% endif
+%% endfor
+}
+%%endfor

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -125,8 +125,16 @@ class Instance(Module):
         env.substitutions = properties
         env.outbasepath = "modm/src/modm/platform/adc"
 
+        global props
+        properties["shared_irq_ids"] = props["shared_irq_ids"]
+        props["instances"].append(self.instance)
+
+        properties["resolution"] = 12
+
         env.template("adc.hpp.in", "adc_{}.hpp".format(self.instance))
         env.template("adc_impl.hpp.in", "adc_{}_impl.hpp".format(self.instance))
+        env.template("adc_interrupt.hpp.in", "adc_interrupt_{}.hpp".format(self.instance))
+        env.template("adc_interrupt.cpp.in", "adc_interrupt_{}.cpp".format(self.instance))
 
 
 def init(module):
@@ -139,11 +147,28 @@ def prepare(module, options):
         return False
 
     module.depends(
+        ":architecture:adc",
+        ":math:algorithm",
+        ":utils",
         ":architecture:delay",
         ":architecture:register",
         ":cmsis:device",
         ":platform:gpio",
         ":platform:rcc")
+
+    global props
+    props = {}
+    props["instances"] = []
+
+    shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
+    shared_irqs = [v for v in shared_irqs if v.startswith("ADC") and "_" in v]
+    props["shared_irqs"] = {}
+    props["shared_irq_ids"] = []
+    for irq in shared_irqs:
+        parts = irq[3:].split("_")
+        shared_irqs_ids = (int(parts[0]), int(parts[1]) )
+        props["shared_irqs"][irq] = shared_irqs_ids
+        props["shared_irq_ids"].extend(shared_irqs_ids)
 
     for instance in listify(device.get_driver("adc")["instance"]):
         module.add_submodule(Instance(int(instance)))
@@ -158,5 +183,13 @@ def build(env):
     properties["target"] = device.identifier
     properties["driver"] = driver
 
+    global props
+    properties["shared_irq_ids"] = props["shared_irq_ids"]
+    properties["instances"] = props["instances"]
+    properties["shared_irqs"] = props["shared_irqs"]
+
     env.substitutions = properties
     env.outbasepath = "modm/src/modm/platform/adc"
+
+    if any(i in props["shared_irq_ids"] for i in props["instances"]):
+        env.template("adc_shared_interrupts.cpp.in")


### PR DESCRIPTION
We (TU Vienna Racing Team) had quite a lot of troubles with modm and the ADC in the STM we use most of the time (STM32F303RB). See #438 (and many similar problems we didn't open issues for).
After quite a lot of debugging the code like shown in this PR is working fine on our hardware with the modm ADC sampler.
I don't know if this code is "merge-ready" and certainly needs testing on other F3-series STMs with different settings and use cases.