### PR TITLE
[bugfix] Add a short delay to loop in HD77480::writeCRGAM()

### DIFF
--- a/src/modm/driver/display/hd44780_base_impl.hpp
+++ b/src/modm/driver/display/hd44780_base_impl.hpp
@@ -177,6 +177,7 @@ modm::Hd44780Base<DATA, RW, RS, E>::writeCGRAM(uint8_t character, uint8_t *cg)
 	while(not writeCommand(SetCGRAM_Address | (character << 3)))
 		;
 	for (std::size_t ii = 0; ii < 8; ++ii) {
+		modm::delay(50us);
 		writeRAM(cg[ii]);
 	}
 	return true;


### PR DESCRIPTION
Sometimes modm is to fast for old Hardware.
As soon as i add this little delay, the custom chars look like intended instead of random.

- I think the hack is acceptable cause CGRAM is typically written only once on initialisation. 