### PR TITLE
Align the tables to copy in linker script to 8 bytes

### DIFF
--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -102,7 +102,7 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 	%% if vector_table_location == "ram"
 		%% do sections.append("vector_table_ram")
 	%% endif
-	.table.copy.intern : ALIGN(4)
+	.table.copy.intern : ALIGN(8)
 	{
 		__table_copy_intern_start = .;
 		LONG(__data_load)


### PR DESCRIPTION
When building with -Os flag there will be a `ldrd` instruction in 
```c++
static inline void
table_copy(const uint32_t *const start, const uint32_t *const end)
```
The requirement of that instruction is that the source address must be aligned to 8 bytes.

Using -Os will not inline the function.