### PR TITLE
[scons] Simplify Scons tooling, misc. fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ CMakeLists.txt
 
 # ignore generated code in the example folder
 examples/**/modm
+examples/**/artifacts
 examples/**/compile_commands.json
 examples/**/SConstruct
 examples/**/Makefile

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "ext/modm-devices"]
 	path = ext/modm-devices
 	url = https://github.com/modm-io/modm-devices.git
-[submodule "ext/dlr/scons-build-tools"]
-	path = ext/dlr/scons-build-tools
-	url = https://github.com/modm-io/scons-build-tools.git
 [submodule "ext/ros/ros-lib"]
 	path = ext/ros/ros-lib
 	url = https://github.com/modm-io/ros-lib

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,10 @@ Make sure you've [installed all tools required for building modm](https://modm.i
 
 ## TL;DR
 
+To compile any example:
+
 ```
+cd modm/examples/generic/blinky  # cd into the example
 lbuild build    # generate modm library (call only once)
 scons program   # compile and upload to your development board
 ```
@@ -19,7 +22,7 @@ To debug with GDB in TUI mode:
 
 ```
 scons program profile=debug # compile and upload debug profile
-scons gdb profile=debug     # launch OpenOCD and GDB for debugging
+scons debug profile=debug   # launch OpenOCD and GDB for debugging
 ```
 
 To generate your target specific Doxygen documentation:

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -166,6 +166,14 @@ def prepare(module, options):
             maximum=2 ** 16,
             default="3*1024"))
 
+    if "f" in options[":target"].get_driver("core")["type"]:
+        module.add_option(
+            EnumerationOption(
+                name="float-abi",
+                description="Floating point ABI",
+                enumeration=["soft", "softfp", "hard"],
+                default="hard"))
+
     memories = listify(options[":target"].get_driver("core")["memory"])
 
     # Cortex-M0 does not have remappable vector table, so it will remain in Flash
@@ -258,6 +266,7 @@ def build(env):
         "with_fault_storage": env.has_module(":platform:fault"),
         "with_memory_traits": env.has_module(":architecture:memory"),
         "with_assert": env.has_module(":architecture:assert"),
+        "with_fpu": env.get("float-abi", "soft") != "soft",
     })
     env.outbasepath = "modm/src/modm/platform/core"
 
@@ -345,7 +354,7 @@ def build(env):
             "7f": "-mfpu=fpv5-sp-d16",
             "7fd": "-mfpu=fpv5-d16",
         }[fpu]
-        env.collect(":build:archflags", "-mfloat-abi=hard", fpu_spec)
+        env.collect(":build:archflags", "-mfloat-abi={}".format(env["float-abi"]), fpu_spec)
         single_precision = ("-sp-" in fpu_spec)
     if single_precision:
         env.collect(":build:ccflags", "-fsingle-precision-constant",

--- a/src/modm/platform/core/cortex/module.md
+++ b/src/modm/platform/core/cortex/module.md
@@ -309,7 +309,7 @@ This module adds these architecture specific [compiler options][options]:
 
 - `-mcpu=cortex-m{type}`: the target to compile for.
 - `-mthumb`: only Thumb2 instruction set is supported.
-- `-mfloat-abi=hard`: if FPU available use the fastest ABI available.
+- `-mfloat-abi={soft, softfp, hard}`: the FPU ABI: `hard` is fastest.
 - `-mfpu=fpv{4, 5}-{sp}-d16`: single or double precision FPU.
 - `-fsingle-precision-constant`: if SP-FPU, treat all FP constants as SP.
 - `-Wdouble-promotion`: if SP-FPU, warn if FPs are promoted to doubles.

--- a/src/modm/platform/core/cortex/startup.c.in
+++ b/src/modm/platform/core/cortex/startup.c.in
@@ -97,7 +97,7 @@ void __modm_startup(void)
 	SCB_EnableICache();
 %% endif
 
-%% if "f" in core
+%% if with_fpu
 	// Enable FPU in privileged and user mode
 	SCB->CPACR |= ((3UL << 10*2) | (3UL << 11*2));
 %% endif

--- a/tools/build_script_generator/cmake/cmake_scripts/configure-gcc.cmake.in
+++ b/tools/build_script_generator/cmake/cmake_scripts/configure-gcc.cmake.in
@@ -1,5 +1,5 @@
 # Copyright (c) 2018, Sergiy Yevtushenko
-# Copyright (c) 2018-2019, Niklas Hauser
+# Copyright (c) 2018-2019, 2021, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -13,7 +13,9 @@ endif()
 
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
+%% if platform == "hosted"
 find_package(PkgConfig)
+%% endif
 
 if(NOT TOOL_EXECUTABLE_PREFIX)
 %% if core.startswith("cortex-m")
@@ -44,11 +46,11 @@ set(CMAKE_C_COMPILER "${TOOL_EXECUTABLE_PREFIX}gcc${TOOL_EXECUTABLE_SUFFIX}" CAC
 set(CMAKE_CXX_COMPILER "${TOOL_EXECUTABLE_PREFIX}g++${TOOL_EXECUTABLE_SUFFIX}" CACHE INTERNAL "c++")
 set(CMAKE_ASM_COMPILER "${CMAKE_C_COMPILER}"     CACHE INTERNAL "asm")
 
-set(CMAKE_AR           "${TOOL_EXECUTABLE_PREFIX}ar"      CACHE INTERNAL "ar")
-set(CMAKE_RANLIB       "${TOOL_EXECUTABLE_PREFIX}ranlib"  CACHE INTERNAL "ranlib")
 if(TOOL_EXECUTABLE_SUFFIX STREQUAL "")
     set(CMAKE_AS       "${TOOL_EXECUTABLE_PREFIX}as"      CACHE INTERNAL "as")
     set(CMAKE_NM       "${TOOL_EXECUTABLE_PREFIX}nm"      CACHE INTERNAL "nm")
+    set(CMAKE_AR       "${TOOL_EXECUTABLE_PREFIX}ar"      CACHE INTERNAL "ar")
+    set(CMAKE_RANLIB   "${TOOL_EXECUTABLE_PREFIX}ranlib"  CACHE INTERNAL "ranlib")
 else()
     set(CMAKE_AS       "${CMAKE_CXX_COMPILER}"            CACHE INTERNAL "as")
     set(CMAKE_NM       "${TOOL_EXECUTABLE_PREFIX}gcc-nm${TOOL_EXECUTABLE_SUFFIX}"     CACHE INTERNAL "nm")
@@ -70,6 +72,12 @@ set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Used to make stdlibc++ paths in ELF relative to compiler
+find_program(MODM_GCC_PATH NAMES ${CMAKE_C_COMPILER})
+get_filename_component(MODM_GCC_PATH ${MODM_GCC_PATH} REALPATH)
+get_filename_component(MODM_GCC_PATH ${MODM_GCC_PATH} DIRECTORY)
+get_filename_component(MODM_GCC_PATH ${MODM_GCC_PATH} DIRECTORY)
 
 if(APPLE)
 %% if platform == "hosted"

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -46,6 +46,7 @@ def build(env):
         subs = {
             "target_base": "${CMAKE_PROJECT_NAME}",
             "project_source_dir": "${CMAKE_CURRENT_SOURCE_DIR}",
+            "gccpath": "${MODM_GCC_PATH}",
         }
         if "{" in flag:
             return flag.format(**subs)

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -1,5 +1,5 @@
 # Copyright (c) 2018, Sergiy Yevtushenko
-# Copyright (c) 2018-2019, Niklas Hauser
+# Copyright (c) 2018-2019, 2021, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -59,6 +59,7 @@ program-bmp: build
 ui?=tui
 debug: build
 	@python3 modm/modm_tools/gdb.py -x modm/gdbinit -x modm/openocd_gdbinit \
+			-ex "dir $(dir $(realpath $(dir $(realpath $(shell which arm-none-eabi-gcc)))))" \
 			$(ELF_FILE) -ui=$(ui) \
 			openocd -f modm/openocd.cfg
 

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -218,6 +218,8 @@ def common_compiler_flags(compiler, target):
         "-funsigned-char",
         "-fwrapv",
         # "-fmerge-all-constants",
+        "-ffile-prefix-map={project_source_dir}=.",
+        "-ffile-prefix-map={gccpath}=.",
 
         "-g3",
         "-gdwarf-3",

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -99,9 +99,14 @@ def prepare(module, options):
     module.add_collector(
         PathCollector(name="path.library",
                       description="Search path for static libraries"))
+    def validate_library(library):
+        if library.startswith("lib") or library.endswith(".a"):
+            raise ValueError("Libraries must only contain `name` not `libname.a`!")
+        return library
     module.add_collector(
         StringCollector(name="library",
-                        description="Libraries to link against"))
+                        description="Libraries to link against",
+                        validate=validate_library))
     module.add_collector(
         StringCollector(name="pkg-config",
                         description="Packages to configure against"))

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -137,10 +137,16 @@ def build(env):
         env.copy("site_tools/info.c.in")
 
     # Generate the env.BuildTarget tool
+    linkerscript = env.get(":platform:cortex-m:linkerscript.override")
+    linkerscript = env.relative_outpath(linkerscript) if linkerscript \
+                   else "$BASEPATH/modm/link/linkerscript.ld"
     env.substitutions = env.query("::device")
-    env.substitutions["upload_with_artifact"] = env.has_module(":crashcatcher")
-    env.substitutions["with_compilation_db"] = env.has_module(":build:compilation_db")
-    env.substitutions["program_extension"] = ".exe" if env[":target"].identifier.family == "windows" else ".elf"
+    env.substitutions.update({
+        "upload_with_artifact": env.has_module(":crashcatcher"),
+        "with_compilation_db": env.has_module(":build:compilation_db"),
+        "program_extension": ".exe" if env[":target"].identifier.family == "windows" else ".elf",
+        "linkerscript": linkerscript,
+    })
     env.outbasepath = "modm/scons/site_tools"
     env.template("resources/build_target.py.in", "build_target.py")
 

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -84,11 +84,11 @@ def build(env):
     }
     tools = {
         "build_target",
+        "comstr",
         "find_files",
         "qtcreator",
         "settings_buildpath",
         "template",
-        "utils_buildformat",
     }
     if env.has_module(":communication:xpcc:generator"):
         tools.add("xpcc_generator")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -87,8 +87,8 @@ def build(env):
         "comstr",
         "find_files",
         "qtcreator",
-        "settings_buildpath",
         "template",
