### PR TITLE
[display] Fix color paradox of monochrome displays 

### DIFF
--- a/src/modm/driver/display/ili9341.hpp
+++ b/src/modm/driver/display/ili9341.hpp
@@ -15,7 +15,7 @@
 #include <modm/architecture/interface/register.hpp>
 #include <modm/math/utils/endianness.hpp>
 #include <modm/platform/gpio/base.hpp>
-#include <modm/ui/display/graphic_display.hpp>
+#include <modm/ui/display/colored_graphic_display.hpp>
 
 namespace modm
 {

--- a/src/modm/driver/display/parallel_tft.hpp
+++ b/src/modm/driver/display/parallel_tft.hpp
@@ -16,7 +16,7 @@
 #define MODM_PARALLEL_TFT_HPP
 
 #include <modm/architecture/interface/delay.hpp>
-#include <modm/ui/display/graphic_display.hpp>
+#include <modm/ui/display/colored_graphic_display.hpp>
 
 namespace modm
 {

--- a/src/modm/ui/display/colored_graphic_display.cpp
+++ b/src/modm/ui/display/colored_graphic_display.cpp
@@ -1,0 +1,26 @@
+#include "colored_graphic_display.hpp"
+
+// ----------------------------------------------------------------------------
+void
+modm::ColoredGraphicDisplay::setColor(const glcd::Color& newColor)
+{
+//	if (newColor == glcd::Color::black()) {
+//		draw = &modm::GraphicDisplay::clearPixel;
+//	}
+//	else {
+//		draw = &modm::GraphicDisplay::setPixel;
+//	}
+
+	/* When using a multicolor display we don't need clearPixel(), or at least
+	 * not the way it was implemented above. Maybe check if newColor equals
+	 * backgroundColor.
+	 * */
+	draw = &modm::ColoredGraphicDisplay::setPixel;
+	this->foregroundColor = newColor;
+}
+
+void
+modm::ColoredGraphicDisplay::setBackgroundColor(const glcd::Color& newColor)
+{
+	this->backgroundColor = newColor;
+}

--- a/src/modm/ui/display/colored_graphic_display.hpp
+++ b/src/modm/ui/display/colored_graphic_display.hpp
@@ -1,0 +1,108 @@
+#ifndef MODM_COLORED_GRAPHIC_DISPLAY_HPP
+#define MODM_COLORED_GRAPHIC_DISPLAY_HPP
+
+#include <modm/platform.hpp>
+
+#include "graphic_display.hpp"
+
+using namespace modm::platform;
+
+namespace modm
+{
+namespace glcd
+{
+// RGB16 (565) Format
+/// @ingroup modm_ui_display
+class Color
+{
+public:
+	static modm_always_inline Color white()			{ return Color(0xffff); };
+	static modm_always_inline Color yellow()		{ return Color(0xFFE0); };
+	static modm_always_inline Color magenta()		{ return Color(0xF81F); };
+	static modm_always_inline Color red()			{ return Color(0xF800); };
+	static modm_always_inline Color orange()		{ return Color(0xFD20); };
+	static modm_always_inline Color sliver()		{ return Color(0xC618); };
+	static modm_always_inline Color gray()			{ return Color(0x8410); };
+	static modm_always_inline Color maroon()		{ return Color(0x8000); };
+	static modm_always_inline Color lime()			{ return Color(0x07E0); };
+	static modm_always_inline Color green()			{ return Color(0x0400); };
+	static modm_always_inline Color blue()			{ return Color(0x001F); };
+	static modm_always_inline Color navy()			{ return Color(0x0010); };
+	static modm_always_inline Color black()			{ return Color(0x0000); };
+	static modm_always_inline Color signalViolet()	{ return Color(0x8010); }; //0x84D0
+	static modm_always_inline Color emeraldGreen()	{ return Color(0x5DCC); };
+
+	/**
+	 * @param	red
+	 * 		Range [0..255]
+	 * @param	green
+	 * 		Range [0..255]
+	 * @param	blue
+	 * 		Range [0..255]
+	 */
+	Color(uint8_t red, uint8_t green, uint8_t blue)
+		: color(((static_cast<uint16_t>(red >> 3) << 11) |
+				 (static_cast<uint16_t>(green >> 2) << 5) | static_cast<uint16_t>(blue >> 3)))
+	{}
+
+	Color(uint16_t color) : color(color) {}
+
+	Color() : color(0) {}
+
+	inline uint16_t
+	getValue() const
+	{
+		return color;
+	}
+
+	bool
+	operator==(const Color& other) const
+	{
+		return (color == other.color);
+	}
+
+private:
+	uint16_t color;
+};
+}  // namespace glcd
+
+class ColoredGraphicDisplay : public GraphicDisplay
+{
+public:
+	ColoredGraphicDisplay()
+		: foregroundColor(glcd::Color::white()), backgroundColor(glcd::Color::black())
+	{}
+	/**
+	 * Set a new foreground color.
+	 *
+	 * The foreground color is used for all drawing operations. Default
+	 * is white.
+	 *
+	 * @see	setBackgroundColor()
+	 */
+	void
+	setColor(const glcd::Color& color);
+
+	inline glcd::Color
+	getForegroundColor() const
+	{
+		return this->foregroundColor;
+	}
+
+	/**
+	 * Set new background color.
+	 *
+	 * The background color used when clearing the screen. Default is black.
+	 *
+	 * @see	setColor()
+	 */
+	void
+	setBackgroundColor(const glcd::Color& color);
+
+protected:
+	glcd::Color foregroundColor;
+	glcd::Color backgroundColor;
+};
+}  // namespace modm
+
+#endif  // MODM_COLORED_GRAPHIC_DISPLAY_HPP

--- a/src/modm/ui/display/graphic_display.cpp
+++ b/src/modm/ui/display/graphic_display.cpp
@@ -27,35 +27,8 @@ modm::GraphicDisplay::GraphicDisplay() :
 	IOStream(writer),
 	writer(this),
 	draw(&modm::GraphicDisplay::setPixel),
-	foregroundColor(glcd::Color::white()),
-	backgroundColor(glcd::Color::black()),
 	font(modm::accessor::asFlash(modm::font::FixedWidth5x8))
 {
-}
-
-// ----------------------------------------------------------------------------
-void
-modm::GraphicDisplay::setColor(const glcd::Color& newColor)
-{
-//	if (newColor == glcd::Color::black()) {
-//		draw = &modm::GraphicDisplay::clearPixel;
-//	}
-//	else {
-//		draw = &modm::GraphicDisplay::setPixel;
-//	}
-
-	/* When using a multicolor display we don't need clearPixel(), or at least
-	 * not the way it was implemented above. Maybe check if newColor equals
-	 * backgroundColor.
-	 * */
-	draw = &modm::GraphicDisplay::setPixel;
-	this->foregroundColor = newColor;
-}
-
-void
-modm::GraphicDisplay::setBackgroundColor(const glcd::Color& newColor)
-{
-	this->backgroundColor = newColor;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/modm/ui/display/graphic_display.hpp
+++ b/src/modm/ui/display/graphic_display.hpp
@@ -33,66 +33,6 @@ namespace modm
 	{
 		/// @ingroup modm_ui_display
 		typedef Vector<int16_t, 2> Point;
-
-		// RGB16 (565) Format
-		/// @ingroup modm_ui_display
-		class Color
-		{
-		public:
-			static modm_always_inline Color white()   { return Color(0xffff); };
-			static modm_always_inline Color yellow()  { return Color(0xFFE0); };
-			static modm_always_inline Color magenta() { return Color(0xF81F); };
-			static modm_always_inline Color red()     { return Color(0xF800); };
-			static modm_always_inline Color orange()  { return Color(0xFD20); };
-			static modm_always_inline Color sliver()  { return Color(0xC618); };
-			static modm_always_inline Color gray()    { return Color(0x8410); };
-			static modm_always_inline Color maroon()  { return Color(0x8000); };
-			static modm_always_inline Color lime()    { return Color(0x07E0); };
-			static modm_always_inline Color green()   { return Color(0x0400); };
-			static modm_always_inline Color blue()    { return Color(0x001F); };
-			static modm_always_inline Color navy()    { return Color(0x0010); };
-			static modm_always_inline Color black()   { return Color(0x0000); };
-			static modm_always_inline Color signalViolet()   { return Color(0x8010); }; //0x84D0
-			static modm_always_inline Color emeraldGreen()   { return Color(0x5DCC); };
-
-			/**
-			 * @param	red
-			 * 		Range [0..255]
-			 * @param	green
-			 * 		Range [0..255]
-			 * @param	blue
-			 * 		Range [0..255]
-			 */
-			Color(uint8_t red, uint8_t green, uint8_t blue) :
-				color(((static_cast<uint16_t>(red >> 3) << 11) |
-						(static_cast<uint16_t>(green >> 2) << 5) |
-						static_cast<uint16_t>(blue >> 3)))
-			{
-			}
-
-			Color(uint16_t color) :
-				color(color)
-			{
-			}
-
-			Color() : color(0)
-			{
-			}
-
-			inline uint16_t
-			getValue() const
-			{
-				return color;
-			}
-
-			bool
-			operator == (const Color& other) const {
-				return (color == other.color);
-			}
-
-		private:
-			uint16_t color;
-		};
 	}
 
 	// TODO
@@ -162,33 +102,6 @@ namespace modm
 		 */
 		virtual void
 		update() = 0;
-
-		/**
-		 * Set a new foreground color.
-		 *
-		 * The foreground color is used for all drawing operations. Default
-		 * is white.
-		 *
-		 * @see	setBackgroundColor()
-		 */
-		void
-		setColor(const glcd::Color& color);
-
-		inline glcd::Color
-		getForegroundColor() const
-		{
-			return this->foregroundColor;
-		}
-
-		/**
-		 * Set new background color.
-		 *
-		 * The background color used when clearing the screen. Default is black.
-		 *
-		 * @see	setColor()
-		 */
-		void
-		setBackgroundColor(const glcd::Color& color);
 
 		/**
 		 * Limit the coordinate system to a smaller area.
@@ -469,8 +382,6 @@ namespace modm
 		// callback function for drawing pixels
 		void (GraphicDisplay::*draw)(int16_t x, int16_t y);
 
-		glcd::Color foregroundColor;
-		glcd::Color backgroundColor;
 		modm::accessor::Flash<uint8_t> font;
 		glcd::Point cursor;
 	};

--- a/src/modm/ui/display/monochrome_graphic_display_buffered_vertical.hpp
+++ b/src/modm/ui/display/monochrome_graphic_display_buffered_vertical.hpp
@@ -46,6 +46,8 @@ public:
     static constexpr int16_t displayBufferWidth = Width;
     static constexpr int16_t displayBufferHeight = Height / 8;
 
+    MonochromeGraphicDisplayBufferedVertical() { this->setColor(glcd::Color::black()); }
+
     virtual ~MonochromeGraphicDisplayBufferedVertical() = default;
 
     virtual inline uint16_t

--- a/src/modm/ui/display/monochrome_graphic_display_buffered_vertical.hpp
+++ b/src/modm/ui/display/monochrome_graphic_display_buffered_vertical.hpp
@@ -15,9 +15,9 @@
 #ifndef MODM_MONOCHROME_GRAPHIC_DISPLAY_BUFFERED_VERTICAL_HPP
 #define MODM_MONOCHROME_GRAPHIC_DISPLAY_BUFFERED_VERTICAL_HPP
 
-#include "graphic_display.hpp"
-
 #include <stdlib.h>
+
+#include "graphic_display.hpp"
 
 namespace modm
 {
@@ -33,69 +33,65 @@ namespace modm
  * \author	Fabian Greif
  * \ingroup	modm_ui_display
  */
-template <int16_t Width, int16_t Height>
+template<int16_t Width, int16_t Height>
 class MonochromeGraphicDisplayBufferedVertical : public GraphicDisplay
 {
-    // Height must be a multiple of 8
-    static_assert((Height % 8) == 0, "height must be a multiple of 8");
+	// Height must be a multiple of 8
+	static_assert((Height % 8) == 0, "height must be a multiple of 8");
 
-    static_assert(Width > 0, "width must be greater than 0");
-    static_assert(Height > 0, "height must be greater than 0");
+	static_assert(Width > 0, "width must be greater than 0");
+	static_assert(Height > 0, "height must be greater than 0");
 
 public:
-    static constexpr int16_t displayBufferWidth = Width;
-    static constexpr int16_t displayBufferHeight = Height / 8;
+	static constexpr int16_t displayBufferWidth = Width;
+	static constexpr int16_t displayBufferHeight = Height / 8;
 
-    MonochromeGraphicDisplayBufferedVertical() { this->setColor(glcd::Color::black()); }
+	virtual ~MonochromeGraphicDisplayBufferedVertical() = default;
 
-    virtual ~MonochromeGraphicDisplayBufferedVertical() = default;
+	virtual inline uint16_t
+	getWidth() const override
+	{
+		return Width;
+	}
 
-    virtual inline uint16_t
-    getWidth() const override
-    {
-        return Width;
-    }
+	virtual inline uint16_t
+	getHeight() const override
+	{
+		return Height;
+	}
 
-    virtual inline uint16_t
-    getHeight() const override
-    {
-        return Height;
-    }
+	/**
+	 * \brief	Clear the complete screen
+	 *
+	 * Use fillRectangle() to clear certain areas of the screen.
+	 */
+	virtual void
+	clear() override;
 
-    /**
-     * \brief	Clear the complete screen
-     *
-     * Use fillRectangle() to clear certain areas of the screen.
-     */
-    virtual void
-    clear() override;
-
-    // Faster version adapted for the RAM buffer
-    virtual void
-    drawImageRaw(glcd::Point upperLeft,
-                 uint16_t width,
-                 uint16_t height,
-                 modm::accessor::Flash<uint8_t> data) override;
+	// Faster version adapted for the RAM buffer
+	virtual void
+	drawImageRaw(glcd::Point upperLeft, uint16_t width, uint16_t height,
+				 modm::accessor::Flash<uint8_t> data) override;
 
 protected:
-    // Faster version adapted for the RAM buffer
-    virtual void
-    drawHorizontalLine(glcd::Point start, uint16_t length) override;
+	// Faster version adapted for the RAM buffer
+	virtual void
+	drawHorizontalLine(glcd::Point start, uint16_t length) override;
 
-    // TODO Faster version adapted for the RAM buffer
-    // virtual void
-    // drawVerticalLine(glcd::Point start, uint8_t length);
+	// TODO Faster version adapted for the RAM buffer
+	// virtual void
+	// drawVerticalLine(glcd::Point start, uint8_t length);
 
-    virtual void
-    setPixel(int16_t x, int16_t y) override;
+	virtual void
+	setPixel(int16_t x, int16_t y) override;
 
-    virtual void
-    clearPixel(int16_t x, int16_t y) override;
+	virtual void
+	clearPixel(int16_t x, int16_t y) override;
 
-    virtual bool
-    getPixel(int16_t x, int16_t y) override;
-
-    uint8_t display_buffer[displayBufferWidth][displayBufferHeight];
+	virtual bool
+	getPixel(int16_t x, int16_t y) override;
+    
+	uint8_t display_buffer[displayBufferWidth][displayBufferHeight];
 };
 }  // namespace modm
 

--- a/src/modm/ui/display/monochrome_graphic_display_buffered_vertical_impl.hpp
+++ b/src/modm/ui/display/monochrome_graphic_display_buffered_vertical_impl.hpp
@@ -20,6 +20,7 @@ template <int16_t Width, int16_t Height>
 void
 modm::MonochromeGraphicDisplayBufferedVertical<Width, Height>::clear()
 {
+    // OPTIMIZE use memcpy
     for (int_fast16_t y = 0; y < Height / 8; ++y)
     {
         for (int_fast16_t x = 0; x < Width; ++x)
@@ -39,7 +40,8 @@ modm::MonochromeGraphicDisplayBufferedVertical<Width, Height>::drawHorizontalLin
 {
     const int16_t y = start.getY() / 8;
 
-    if (this->foregroundColor == glcd::Color::black())
+    // if (this->foregroundColor == glcd::Color::black())
+    if(true)
     {
         const uint8_t mask = 1 << (start.getY() & 0x07);
         for (int_fast16_t x = start.getX(); x < static_cast<int16_t>(start.getX() + length); ++x)

--- a/src/modm/ui/display/virtual_graphic_display.cpp
+++ b/src/modm/ui/display/virtual_graphic_display.cpp
@@ -12,7 +12,7 @@
 
 #include "virtual_graphic_display.hpp"
 
-modm::VirtualGraphicDisplay::VirtualGraphicDisplay(modm::GraphicDisplay* display,
+modm::VirtualGraphicDisplay::VirtualGraphicDisplay(modm::ColoredGraphicDisplay* display,
 		modm::glcd::Point leftUpper, modm::glcd::Point rightLower):
 		display(display), leftUpper(leftUpper), rightLower(rightLower),
 		width(static_cast<uint16_t>(this->rightLower[0] - this->leftUpper[0])),
@@ -21,7 +21,7 @@ modm::VirtualGraphicDisplay::VirtualGraphicDisplay(modm::GraphicDisplay* display
 }
 
 void
-modm::VirtualGraphicDisplay::setDisplay(modm::GraphicDisplay* display)
+modm::VirtualGraphicDisplay::setDisplay(modm::ColoredGraphicDisplay* display)
 {
 	this->display = display;
 	return;

--- a/src/modm/ui/display/virtual_graphic_display.hpp
+++ b/src/modm/ui/display/virtual_graphic_display.hpp
@@ -16,20 +16,20 @@
 #ifndef MODM_VIRTUAL_GRAPHIC_DISPLAY
 #define MODM_VIRTUAL_GRAPHIC_DISPLAY
 
-#include <modm/ui/display/graphic_display.hpp>
+#include <modm/ui/display/colored_graphic_display.hpp>
 
 namespace modm
 {
 	/// @ingroup modm_ui_display
 	class VirtualGraphicDisplay:
-			public modm::GraphicDisplay
+			public modm::ColoredGraphicDisplay
 	{
 	public:
-		VirtualGraphicDisplay(modm::GraphicDisplay* display,
+		VirtualGraphicDisplay(modm::ColoredGraphicDisplay* display,
 				modm::glcd::Point leftUpper, modm::glcd::Point rightLower);
 
 		void
-		setDisplay(modm::GraphicDisplay* display);
+		setDisplay(modm::ColoredGraphicDisplay* display);
 
 		virtual inline uint16_t
 		getWidth() const
@@ -61,7 +61,7 @@ namespace modm
 		getPixel(int16_t x, int16_t y);
 
  	private:
-		modm::GraphicDisplay* display;
+		modm::ColoredGraphicDisplay* display;
 		modm::glcd::Point leftUpper;
 		modm::glcd::Point rightLower;
 		const uint16_t width;


### PR DESCRIPTION
In `MonochromeGraphicDisplayBufferedVertical<Width, Height>::drawHorizontalLine` no pixels are set, because `this->foregroundColor != glcd::Color::black()`. The default foregroundColor fot graphic displays is Color::white()!

So i have to `myMonochromeDisplay.setColor(Color::black())` after instantiation of my display to have horizontal lines renders.

**-> That's confusing, cause anything else - like text, diagonal lines, circles - renders (in black) out of the box!**