### PR TITLE
[avr] Add default fuses to BSPs and documentation for scons program-fuses

### DIFF
--- a/src/modm/board/al_avreb_can/board_fuses.cpp
+++ b/src/modm/board/al_avreb_can/board_fuses.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "board.hpp"
+
+// Default fuses for the AT90CAN128 bootloader
+// see https://www.alvidi.de/data_sheets/pdf/bootloader/bootloader.pdf
+modm_weak FUSES =
+{
+	0xFF, // .low
+	0x98, // .high
+	0xFF, // .extended
+};

--- a/src/modm/board/al_avreb_can/module.lb
+++ b/src/modm/board/al_avreb_can/module.lb
@@ -37,6 +37,3 @@ def build(env):
     env.copy('.')
     env.collect(":build:default.avrdude.port", "usb");
     env.collect(":build:default.avrdude.programmer", "avrispmkII");
-    # env.collect(":build:default.avrdude.efuse", "0xff");
-    # env.collect(":build:default.avrdude.hfuse", "0xd9");
-    # env.collect(":build:default.avrdude.lfuse", "0xfe");

--- a/src/modm/board/arduino_uno/board_fuses.cpp
+++ b/src/modm/board/arduino_uno/board_fuses.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "board.hpp"
+
+// Defaults taken from Arduino's boards.txt
+// see https://github.com/arduino/ArduinoCore-avr/blob/master/boards.txt
+modm_weak FUSES =
+{
+	0xFF, // .low
+	0xDE, // .high
+	0xFD, // .extended
+};

--- a/src/modm/board/mega_2560_pro/board_fuses.cpp
+++ b/src/modm/board/mega_2560_pro/board_fuses.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "board.hpp"
+
+// Defaults taken from Arduino's boards.txt
+// see https://github.com/arduino/ArduinoCore-avr/blob/master/boards.txt
+modm_weak FUSES =
+{
+	0xFF, // .low
+	0xD8, // .high
+	0xFD, // .extended
+};

--- a/src/modm/platform/core/avr/main.hpp
+++ b/src/modm/platform/core/avr/main.hpp
@@ -15,6 +15,7 @@
 #define	MODM_AVR_MAIN_HPP
 
 #include <stdint.h>
+#include <avr/io.h>
 
 /// @cond
 // saves a couple of bytes of stack and program.

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -144,6 +144,30 @@ shutdown command invoked
 ```
 
 
+#### scons program-fuses
+
+```
+scons program-fuses profile={debug|release} [firmware={hash or file}]
+```
+
+Writes all fuses onto your target connected to avrdude.
+(\* *only AVR targets*)
+
+You can define the fuse values in your source code via the [`FUSES` struct ELF
+section][fuses] mechanism, they are automatically used by avrdude. For fuse
+values see the [AVR Fuse Calculator][fusecalc].
+
+```c
+#include <avr/io.h>
+FUSES =
+{
+    LFUSE_DEFAULT, // .low
+    HFUSE_DEFAULT, // .high
+    EFUSE_DEFAULT, // .extended
+};
+```
+
+
 #### scons program-dfu
 
 ```
@@ -690,3 +714,5 @@ can be accessed as `#include <image.hpp>`.
 [scons]: http://scons.org
 [scons_tools]: https://github.com/modm-io/scons-build-tools
 [bmp]: https://github.com/blacksphere/blackmagic
+[fuses]: https://www.nongnu.org/avr-libc/user-manual/group__avr__fuse.html
+[fusecalc]: https://www.engbedded.com/fusecalc/

--- a/tools/modm_tools/avrdude.py
+++ b/tools/modm_tools/avrdude.py
@@ -98,6 +98,7 @@ if __name__ == "__main__":
     parser.add_argument(
             "--fuse",
             dest="fuses",
+            choices=["lfuse", "hfuse", "efuse"],
             action="append",
             help="The fuses to write to the target.")
 


### PR DESCRIPTION
AVR fuse support is done via ELF section: https://www.nongnu.org/avr-libc/user-manual/group__avr__fuse.html
Alternative to #586.

- [x] Tested in hardware using the Arduino Nano.

cc @TomSaw 