### PR TITLE
[example] Fixed 2 bugs in example/arduino_nano/color

### DIFF
--- a/examples/arduino_nano/color/main.cpp
+++ b/examples/arduino_nano/color/main.cpp
@@ -51,6 +51,8 @@ public:
 		// Setup WaitTime to further slow down samplerate
 		PT_CALL(sensor.setWaitTime(modm::tcs3472::WaitTime::MSEC_2_4));
 
+		// Dummy read required
+		PT_CALL(sensor.readColor());
 		// Fetch one sample ...
 		PT_CALL(sensor.readColor());
 		// ...and set the high threshold 20% above current clear
@@ -59,13 +61,14 @@ public:
 		while (true)
 		{
 			PT_CALL(sensor.reloadInterrupt());
+			PT_WAIT_UNTIL(TCS3472_INT::read() == false);
 			if (PT_CALL(sensor.readColor()))
 			{
 				const auto color = data.getColor();
 				MODM_LOG_INFO << "RGB: " << color;
 				modm::color::HsvT<uint16_t> hsv;
 				color.toHsv(&hsv);
-				MODM_LOG_INFO << "HSV: " << hsv << modm::endl;
+				MODM_LOG_INFO << "\tHSV: " << hsv << modm::endl;
 			}
 		}
 

--- a/examples/nucleo_f446re/color/main.cpp
+++ b/examples/nucleo_f446re/color/main.cpp
@@ -70,7 +70,7 @@ public:
 				MODM_LOG_INFO << "RGB: " << color;
 				modm::color::HsvT<uint16_t> hsv;
 				color.toHsv(&hsv);
-				MODM_LOG_INFO << "HSV: " << hsv << modm::endl;
+				MODM_LOG_INFO << "\tHSV: " << hsv << modm::endl;
 			}
 			timeout.restart(500ms);
 			PT_WAIT_UNTIL(timeout.isExpired());

--- a/examples/stm32f4_discovery/colour_tcs3414/main.cpp
+++ b/examples/stm32f4_discovery/colour_tcs3414/main.cpp
@@ -102,7 +102,7 @@ public:
 				stream << "RGB: " << color;
 				modm::color::HsvT<uint16_t> hsv;
 				color.toHsv(&hsv);
-				stream << "  " << hsv << modm::endl;
+				stream << "\tHSV: " << hsv << modm::endl;
 			}
 			timeout.restart(500ms);
 			PT_WAIT_UNTIL(timeout.isExpired());


### PR DESCRIPTION
Fixed 2 bugs in example/arduino_nano/color
+
Took the chance to beautify other color-examples by adding Descriptor "HSV: " to output-stream.