### PR TITLE
[driver] Added TCS3472 missing features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
           name: Examples AVR Series
           when: always
           command: |
-            (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno)
+            (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno arduino_nano)
       - run:
           name: Compile AVR Unittests AT90CAN
           when: always

--- a/examples/arduino_nano/color/main.cpp
+++ b/examples/arduino_nano/color/main.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Thomas Sommer
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/driver/color/tcs3472.hpp>
+#include <modm/processing.hpp>
+
+using namespace modm::platform;
+
+class Sensorthread : public modm::pt::Protothread
+{
+private:
+	modm::ShortTimeout timeout;
+
+	modm::tcs3472::Data data;
+	modm::Tcs3472<I2cMaster> sensor{data};
+	using TCS3472_INT = Board::D2;
+
+public:
+	bool
+	update()
+	{
+		PT_BEGIN();
+
+		TCS3472_INT::setInput(Gpio::InputType::PullUp);
+
+		MODM_LOG_INFO << "Ping TCS34725" << modm::endl;
+		// ping the device until it responds
+		while (true)
+		{
+			// we wait until the task started
+			if (PT_CALL(sensor.ping())) { break; }
+			// otherwise, try again in 100ms
+			timeout.restart(100ms);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		MODM_LOG_INFO << "TCS34725 responded" << modm::endl;
+
+		PT_CALL(sensor.initialize(modm::tcs3472::Enable::POWER_ON_INTERRUPT_AND_WAITTIME));
+		PT_CALL(sensor.configure(modm::tcs3472::Gain::X16, modm::tcs3472::IntegrationTime::MSEC_2_4));
+		PT_CALL(sensor.setInterruptPersistenceFilter(modm::tcs3472::InterruptPersistence::CNT_20));
+		// Setup WaitTime to further slow down samplerate
+		PT_CALL(sensor.setWaitTime(modm::tcs3472::WaitTime::MSEC_2_4));
+
+		// Fetch one sample ...
+		PT_CALL(sensor.readColor());
+		// ...and set the high threshold 20% above current clear
+		PT_CALL(sensor.setInterruptHighThreshold(data.getClear() * 1.2));
+
+		while (true)
+		{
+			PT_CALL(sensor.reloadInterrupt());
+			if (PT_CALL(sensor.readColor()))
+			{
+				const auto color = data.getColor();
+				MODM_LOG_INFO << "RGB: " << color;
+				modm::color::HsvT<uint16_t> hsv;
+				color.toHsv(&hsv);
+				MODM_LOG_INFO << "HSV: " << hsv << modm::endl;
+			}
+		}
+
+		PT_END();
+	}
+};
+
+Sensorthread sensorthread;
+
+int
+main()
+{
+	Board::initialize();
+	I2cMaster::initialize<Board::SystemClock, 100_kHz>();
+
+	LedD13::setOutput();
+	modm::ShortPeriodicTimer heartbeat(500ms);
+
+	while (true)
+	{
+		sensorthread.update();
+		if (heartbeat.execute()) Board::LedD13::toggle();
+	}
+}

--- a/examples/arduino_nano/color/project.xml
+++ b/examples/arduino_nano/color/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:arduino-nano</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/arduino_nano/color</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:platform:i2c</module>
+    <module>modm:driver:tcs3472</module>
+  </modules>
+</library>

--- a/examples/nucleo_f446re/color/main.cpp
+++ b/examples/nucleo_f446re/color/main.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2014-2018, 2021 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+#include <modm/driver/color/tcs3472.hpp>
+
+class ThreadOne : public modm::pt::Protothread
+{
+public:
+	bool
+	update()
+	{
+		PT_BEGIN();
+
+		MODM_LOG_INFO << "Ping the device from ThreadOne" << modm::endl;
+
+		// ping the device until it responds
+		while (true)
+		{
+			// we wait until the task started
+			if (PT_CALL(sensor.ping())) {
+			 	break;
+			}
+			// otherwise, try again in 100ms
+			timeout.restart(100ms);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		MODM_LOG_INFO << "Device responded" << modm::endl;
+
+		while (true)
+		{
+			if (PT_CALL(sensor.initialize())) {
+				break;
+			}
+			// otherwise, try again in 100ms
+			timeout.restart(100ms);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		MODM_LOG_INFO << "Device initialized" << modm::endl;
+
+		while (true)
+		{
+			if (PT_CALL(sensor.configure(sensor.Gain::X4, sensor.IntegrationTime::MSEC_101))) {
+				break;
+			}
+			// otherwise, try again in 100ms
+			timeout.restart(100ms);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		MODM_LOG_INFO << "Device configured" << modm::endl;
+
+		while (true)
+		{
+			if (PT_CALL(sensor.readColor()))
+			{
+				const auto color = data.getColor();
+				MODM_LOG_INFO << "RGB: " << color;
+				modm::color::HsvT<uint16_t> hsv;
+				color.toHsv(&hsv);
+				MODM_LOG_INFO << "  " << hsv << modm::endl;
+			}
+			timeout.restart(500ms);
+			PT_WAIT_UNTIL(timeout.isExpired());
+		}
+
+		PT_END();
+	}
+
+private:
+	modm::ShortTimeout timeout;
+	modm::tcs3472::Data data;
+	modm::Tcs3472<I2cMaster1> sensor{data};
+};
+ThreadOne one;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+
+	I2cMaster1::connect<Board::D14::Sda, Board::D15::Scl>();
+	I2cMaster1::initialize<Board::SystemClock, 100_kHz>();
+
+	MODM_LOG_INFO << "\n\nWelcome to TCS3472 demo!\n\n";
+
+	modm::ShortPeriodicTimer tmr(500ms);
+	while (true)
+	{
+		one.update();
+		if (tmr.execute()) Board::LedD13::toggle();
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f446re/color/project.xml
+++ b/examples/nucleo_f446re/color/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:nucleo-f446re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f446re/color</option>
+  </options>
+  <modules>
+    <module>modm:driver:tcs3472</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/driver/color/tcs3414.hpp
+++ b/src/modm/driver/color/tcs3414.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013, David Hebbeker
  * Copyright (c) 2013-2014, Sascha Schade
- * Copyright (c) 2013-2016, 2018, Niklas Hauser
+ * Copyright (c) 2013-2016, 2018, 2021, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -11,315 +11,229 @@
  */
 // ----------------------------------------------------------------------------
 
-/**
- * \file	tcs3414.hpp
- * \date	02 Mar 2013
- * \author	David Hebbeker
- */
-
 #ifndef MODM_TCS3414_HPP
 #define MODM_TCS3414_HPP
 
 #include <stdint.h>
-
 #include <modm/ui/color.hpp>
 #include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/math/utils/endianness.hpp>
 
 namespace modm
 {
-/**
- * \brief 	Settings to configure the digital color sensor TCS3414 / TCS3413 / TCS3415 / TCS3416.
- * \see		Tcs3414
- * \ingroup	modm_driver_tcs3414
- *
- * Device   Address
- * TCS3413  0x29
- *       4  0x39
- *       5  0x49
- *       6  0x59
- *
- */
+
+// forward declaration for friending with tcs3414::Data
+template < class I2cMaster >
+class Tcs3414;
+
+/// @ingroup	modm_driver_tcs3414
 struct tcs3414
 {
-	/** @name Gain_Register
-	 * @{
+	/** Device Address depends on version TCS341x
+	 *
+	 * - TCS3413 = 0x29
+	 * - TCS3414 = 0x39
+	 * - TCS3415 = 0x49
+	 * - TCS3416 = 0x59
 	 */
+	static constexpr uint8_t
+	addr(uint8_t version=4)
+	{ return ((version - 1) << 4) | 0x09; }
 
-	//! \brief 	Analog gain control
-	enum class Gain : uint8_t
+	/// Analog gain control
+	enum class
+	Gain : uint8_t
 	{
-		X1	= 0b000000,	//!< x1 gain
-		X4	= 0b010000,	//!< x4 gain
-		X16	= 0b100000,	//!< x16 gain
-		X64	= 0b110000,	//!< x64 gain
-		DEFAULT = 0		//!< default value on chip reset
+		X1	= 0b000000,	///< x1 gain
+		X4	= 0b010000,	///< x4 gain
+		X16	= 0b100000,	///< x16 gain
+		X64	= 0b110000,	///< x64 gain
 	};
 
-	//! \brief 	Prescaler mode
-	enum class Prescaler : uint8_t
+	/// Prescaler mode
+	enum class
+	Prescaler : uint8_t
 	{
-		D1	= 0b000,	//!< divide by 1
-		D2	= 0b001,	//!< divide by 2
-		D4	= 0b010,	//!< divide by 4
-		D8	= 0b011,	//!< divide by 8
-		D16	= 0b100,	//!< divide by 16
-		D32	= 0b101,	//!< divide by 32
-		D64	= 0b110,	//!< divide by 64
-		DEFAULT = 0		//!< default value on chip reset
-	};
-	//! @}
-
-
-	/** @name Timing register
-	 * @{
-	 */
-
-	//! \brief 	Select mode how to choose the integration time
-	enum class IntegrationMode : uint8_t
-	{
-		INTERNAL	= 0b000000,	//!< integrates with the free-running mode
-		ADC_CTR		= 0b010000,	//!< use the ADC enable bit field in the control register to start and stop integration
-		SYNC_NOM	= 0b100000,	//!< use synchronize signal to integrate over nominal integration time
-		SYNC_COUNT	= 0b110000,	//!< integrate over pulse count pulses of the sync pin
-		DEFAULT = 0				//!< default value on chip reset
+		D1	= 0b000,	///< divide by 1
+		D2	= 0b001,	///< divide by 2
+		D4	= 0b010,	///< divide by 4
+		D8	= 0b011,	///< divide by 8
+		D16	= 0b100,	///< divide by 16
+		D32	= 0b101,	///< divide by 32
+		D64	= 0b110,	///< divide by 64
 	};
 
-	//! \brief 	Integration for a fixed time
-	enum class NominalIntegrationTime : uint8_t
+	/// Select mode how to choose the integration time
+	enum class
+	IntegrationMode : uint8_t
 	{
-		MSEC_12		= 0b0000,	//!< integrate over 12 ms
-		MSEC_100	= 0b0001,	//!< integrate over 100 ms
-		MSEC_400	= 0b0010,	//!< integrate over 400 ms
-		DEFAULT = 0				//!< default value on chip reset
+		INTERNAL	= 0b000000,	///< integrates with the free-running mode
+		ADC_CTR		= 0b010000,	///< use the ADC enable bit field in the control register to start and stop integration
+		SYNC_NOM	= 0b100000,	///< use synchronize signal to integrate over nominal integration time
+		SYNC_COUNT	= 0b110000,	///< integrate over pulse count pulses of the sync pin
 	};
 
-	//! \brief 	The number of pulses on sync pin to integrate over
-	enum class SyncPulseCount : uint8_t
+	/// Integration for a fixed time
+	enum class
+	NominalIntegrationTime : uint8_t
 	{
-		PULSES_1	= 0b0000,	//!< integrate over 1 pulses of sync pin
-		PULSES_2	= 0b0001,	//!< integrate over 2 pulses of sync pin
-		PULSES_4	= 0b0010,	//!< integrate over 4 pulses of sync pin
-		PULSES_8	= 0b0011,	//!< integrate over 8 pulses of sync pin
-		PULSES_16	= 0b0100,	//!< integrate over 16 pulses of sync pin
-		PULSES_32	= 0b0101,	//!< integrate over 32 pulses of sync pin
-		PULSES_64	= 0b0110,	//!< integrate over 64 pulses of sync pin
-		PULSES_128	= 0b0111,	//!< integrate over 128 pulses of sync pin
-		PULSES_256	= 0b1000,	//!< integrate over 256 pulses of sync pin
-		DEFAULT = 0		//!< default value on chip reset
+		MSEC_12  = 0b0000,	///< integrate over 12 ms
+		MSEC_100 = 0b0001,	///< integrate over 100 ms
+		MSEC_400 = 0b0010,	///< integrate over 400 ms
 	};
-	//! @}
 
-	//! \brief 	Register addresses
-	enum class RegisterAddress : uint8_t
+	/// The number of pulses on sync pin to integrate over
+	enum class
+	SyncPulseCount : uint8_t
 	{
-		CONTROL					= 0x00,	//!< Control of basic functions
-		TIMING					= 0x01,	//!< Integration time control  @see Tcs3414::setIntegrationTime
-		INTERRUPT				= 0x02,	//!< Interrupt settings
-		INT_SOURCE				= 0x03,	//!< Interrupt source
-		ID						= 0x04,	//!< Part number
-		GAIN					= 0x07,	//!< Sensitivity settings @see Tcs3414::setGain
-		LOW_THRESH_LOW_BYTE		= 0x08,	//!< Low byte of low interrupt threshold
-		LOW_THRESH_HIGH_BYTE	= 0x09,	//!< High byte of low interrupt threshold
-		HIGH_THRESH_LOW_BYTE	= 0x0A,	//!< Low byte of high interrupt threshold
-		HIGH_THRESH_HIGH_BYTE	= 0x0B,	//!< High byte of high interrupt threshold
+		PULSES_1	= 0b0000,	///< integrate over 1 pulses of sync pin
+		PULSES_2	= 0b0001,	///< integrate over 2 pulses of sync pin
+		PULSES_4	= 0b0010,	///< integrate over 4 pulses of sync pin
+		PULSES_8	= 0b0011,	///< integrate over 8 pulses of sync pin
+		PULSES_16	= 0b0100,	///< integrate over 16 pulses of sync pin
+		PULSES_32	= 0b0101,	///< integrate over 32 pulses of sync pin
+		PULSES_64	= 0b0110,	///< integrate over 64 pulses of sync pin
+		PULSES_128	= 0b0111,	///< integrate over 128 pulses of sync pin
+		PULSES_256	= 0b1000,	///< integrate over 256 pulses of sync pin
+	};
+
+	/// Register addresses
+	enum class
+	RegisterAddress : uint8_t
+	{
+		CONTROL					= 0x00,	///< Control of basic functions
+		TIMING					= 0x01,	///< Integration time control  @see Tcs3414::setIntegrationTime
+		INTERRUPT				= 0x02,	///< Interrupt settings
+		INT_SOURCE				= 0x03,	///< Interrupt source
+		ID						= 0x04,	///< Part number
+		GAIN					= 0x07,	///< Sensitivity settings @see Tcs3414::setGain
+		LOW_THRESH_LOW_BYTE		= 0x08,	///< Low byte of low interrupt threshold
+		LOW_THRESH_HIGH_BYTE	= 0x09,	///< High byte of low interrupt threshold
+		HIGH_THRESH_LOW_BYTE	= 0x0A,	///< Low byte of high interrupt threshold
+		HIGH_THRESH_HIGH_BYTE	= 0x0B,	///< High byte of high interrupt threshold
 		// Data registers
-		DATA1LOW				= 0x10,	//!< Low byte of ADC green channel
-		DATA1HIGH				= 0x11,	//!< High byte of ADC green channel
-		DATA2LOW				= 0x12,	//!< Low byte of ADC green channel
-		DATA2HIGH				= 0x13,	//!< High byte of ADC green channel
-		DATA3LOW				= 0x14,	//!< Low byte of ADC green channel
-		DATA3HIGH				= 0x15,	//!< High byte of ADC green channel
-		DATA4LOW				= 0x16,	//!< Low byte of ADC green channel
-		DATA5HIGH				= 0x17	//!< High byte of ADC green channel
+		DATA1LOW				= 0x10,	///< Low byte of ADC green channel
+		DATA1HIGH				= 0x11,	///< High byte of ADC green channel
+		DATA2LOW				= 0x12,	///< Low byte of ADC green channel
+		DATA2HIGH				= 0x13,	///< High byte of ADC green channel
+		DATA3LOW				= 0x14,	///< Low byte of ADC green channel
+		DATA3HIGH				= 0x15,	///< High byte of ADC green channel
+		DATA4LOW				= 0x16,	///< Low byte of ADC green channel
+		DATA5HIGH				= 0x17	///< High byte of ADC green channel
 	};
 
-	typedef uint16_t	UnderlyingType;		//!< datatype of color values
-	typedef color::RgbT<UnderlyingType> Rgb;
 
+	using Rgb = color::RgbT<uint16_t>;
+
+	struct modm_packed
+	Data
+	{
+		inline Rgb
+		getColor()
+		{ return {getRed(), getGreen(), getBlue()}; }
+
+		/** Normalize color values based on clear value
+		 *
+		 * Imagine a low band light. For example a green laser. In case the filters
+		 * of this sensors do not transfer this wavelength well, it might
+		 * result in all colors being very low. The clear value will not
+		 * filter colors and thus it will see a bright light (intensity).
+		 * In order to still have some signal the very low green value can be
+		 * amplified with the clear value.
+		 */
+		inline Rgb
+		getNormalizedColor()
+		{
+			Rgb color = getColor();
+			float scalar = getClear() / float(color.red + color.green + color.blue);
+			color.red *= scalar;
+			color.green *= scalar;
+			color.blue *= scalar;
+			return color;
+		}
+
+		inline uint16_t
+		getClear()  { return getValue(3); }
+		inline uint16_t
+		getRed() { return getValue(1); }
+		inline uint16_t
+		getGreen() { return getValue(0); }
+		inline uint16_t
+		getBlue() { return getValue(2); }
+
+		inline uint16_t
+		operator[] (uint8_t index)
+		{ return (index < 4) ? getValue(index) : 0; }
+
+	protected:
+		inline uint16_t
+		getValue(uint8_t index)
+		{ return modm::fromLittleEndian(reinterpret_cast<uint16_t*>(data+2)[index]); }
+
+		// [2B-alignment, read-byte-count], green, red, blue, clear
+		uint8_t data[2 + sizeof(uint16_t) * 4];
+		template<class I2cMaster> friend class Tcs3414;
+	};
 };
 
 /**
- * \brief	TCS3414 Digital Color Sensors
+ * TCS3414 Digital Color Sensors
  *
- * \todo	Not all features of the sensors are implemented in this driver
- * 			yet.
+ * @todo	Not all features of the sensors are implemented in this driver yet.
  *
- * \tparam	I2CMaster	I2C interface which needs an \em initialized
- * 						modm::i2c::Master
- * \see		tcs3414
- * \author	David Hebbeker
- * \ingroup	modm_driver_tcs3414
+ * @see		tcs3414
+ * @author	David Hebbeker, Niklas Hauser
+ * @ingroup	modm_driver_tcs3414
  */
 template < typename I2cMaster >
 class Tcs3414 : public tcs3414, public modm::I2cDevice< I2cMaster, 2 >
 {
 public:
-	Tcs3414(uint8_t address = 0x39);
+	Tcs3414(Data &data, uint8_t address = addr());
 
-	//! \brief 	Power up sensor and start conversions
-	// Blocking
-	bool inline
-	initializeBlocking()
-	{
-		return RF_CALL_BLOCKING(initialize());
-	}
-
-	//! \brief 	Configures some of the most important settings for the sensor.
-	static inline bool
-	configure(
-			const Gain                   gain      = Gain::DEFAULT,
-			const Prescaler              prescaler = Prescaler::DEFAULT,
-			const IntegrationMode        mode      = IntegrationMode::DEFAULT,
-			const NominalIntegrationTime time      = NominalIntegrationTime::DEFAULT)
-	{
-		return configure(gain, prescaler, mode, static_cast<uint8_t>(time));
-	}
-
-	//! \brief	Configures some of the most important settings for the sensor.
-	static inline bool
-	configure(
-			const Gain            gain      = Gain::DEFAULT,
-			const Prescaler       prescaler = Prescaler::DEFAULT,
-			const IntegrationMode mode      = IntegrationMode::DEFAULT,
-			const SyncPulseCount  time      = SyncPulseCount::DEFAULT)
-	{
-		return configure(gain, prescaler, mode, static_cast<uint8_t>(time));
-	}
-
-	//! \brief	The gain can be used to adjust the sensitivity of all ADC output channels.
-	modm::ResumableResult<bool>
-	setGain(
-			const Gain      gain      = Gain::DEFAULT,
-			const Prescaler prescaler = Prescaler::DEFAULT)
-	{
-		return writeRegister(RegisterAddress::GAIN,
-				static_cast<uint8_t>(gain) | static_cast<uint8_t>(prescaler));
-	}
-
-	//! \brief Sets the integration time for the ADCs.
-	modm::ResumableResult<bool>
-	setIntegrationTime(
-			const IntegrationMode        mode = IntegrationMode::DEFAULT,
-			const NominalIntegrationTime time = NominalIntegrationTime::DEFAULT)
-	{
-		return setIntegrationTime(mode, static_cast<uint8_t>(time));
-	}
-
-	//! \brief Sets the integration time for the ADCs.
-	modm::ResumableResult<bool>
-	setIntegrationTime(
-			const IntegrationMode mode = IntegrationMode::DEFAULT,
-			const SyncPulseCount  time = SyncPulseCount::DEFAULT)
-	{
-		return setIntegrationTime(mode, static_cast<uint8_t>(time));
-	}
-
-	/**
-	 * @name Return already sampled color
-	 * @{
-	 */
-	inline static tcs3414::Rgb
-	getOldColors()
-	{
-		return color;
-	};
-
-	//!@}
-
-	/**
-	 * @name Sample and return fresh color values
-	 * @{
-	 */
-	inline static tcs3414::Rgb
-	getNewColors()
-	{
-		refreshAllColors();
-		return getOldColors();
-	};
-
-	//!@}
-
-	//! \brief	Read current samples of ADC conversions for all channels.
-	// Non-blocking
-	modm::ResumableResult<bool>
-	refreshAllColors();
-
-	// MARK: - TASKS
 	modm::ResumableResult<bool>
 	initialize()
-	{
-		return writeRegister(RegisterAddress::CONTROL, 0b11);	// control to power up and start conversion
-	};
+	{ return writeRegister(RegisterAddress::CONTROL, 0b11); };
 
 	modm::ResumableResult<bool>
-	configure(
-			const Gain            gain      = Gain::DEFAULT,
-			const Prescaler       prescaler = Prescaler::DEFAULT,
-			const IntegrationMode mode      = IntegrationMode::DEFAULT,
-			const uint8_t time = 0);
+	configure(Gain gain = Gain::X1, Prescaler prescaler = Prescaler::D1)
+	{ return setGain(gain, prescaler); }
 
-private:
-	//! \brief Sets the integration time for the ADCs.
+public:
+	/// The gain can be used to adjust the sensitivity of all ADC output channels.
 	modm::ResumableResult<bool>
-	setIntegrationTime(
-			const IntegrationMode mode = IntegrationMode::DEFAULT,
-			const uint8_t         time = 0)
-	{
-		return writeRegister(
-				RegisterAddress::TIMING,
-				static_cast<uint8_t>(mode) | time );
-	}
+	setGain(Gain gain = Gain::X1, Prescaler prescaler = Prescaler::D1)
+	{ return writeRegister(RegisterAddress::GAIN, uint8_t(gain) | uint8_t(prescaler)); }
 
-private:
-	uint8_t commandBuffer[4];
-	bool success;
-
-private:
-	//! \brief	Read value of specific register.
+	/// Sets the integration time for the ADCs.
 	modm::ResumableResult<bool>
-	readRegisters(
-			const RegisterAddress address,
-			uint8_t * const values,
-			const uint8_t count = 1);
+	setIntegrationTime(IntegrationMode mode, NominalIntegrationTime time)
+	{ return writeRegister(RegisterAddress::TIMING, uint8_t(mode) | uint8_t(time)); }
+
+	/// Sets the integration time for the ADCs.
+	modm::ResumableResult<bool>
+	setIntegrationTime(IntegrationMode mode, SyncPulseCount time)
+	{ return writeRegister(RegisterAddress::TIMING, uint8_t(mode) | uint8_t(time)); }
+
+public:
+	/// Read current samples of ADC conversions for all channels.
+	modm::ResumableResult<bool>
+	readColor()
+	{ return readRegisters(RegisterAddress::DATA1LOW, data.data+1, sizeof(data.data)); }
+
+public:
+	modm::ResumableResult<bool>
+	readRegisters(RegisterAddress address, uint8_t *values, uint8_t count = 1);
 
 	modm::ResumableResult<bool>
-	writeRegister(
-			const RegisterAddress address,
-			const uint8_t value);
+	writeRegister(RegisterAddress address, uint8_t value);
 
-private:
-	class uint16_t_LOW_HIGH
-	{
-	private:
-		uint8_t low;
-		uint8_t high;
-	public:
-		uint16_t
-		get() const
-		{
-			uint16_t value = low;
-			value |= high << 8;
-			return value;
-		}
-		inline uint8_t getLSB()	const { return low; }
-		inline uint8_t getMSB()	const { return high; }
-	} modm_packed;
-
-	static union Data
-	{
-		uint8_t dataBytes[2*4];
-		struct
-		{
-			uint16_t_LOW_HIGH green;
-			uint16_t_LOW_HIGH red;
-			uint16_t_LOW_HIGH blue;
-			uint16_t_LOW_HIGH clear;
-		} modm_packed;
-	} data;
-
-	static Rgb	color;
+protected:
+	Data &data;
+	uint8_t buffer[3];
 };
-}
+
+}	// namespace modm
 
 #include "tcs3414_impl.hpp"
 

--- a/src/modm/driver/color/tcs3414_impl.hpp
+++ b/src/modm/driver/color/tcs3414_impl.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013, David Hebbeker
  * Copyright (c) 2013-2014, Sascha Schade
- * Copyright (c) 2013-2015, Niklas Hauser
+ * Copyright (c) 2013-2015, 2021, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -15,121 +15,42 @@
 #	error	"Don't include this file directly, use 'tcs3414.hpp' instead!"
 #endif
 
-template<typename I2cMaster>
-typename modm::Tcs3414<I2cMaster>::Data modm::Tcs3414<I2cMaster>::data;
-
-template<typename I2cMaster>
-typename modm::tcs3414::Rgb modm::Tcs3414<I2cMaster>::color;
 
 template < typename I2cMaster >
-modm::Tcs3414<I2cMaster>::Tcs3414(uint8_t address)
-: I2cDevice<I2cMaster,2>(address),
-  commandBuffer{0,0,0,0}
-{
-}
+modm::Tcs3414<I2cMaster>::Tcs3414(Data &data, uint8_t address)
+	: I2cDevice<I2cMaster,2>(address), data(data)
+{}
 
 // ----------------------------------------------------------------------------
 template<typename I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3414<I2cMaster>::configure(
-		const Gain gain,
-		const Prescaler prescaler,
-		const IntegrationMode mode,
-		const uint8_t time)
+modm::Tcs3414<I2cMaster>::writeRegister(RegisterAddress address, uint8_t value)
 {
 	RF_BEGIN();
 
-	if ( RF_CALL(setGain(gain, prescaler)) )
-	{
-		if ( RF_CALL(setIntegrationTime(mode, time)) )
-		{
-			RF_RETURN(true);
-		}
-	}
+	buffer[0] =	0x80 |				// write command
+				0x40 |				// with SMB read/write block protocol
+				uint8_t(address);	// at this address
+	// buffer[1] contains ignored byte count
+	buffer[2] = value;
 
-	RF_END_RETURN(false);
-}
+	this->transaction.configureWrite(buffer, 2);
 
-// ----------------------------------------------------------------------------
-// MARK: - Tasks
-template < class I2cMaster >
-modm::ResumableResult<bool>
-modm::Tcs3414<I2cMaster>::refreshAllColors()
-{
-	RF_BEGIN();
-
-	if ( RF_CALL(readRegisters(
-			RegisterAddress::DATA1LOW,
-			data.dataBytes,
-			sizeof(data.dataBytes)
-	) ) )
-	{
-		// adapt the values to the overall light intensity
-		// so that R + G + B = C
-		color.red	= data.red.get();
-		color.green	= data.green.get();
-		color.blue	= data.blue.get();
-
-		{
-			// START --> This part is not really necessary
-			// Rationale:
-			// Imagine a low band light. For example a green laser. In case the filters
-			// of this sensors do not transfer this wavelength well, it might
-			// result in all colors being very low. The clear value will not
-			// filter colors and thus it will see a bright light (intensity).
-			// In order to still have some signal the very low green value can be
-			// amplified with the clear value.
-			const float c =	static_cast<float>(color.red) +
-					static_cast<float>(color.green) +
-					static_cast<float>(color.blue);
-			const float f = data.clear.get() / c;
-			color.red	*= f;
-			color.green	*= f;
-			color.blue	*= f;
-		}
-
-		// <-- END
-		RF_RETURN(true);
-	}
-
-	RF_END_RETURN(false);
-}
-
-// ----------------------------------------------------------------------------
-template<typename I2cMaster>
-modm::ResumableResult<bool>
-modm::Tcs3414<I2cMaster>::writeRegister(
-		const RegisterAddress address,
-		const uint8_t value)
-{
-	RF_BEGIN();
-
-	commandBuffer[0] =
-				0x80							// write command
-			|	0x40							// with SMB read/write protocol
-			|	static_cast<uint8_t>(address);	// at this address
-	commandBuffer[2] = value;
-
-	this->transaction.configureWrite(commandBuffer, 3);
-
-	RF_END_RETURN_CALL( this->runTransaction() );
+	RF_END_RETURN_CALL(this->runTransaction());
 }
 
 template<typename I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3414<I2cMaster>::readRegisters(
-		const RegisterAddress address,
-		uint8_t* const values,
-		const uint8_t count)
+modm::Tcs3414<I2cMaster>::readRegisters(RegisterAddress address, uint8_t* values,
+                                        uint8_t count)
 {
 	RF_BEGIN();
 
-	commandBuffer[0] =
-			static_cast<uint8_t>(0x80)		// write command
-			| static_cast<uint8_t>(0x40)		// with SMB read/write protocol
-			| static_cast<uint8_t>(address);	// at this address
+	buffer[0] =	0x80 |				// write command
+				0x40 |				// with SMB read/write block protocol
+				uint8_t(address);	// at this address
 
-	this->transaction.configureWriteRead(commandBuffer, 1, values, count);
+	this->transaction.configureWriteRead(buffer, 1, values, count);
 
-	RF_END_RETURN_CALL( this->runTransaction() );
+	RF_END_RETURN_CALL(this->runTransaction());
 }

--- a/src/modm/driver/color/tcs3472.lb
+++ b/src/modm/driver/color/tcs3472.lb
@@ -19,7 +19,8 @@ def init(module):
 def prepare(module, options):
     module.depends(
         ":architecture:i2c.device",
-        ":ui:color")
+        ":ui:color",
+        ":math:utils")
     return True
 
 def build(env):

--- a/src/modm/driver/color/tcs3472_impl.hpp
+++ b/src/modm/driver/color/tcs3472_impl.hpp
@@ -2,8 +2,9 @@
 /*
  * Copyright (c) 2013, David Hebbeker
  * Copyright (c) 2013-2014, Sascha Schade
- * Copyright (c) 2013-2015, Niklas Hauser
+ * Copyright (c) 2013-2015, 2021, Niklas Hauser
  * Copyright (c) 2017, Arjun Sarin
+ * Copyright (c) 2021, Thomas Sommer
  *
  * This file is part of the modm project.
  *
@@ -14,34 +15,76 @@
 // ----------------------------------------------------------------------------
 
 #ifndef MODM_TCS3472_HPP
-#	error	"Don't include this file directly, use 'tcs3471.hpp' instead!"
+#error "Don't include this file directly, use 'tcs3472.hpp' instead!"
 #endif
 
 template<typename I2cMaster>
-typename modm::Tcs3472<I2cMaster>::Data modm::Tcs3472<I2cMaster>::data;
-
-template<typename I2cMaster>
-typename modm::tcs3472::Rgb modm::Tcs3472<I2cMaster>::color;
-
-template < typename I2cMaster >
-modm::Tcs3472<I2cMaster>::Tcs3472(uint8_t address)
-: I2cDevice<I2cMaster,2>(address),
-  commandBuffer{0,0,0,0}
-{
-}
+modm::Tcs3472<I2cMaster>::Tcs3472(Data &data, uint8_t address)
+	: I2cDevice<I2cMaster, 2>(address), data(data)
+{}
 
 // ----------------------------------------------------------------------------
 template<typename I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3472<I2cMaster>::configure(
-                        const Gain	gain,
-                        const uint8_t 	int_time)
+modm::Tcs3472<I2cMaster>::setInterruptLowThreshold(uint16_t threshold)
 {
 	RF_BEGIN();
 
-        if ( RF_CALL(setGain(gain) ) )
+	if (RF_CALL(writeRegister(RegisterAddress::LOW_THRESH_LOW_BYTE, threshold)))
 	{
-                if ( RF_CALL(setIntegrationTime(int_time)) )
+		modm::delay(20us);
+		if (RF_CALL(writeRegister(RegisterAddress::LOW_THRESH_HIGH_BYTE, threshold >> 8)))
+		{
+			RF_RETURN(true);
+		}
+	}
+
+	RF_END_RETURN(false);
+}
+
+template<typename I2cMaster>
+modm::ResumableResult<bool>
+modm::Tcs3472<I2cMaster>::setInterruptHighThreshold(uint16_t threshold)
+{
+	RF_BEGIN();
+
+	if (RF_CALL(writeRegister(RegisterAddress::HIGH_THRESH_LOW_BYTE, threshold)))
+	{
+		if (RF_CALL(writeRegister(RegisterAddress::HIGH_THRESH_HIGH_BYTE, threshold >> 8)))
+		{
+			RF_RETURN(true);
+		}
+	}
+
+	RF_END_RETURN(false);
+}
+
+template<typename I2cMaster>
+modm::ResumableResult<bool>
+modm::Tcs3472<I2cMaster>::setWaitTime(WaitTime wait_time, bool wait_long)
+{
+	RF_BEGIN();
+
+	if (RF_CALL(writeRegister(RegisterAddress::CONFIGURATION, wait_long ? 1 << 1 : 0)))
+	{
+		if (RF_CALL(writeRegister(RegisterAddress::WAIT_TIME, uint8_t(wait_time))))
+		{
+			RF_RETURN(true);
+		}
+	}
+
+	RF_END_RETURN(false);
+}
+
+template<typename I2cMaster>
+modm::ResumableResult<bool>
+modm::Tcs3472<I2cMaster>::configure(Gain gain, IntegrationTime int_time)
+{
+	RF_BEGIN();
+
+	if (RF_CALL(setGain(gain)))
+	{
+		if (RF_CALL(setIntegrationTime(int_time)))
 		{
 			RF_RETURN(true);
 		}
@@ -52,86 +95,46 @@ modm::Tcs3472<I2cMaster>::configure(
 
 // ----------------------------------------------------------------------------
 // MARK: - Tasks
-template < class I2cMaster >
+template<class I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3472<I2cMaster>::refreshAllColors()
+modm::Tcs3472<I2cMaster>::reloadInterrupt()
 {
 	RF_BEGIN();
 
-        // start reading in CDATALOW, continue reading in following registers
-        // with the auto-increment mode of the i2c protocoll @see Tcs3472::readRegisters
-	if ( RF_CALL(readRegisters(
-                        RegisterAddress::CDATALOW,
-			data.dataBytes,
-			sizeof(data.dataBytes)
-	) ) )
-	{
-		// adapt the values to the overall light intensity
-		// so that R + G + B = C
-		color.red	= data.red.get();
-		color.green	= data.green.get();
-		color.blue	= data.blue.get();
+	// Only send command, don't append data! otherwise the reload is not working!
+	buffer[0] = 0x80 | uint8_t(RegisterAddress::RELOAD_INTERRUPT);
 
-		{
-			// START --> This part is not really necessary
-			// Rationale:
-			// Imagine a low band light. For example a green laser. In case the filters
-			// of this sensors do not transfer this wavelength well, it might
-			// result in all colors being very low. The clear value will not
-			// filter colors and thus it will see a bright light (intensity).
-			// In order to still have some signal the very low green value can be
-			// amplified with the clear value.
-			const float c =	static_cast<float>(color.red) +
-					static_cast<float>(color.green) +
-					static_cast<float>(color.blue);
-			const float f = data.clear.get() / c;
-			color.red	*= f;
-			color.green	*= f;
-			color.blue	*= f;
-		}
+	this->transaction.configureWrite(buffer, 1);
 
-		// <-- END
-		RF_RETURN(true);
-	}
-
-	RF_END_RETURN(false);
+	RF_END_RETURN_CALL(this->runTransaction());
 }
 
 // ----------------------------------------------------------------------------
 template<typename I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3472<I2cMaster>::writeRegister(
-		const RegisterAddress address,
-		const uint8_t value)
+modm::Tcs3472<I2cMaster>::writeRegister(RegisterAddress address, uint8_t value)
 {
 	RF_BEGIN();
 
-	commandBuffer[0] =
-				0x80							// write command
-			|	0x40							// with SMB read/write protocol
-			|	static_cast<uint8_t>(address);	// at this address
-	commandBuffer[2] = value;
+	buffer[0] = 0x80 | uint8_t(address);
+	buffer[1] = value;
 
-	this->transaction.configureWrite(commandBuffer, 3);
+	this->transaction.configureWrite(buffer, 2);
 
-	RF_END_RETURN_CALL( this->runTransaction() );
+	RF_END_RETURN_CALL(this->runTransaction());
 }
 
 template<typename I2cMaster>
 modm::ResumableResult<bool>
-modm::Tcs3472<I2cMaster>::readRegisters(
-		const RegisterAddress address,
-		uint8_t* const values,
-		const uint8_t count)
+modm::Tcs3472<I2cMaster>::readRegisters(RegisterAddress address, uint8_t *const values,
+										uint8_t count)
 {
 	RF_BEGIN();
 
-	commandBuffer[0] =
-			static_cast<uint8_t>(0x80)		// write command
-			| static_cast<uint8_t>(0x40)		// with SMB read/write protocol
-			| static_cast<uint8_t>(address);	// at this address
+	buffer[0] = 0x80 | 0x20 |		// read command auto increment
+				uint8_t(address);	// at this address
 
-	this->transaction.configureWriteRead(commandBuffer, 1, values, count);
+	this->transaction.configureWriteRead(buffer, 1, values, count);
 
-	RF_END_RETURN_CALL( this->runTransaction() );
+	RF_END_RETURN_CALL(this->runTransaction());
 }


### PR DESCRIPTION
Significantly improves possible performance. Got sample-rates up to 200Hz now:

### Bug
- shrinked commandBuffer[4] -> commandBuffer[3]. Until now, the driver send a placeholder on every request witch seems not to be necessary.

### Features
- Interrupt control
   - enable and reload Interrupts
   - set interrupt persistence filter
   - set interrupt thresholds for the comparator that triggers interrupts
   - getter for clear value - (Cause the interrupt-comparator is wired to clear value, it's good to inspect actual readings to setup comparator-threesholds)
- set and enable waittime (delay between samples, conceived for energy savings)

_Sry for the reformatted code... if that's a problem, i'll fix it._