### PR TITLE
[ci] Use workflow_dispatch on label creation

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -1,13 +1,12 @@
 name: Compile HAL for all devices
 
 on:
-  pull_request_review:
-    types: [submitted]
-  workflow_dispatch:
+  pull_request:
+    types: [labeled]
 
 jobs:
   avr-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-avr:latest
@@ -27,7 +26,7 @@ jobs:
           path: test/all/log
 
   samd-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -47,7 +46,7 @@ jobs:
           path: test/all/log
 
   stm32f0-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -67,7 +66,7 @@ jobs:
           path: test/all/log
 
   stm32f1-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -87,7 +86,7 @@ jobs:
           path: test/all/log
 
   stm32f2-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -107,7 +106,7 @@ jobs:
           path: test/all/log
 
   stm32f3-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -127,7 +126,7 @@ jobs:
           path: test/all/log
 
   stm32f4-compile-all-1:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -147,7 +146,7 @@ jobs:
           path: test/all/log
 
   stm32f4-compile-all-2:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -167,7 +166,7 @@ jobs:
           path: test/all/log
 
   stm32f4-compile-all-3:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -187,7 +186,7 @@ jobs:
           path: test/all/log
 
   stm32f7-compile-all-1:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -207,7 +206,7 @@ jobs:
           path: test/all/log
 
   stm32f7-compile-all-2:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -227,7 +226,7 @@ jobs:
           path: test/all/log
 
   stm32l1-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -247,7 +246,7 @@ jobs:
           path: test/all/log
 
   stm32l4-compile-all-1:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -267,7 +266,7 @@ jobs:
           path: test/all/log
 
   stm32l4-compile-all-2:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -287,7 +286,7 @@ jobs:
           path: test/all/log
 
   stm32l4-compile-all-3:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -307,7 +306,7 @@ jobs:
           path: test/all/log
 
   stm32g0-compile-all:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -327,7 +326,7 @@ jobs:
           path: test/all/log
 
   stm32g4-compile-all-1:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest
@@ -347,7 +346,7 @@ jobs:
           path: test/all/log
 
   stm32g4-compile-all-2:
-    if: github.event.review.state == 'approved'
+    if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/modm-ext/modm-build-cortex-m:latest


### PR DESCRIPTION
Tested here: https://github.com/salkinium/modm/pull/1 

Unfortunately we'll have to remove and add the `ci:hal` label to restart the CI, however, it's only a small line in the version history and I don't expect we need to do it too often (considering the quick hal jobs).

![](https://user-images.githubusercontent.com/163066/113032725-72118100-9190-11eb-86a9-7b044b45b011.png)


cc @rleh 