### PR TITLE
[fix] Fixed SSD1306::initialize() cast to bool for return 

### DIFF
--- a/src/modm/driver/display/ssd1306_impl.hpp
+++ b/src/modm/driver/display/ssd1306_impl.hpp
@@ -49,7 +49,7 @@ modm::Ssd1306<I2cMaster, Height>::initialize()
 //	commandBuffer[11] &= RF_CALL(writeCommand(Command::SetPageAddress, 0, 7));
 	commandBuffer[11] &= RF_CALL(writeCommand(Command::SetDisplayOn));
 
-	RF_END_RETURN(commandBuffer[11]);
+	RF_END_RETURN(bool(commandBuffer[11]));
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fix for this warning:

`modm/src/modm/driver/display/ssd1306_impl.hpp:52:32: warning: narrowing conversion of '((modm::Ssd1306<modm::platform::I2cMaster1>*)this)->modm::Ssd1306<modm::platform::I2cMaster1>::commandBuffer[11]' from 'uint8_t' {aka 'unsigned char'} to 'bool' [-Wnarrowing]
   52 |  RF_END_RETURN(commandBuffer[11]);
modm/src/modm/processing/resumable/macros.hpp:188:29: note: in definition of macro 'RF_RETURN_0'
  188 |    return {modm::rf::Stop, (result)}; \`