### PR TITLE
[ui] Support to stream color::HsvT like color::RgbT

### DIFF
--- a/src/modm/ui/color.hpp
+++ b/src/modm/ui/color.hpp
@@ -129,6 +129,9 @@ typedef HsvT<>	Hsv;
 template <typename UnderlyingType>
 IOStream& operator << ( IOStream& os, const color::RgbT<UnderlyingType>& color);
 
+template <typename UnderlyingType>
+IOStream& operator << ( IOStream& os, const color::HsvT<UnderlyingType>& color);
+
 } // namespace color
 
 } // namespace modm

--- a/src/modm/ui/color_impl.hpp
+++ b/src/modm/ui/color_impl.hpp
@@ -75,3 +75,11 @@ modm::color::operator << ( modm::IOStream& os, const modm::color::RgbT<Underlyin
 	os << color.red << "\t" << color.green << "\t" << color.blue;
 	return os;
 }
+
+template <typename UnderlyingType>
+modm::IOStream&
+modm::color::operator << ( modm::IOStream& os, const modm::color::HsvT<UnderlyingType>& color)
+{
+	os << color.hue << "\t" << color.saturation << "\t" << color.value;
+	return os;
+}


### PR DESCRIPTION
Added support for streaming HSL-Colors:
- Implementation is copy&pasted from existing modm::color::RgbT<>