### PR TITLE
[docs] Fix dark mode on homepage

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,9 +21,22 @@ theme:
   include_search_page: false
   search_index_only: true
   palette:
-    primary: 'indigo'
-    accent: 'cyan'
-    scheme: preference
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: cyan
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
   # logo: '../images/logo.svg'
   font:
     text: 'Ubuntu'


### PR DESCRIPTION
Aparently the color toggle feature just dropped into the free version of MkDocs Material and of course uses a different setting, which broke dark mode on the homepage.
https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle

This fixes that and we get a toggle for free, which is nice.

cc @rleh