### PR TITLE
[docs] Fix docs for STM32F4 with ethernet

### DIFF
--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -20,8 +20,13 @@ class FreeRTOS_TCP_LAN8720A(Module):
 This module implements TCP over Ethernet via the LAN8720A transceiver.
 """
     def prepare(self, module, options):
+        device = options[":target"]
+        if not device.has_driver("eth:stm32*"):
+            return False
+        if device.identifier.family not in ["f7"]:
+            return False
         module.depends(":platform:eth", ":driver:lan8720a")
-        return options[":target"].has_driver("eth:stm32*")
+        return True
 
     def build(self, env):
         env.outbasepath = "modm/ext/freertos_plus_tcp"

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -107,7 +107,7 @@ def main():
     device_list = []
     board_list = []
     if args.test:
-        device_list = ["hosted-linux", "atmega328p-au", "stm32f103c8t6", "stm32g474cet6", "samd21g18a-uu"]
+        device_list = ["hosted-linux", "atmega328p-au", "stm32f103c8t6", "stm32g474cet6", "samd21g18a-uu", "stm32f417zgt6"]
         board_list = [("arduino-nano", "atmega328p-au"), ("arduino-uno", "atmega328p-au"), ("nucleo-g474re", "stm32g474ret6"),
                       ("blue-pill", "stm32f103c8t6"), ("feather-m0", "samd21g18a-uu")]
     elif args.test2:


### PR DESCRIPTION
Unfortunately I didn't set the `:freertos:tcp:lan8720a` module enabled correctly and thus F2/F4 devices with ethernet could not resolve the `:platform:eth` module, which is only implemented for F7.

cc @rleh 