### PR TITLE
Nucleo-L452RE BSP & 2046 Touch driver & minor fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Examples STM32L4 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc)
+          (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc nucleo_l452re)
       - name: Examples STM32G4 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ you specific needs.
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp102">TMP102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl53l0">VL53L0</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl6180">VL6180</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ws2812">WS2812</a></td>

--- a/README.md
+++ b/README.md
@@ -472,13 +472,15 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l152re">NUCLEO-L152RE</a></td>
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l432kc">NUCLEO-L432KC</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32f030_demo">STM32F030-DEMO</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/blue_pill_f103/graphics/main.cpp
+++ b/examples/blue_pill_f103/graphics/main.cpp
@@ -48,6 +48,7 @@ main()
 		display::Sck::Sck, display::Miso::Miso, display::Mosi::Mosi>();
 	display::Spi::initialize<SystemClock, 1125_kHz>();
 	tft.initialize();
+	tft.enableBacklight(true);
 	LedGreen::set();
 	tft.setColor(modm::glcd::Color::black());
 	int16_t w = tft.getWidth();

--- a/examples/nucleo_l452re/blink/main.cpp
+++ b/examples/nucleo_l452re/blink/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	initialize();
+
+	while (true)
+	{
+		LedGreen::toggle();
+		modm::delay(Button::read() ? 250ms : 500ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l452re/blink/project.xml
+++ b/examples/nucleo_l452re/blink/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-l452re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l452r3/blink</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_l452re/graphics_touch/main.cpp
+++ b/examples/nucleo_l452re/graphics_touch/main.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, Henrik Hose
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/driver/display/ili9341_spi.hpp>
+
+#include <modm/driver/touch/touch2046.hpp>
+
+using namespace Board;
+
+namespace tft
+{
+	using DmaRx = Dma1::Channel2;
+	using DmaTx = Dma1::Channel3;
+	using Spi = SpiMaster1_Dma<DmaRx, DmaTx>;
+	//using Spi = SpiMaster1;
+	using Cs = modm::platform::GpioC8;
+	using Sck = modm::platform::GpioA5;
+	using Miso = modm::platform::GpioA6;
+	using Mosi = modm::platform::GpioA7;
+	using DataCommands = modm::platform::GpioC5;
+	using Reset = modm::platform::GpioC6;
+	using Backlight = modm::platform::GpioC9;
+}
+
+modm::Ili9341Spi<
+	tft::Spi,
+	tft::Cs,
+	tft::DataCommands,
+	tft::Reset,
+	tft::Backlight
+> tftController;
+
+namespace touch
+{
+	using Spi = SpiMaster2;
+	using Cs = modm::platform::GpioB3;
+	using Sck = modm::platform::GpioB13;
+	using Miso = modm::platform::GpioB14;
+	using Mosi = modm::platform::GpioB15;
+	//using Interrupt = modm::platform::GpioA10;
+}
+
+modm::Touch2046<touch::Spi, touch::Cs> touchController;
+
+
+int
+main()
+{
+	using namespace modm::literals;
+	Board::initialize();
+	Dma1::enable();
+
+	tft::Spi::connect<
+		tft::Sck::Sck,
+		tft::Miso::Miso,
+		tft::Mosi::Mosi>();
+	tft::Spi::initialize<SystemClock, 40_MHz>();
+	tftController.initialize();
+	tftController.enableBacklight(true);
+
+	touch::Spi::connect<
+		touch::Sck::Sck,
+		touch::Miso::Miso,
+		touch::Mosi::Mosi>();
+	touch::Spi::initialize<SystemClock, 2500_kHz>();
+	modm::touch2046::Calibration cal{
+		.OffsetX = -11,
+		.OffsetY = 335,
+		.FactorX = 22018,
+		.FactorY = -29358,
+		.MaxX = 240,
+		.MaxY = 320,
+		.ThresholdZ = 500,
+	};
+	touchController.setCalibration(cal);
+
+	LedGreen::set();
+
+	tftController.setColor(modm::glcd::Color::black());
+	tftController.setBackgroundColor(modm::glcd::Color::red());
+	tftController.clear();
+
+	tftController.setFont(modm::font::ArcadeClassic);
+	tftController.setColor(modm::glcd::Color::white());
+	tftController.setCursor(10,12);
+	tftController << "(10,10)";
+	tftController.setCursor(150,202);
+	tftController << "(150,200)";
+	tftController.drawLine(5, 10, 15, 10);
+	tftController.drawLine(10, 5, 10, 15);
+	tftController.drawLine(145, 200, 155, 200);
+	tftController.drawLine(150, 195, 150, 205);
+
+	tftController.setColor(modm::glcd::Color::black());
+	tftController.setFont(modm::font::Ubuntu_36);
+
+	int16_t X = 0;
+	int16_t Y = 0;
+	int16_t Z = 0;
+
+	while (true)
+	{
+		LedGreen::set();
+
+		std::tie(X, Y, Z) = RF_CALL_BLOCKING(touchController.getRawValues());
+		tftController.setColor(modm::glcd::Color::red());
+		tftController.fillRectangle({30, 50}, 90, 115);
+		tftController.setColor(modm::glcd::Color::black());
+		tftController.setCursor(0, 50);
+		tftController << "X=" << X;
+		tftController.setCursor(0, 90);
+		tftController << "Y=" << Y;
+		tftController.setCursor(0, 130);
+		tftController << "Z=" << Z;
+
+		tftController.setColor(modm::glcd::Color::red());
+		tftController.fillRectangle({30, 220}, 120, 35);
+		tftController.setColor(modm::glcd::Color::black());
+		if(RF_CALL_BLOCKING(touchController.isTouched())) {
+			std::tie(X, Y) = RF_CALL_BLOCKING(touchController.getTouchPosition());
+			tftController.setCursor(5, 220);
+			tftController << "> (" << X << "," << Y << ")";
+		}
+
+		LedGreen::reset();
+		modm::delay(300ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l452re/graphics_touch/project.xml
+++ b/examples/nucleo_l452re/graphics_touch/project.xml
@@ -1,0 +1,15 @@
+<library>
+  <extends>modm:nucleo-l452re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l452re/graphics_touch</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:driver:ili9341</module>
+    <module>modm:driver:touch2046</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:platform:dma</module>
+    <module>modm:docs</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/spi_master.hpp
+++ b/src/modm/architecture/interface/spi_master.hpp
@@ -117,7 +117,7 @@ public:
 	 *      number of bytes to be shifted out
 	 */
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length);
 
 	/**
 	 * Swap a single byte and wait for completion non-blocking!.
@@ -154,7 +154,7 @@ public:
 	 *      number of bytes to be shifted out
 	 */
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 #endif
 };
 

--- a/src/modm/board/nucleo_l452re/board.hpp
+++ b/src/modm/board/nucleo_l452re/board.hpp
@@ -1,0 +1,137 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2017, Sascha Schade
+ * Copyright (c) 2017-2018, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_L452RE_HPP
+#define MODM_STM32_NUCLEO_L452RE_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_l452re
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_l452re
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32L4 running at 80MHz generated from the
+/// internal high speed oscillator
+
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 80_MHz;
+	static constexpr uint32_t Ahb  = Frequency;
+	static constexpr uint32_t Ahb2 = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+
+	static constexpr uint32_t Adc1 = Ahb2;
+
+	static constexpr uint32_t Can1 = Apb1;
+
+	static constexpr uint32_t Comp1 = Apb2;
+	static constexpr uint32_t Comp2 = Apb2;
+
+	static constexpr uint32_t Dac1 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Spi1 = Apb2;
+
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+
+	static constexpr uint32_t Timer1 = Apb2;
+
+	static constexpr uint32_t Timer2 = Apb1;
+	static constexpr uint32_t Timer6 = Apb1;
+
+	static constexpr uint32_t Timer15 = Apb2;
+	static constexpr uint32_t Timer16 = Apb2;
+
+	static constexpr uint32_t Uart4 = Apb1;
+
+	static constexpr uint32_t Usart1 = Apb2;
+
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+
+	static constexpr uint32_t Usb = Apb1;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableInternalClock();	// 16MHz
+		Rcc::PllFactors pllFactors{
+			.pllM = 1,	//  16MHz / M= 1 ->  16MHz
+			.pllN = 10,	//  16MHz * N=10 -> 160MHz
+			.pllR = 2,	// 160MHz / R= 2 ->  80MHz = F_cpu
+		};
+		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		// APB1 has max. 80MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo64_arduino.hpp"
+
+// Button connects to GND
+using Button = GpioInverted<GpioInputC13>;
+
+// User LD2
+using LedGreen = GpioOutputA5;
+using Leds = SoftwareGpioPort< LedGreen >;
+
+namespace stlink
+{
+using Tx = GpioOutputA2;
+using Rx = GpioInputA3;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+}
+
+} // Board namespace
+
+#endif	// MODM_STM32_NUCLEO_L452RE_HPP

--- a/src/modm/board/nucleo_l452re/board.xml
+++ b/src/modm/board/nucleo_l452re/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32l452ret6</option>
+
+    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-l452re</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_l452re/module.lb
+++ b/src/modm/board/nucleo_l452re/module.lb
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-l452re"
+    module.description = """\
+# NUCLEO-L452RE
+
+[Nucleo kit for STM32L452RE](https://www.st.com/en/evaluation-tools/nucleo-l452re.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32l452ret"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
+    env.collect(":build:openocd.source", "board/stm32l4discovery.cfg");

--- a/src/modm/driver/display/ili9341_impl.hpp
+++ b/src/modm/driver/display/ili9341_impl.hpp
@@ -193,7 +193,7 @@ Ili9341<Interface, Reset, Backlight, BufferSize>::clear()
 {
 	auto const saveForegroundColor { foregroundColor };
 	foregroundColor = backgroundColor;
-	fillRectangle(glcd::Point(0, 0), Height, Width);
+	fillRectangle(glcd::Point(0, 0), Width, Height);
 	foregroundColor = saveForegroundColor;
 }
 

--- a/src/modm/driver/touch/ads7843.lb
+++ b/src/modm/driver/touch/ads7843.lb
@@ -20,8 +20,10 @@ The ADS7843 by Texas Instruments is the de-facto standard for cheap
 resistive touch screens.
 
 There are many compatible devices from other manufacturers available,
-such as the UH7843 by Zilltek, the TSC2046 and the XPT2046 by XPTEK.
-All of these are 100%% compatible with the ADS7843.
+such as the UH7843 by Zilltek.
+
+TSC2046, XPT2046 and other *2046 chips seem to be not fully compatible
+with the ADS7843 and have their own driver "modm:driver:touch2046".
 """
 
 def prepare(module, options):

--- a/src/modm/driver/touch/touch2046.hpp
+++ b/src/modm/driver/touch/touch2046.hpp
@@ -1,0 +1,134 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_TOUCH2046_HPP
+#define MODM_TOUCH2046_HPP
+
+#include <modm/architecture/interface/spi_device.hpp>
+#include <modm/architecture/interface/gpio.hpp>
+#include <modm/processing/resumable.hpp>
+
+namespace modm
+{
+
+/// \ingroup modm_driver_touch2046
+struct touch2046 {
+	enum class Orientation {
+		Normal,
+		//...
+	};
+
+	/**
+	 * Calibration values are used to calculate touch point
+	 * from raw values.
+	 *
+	 * \ref FactorX and \ref FactorY scaled by 1000000 to avoid float
+	 * arithmetic. E.g. to get a factor of 0.75 \ref FactorX has to be
+	 * set to 750'000.
+	 *
+	 * isTouched() = bool(Z > ThresholdZ)
+	 *
+	 * X = (rawX * FactorX / 1000000) + OffsetX
+	 * limited to [0, MaxX]
+	 * Y = (rawY * FactorY / 1000000) + OffsetY
+	 * limited to [0, MaxY]
+	 *
+	 * Orientation (rotation, mirror) are applied after the
+	 * above operations.
+	 */
+	struct Calibration
+	{
+		int16_t OffsetX = 0;
+		int16_t OffsetY = 0;
+		int32_t FactorX = 1'000'000;
+		int32_t FactorY = 1'000'000;
+		uint16_t MaxX = 240;
+		uint16_t MaxY = 320;
+		uint16_t ThresholdZ = 1500;
+		Orientation orientation = Orientation::Normal;
+	};
+};
+
+/**
+ * \ingroup	modm_driver_touch2046
+ * \author	Raphael Lehmann
+ *
+ * Datasheet TSC2046: https://www.ti.com/lit/ds/symlink/tsc2046.pdf
+ */
+template < class SpiMaster, class Cs>
+class Touch2046 : public touch2046, public modm::SpiDevice< SpiMaster >, protected modm::NestedResumable<3>
+{
+public:
+	/**
+	 * Set calibration data
+	 *
+	 * See \ref Calibration.
+	 */
+	void
+	setCalibration(Calibration calibration) {
+		cal = calibration;
+	}
+
+	/**
+	 * Get raw X, Y and Z values
+	 *
+	 * \return	Position and intensity of touch point. Full int16_t range.
+	 */
+	modm::ResumableResult<std::tuple<uint16_t,uint16_t,uint16_t>>
+	getRawValues();
+
+	/**
+	 * Is screen touched?
+	 *
+	 * \return bool true if screen is touched
+	 */
+	modm::ResumableResult<bool>
+	isTouched();
+
+	/**
+	 * Get touch position
+	 *
+	 * \return	Position (X, Y) of touch point.
+	 */
+	modm::ResumableResult<std::tuple<uint16_t,uint16_t>>
+	getTouchPosition();
+
+private:
+	static constexpr uint8_t MeasureZ1 = 0xB1;
+	static constexpr uint8_t MeasureZ2 = 0xC1;
+	static constexpr uint8_t MeasureX = 0xD1;
+	static constexpr uint8_t MeasureY = 0x91;
+	static constexpr uint8_t Powerdown = 0b1111'1100;
+	static constexpr std::array<uint8_t, 17> bufferWrite = {
+		MeasureZ1, 0x00,
+		MeasureZ2, 0x00,
+		MeasureY, 0x00,
+		MeasureX, 0x00,
+		MeasureY, 0x00,
+		MeasureX, 0x00,
+		MeasureY, 0x00,
+		(MeasureX & Powerdown), 0x00,
+		0x00};
+	std::array<uint16_t, 9> bufferRead = {};
+
+	uint16_t x = 0;
+	uint16_t y = 0;
+	uint16_t z = 0;
+
+	Calibration cal;
+};
+
+} // modm namespace
+
+#include "touch2046_impl.hpp"
+
+#endif // MODM_TOUCH2046_HPP

--- a/src/modm/driver/touch/touch2046.lb
+++ b/src/modm/driver/touch/touch2046.lb
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:touch2046"
+    module.description = """\
+# TSC2046/x2046 Resistive Touch Controller
+
+The TSC2046 by Texas Instruments is a popular touchscreen controller
+on cheap displays.
+
+https://www.ti.com/lit/ds/symlink/tsc2046.pdf
+
+There are many compatible devices from other manufacturers available,
+such as the XPT2046 by XPTEK or "2046" labeled chips from unknown manufacturers.
+All of these are compatible with the TSC2046.
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:spi.device",
+        ":processing:resumable")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/touch"
+    env.copy("touch2046.hpp")
+    env.copy("touch2046_impl.hpp")

--- a/src/modm/driver/touch/touch2046_impl.hpp
+++ b/src/modm/driver/touch/touch2046_impl.hpp
@@ -1,0 +1,79 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_TOUCH2046_HPP
+	#error	"Don't include this file directly, use 'touch2046.hpp' instead!"
+#endif
+
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<std::tuple<uint16_t,uint16_t,uint16_t>>
+modm::Touch2046<SpiMaster, Cs>::getRawValues()
+{
+	RF_BEGIN();
+
+	RF_WAIT_UNTIL(this->acquireMaster());
+	Cs::reset();
+
+	RF_CALL(SpiMaster::transfer(
+		bufferWrite.data(),
+		reinterpret_cast<uint8_t*>(bufferRead.data()) + 1,
+		17));
+
+	z = 4095 + (modm::fromBigEndian(bufferRead[1]) >> 3)
+		- (modm::fromBigEndian(bufferRead[2]) >> 3);
+
+	y = (modm::fromBigEndian(bufferRead[3]) >> 3)
+		+ (modm::fromBigEndian(bufferRead[5]) >> 3)
+		+ (modm::fromBigEndian(bufferRead[7]) >> 3);
+
+	x = (modm::fromBigEndian(bufferRead[4]) >> 3)
+		+ (modm::fromBigEndian(bufferRead[6]) >> 3)
+		+ (modm::fromBigEndian(bufferRead[8]) >> 3);
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	RF_END_RETURN(std::make_tuple(x, y, z));
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<bool>
+modm::Touch2046<SpiMaster, Cs>::isTouched()
+{
+	RF_BEGIN();
+	std::tie(std::ignore, std::ignore, z) = RF_CALL(getRawValues());
+	RF_END_RETURN(z > cal.ThresholdZ);
+}
+
+template < class SpiMaster, class Cs >
+modm::ResumableResult<std::tuple<uint16_t,uint16_t>>
+modm::Touch2046<SpiMaster, Cs>::getTouchPosition()
+{
+	RF_BEGIN();
+
+	std::tie(x, y, std::ignore) = RF_CALL(getRawValues());
+
+	x = std::min<uint16_t>(
+		((static_cast<int32_t>(x * cal.FactorX) / 1'000'000)
+		+ cal.OffsetX),
+		cal.MaxX);
+	y = std::min<uint16_t>(
+		((static_cast<int32_t>(y * cal.FactorY) / 1'000'000)
+		+ cal.OffsetY),
+		cal.MaxY);
+
+	// todo: orientation processing
+
+	RF_END_RETURN(std::make_tuple(x, y));
+}

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
@@ -116,7 +116,7 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 }
 
 modm::ResumableResult<void>
-modm::platform::SpiMaster{{ id }}::transfer(uint8_t *tx, uint8_t *rx, std::size_t length)
+modm::platform::SpiMaster{{ id }}::transfer(const uint8_t *tx, uint8_t *rx, std::size_t length)
 {
 %% if options["busywait"]
 	for (std::size_t index = 0; index < length; index++)

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
@@ -140,7 +140,7 @@ public:
 	}
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length)
 	{
 %% if options["busywait"]
 		transfer(tx, rx, length);
@@ -154,7 +154,7 @@ public:
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 	// end documentation inherited
 
 protected:

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
@@ -152,7 +152,7 @@ modm::platform::UartSpiMaster{{id}}::transfer(uint8_t data)
 
 modm::ResumableResult<void>
 modm::platform::UartSpiMaster{{id}}::transfer(
-		uint8_t *tx, uint8_t *rx, std::size_t length)
+		const uint8_t *tx, uint8_t *rx, std::size_t length)
 {
 	// this is a manually implemented "fast resumable function"
 	// there is no context or nesting protection, since we don't need it.

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
@@ -160,7 +160,7 @@ public:
 	}
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length)
 	{
 		RF_CALL_BLOCKING(transfer(tx, rx, length));
 	}
@@ -170,7 +170,7 @@ public:
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 	// end documentation inherited
 
 protected:

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
@@ -72,14 +72,14 @@ public:
 	transferBlocking(uint8_t data);
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length);
 
 
 	static modm::ResumableResult<uint8_t>
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 	// end documentation inherited
 
 private:

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
@@ -180,7 +180,7 @@ modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::transferBlocking(uint8_t data
 template <typename Sck, typename Mosi, typename Miso>
 void
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::transferBlocking(
-		uint8_t *tx, uint8_t *rx, std::size_t length)
+		const uint8_t *tx, uint8_t *rx, std::size_t length)
 {
 	uint8_t tx_byte = 0xff;
 	uint8_t rx_byte;
@@ -206,7 +206,7 @@ modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::transfer(uint8_t data)
 template <typename Sck, typename Mosi, typename Miso>
 modm::ResumableResult<void>
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::transfer(
-		uint8_t *tx, uint8_t *rx, std::size_t length)
+		const uint8_t *tx, uint8_t *rx, std::size_t length)
 {
 	transferBlocking(tx, rx, length);
 	return {modm::rf::Stop, 0};

--- a/src/modm/platform/spi/stm32/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.cpp.in
@@ -99,7 +99,7 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 
 modm::ResumableResult<void>
 modm::platform::SpiMaster{{ id }}::transfer(
-		uint8_t * tx, uint8_t * rx, std::size_t length)
+		const uint8_t * tx, uint8_t * rx, std::size_t length)
 {
 	// this is a manually implemented "fast resumable function"
 	// there is no context or nesting protection, since we don't need it.

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -131,7 +131,7 @@ public:
 	}
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length)
 	{
 		RF_CALL_BLOCKING(transfer(tx, rx, length));
 	}
@@ -141,7 +141,7 @@ public:
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 	// end documentation inherited
 };
 

--- a/src/modm/platform/spi/stm32/spi_master_dma.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master_dma.hpp.in
@@ -63,7 +63,7 @@ public:
 	}
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length)
 	{
 		RF_CALL_BLOCKING(transfer(tx, rx, length));
 	}
@@ -72,7 +72,7 @@ public:
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 
 private:
 	static void

--- a/src/modm/platform/spi/stm32/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master_dma_impl.hpp.in
@@ -89,7 +89,7 @@ modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(uint
 
 template <class DmaChannelRx, class DmaChannelTx>
 modm::ResumableResult<void>
-modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(uint8_t *tx,
+modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(const uint8_t *tx,
 		uint8_t *rx, std::size_t length)
 {
 	// this is a manually implemented "fast resumable function"

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
@@ -108,7 +108,7 @@ modm::platform::UartSpiMaster{{ id }}::transfer(uint8_t data)
 
 modm::ResumableResult<void>
 modm::platform::UartSpiMaster{{ id }}::transfer(
-		uint8_t * tx, uint8_t * rx, std::size_t length)
+		const uint8_t * tx, uint8_t * rx, std::size_t length)
 {
 	// this is a manually implemented "fast resumable function"
 	// there is no context or nesting protection, since we don't need it.

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
@@ -118,7 +118,7 @@ public:
 	}
 
 	static void
-	transferBlocking(uint8_t *tx, uint8_t *rx, std::size_t length)
+	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length)
 	{
 		RF_CALL_BLOCKING(transfer(tx, rx, length));
 	}
@@ -128,7 +128,7 @@ public:
 	transfer(uint8_t data);
 
 	static modm::ResumableResult<void>
-	transfer(uint8_t *tx, uint8_t *rx, std::size_t length);
+	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
 };
 
 } // namespace platform


### PR DESCRIPTION
- Nucleo-L452RE BSP
  - incl. Blink and Graphics-Touch (Ili9341 + TSC2046) examples
- 2046 Touch driver
- Make `uint8_t*` `const` in  `SpiMaster*::transfer(rx*, tx*, len)`
- Ili9341: Fix width/height swap in clear() function
- Example blue-pill/graphics: enabe backlight, so that the display actually displays something

cc @hshose

---

While creating this PR I noticed the [`ads7843`-driver](https://modm.io/reference/module/modm-driver-ads7843/) which should be compatible with the `*2046` touchscreen drivers...