### PR TITLE
fix: configure USB::Id as PullUp in add to OpenDrain

### DIFF
--- a/src/modm/platform/usb/stm32/usb.hpp.in
+++ b/src/modm/platform/usb/stm32/usb.hpp.in
@@ -53,6 +53,7 @@ public:
 
 %% if is_otg
 		Id::configure(Gpio::OutputType::OpenDrain, Gpio::OutputSpeed::High);
+		Id::configure(Gpio::InputType::PullUp);
 %% endif
 %% endif
 		Connector::connect();


### PR DESCRIPTION
After issues with the USB example code (generic/usb) on a STM32F407-Disco board,
Found that I needed to set up Id line as a pullup in addition to Output/OpenDrain (#554 )

(Same as in the tinyusb implementation)

One question remains: why @rleh  was able to run the example without any problems ?
No clue...