### PR TITLE
Fix USART length setting for odd/even parity setups.

### DIFF
--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -38,7 +38,11 @@ modm::platform::{{ name }}::setParity(const Parity parity)
 	flags |= static_cast<uint32_t>(parity);
 	if (parity != Parity::Disabled) {
 		// Parity Bit counts as 9th bit -> enable 9 data bits
+#ifdef USART_CR1_M1
+		flags |= USART_CR1_M0;
+#else
 		flags |= USART_CR1_M;
+#endif
 	}
 	{{ peripheral }}->CR1 = flags;
 


### PR DESCRIPTION
The prior code set the length to incorrectly if odd or even parity was used.
The fix works fine on the stm32f042. There is also an example that uses an USART with parity, I also checked the output on a scope.

The #ifdef is copied from "setWordLength", but i couldn't test it with a STM32 that doesn't have USART_CR1_M1.