+        "utils_buildpath",
     }
     if env.has_module(":communication:xpcc:generator"):
         tools.add("xpcc_generator")

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -26,6 +26,9 @@ def prepare(module, options):
         PathOption(name="cache_dir", default="", empty_ok=True, absolute=True,
                    description=descr_cache_dir))
     module.add_option(
+        PathOption(name="path.artifact", default="artifacts", absolute=True,
+                   description=descr_path_artifact))
+    module.add_option(
         PathOption(name="image.source", default="", empty_ok=True, absolute=True,
                    description=descr_image_source))
 
@@ -161,6 +164,7 @@ def post_build(env):
     subs.update({
         "build_path": env.relative_outpath(env[":build:build.path"]),
         "cache_dir": env.relative_outpath(cache_dir) if len(cache_dir) else "",
+        "artifact_path": env.relative_outpath(env["path.artifact"]),
         "generated_paths": repositories,
         "is_unittest": is_unittest,
 
@@ -244,6 +248,13 @@ descr_cache_dir = """# Path to SConstruct CacheDir
 
 If value is `$cache`, the cache is placed into the top-level `build/` folder.
 You can disable CacheDir by setting an empty string.
+"""
+
+descr_path_artifact = """# Path to Artifact Store
+
+The artifact folder contains ELF files named by their GNU build id hash. This
+allows identification of firmware on the device via serial output and is useful
+for archiving or post-mortem debugging.
 """
 
 descr_image_source = """# Path to directory containing .pbm files"""

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -80,14 +80,15 @@ def build(env):
     # SCons tools and toolpaths
     toolpaths = {
         "scons/site_tools",
-        "ext/dlr/scons/site_tools"
     }
     tools = {
         "build_target",
         "comstr",
         "find_files",
+        "gcc_retarget",
         "qtcreator",
         "template",
+        "utils",
         "utils_buildpath",
     }
     if env.has_module(":communication:xpcc:generator"):
@@ -101,29 +102,15 @@ def build(env):
 
     device = env.query("::device")
     if device["core"].startswith("cortex-m"):
-        tools.update({"compiler_arm_none_eabi_gcc", "size", "log_itm", "artifact",
-                      "openocd", "openocd_remote", "bmp", "crashdebug", "dfu"})
+        tools.update({"size", "log_itm", "artifact", "openocd",
+                     "openocd_remote", "bmp", "crashdebug", "dfu"})
         if device["platform"] in ["sam"]:
             tools.update({"bossac"})
     elif device["core"].startswith("avr"):
-        tools.update({"compiler_avr_gcc", "size", "avrdude"})
-    else: # hosted
-        tools.update({"compiler_hosted_gcc"})
+        tools.update({"size", "avrdude"})
 
     env.collect("path.tools", *toolpaths)
     env.collect("tools", *tools)
-
-    # Add common DLR SCons build tools
-    tools.update({
-        "settings_gcc_default_internal",
-        "utils_common",
-        "utils_gcc_version",
-    })
-    env.outbasepath = "modm/ext/dlr/scons/site_tools"
-    for tool in tools:
-        path = repopath("ext/dlr/scons-build-tools/site_tools/{}.py".format(tool))
-        if exists(path):
-            env.copy(path, "{}.py".format(tool))
 
     # Copy only these modm SCons build tools
     env.outbasepath = "modm/scons/"

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -64,8 +64,9 @@ def build(env):
 
     def flag_format(flag):
         subs = {
-            "target_base": "\"${TARGET.base}\"",
-            "project_source_dir": "abspath(\"..\")",
+            "target_base": '"${TARGET.base}"',
+            "project_source_dir": 'env["BASEPATH"]',
+            "gccpath": 'env["GCC_PATH"]'
         }
         flag = '"{}"'.format(flag)
         vals = ["{}={}".format(t, r) for t, r in subs.items() if "{{{}}}".format(t) in flag]

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -37,7 +37,7 @@ This module generates these SCons methods depending on the target.
 
 Defaults to **scons build**.
 
-You can add these arguments to any of the scons commands:
+You can add these arguments to any of the SCons commands:
 
 - `verbose=1`: gives a more verbose output, so you can, for example, check what
   options the compiler is called with.
@@ -51,6 +51,11 @@ module documentation.
     When working with the debug profile, make sure to add `profile=debug` to all
     commands, especially `scons program profile=debug` and
     `scons debug profile=debug`!
+
+Some SCons commands take a `firmware={GNU Build ID or path/to/firmware.elf}`
+argument that specifies which firmware to use for the command. It is useful in
+combination with the `scons artifact` command to preserve a specific firmware
+version for later.
 
 
 #### scons build
@@ -78,7 +83,7 @@ Linking········ /build/{debug|release}/blink.elf
 #### scons size
 
 ```
-scons size profile={debug|release}
+scons size profile={debug|release} [firmware={hash or file}]
 ```
 
 Displays the static Flash and RAM consumption of your target.
@@ -104,7 +109,7 @@ Heap:     16.4 MiB
 #### scons program
 
 ```
-scons program profile={debug|release} [port={serial-port}]
+scons program profile={debug|release} [port={serial-port}] [firmware={hash or file}]
 ```
 
 Writes the executable onto your target via Avrdude or OpenOCD.
@@ -142,7 +147,7 @@ shutdown command invoked
 #### scons program-dfu
 
 ```
-scons program-dfu profile={debug|release}
+scons program-dfu profile={debug|release} [firmware={hash or file}]
 ```
 
 Writes the executable onto your target via Device Firmware Update (DFU) over USB.
@@ -200,7 +205,7 @@ scons: done building targets.
 #### scons program-bmp
 
 ```
-scons program-bmp profile={debug|release} [port={serial-port}]
+scons program-bmp profile={debug|release} [port={serial-port}] [firmware={hash or file}]
 ```
 
 [Black Magic Probe][bmp] is convenient tool to convert cheap USB ST-LINK V2 clones
@@ -247,7 +252,7 @@ scons: done building targets.
 #### scons program-remote
 
 ```
-scons program-remote profile={debug|release} [host={ip or hostname}]
+scons program-remote profile={debug|release} [host={ip or hostname}] [firmware={hash or file}]
 ```
 
 Writes the executable onto your target connected to a remote OpenOCD process
@@ -263,7 +268,7 @@ Compiles and executes your program on your computer.
 #### scons debug
 
 ```
-scons debug profile={debug|release} ui={tui|web}
+scons debug profile={debug|release} ui={tui|web} [firmware={hash or file}]
 ```
 
 Launches OpenOCD in the background, then launches GDB in foreground with the
@@ -288,7 +293,7 @@ This is just a convenience wrapper for the debug functionality defined in the
 #### scons debug-bmp
 
 ```
-scons debug-bmp profile={debug|release} ui={tui|web} port={serial-port}
+scons debug-bmp profile={debug|release} ui={tui|web} port={serial-port} [firmware={hash or file}]
 ```
 
 Launches GDB to debug via Black Magic Probe.
@@ -314,7 +319,7 @@ See the `:platform:fault` module for details how to receive the coredump data.
 #### scons program-remote
 
 ```
-scons debug-remote profile={debug|release} ui={tui|web} [host={ip or hostname}]
+scons debug-remote profile={debug|release} ui={tui|web} [host={ip or hostname}] [firmware={hash or file}]
 ```
 
 Debugs the executable via a remote OpenOCD process running on your own computer
@@ -403,13 +408,13 @@ Indexing······· {debug|release}/modm/libmodm.a
 #### scons symbols
 
 ```
-scons symbols profile={debug|release}
+scons symbols profile={debug|release} [firmware={hash or file}]
 ```
 
 Dumps the symbol table for your executable.
 
 ```
- $ scons symbols
+ $ scons symbols [firmware={hash or file}]
 Show symbols for '{debug|release}/blink.elf':
 536871656 00000001 b (anonymous namespace)::nextOperation
 536871657 00000001 b (anonymous namespace)::checkNextOperation
@@ -426,7 +431,7 @@ Show symbols for '{debug|release}/blink.elf':
 #### scons listing
 
 ```
-scons listing profile={debug|release}
+scons listing profile={debug|release} [firmware={hash or file}]
 ```
 
 Decompiles your executable into an annotated assembly listing.
@@ -463,7 +468,7 @@ main()
 #### scons bin
 
 ```
-scons bin profile={debug|release}
+scons bin profile={debug|release} [firmware={hash or file}]
 ```
 
 Creates a binary file of your executable.
@@ -477,7 +482,7 @@ Binary File···· {debug|release}/blink.bin
 #### scons hex
 
 ```
-scons hex profile={debug|release}
+scons hex profile={debug|release} [firmware={hash or file}]
 ```
 
 Creates a Intel-hex file of your executable.
@@ -495,7 +500,8 @@ scons artifact profile={debug|release}
 ```
 
 Caches the ELF and binary file of the newest compiled executable identified by
-the hash of the binary file in `{build_path}/artifacts/{hash}.elf`.
+the hash of the binary file in `artifacts/{hash}.elf`. You can change this path
+with the `modm:build:scons:path.artifact` option.
 
 ```
  $ scons artifact

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -65,14 +65,13 @@ Example for a STM32 target:
 
 ```
  $ scons build
-Compiling C++·· build/release/main.o
-Compiling C···· build/release/modm/ext/tlsf/tlsf.o
+Compiling C++·· {debug|release}/main.o
+Compiling C···· {debug|release}/modm/ext/gcc/cabi.o
     ...
-Compiling C++·· build/release/modm/src/modm/ui/display/virtual_graphic_display.o
-Compiling C++·· build/release/modm/src/modm/utils/dummy.o
-Create Library· build/release/modm/libmodm.a
-Indexing······· build/release/modm/libmodm.a
-Linking········ build/release/game_of_life.elf
+Compiling C++·· {debug|release}/modm/src/modm/utils/dummy.o
+Archiving······ {debug|release}/modm/libmodm.a
+Indexing······· {debug|release}/modm/libmodm.a
+Linking········ /build/{debug|release}/blink.elf
 ```
 
 
@@ -88,8 +87,7 @@ Example for a STM32 target with 16MB external heap:
 
 ```
  $ scons size
-Memory usage:.. build/release/game_of_life.elf
-
+Memory usage··· /build/{debug|release}/blink.elf
 Program:  12.8 KiB (0.6% used)
 (.data + .fastcode + .fastdata + .hardware_init + .reset + .rodata +
  .table.copy.extern + .table.copy.intern + .table.section_heap +
@@ -118,8 +116,8 @@ Example for a STM32 target:
 
 ```
  $ scons program
-.----OpenOCD--- build/release/game_of_life.elf
-'-------------> stm32f469nih
+╭────────────── /build/{debug|release}/blink.elf
+╰───OpenOCD───> stm32f469nih
 Open On-Chip Debugger 0.10.0
     ...
 Info : using stlink api v2
@@ -132,7 +130,7 @@ Info : device id = 0x10006434
 Info : flash size = 2048kbytes
 Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
     ...
-wrote 16384 bytes from file build/release/game_of_life.elf in 0.589736s (27.131 KiB/s)
+wrote 16384 bytes from file {debug|release}/blink.elf in 0.589736s (27.131 KiB/s)
 ** Programming Finished **
 ** Verify Started **
 verified 13064 bytes in 0.296308s (43.056 KiB/s)
@@ -154,7 +152,10 @@ and can be accessed by pressing the BOOT0-Button during startup.
 
 ```
 $ scons program-dfu
-dfu_stm32_programmer: program [...]/blink/release/blink.bin
+Binary File···· /build/{debug|release}/blink.bin
+╭────────────── /build/{debug|release}/blink.bin
+╰─────DFU─────> stm32f469nih
+dfu_stm32_programmer: program /build/{debug|release}/blink.bin
 dfu-util 0.9
 
 Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
@@ -221,7 +222,8 @@ You can let the tool guess the port or explicitly specify it:
 
 ```
 $ scons program-bmp port=/dev/cu.usbmodemDEADBEEF
-[...]
+╭─Black─Magic── /build/{debug|release}/blink.elf
+╰────Probe────> stm32f103rbt6
 Remote debugging using /dev/cu.usbmodemDEADBEEF
 Target voltage: unknown
 Available Targets:
@@ -254,7 +256,7 @@ running on your own computer (host=`localhost`) or somewhere else.
 
 #### scons run
 
-Executes your project on your computer.
+Compiles and executes your program on your computer.
 (\* *only Hosted targets*)
 
 
@@ -297,15 +299,17 @@ Launches GDB to debug via Black Magic Probe.
 
 ```
 scons debug-coredump profile={debug|release} ui={tui|web} \
-                     firmware={GNU Build ID} coredump={path/to/coredump.txt}
+                     coredump={path/to/coredump.txt} \
+                     [firmware={GNU Build ID or path/to/firmware.elf}]
 ```
 
 Launches GDB for post-mortem debugging with the firmware identified by the
-`firmware={hash}` argument using the data from the `coredump={filepath}`
-argument.
+(optional) `firmware={hash or filepath}` argument using the data from the
+`coredump={filepath}` argument.
 (\* *only ARM Cortex-M targets*)
 
 See the `:platform:fault` module for details how to receive the coredump data.
+
 
 #### scons program-remote
 
@@ -361,8 +365,8 @@ displays the serial output stream.
 
 ```
  $ scons log-itm fcpu=64000000
-.----OpenOCD--> Single Wire Viewer
-'------SWO----- stm32f103rbt6
+╭───OpenOCD───> Single Wire Viewer
+╰─────SWO────── stm32f103rbt6
 Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 Info : The selected transport took over low-level target control.
@@ -391,7 +395,7 @@ application.
 Compiling C++·· {debug|release}/modm/ext/gcc/assert.o
     ...
 Compiling C++·· {debug|release}/modm/src/modm/utils/dummy.o
-Create Library· {debug|release}/modm/libmodm.a
+Archiving······ {debug|release}/modm/libmodm.a
 Indexing······· {debug|release}/modm/libmodm.a
 ```
 
@@ -406,7 +410,7 @@ Dumps the symbol table for your executable.
 
 ```
  $ scons symbols
-Show symbols for 'build/release/game_of_life.elf':
+Show symbols for '{debug|release}/blink.elf':
 536871656 00000001 b (anonymous namespace)::nextOperation
 536871657 00000001 b (anonymous namespace)::checkNextOperation
 536871658 00000001 b (anonymous namespace)::error
@@ -431,8 +435,8 @@ into assembly instructions:
 
 ```
  $ scons listing
-Ext. Listing··· build/release/game_of_life.lss
- $ less build/release/game_of_life.lss
+Listing········ {debug|release}/blink.lss
+ $ less {debug|release}/blink.lss
     ...
 Disassembly of section .text:
     ...
@@ -450,8 +454,8 @@ main()
  8000d7a:   f000 fd91   bl  80018a0 <_ZN5Board17initializeDisplayEv>
     Board::initializeTouchscreen();
  8000d7e:   f7ff fc55   bl  800062c <_ZN5Board21initializeTouchscreenEv>
-    game_of_life();
- 8000d82:   f7ff feff   bl  8000b84 <_Z12game_of_lifev>
+    blink();
+ 8000d82:   f7ff feff   bl  8000b84 <_Z12blinkv>
     ...
 ```
 
@@ -466,7 +470,7 @@ Creates a binary file of your executable.
 
 ```
  $ scons bin
-Binary File···· build/release/game_of_life.bin
+Binary File···· {debug|release}/blink.bin
 ```
 
 
@@ -481,7 +485,8 @@ the hash of the binary file in `{build_path}/artifacts/{hash}.elf`.
 
 ```
  $ scons artifact
-Cache Artifact· build/release/game_of_life.elf
+╭───Artifact─── /build/release/blink.elf
+╰────Cache────> artifacts/0214523ab713bc7bdfb37d902e65dae8305f4754.elf
 ```
 
 
@@ -495,14 +500,14 @@ Cleans the build artifacts.
 
 ```
  $ scons -c
-Removed build/release/main.o
-Removed build/release/modm/ext/tlsf/tlsf.o
-
-Removed build/release/modm/src/modm/ui/display/virtual_graphic_display.o
-Removed build/release/modm/src/modm/utils/dummy.o
-Removed build/release/modm/libmodm.a
-Removed build/release/game_of_life.elf
-Removed build/release/game_of_life.lss
+Removed {debug|release}/main.o
+Removed {debug|release}/modm/ext/tlsf/tlsf.o
+    ...
+Removed {debug|release}/modm/src/modm/ui/display/virtual_graphic_display.o
+Removed {debug|release}/modm/src/modm/utils/dummy.o
+Removed {debug|release}/modm/libmodm.a
+Removed {debug|release}/blink.elf
+Removed {debug|release}/blink.lss
 ```
 
 

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -474,6 +474,20 @@ Binary File···· {debug|release}/blink.bin
 ```
 
 
+#### scons hex
+
+```
+scons hex profile={debug|release}
+```
+
+Creates a Intel-hex file of your executable.
+
+```
+ $ scons hex
+Hex File······· {debug|release}/blink.hex
+```
+
+
 #### scons artifact
 
 ```

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -16,6 +16,11 @@ profile = ARGUMENTS.get("profile", "release")
 env["CONFIG_PROFILE"] = profile
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
 env["BASEPATH"] = abspath("..")
+%% if core.startswith("avr")
+env["COMPILERPREFIX"] = "avr-"
+%% elif core.startswith("cortex-m")
+env["COMPILERPREFIX"] = "arm-none-eabi-"
+%% endif
 %% if family == "darwin"
 # Using homebrew gcc on macOS instead of clang
 env["COMPILERSUFFIX"] = env.Detect(["gcc-11", "gcc-10"])[3:]

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -11,10 +11,11 @@
 from os.path import join, abspath
 Import("env")
 
-profile = env["CONFIG_PROFILE"]
+profile = ARGUMENTS.get("profile", "release")
 %% if is_modm
+env["CONFIG_PROFILE"] = profile
 env["BUILDPATH"] = join(env["CONFIG_BUILD_BASE"], profile)
-env["BASEPATH"] = abspath(".")
+env["BASEPATH"] = abspath("..")
 %% if family == "darwin"
 # Using homebrew gcc on macOS instead of clang
 env["COMPILERSUFFIX"] = env.Detect(["gcc-11", "gcc-10"])[3:]
@@ -112,21 +113,21 @@ env["CONFIG_AVRDUDE_OPTIONS"] = "{{ avrdude_options }}"
 env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ avrdude_baudrate }}"
 %% endif
 %% elif core.startswith("cortex-m")
-env.Append(MODM_OPENOCD_CONFIGFILES="$BASEPATH/openocd.cfg")
-env.Append(MODM_OPENOCD_GDBINIT="$BASEPATH/openocd_gdbinit")
-env.Append(MODM_GDBINIT="$BASEPATH/gdbinit")
+env.Append(MODM_OPENOCD_CONFIGFILES = "$BASEPATH/modm/openocd.cfg")
+env.Append(MODM_OPENOCD_GDBINIT = "$BASEPATH/modm/openocd_gdbinit")
+env.Append(MODM_GDBINIT = "$BASEPATH/modm/gdbinit")
 %% if platform == "sam"
 %% if bossac_offset
-env.Append(MODM_BOSSAC_OFFSET={{ bossac_offset }})
+env.Append(MODM_BOSSAC_OFFSET = {{ bossac_offset }})
 %% endif
 %% if bossac_options
-env.Append(MODM_BOSSAC_OPTIONS="{{ bossac_options }}")
+env.Append(MODM_BOSSAC_OPTIONS = "{{ bossac_options }}")
 %% endif
 %% endif
 %% endif
 
 # XPCC generator tool path
-env["XPCC_SYSTEM_DESIGN"] = join(abspath("."), "tools", "xpcc_generator")
+env["XPCC_SYSTEM_DESIGN"] = "$BASEPATH/modm/tools/xpcc_generator"
 %% endif
 
 

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -8,7 +8,8 @@
 
 #!/usr/bin/env python3
 
-from os.path import join, abspath
+from os.path import join, abspath, realpath, dirname
+import shutil
 Import("env")
 
 profile = ARGUMENTS.get("profile", "release")
@@ -36,6 +37,7 @@ env.Append(toolpath=[
 %% for tool in tools | sort
 env.Tool("{{tool}}")
 %% endfor
+env["GCC_PATH"] = dirname(dirname(realpath(shutil.which(env["CC"]))))
 
 %% macro generate_flags_for_profile(name, profile, append=False)
 env{% if append %}.Append({{name | upper}}{% else %}["{{name | upper}}"]{% endif %} = [
@@ -121,6 +123,7 @@ env["CONFIG_AVRDUDE_BAUDRATE"] = "{{ avrdude_baudrate }}"
 env.Append(MODM_OPENOCD_CONFIGFILES = "$BASEPATH/modm/openocd.cfg")
 env.Append(MODM_OPENOCD_GDBINIT = "$BASEPATH/modm/openocd_gdbinit")
 env.Append(MODM_GDBINIT = "$BASEPATH/modm/gdbinit")
+env.Append(MODM_GDB_COMMANDS = "dir $GCC_PATH")
 %% if platform == "sam"
 %% if bossac_offset
 env.Append(MODM_BOSSAC_OFFSET = {{ bossac_offset }})

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -17,7 +17,7 @@ CacheDir("{{ cache_dir | modm.windowsify(escape_level=1)}}")
 env = DefaultEnvironment(tools=[], ENV=os.environ)
 env["CONFIG_PROJECT_NAME"] = "{{ options[":build:project.name"] }}"
 env["CONFIG_BUILD_BASE"] = abspath("{{ build_path | modm.windowsify(escape_level=1)}}")
-env["CONFIG_ARTIFACT_PATH"] = join(env["CONFIG_BUILD_BASE"], "artifact")
+env["CONFIG_ARTIFACT_PATH"] = abspath("{{ artifact_path | modm.windowsify(escape_level=1)}}")
 generated_paths = {{ generated_paths }}
 
 # Building all libraries

--- a/tools/build_script_generator/scons/resources/SConstruct.in
+++ b/tools/build_script_generator/scons/resources/SConstruct.in
@@ -11,20 +11,14 @@
 import os
 from os.path import join, abspath
 
-# User Configurable Options
-project_name = "{{ options[":build:project.name"] }}"
-build_path = "{{ build_path | modm.windowsify(escape_level=1)}}"
-generated_paths = {{ generated_paths }}
 %% if cache_dir | length
 CacheDir("{{ cache_dir | modm.windowsify(escape_level=1)}}")
 %% endif
-
-# SCons environment with all tools
 env = DefaultEnvironment(tools=[], ENV=os.environ)
-env["CONFIG_BUILD_BASE"] = abspath(build_path)
+env["CONFIG_PROJECT_NAME"] = "{{ options[":build:project.name"] }}"
+env["CONFIG_BUILD_BASE"] = abspath("{{ build_path | modm.windowsify(escape_level=1)}}")
 env["CONFIG_ARTIFACT_PATH"] = join(env["CONFIG_BUILD_BASE"], "artifact")
-env["CONFIG_PROJECT_NAME"] = project_name
-env["CONFIG_PROFILE"] = ARGUMENTS.get("profile", "release")
+generated_paths = {{ generated_paths }}
 
 # Building all libraries
 libraries = env.SConscript(dirs=generated_paths, exports="env")
@@ -36,7 +30,7 @@ headers = env.FindHeaderFiles("{{ unittest_source }}")
 sources = [env.UnittestRunner(target="unittest_runner.cpp", source=headers)]
 %% else
 env.Append(CPPPATH=".")
-ignored = [".lbuild_cache", build_path] + generated_paths
+ignored = [".lbuild_cache", env["CONFIG_BUILD_BASE"]] + generated_paths
 sources = []
 %% endif
 

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -10,11 +10,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-from os.path import abspath, relpath
+from os.path import join, abspath, relpath
 
 def build_target(env, sources):
 	# Building application
 	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+"{{ program_extension }}", source=sources)
+	# Clean additional artifacts
+	env.Clean(program, join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".bin"))
+	env.Clean(program, join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".hex"))
+	env.Clean(program, join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".lss"))
 
 %% if with_compilation_db
 	env.Command("compile_commands.json", sources,
@@ -27,6 +31,7 @@ def build_target(env, sources):
 	env.Alias("symbols", env.Symbols(program))
 	env.Alias("listing", env.Listing(program))
 	env.Alias("bin", env.Bin(program))
+	env.Alias("hex", env.Hex(program))
 	env.Alias("build", program)
 %% if platform in ["hosted"]
 	env.Alias("run", env.Run(program))

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -15,6 +15,7 @@ from os.path import join, abspath, relpath
 def build_target(env, sources):
 	# Building application
 	program = env.Program(target=env["CONFIG_PROJECT_NAME"]+"{{ program_extension }}", source=sources)
+	chosen_program = env.ChooseFirmware(program)
 	# Clean additional artifacts
 	env.Clean(program, join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".bin"))
 	env.Clean(program, join(env["BUILDPATH"], env["CONFIG_PROJECT_NAME"]+".hex"))
@@ -28,10 +29,10 @@ def build_target(env, sources):
 %% endif
 
 	env.Alias("qtcreator", env.QtCreatorProject(sources))
-	env.Alias("symbols", env.Symbols(program))
-	env.Alias("listing", env.Listing(program))
-	env.Alias("bin", env.Bin(program))
-	env.Alias("hex", env.Hex(program))
+	env.Alias("symbols", env.Symbols(chosen_program))
+	env.Alias("listing", env.Listing(chosen_program))
+	env.Alias("bin", env.Bin(chosen_program))
+	env.Alias("hex", env.Hex(chosen_program))
 	env.Alias("build", program)
 %% if platform in ["hosted"]
 	env.Alias("run", env.Run(program))
@@ -39,24 +40,24 @@ def build_target(env, sources):
 %% else
 	# The executable depends on the linkerscript
 	env.Depends(target=program, dependency="{{ linkerscript }}")
-	env.Alias("size", env.Size(program))
+	env.Alias("size", env.Size(chosen_program))
 	%% if core.startswith("cortex-m")
 	env.Alias("log-itm", env.LogItmOpenOcd())
 
 	env.Alias("artifact", env.CacheArtifact(program))
 		%% set artifact = ', "artifact"' if upload_with_artifact else ''
-	env.Alias("program-openocd", [env.ProgramOpenOcd(program){{ artifact }}])
-	env.Alias("program-remote", [env.ProgramGdbRemote(program){{ artifact }}])
-	env.Alias("program-bmp", [env.ProgramBMP(program){{ artifact }}])
-	env.Alias('program-dfu', [env.ProgramDFU(env.Bin(program)){{ artifact }}])
+	env.Alias("program-openocd", [env.ProgramOpenOcd(chosen_program){{ artifact }}])
+	env.Alias("program-remote", [env.ProgramGdbRemote(chosen_program){{ artifact }}])
+	env.Alias("program-bmp", [env.ProgramBMP(chosen_program){{ artifact }}])
+	env.Alias('program-dfu', [env.ProgramDFU(env.Bin(chosen_program)){{ artifact }}])
 		%% if platform in ["sam"]
-	env.Alias("program-bossac", [env.ProgramBossac(env.Bin(program)){{ artifact }}])
+	env.Alias("program-bossac", [env.ProgramBossac(env.Bin(chosen_program)){{ artifact }}])
 		%% endif
 
-	env.Alias("debug-openocd", env.DebugOpenOcd(program))
-	env.Alias("debug-remote", env.DebugGdbRemote(program))
-	env.Alias("debug-bmp", env.DebugBMP(program))
-	env.Alias("debug-coredump", env.DebugCoredump(program))
+	env.Alias("debug-openocd", env.DebugOpenOcd(chosen_program))
+	env.Alias("debug-remote", env.DebugGdbRemote(chosen_program))
+	env.Alias("debug-bmp", env.DebugBMP(chosen_program))
+	env.Alias("debug-coredump", env.DebugCoredump(chosen_program))
 
 	env.Alias("reset-openocd", env.ResetOpenOcd())
 	env.Alias("reset-bmp", env.ResetBMP())
@@ -68,8 +69,8 @@ def build_target(env, sources):
 	env.Alias("debug", "debug-openocd")
 
 	%% elif core.startswith("avr")
-	env.Alias("program-avrdude", env.ProgramAvrdude(program))
-	env.Alias("program-fuses", env.ProgramAvrdudeFuses(program))
+	env.Alias("program-avrdude", env.ProgramAvrdude(chosen_program))
+	env.Alias("program-fuses", env.ProgramAvrdudeFuses(chosen_program))
 	env.Alias("program", "program-avrdude")
 	%% endif
 

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018-2019, Niklas Hauser
+# Copyright (c) 2018-2021, Niklas Hauser
 # Copyright (c) 2019, Raphael Lehmann
 #
 # This file is part of the modm project.
@@ -33,7 +33,7 @@ def build_target(env, sources):
 	env.Alias("all", ["build", "run"])
 %% else
 	# The executable depends on the linkerscript
-	env.Depends(target=program, dependency="$BASEPATH/link/linkerscript.ld")
+	env.Depends(target=program, dependency="{{ linkerscript }}")
 	env.Alias("size", env.Size(program))
 	%% if core.startswith("cortex-m")
 	env.Alias("log-itm", env.LogItmOpenOcd())

--- a/tools/build_script_generator/scons/site_tools/avrdude.py
+++ b/tools/build_script_generator/scons/site_tools/avrdude.py
@@ -28,25 +28,18 @@ def avrdude_flash(env, source, alias="avrdude_flash"):
 	def call_program(target, source, env):
 		call_avrdude(env, source[0])
 
-	action = Action(call_program, cmdstr="$PROGRAM_AVRDUDE_STR")
+	action = Action(call_program, cmdstr="$PROGRAM_AVRDUDE_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 def avrdude_fuse(env, source, alias="avrdude_fuse"):
 	def call_fuse(target, source, env):
 		call_avrdude(env, source[0], fuses=["hfuse", "lfuse", "efuse"])
 
-	action = Action(call_fuse, cmdstr="$PROGRAM_AVRDUDE_STR")
+	action = Action(call_fuse, cmdstr="$PROGRAM_AVRDUDE_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	# build messages
-	if ARGUMENTS.get("verbose") != "1":
-		env["PROGRAM_AVRDUDE_STR"] = \
-			"{0}.-------------- {1}$SOURCE\n" \
-			"{0}'---Avrdude---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
 	env.AddMethod(avrdude_flash, "ProgramAvrdude")
 	env.AddMethod(avrdude_fuse, "ProgramAvrdudeFuses")
 

--- a/tools/build_script_generator/scons/site_tools/bitmap.py
+++ b/tools/build_script_generator/scons/site_tools/bitmap.py
@@ -24,10 +24,6 @@ def bitmap_action(target, source, env):
 	bitmap.convert(image=str(source[0]),
 	               outpath=dirname(str(target[0])))
 
-def bitmap_string(target, source, env):
-    return "{0}Create Bitmap·· {1}{3}{2}" \
-           .format("\033[;0;32m", "\033[;0;33m", "\033[;0;0m", str(target[0]))
-
 def bitmap_emitter(target, source, env):
 	header = splitext(str(target[0]))[0] + ".hpp"
 	target.append(header)
@@ -35,15 +31,12 @@ def bitmap_emitter(target, source, env):
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	env.Append(
-		BUILDERS = {
-			'Bitmap': env.Builder(
-				action = env.Action(bitmap_action, bitmap_string),
-				suffix = '.cpp',
-				src_suffix = '.pbm',
-				emitter = bitmap_emitter,
-				single_source = True),
-	})
+	env['BUILDERS']['Bitmap'] = env.Builder(
+		action = Action(bitmap_action, cmdstr="$BITMAPCOMSTR"),
+		suffix = '.cpp',
+		src_suffix = '.pbm',
+		emitter = bitmap_emitter,
+		single_source = True)
 
 def exists(env):
 	return True

--- a/tools/build_script_generator/scons/site_tools/bmp.py
+++ b/tools/build_script_generator/scons/site_tools/bmp.py
@@ -20,7 +20,7 @@ def black_magic_probe_program(env, source, alias='black_magic_probe_program'):
 	def call_bmp_program(target, source, env):
 		bmp.program(source=source[0].abspath, port=ARGUMENTS.get("port", "auto"))
 
-	action = Action(call_bmp_program, cmdstr="$BLACK_MAGIC_PROBE_PROGRAM_COMSTR")
+	action = Action(call_bmp_program, cmdstr="$BMP_PROGRAM_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -30,7 +30,7 @@ def black_magic_probe_debug(env, source, alias='black_magic_probe_debug'):
 		gdb.call(source=source[0].abspath, backend=backend,
 				 ui=ARGUMENTS.get("ui", "tui"))
 
-	action = Action(call_bmp_debug, cmdstr="$BLACK_MAGIC_PROBE_DEBUG_COMSTR")
+	action = Action(call_bmp_debug, cmdstr="$BMP_DEBUG_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -39,25 +39,11 @@ def black_magic_probe_reset(env, alias='black_magic_probe_reset'):
 		backend = bmp.BlackMagicProbeBackend(port=ARGUMENTS.get("port", "auto"))
 		gdb.call(backend=backend, commands=["kill", "quit"])
 
-	action = Action(call_bmp_reset, cmdstr="$BLACK_MAGIC_PROBE_RESET_COMSTR")
+	action = Action(call_bmp_reset, cmdstr="$BMP_RESET_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, '', action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	if not ARGUMENTS.get('verbose'):
-		env["BLACK_MAGIC_PROBE_PROGRAM_COMSTR"] = \
-			"{0}.-Black-Magic-- {1}$SOURCE\n" \
-			"{0}'----Probe----> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["BLACK_MAGIC_PROBE_DEBUG_COMSTR"] = \
-			"{0}.-----GDB-----> {1}$SOURCE\n" \
-			"{0}'-----BMP-----> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["BLACK_MAGIC_PROBE_RESET_COMSTR"] = \
-			"{0}.----Reset----- {1}\n" \
-			"{0}'-----BMP-----> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
 	env.AddMethod(black_magic_probe_program, 'ProgramBMP')
 	env.AddMethod(black_magic_probe_debug, 'DebugBMP')
 	env.AddMethod(black_magic_probe_reset, 'ResetBMP')

--- a/tools/build_script_generator/scons/site_tools/bmp.py
+++ b/tools/build_script_generator/scons/site_tools/bmp.py
@@ -27,8 +27,9 @@ def black_magic_probe_program(env, source, alias='black_magic_probe_program'):
 def black_magic_probe_debug(env, source, alias='black_magic_probe_debug'):
 	def call_bmp_debug(target, source, env):
 		backend = bmp.BlackMagicProbeBackend(port=ARGUMENTS.get("port", "auto"))
-		gdb.call(source=source[0].abspath, backend=backend,
-				 ui=ARGUMENTS.get("ui", "tui"))
+		gdb.call(source=source[0].abspath, backend=backend, ui=ARGUMENTS.get("ui", "tui"),
+			 	 config=map(env.subst, env.Listify(env.get("MODM_GDBINIT", []))),
+			 	 commands=map(env.subst, env.Listify(env.get("MODM_GDB_COMMANDS", []))))
 
 	action = Action(call_bmp_debug, cmdstr="$BMP_DEBUG_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))

--- a/tools/build_script_generator/scons/site_tools/bossac.py
+++ b/tools/build_script_generator/scons/site_tools/bossac.py
@@ -26,18 +26,11 @@ def bossac_program(env, source, alias="bossac_program"):
 						   port=ARGUMENTS.get("port", "auto"),
 						   options=env.get("MODM_BOSSAC_OPTIONS"))
 
-	action = Action(call_program, cmdstr="$PROGRAM_BOSSAC_STR")
+	action = Action(call_program, cmdstr="$PROGRAM_BOSSAC_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	# build messages
-	if ARGUMENTS.get("verbose") != "1":
-		env["PROGRAM_BOSSAC_STR"] = \
-			"{0}.-------------- {1}$SOURCE\n" \
-			"{0}'----BOSSAc---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
 	env.AddMethod(bossac_program, "ProgramBossac")
 
 def exists(env):

--- a/tools/build_script_generator/scons/site_tools/comstr.py
+++ b/tools/build_script_generator/scons/site_tools/comstr.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2013-2014, 2016-2017, German Aerospace Center (DLR)
+# Copyright (c) 2018, 2021, Niklas Hauser
+# Copyright (c) 2018, Fabian Greif
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+# - 2013-2014, 2016-2017, Fabian Greif (DLR RY-AVS)
+# - 2018, 2021, Niklas Hauser
+# - 2018, Fabian Greif
+
+import sys
+import os
+
+from SCons.Script import *
+
+# ─────-------------------------------------------------------
+def generate(env, **kw):
+    colors = {
+        'cyan':         '\033[;0;36m',
+        'purple':       '\033[;0;35m',
+        'blue':         '\033[;0;34m',
+        'green':        '\033[;0;32m',
+        'boldgreen':    '\033[;1;32m',
+        'lightgreen':   '\033[;0;92m',
+        'yellow':       '\033[;0;33m',
+        'boldyellow':   '\033[;1;33m',
+        'lightyellow':  '\033[;0;93m',
+        'red':          '\033[;0;31m',
+        'boldred':      '\033[;1;31m',
+        'end':          '\033[;0;0m',
+    }
+
+    # If the output is not a terminal, remove the colors
+    if not sys.stdout.isatty():
+        for key in colors:
+            colors[key] = ''
+
+    default = (colors['green'], colors['yellow'], colors['end'])
+    library = (colors['boldgreen'], colors['yellow'], colors['end'])
+    linking = (colors['boldgreen'], colors['boldyellow'], colors['end'])
+    install = (colors['green'], colors['yellow'], colors['green'], colors['boldyellow'], colors['end'])
+    template = install
+
+    # build messages
+    if ARGUMENTS.get('verbose') != '1':
+        # Warning: Due to an inconsistency in SCons these ASCII-art arrow are
+        #          necessary to keep the indentation. Spaces would be removed.
+        #
+        # See also:
+        # http://scons.tigris.org/ds/viewMessage.do?dsForumId=1268&dsMessageId=2425232
+
+        # Relative path is enough
+        env['CCCOMSTR'] =       "%sCompiling C···· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['CXXCOMSTR'] =      "%sCompiling C++·· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['ASCOMSTR'] =       "%sAssembling····· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['ASPPCOMSTR'] =     env['ASCOMSTR']
+        env['RANLIBCOMSTR'] =   "%sIndexing······· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['ARCOMSTR'] =       "%sArchiving······ %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % library
+        env['STRIPCOMSTR'] =    "%sStripping······ %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % linking
+        env['SYMBOLSCOMSTR'] =  "%sSymbols········ %s${str(SOURCE).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        # Full path for information
+        env['SIZECOMSTR'] =     "%sMemory usage··· %s$SOURCE%s" % default
+        env['LINKCOMSTR'] =     "%sLinking········ %s$TARGET%s" % linking
+        env['HEXCOMSTR'] =      "%sHex File······· %s$TARGET%s" % default
+        env['BINCOMSTR'] =      "%sBinary File···· %s$TARGET%s" % default
+        env['LSSCOMSTR'] =      "%sListing········ %s$TARGET%s" % default
+
+        # modm tools format strings
+        env['BITMAPCOMSTR'] =   "%sBitmap········· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['FONTCOMSTR'] =     "%sFont··········· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+        env['UNITTESTCOMSTR'] = "%sUnittest······· %s${str(TARGET).replace(BUILDPATH,CONFIG_PROFILE)}%s" % default
+
+        # modm tools templating
+        env["JINJA_TEMPLATE_COMSTR"] =   "%s╭────Jinja2──── %s$SOURCE\n" \
+                                         "%s╰───Template──> %s$TARGET%s" % template
+
+        env["XPCC_PACKETS_COMSTR"] =     "%s╭─────XPCC───── %s$SOURCE\n" \
+                                         "%s╰───Packets───> %s$TARGET%s" % template
+
+        env["XPCC_IDENTIFIER_COMSTR"] =  "%s╭─────XPCC───── %s$SOURCE\n" \
+                                         "%s╰-Identifier──> %s$TARGET%s" % template
+
+        env["XPCC_POSTMAN_COMSTR"] =     "%s╭─────XPCC───── %s$SOURCE\n" \
+                                         "%s╰───Postman───> %s$TARGET%s" % template
+
+        env["XPCC_COMM_STUBS_COMSTR"] =  "%s╭─────XPCC───── %s$SOURCE\n" \
+                                         "%s╰─Comm─Stubs──> %s$TARGET%s" % template
+
+        env["XPCC_TASK_CALLER_COMSTR"] = "%s╭─────XPCC───── %s$SOURCE\n" \
+                                         "%s╰─Task─Caller─> %s$TARGET%s" % template
+
+        # modm tools installing
+        env["ARTIFACT_COMSTR"] =         "%s╭───Artifact─── %s$SOURCE\n" \
+                                         "%s╰────Cache────> %s$ARTIFACT_FILEPATH%s" % install
+
+        env["DEBUG_OPENOCD_COMSTR"] =    "%s╭─────GDB─────> %s$SOURCE\n" \
+                                         "%s╰───OpenOCD───> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["PROGRAM_OPENOCD_COMSTR"] =  "%s╭────────────── %s$SOURCE\n" \
+                                         "%s╰───OpenOCD───> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["RESET_OPENOCD_COMSTR"] =    "%s╭────Reset───── %s\n" \
+                                         "%s╰───OpenOCD───> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["PROGRAM_AVRDUDE_COMSTR"] =  "%s╭────────────── %s$SOURCE\n" \
+                                         "%s╰───Avrdude───> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["BMP_PROGRAM_COMSTR"] =      "%s╭─Black─Magic── %s$SOURCE\n" \
+                                         "%s╰────Probe────> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["BMP_DEBUG_COMSTR"] =        "%s╭─────GDB─────> %s$SOURCE\n" \
+                                         "%s╰─────BMP─────> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["BMP_RESET_COMSTR"] =        "%s╭────Reset───── %s\n" \
+                                         "%s╰─────BMP─────> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["PROGRAM_BOSSAC_COMSTR"] =   "%s╭────────────── %s$SOURCE\n" \
+                                         "%s╰────BOSSAc───> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["DEBUG_COREDUMP_COMSTR"] =   "%s╭─────GDB─────> %s$SOURCE\n" \
+                                         "%s╰───Coredump──> %s$CONFIG_DEVICE_NAME ($COREDUMP_FILE)%s" % install
+
+        env['PROGRAM_DFU_COMSTR'] =      "%s╭────────────── %s$SOURCE\n" \
+                                         "%s╰─────DFU─────> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["ITM_OPENOCD_COMSTR"] =      "%s╭───OpenOCD───> %sSingle Wire Viewer\n" \
+                                         "%s╰─────SWO────── %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["PROGRAM_REMOTE_COMSTR"] =   "%s╭────────────── %s$SOURCE\n" \
+                                         "%s╰─Rem─OpenOCD─> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["DEBUG_REMOTE_COMSTR"] =     "%s╭─────GDB─────> %s$SOURCE\n" \
+                                         "%s╰─Rem─OpenOCD─> %s$CONFIG_DEVICE_NAME%s" % install
+
+        env["RESET_REMOTE_COMSTR"] =     "%s╭────Reset───── %s\n" \
+                                         "%s╰─Remote─GDB──> %s$CONFIG_DEVICE_NAME%s" % install
+
+def exists(env):
+    return True

--- a/tools/build_script_generator/scons/site_tools/crashdebug.py
+++ b/tools/build_script_generator/scons/site_tools/crashdebug.py
@@ -44,7 +44,8 @@ def run_post_mortem_gdb(target, source, env):
 			binary_path=env.subst("$BASEPATH/modm/ext/crashcatcher/bins"),
 			coredump=env["COREDUMP_FILE"])
 	gdb.call(source=source, backend=backend, ui=ARGUMENTS.get("ui", "tui"),
-			 config=map(env.subst, env.Listify(env.get("MODM_GDBINIT", []))))
+			 config=map(env.subst, env.Listify(env.get("MODM_GDBINIT", []))),
+			 commands=map(env.subst, env.Listify(env.get("MODM_GDB_COMMANDS", []))))
 
 	return 0
 

--- a/tools/build_script_generator/scons/site_tools/crashdebug.py
+++ b/tools/build_script_generator/scons/site_tools/crashdebug.py
@@ -17,21 +17,10 @@ import platform
 from modm_tools import gdb, crashdebug
 
 def run_post_mortem_gdb(target, source, env):
-	source = str(source[0])
 
-	artifact = ARGUMENTS.get("firmware", None)
-	if artifact is None:
-		print("\n> Using the newest firmware may be inaccurate!\n"
-			  "> Use 'firmware={hash}' argument to specify a specific firmware.\n")
-	else:
-		artifact = artifact.lower()
-		artifactpath = os.path.join(env["CONFIG_ARTIFACT_PATH"], "{}.elf".format(artifact))
-		if os.path.isfile(artifactpath):
-			source = artifactpath
-		else:
-			print("\n> Unable to find artifact '{}' in build cache!\n"
-					"> Run without artifact argument to use newest firmware.\n".format(artifact))
-			return 1
+	if ARGUMENTS.get("firmware") is None:
+		print("\n> Using the latest firmware may be inaccurate!"
+			  "\n> Use the 'firmware={hash or file}' argument to point to a specific firmware.\n")
 
 	if not os.path.isfile(env["COREDUMP_FILE"]):
 		print("\n> Unable to find coredump file!"
@@ -43,7 +32,7 @@ def run_post_mortem_gdb(target, source, env):
 	backend = crashdebug.CrashDebugBackend(
 			binary_path=env.subst("$BASEPATH/modm/ext/crashcatcher/bins"),
 			coredump=env["COREDUMP_FILE"])
-	gdb.call(source=source, backend=backend, ui=ARGUMENTS.get("ui", "tui"),
+	gdb.call(source=source[0].path, backend=backend, ui=ARGUMENTS.get("ui", "tui"),
 			 config=map(env.subst, env.Listify(env.get("MODM_GDBINIT", []))),
 			 commands=map(env.subst, env.Listify(env.get("MODM_GDB_COMMANDS", []))))
 

--- a/tools/build_script_generator/scons/site_tools/dfu.py
+++ b/tools/build_script_generator/scons/site_tools/dfu.py
@@ -25,25 +25,16 @@ import platform
 from SCons.Script import *
 
 # -----------------------------------------------------------------------------
-def dfu_stm32_programmer_flash(env, source, alias='dfu_stm32_program'):
-	actionString  = '$DFU_STM32_PROGRAMMER -v -E2 -R -i 0 -a 0 -s 0x08000000:leave -D $SOURCE'
+def program_dfu(env, source, alias='program_dfu'):
+	actionString  = '$DFU_PROGRAMMER -v -E2 -R -i 0 -a 0 -s 0x08000000:leave -D $SOURCE'
 
-	action = Action(actionString, cmdstr = "$DFU_STM32_PROGRAMMER_COMSTR")
+	action = Action(actionString, cmdstr="$PROGRAM_DFU_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	# build messages
-	if not ARGUMENTS.get('verbose'):
-		env['DFU_STM32_PROGRAMMER_COMSTR'] = \
-			"{0}.-------------- {1}$SOURCE\n" \
-			"{0}'-----DFU-----> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
-	# Name of the binary program to run
-	env['DFU_STM32_PROGRAMMER'] = 'dfu-util'
-
-	env.AddMethod(dfu_stm32_programmer_flash, 'ProgramDFU')
+	env['DFU_PROGRAMMER'] = 'dfu-util'
+	env.AddMethod(program_dfu, 'ProgramDFU')
 
 def exists(env):
-	return env.Detect('dfu_stm32_programmer')
+	return env.Detect('dfu-util')

--- a/tools/build_script_generator/scons/site_tools/font.py
+++ b/tools/build_script_generator/scons/site_tools/font.py
@@ -16,7 +16,7 @@
 # -----------------------------------------------------------------------------
 
 import os
-import os.path
+from SCons.Script import *
 
 script_path = os.path.dirname(__file__)
 command = os.path.join(script_path, "../../tools/font_creator/font_export.py")
@@ -28,10 +28,6 @@ def font_action(target, source, env):
 
 	os.system('python3 "%s" "%s" "%s"' % (command, infile, outfile))
 
-def font_string(target, source, env):
-	return "{0}Create Font···· {1}{3}{2}" \
-	       .format("\033[;0;32m", "\033[;0;33m", "\033[;0;0m", str(source[0]))
-
 def font_emitter(target, source, env):
 	header = os.path.splitext(str(target[0]))[0] + ".hpp"
 	target.append(header)
@@ -40,15 +36,12 @@ def font_emitter(target, source, env):
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	env.Append(
-		BUILDERS = {
-			'Font': env.Builder(
-				action = env.Action(font_action, font_string),
-				suffix = '.cpp',
-				src_suffix = '.font',
-				emitter = font_emitter,
-				single_source = True),
-	})
+	env['BUILDERS']['Font'] = env.Builder(
+		action = Action(font_action, cmdstr="$FONTCOMSTR"),
+		suffix = '.cpp',
+		src_suffix = '.font',
+		emitter = font_emitter,
+		single_source = True)
 
 def exists(env):
 	return True

--- a/tools/build_script_generator/scons/site_tools/gcc_retarget.py
+++ b/tools/build_script_generator/scons/site_tools/gcc_retarget.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2017, German Aerospace Center (DLR)
+# Copyright (c) 2018, Niklas Hauser
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+# - 2016-2017, Fabian Greif (DLR RY-AVS)
+# - 2018, Niklas Hauser
+
+import os
+
+from SCons.Script import *
+
+def strip_binary(env, target, source, options="--strip-unneeded"):
+    return env.Command(target,
+                       source,
+                       Action("$STRIP {} -o $TARGET $SOURCE".format(options),
+                              cmdstr="$STRIPCOMSTR"))
+
+def list_symbols(env, source, alias='__symbols'):
+    action = Action("$NM $SOURCE -S -C --size-sort -td",
+                    cmdstr="$SYMBOLSCOMSTR")
+    return env.AlwaysBuild(env.Alias(alias, source, action))
+
+
+def generate(env, **kw):
+    env.Tool('gcc')
+    env.Tool('g++')
+    env.Tool('gnulink')
+    env.Tool('ar')
+    env.Tool('as')
+    env.Tool('utils')
+
+    # Define executable name of the compiler
+    path = env.get('COMPILERPATH', '')
+    prefix = env.get('COMPILERPREFIX', '')
+    suffix = env.get('COMPILERSUFFIX', '')
+    if suffix != '' and not suffix.startswith('-'):
+        suffix = '-' + suffix
+
+    prefix = path + prefix
+    env['CC'] = prefix + 'gcc' + suffix
+    env['CXX'] = prefix + 'g++' + suffix
+    env['AR'] = prefix + 'ar'
+    env['RANLIB'] = prefix + 'ranlib'
+    if suffix == '':
+        env['AS'] = prefix + 'as'
+        env['NM'] = prefix + 'nm'
+    else:
+        env['AS'] = prefix + 'gcc' + suffix
+        env['NM'] = prefix + 'gcc-nm' + suffix
+        if sys.platform != "darwin":
+            env['AR'] = prefix + 'gcc-ar' + suffix
+            env['RANLIB'] = prefix + 'gcc-ranlib' + suffix
+
+    env['OBJCOPY'] = prefix + 'objcopy'
+    env['OBJDUMP'] = prefix + 'objdump'
+    env['SIZE'] = prefix + 'size'
+    env['STRIP'] = prefix + 'strip'
+
+    env['LINK'] = env['CXX']
+
+    builder_hex = Builder(
+        action=Action("$OBJCOPY -O ihex $SOURCE $TARGET",
+        cmdstr="$HEXCOMSTR"),
+        suffix=".hex",
+        src_suffix="")
+
+    builder_bin = Builder(
+        action=Action("$OBJCOPY -O binary $SOURCE $TARGET",
+        cmdstr="$BINCOMSTR"),
+        suffix=".bin",
+        src_suffix="")
+
+    builder_listing = Builder(
+        action=Action("$OBJDUMP -x -S -l -w $SOURCE > $TARGET",
+        cmdstr="$LSSCOMSTR"),
+        suffix=".lss",
+        src_suffix="")
+
+    env.Append(BUILDERS={
+        'Hex': builder_hex,
+        'Bin': builder_bin,
+        'Listing': builder_listing
+    })
+
+    env.AddMethod(strip_binary, 'Strip')
+    env.AddMethod(list_symbols, 'Symbols')
+
+
+def exists(env):
+    return True
+

--- a/tools/build_script_generator/scons/site_tools/info.py
+++ b/tools/build_script_generator/scons/site_tools/info.py
@@ -27,7 +27,7 @@ def git_info_defines(env, with_status=False):
 	if with_status: defines["MODM_GIT_STATUS"] = 1
 	env.AppendUnique(CPPDEFINES=defines)
 
-	target = join(env["BASEPATH"], "src", "info_git.c")
+	target = join(env["BASEPATH"], "modm", "src", "info_git.c")
 	subs = {"type": "git", "defines": information}
 	sources = env.Jinja2Template(target=target, source=TEMPLATE_SOURCE, substitutions=subs)
 
@@ -41,7 +41,7 @@ def build_info_defines(env):
 	env.AppendUnique(CPPDEFINES=defines)
 
 	information["MODM_BUILD_PROJECT_NAME"] = env.get('CONFIG_PROJECT_NAME', 'Unknown')
-	target = join(env["BASEPATH"], "src", "info_build.c")
+	target = join(env["BASEPATH"], "modm", "src", "info_build.c")
 	subs = {"type": "build", "defines": information}
 	sources = env.Jinja2Template(target=target, source=TEMPLATE_SOURCE, substitutions=subs)
 

--- a/tools/build_script_generator/scons/site_tools/log_itm.py
+++ b/tools/build_script_generator/scons/site_tools/log_itm.py
@@ -17,7 +17,7 @@ import tempfile
 from modm_tools.openocd import OpenOcdBackend, log_itm
 
 # -----------------------------------------------------------------------------
-def log_openocd_itm(env, alias="openocd_itm"):
+def log_openocd_itm(env, alias="log_openocd_itm"):
     def run_openocd_itm(target, source, env):
         fcpu = ARGUMENTS.get("fcpu", None)
         if fcpu is None:
@@ -32,17 +32,11 @@ def log_openocd_itm(env, alias="openocd_itm"):
         log_itm(backend, fcpu, baudrate)
         return 0
 
-    action = Action(run_openocd_itm, cmdstr="$OPENOCD_ITM_STR")
+    action = Action(run_openocd_itm, cmdstr="$ITM_OPENOCD_COMSTR")
     return env.AlwaysBuild(env.Alias(alias, None, action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-    if ARGUMENTS.get('verbose') != '1':
-        env["OPENOCD_ITM_STR"] = \
-            "{0}.----OpenOCD--> {1}Single Wire Viewer\n" \
-            "{0}'------SWO----- {2}$CONFIG_DEVICE_NAME{3}" \
-            .format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
     env.AddMethod(log_openocd_itm, "LogItmOpenOcd")
 
 def exists(env):

--- a/tools/build_script_generator/scons/site_tools/openocd.py
+++ b/tools/build_script_generator/scons/site_tools/openocd.py
@@ -35,7 +35,7 @@ def debug_openocd(env, source, alias="debug_openocd"):
 		gdb.call(source=source[0], backend=backend,
 				 config=map(env.subst, config), ui=ARGUMENTS.get("ui", "tui"))
 
-	action = Action(call_debug_openocd, cmdstr="$DEBUG_OPENOCD_STR")
+	action = Action(call_debug_openocd, cmdstr="$DEBUG_OPENOCD_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -47,7 +47,7 @@ def program_openocd(env, source, alias="program_openocd"):
 						config=map(env.subst, config),
 						search=map(env.subst, searchdir))
 
-	action = Action(call_program_openocd, cmdstr="$PROGRAM_OPENOCD_STR")
+	action = Action(call_program_openocd, cmdstr="$PROGRAM_OPENOCD_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -59,25 +59,11 @@ def reset_openocd(env, alias="reset_openocd"):
 					 config=map(env.subst, config),
 					 search=map(env.subst, searchdir))
 
-	action = Action(call_reset_openocd, cmdstr="$RESET_OPENOCD_STR")
+	action = Action(call_reset_openocd, cmdstr="$RESET_OPENOCD_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, '', action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	if not ARGUMENTS.get('verbose'):
-		env["DEBUG_OPENOCD_STR"] = \
-			"{0}.-----GDB-----> {1}$SOURCE\n" \
-			"{0}'---OpenOCD---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["PROGRAM_OPENOCD_STR"] = \
-			"{0}.-------------- {1}$SOURCE\n" \
-			"{0}'---OpenOCD---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["RESET_OPENOCD_STR"] = \
-			"{0}.----Reset----- {1}\n" \
-			"{0}'---OpenOCD---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
 	env.AddMethod(program_openocd, "ProgramOpenOcd")
 	env.AddMethod(debug_openocd, "DebugOpenOcd")
 	env.AddMethod(reset_openocd, "ResetOpenOcd")

--- a/tools/build_script_generator/scons/site_tools/openocd.py
+++ b/tools/build_script_generator/scons/site_tools/openocd.py
@@ -28,12 +28,13 @@ def debug_openocd(env, source, alias="debug_openocd"):
 	def call_debug_openocd(target, source, env):
 		config_openocd = env.Listify(env.get("MODM_OPENOCD_CONFIGFILES", []))
 		config_searchdirs = env.Listify(env.get("MODM_OPENOCD_SEARCHDIRS", []))
-		config  = env.Listify(env.get("MODM_OPENOCD_GDBINIT", []))
-		config += env.Listify(env.get("MODM_GDBINIT", []))
 		backend = OpenOcdBackend(config=map(env.subst, config_openocd),
 								 search=map(env.subst, config_searchdirs))
-		gdb.call(source=source[0], backend=backend,
-				 config=map(env.subst, config), ui=ARGUMENTS.get("ui", "tui"))
+		config  = env.Listify(env.get("MODM_OPENOCD_GDBINIT", []))
+		config += env.Listify(env.get("MODM_GDBINIT", []))
+		commands = env.Listify(env.get("MODM_GDB_COMMANDS", []))
+		gdb.call(source=source[0], backend=backend, config=map(env.subst, config),
+				 commands=map(env.subst, commands), ui=ARGUMENTS.get("ui", "tui"))
 
 	action = Action(call_debug_openocd, cmdstr="$DEBUG_OPENOCD_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))

--- a/tools/build_script_generator/scons/site_tools/openocd_remote.py
+++ b/tools/build_script_generator/scons/site_tools/openocd_remote.py
@@ -28,7 +28,7 @@ def program_openocd_gdb_remote(env, source, alias='program_openocd_gdb_remote'):
 		         config=map(env.subst, config),
 		         commands=["load", "monitor reset", "disconnect", "quit"])
 
-	action = Action(call_remote_program, cmdstr="$PROGRAM_REMOTE_STR")
+	action = Action(call_remote_program, cmdstr="$PROGRAM_REMOTE_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -41,7 +41,7 @@ def debug_openocd_gdb_remote(env, source, alias='debug_openocd_gdb_remote'):
 		gdb.call(source=source[0], backend=bem.ExtendedRemote(host),
 				 config=map(env.subst, config), ui=ARGUMENTS.get("ui", "tui"),)
 
-	action = Action(call_remote_debug, cmdstr="$DEBUG_REMOTE_STR")
+	action = Action(call_remote_debug, cmdstr="$DEBUG_REMOTE_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, source, action))
 
 # -----------------------------------------------------------------------------
@@ -53,25 +53,11 @@ def reset_openocd_gdb_remote(env, alias='reset_openocd_gdb_remote'):
 		gdb.call(backend=bem.ExtendedRemote(host), config=map(env.subst, config),
 		         commands=["monitor reset", "disconnect", "quit"])
 
-	action = Action(call_remote_reset, cmdstr="$RESET_REMOTE_STR")
+	action = Action(call_remote_reset, cmdstr="$RESET_REMOTE_COMSTR")
 	return env.AlwaysBuild(env.Alias(alias, '', action))
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	if not ARGUMENTS.get('verbose'):
-		env["PROGRAM_REMOTE_STR"] = \
-			"{0}.---Remote----- {1}$SOURCE\n" \
-			"{0}'---OpenOCD---> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["DEBUG_REMOTE_STR"] = \
-			"{0}.------GDB----> {1}$SOURCE\n" \
-			"{0}'-Rem-OpenOCD-> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-		env["RESET_REMOTE_STR"] = \
-			"{0}.----Reset----- {1}\n" \
-			"{0}'-Remote--GDB-> {2}$CONFIG_DEVICE_NAME{3}" \
-			.format("\033[;0;32m", "\033[;0;33m", "\033[;1;33m", "\033[;0;0m")
-
 	env.AddMethod(program_openocd_gdb_remote, 'ProgramGdbRemote')
 	env.AddMethod(debug_openocd_gdb_remote,   'DebugGdbRemote')
 	env.AddMethod(reset_openocd_gdb_remote,   'ResetGdbRemote')

--- a/tools/build_script_generator/scons/site_tools/qtcreator.py
+++ b/tools/build_script_generator/scons/site_tools/qtcreator.py
@@ -60,7 +60,7 @@ def qt_creator_project_method(env, sources, with_modm=False):
 
 	# generate project files
 	proj_path = join(cwd, project_name)
-	temp_path = abspath(join(env["BASEPATH"], "scons", "site_tools", "qtcreator", "project"))
+	temp_path = abspath(join(env["BASEPATH"], "modm", "scons", "site_tools", "qtcreator", "project"))
 	return [
 		env.Jinja2Template(
 			target = proj_path + ".creator",

--- a/tools/build_script_generator/scons/site_tools/unittestm.py
+++ b/tools/build_script_generator/scons/site_tools/unittestm.py
@@ -38,15 +38,11 @@ def unittest_emitter(target, source, env):
 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
-	action_str = "{0}Create Tests··· {1}$TARGET{2}" \
-        .format("\033[;0;32m", "\033[;0;33m", "\033[;0;0m")
-	env.Append(BUILDERS = {
-		'UnittestRunner': Builder(
-				action = SCons.Action.Action(unittest_action, action_str),
-				suffix = '.cpp',
-				emitter = unittest_emitter,
-				target_factory = env.fs.File)
-	})
+	env['BUILDERS']['UnittestRunner'] = env.Builder(
+		action = Action(unittest_action, cmdstr="$UNITTESTCOMSTR"),
+		suffix = '.cpp',
+		emitter = unittest_emitter,
+		target_factory = env.fs.File)
 
 def exists(env):
 	return True

--- a/tools/build_script_generator/scons/site_tools/utils.py
+++ b/tools/build_script_generator/scons/site_tools/utils.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2013-2014, 2016-2017, German Aerospace Center (DLR)
+# Copyright (c) 2018, Niklas Hauser
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+# - 2013-2014, 2016-2017, Fabian Greif (DLR RY-AVS)
+# - 2018, Niklas Hauser
+
+import os
+import os.path
+
+from SCons.Script import *
+
+def _listify(obj):
+    if obj is None:
+        return list()
+    if isinstance(obj, SCons.Node.NodeList):
+        return obj
+    if isinstance(obj, (list, tuple, set)):
+        return list(obj)
+    if hasattr(obj, "__iter__") and not hasattr(obj, "__getitem__"):
+        return list(obj)
+    return [obj, ]
+
+
+def listify(env, *objs):
+    return [entry for obj in objs for entry in _listify(obj)]
+
+
+def remove_from_list(env, identifier, to_remove):
+    """
+    Remove strings from a list.
+
+    E.g.
+    env.RemoveFromList('CXXFLAGS_warning', ['-Wold-style-cast'])
+    """
+    if identifier.startswith('$'):
+        raise Exception("Identifier '%s' must not start with '$'!" % identifier)
+
+    l = env.subst('$' + identifier)
+    if isinstance(l, str):
+        l = l.split(' ')
+    for r in _listify(to_remove):
+        if r in l:
+            l.remove(r)
+    env[identifier] = l
+
+
+def filtered_glob(env, pattern, omit=None, ondisk=True, source=False, strings=False):
+    if omit is None:
+        omit = []
+
+    results = []
+    for p in _listify(pattern):
+        results.extend(filter(lambda f: os.path.basename(f.path) not in omit,
+                              env.Glob(p)))
+    return results
+
+
+def run_program(env, program):
+    return env.Command('thisfileshouldnotexist',
+                       program,
+                       '@"%s"' % program[0].abspath)
+
+
+def phony_target(env, **kw):
+    for target, action in kw.items():
+        env.AlwaysBuild(env.Alias(target, [], action))
+
+
+# -----------------------------------------------------------------------------
+def generate(env, **kw):
+    env.Append(ENV={'PATH': os.environ['PATH']})
+
+    env.AddMethod(remove_from_list, 'RemoveFromList')
+    env.AddMethod(filtered_glob, 'FilteredGlob')
+
+    env.AddMethod(run_program, 'Run')
+    env.AddMethod(phony_target, 'Phony')
+
+    env.AddMethod(listify, 'Listify')
+
+
+def exists(env):
+    return True
+

--- a/tools/build_script_generator/scons/site_tools/utils.py
+++ b/tools/build_script_generator/scons/site_tools/utils.py
@@ -74,6 +74,16 @@ def phony_target(env, **kw):
         env.AlwaysBuild(env.Alias(target, [], action))
 
 
+def artifact_firmware(env, source):
+    firmware = ARGUMENTS.get("firmware", None)
+    if firmware:
+        try:
+            int(firmware, 16) # Validate hexadecimal string
+            source = os.path.join(env["CONFIG_ARTIFACT_PATH"], "{}.elf".format(firmware.lower()))
+        except:
+            source = firmware
+    return source
+
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
     env.Append(ENV={'PATH': os.environ['PATH']})
@@ -85,6 +95,8 @@ def generate(env, **kw):
     env.AddMethod(phony_target, 'Phony')
 
     env.AddMethod(listify, 'Listify')
+
+    env.AddMethod(artifact_firmware, 'ChooseFirmware')
 
 
 def exists(env):

--- a/tools/build_script_generator/scons/site_tools/utils_buildpath.py
+++ b/tools/build_script_generator/scons/site_tools/utils_buildpath.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2013-2014, 2016-2017, German Aerospace Center (DLR)
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+# - 2013-2014, 2016-2017, Fabian Greif (DLR RY-AVS)
+
+import os
+import sys
+
+def relocate_to_buildpath(env, path, strip_extension=False):
+    """ Relocate path from source directory to build directory
+    """
+    path = str(path)
+    if strip_extension:
+        path = os.path.splitext(path)[0]
+
+    # Do not relocate path if is already is inside of the build directory
+    if not os.path.abspath(path).startswith(os.path.abspath(env['BUILDPATH'])):
+        path = os.path.relpath(os.path.abspath(path), env['BASEPATH'])
+        if path.startswith('..'):
+            # if the file is not in a subpath of the current directory
+            # build it in the root directory of the build path
+            while path.startswith('..'):
+                path = path[3:]
+
+        buildpath = os.path.abspath(os.path.join(env['BUILDPATH'], path))
+    else:
+        buildpath = os.path.abspath(path)
+
+    os.makedirs(os.path.dirname(buildpath), exist_ok=True)
+    # buildpath = os.path.relpath(buildpath, env['BASEPATH'])
+    return buildpath
+
+def generate(env, **kw):
+    # These emitters are used to build everything not in place but in a
+    # separate build-directory.
+    def default_emitter(target, source, env):
+        targets = []
+        for infile in target:
+            outfile = env.File(env.Buildpath(infile.get_abspath()))
+            targets.append(outfile)
+        return targets, source
+
+    def shared_emitter(target, source, env):
+        targets = []
+        for infile in target:
+            outfile = env.File(env.Buildpath(infile.get_abspath()))
+            outfile.attributes.shared = 1
+            targets.append(outfile)
+        return targets, source
+
+    env['BUILDERS']['Object'].add_emitter('.cpp', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.c++', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.cc', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.c', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.s', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.sx', default_emitter)
+    env['BUILDERS']['Object'].add_emitter('.S', default_emitter)
+
+    env['BUILDERS']['SharedObject'].add_emitter('.cpp', shared_emitter)
+    env['BUILDERS']['SharedObject'].add_emitter('.c++', shared_emitter)
+    env['BUILDERS']['SharedObject'].add_emitter('.cc', shared_emitter)
+    env['BUILDERS']['SharedObject'].add_emitter('.c', shared_emitter)
+
+    env['LIBEMITTER'] = default_emitter
+    env['PROGEMITTER'] = default_emitter
+
+    env['BUILDPATH_EMITTER'] = default_emitter
+
+    env.AddMethod(relocate_to_buildpath, 'Buildpath')
+
+
+def exists(env):
+    return True

--- a/tools/build_script_generator/scons/site_tools/xpcc_generator.py
+++ b/tools/build_script_generator/scons/site_tools/xpcc_generator.py
@@ -148,7 +148,7 @@ def generate(env, **kw):
 					'--namespace "${namespace}" ' \
 					'${include_paths} ' \
 					'$SOURCE',
-				cmdstr="$SYSTEM_CPP_PACKETS_COMSTR"),
+				cmdstr="$XPCC_PACKETS_COMSTR"),
 			emitter = packet_emitter,
 			source_scanner = env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'],
 			single_source = True,
@@ -164,7 +164,7 @@ def generate(env, **kw):
 					'--namespace "${namespace}" ' \
 					'${include_paths} ' \
 					'$SOURCE',
-				cmdstr="$SYSTEM_CPP_IDENTIFIER_COMSTR"),
+				cmdstr="$XPCC_IDENTIFIER_COMSTR"),
 			emitter = identifier_emitter,
 			source_scanner = env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'],
 			single_source = True,
@@ -181,7 +181,7 @@ def generate(env, **kw):
 					'--namespace "${namespace}" ' \
 					'${include_paths} ' \
 					'$SOURCE',
-				cmdstr="$SYSTEM_CPP_POSTMAN_COMSTR"),
+				cmdstr="$XPCC_POSTMAN_COMSTR"),
 			emitter = postman_emitter,
 			source_scanner = env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'],
 			single_source = True,
@@ -197,7 +197,7 @@ def generate(env, **kw):
 					'--namespace "${namespace}" ' \
 					'${include_paths} ' \
 					'$SOURCE',
-				cmdstr="$SYSTEM_CPP_COMMUNICATION_COMSTR"),
+				cmdstr="$XPCC_COMM_STUBS_COMSTR"),
 			emitter = communication_emitter,
 			source_scanner = env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'],
 			single_source = True,
@@ -213,19 +213,12 @@ def generate(env, **kw):
 					'--namespace "${namespace}" ' \
 					'${include_paths} ' \
 					'$SOURCE',
-				cmdstr="$SYSTEM_CPP_XPCC_TASK_CALLER_COMSTR"),
+				cmdstr="$XPCC_TASK_CALLER_COMSTR"),
 			emitter = xpcc_task_caller_emitter,
 			source_scanner = env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'],
 			single_source = True,
 			target_factory = env.fs.Entry,
 			src_suffix = ".xml")
-
-	if SCons.Script.ARGUMENTS.get('verbose') != '1':
-		env['SYSTEM_CPP_PACKETS_COMSTR'] = "Generate packets from: $SOURCE"
-		env['SYSTEM_CPP_IDENTIFIER_COMSTR'] = "Generate identifier from: $SOURCE"
-		env['SYSTEM_CPP_POSTMAN_COMSTR'] = "Generate postman from: $SOURCE"
-		env['SYSTEM_CPP_COMMUNICATION_COMSTR'] = "Generate communication stubs from: $SOURCE"
-		env['SYSTEM_CPP_XPCC_TASK_CALLER_COMSTR'] = "Generate xpcc task callers from: $SOURCE"
 
 	env.AddMethod(xpcc_communication_header, 'XpccCommunication')
 


### PR DESCRIPTION
I got annoyed with our bloated SCons tooling and our overly verbose logging. So I changed a few things:

- [x] Add a floating point ABI option to `:platform:cortex-m`: Can be useful for regulating IRQ latency on M4/M7.
- [x] Allow the artifact store to be remapped: This allows ELF files to be committed into a repository and accessed later for post-mortem debugging.
- [x] Allow choosing a different `firmware={GNU Build ID or path/to/filename.elf}` for relevant SCons commands (program, debug, listings etc).
- [x] Validate `:build:libaries` format: `-lname.a` for example won't be properly recognized by the linker.
- [x] Centralization of all SCons COMSTR: Makes it easier to maintain and keep beautiful.
- [x] Fixing SCons buildpath relocation, it was off-by-one folder: `build/modm/modm/src` -> `build/modm/src`.
- [x] Using shorter paths for logging when it makes sense. I relocated the compilation paths to the buildpath
- [x] Copying dependency from DLR SCons Tools: We were only using parts of utils, buildpath and gcc, everything else has already been replaced.
- [x] Using relative paths in ELF file so that ELF files can be exchanged between devices/repos
- [x] Add `scons hex` target back and clean `.bin`, `.hex` and `.lss` targets on `scons -c`
- [x] Update documentation

cc @rleh @chris-durand 