### PR TITLE
[docs] Fix table width for HAL matrix

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
   - Reference:
     - Documentation: reference/documentation.md
     - Build Systems: reference/build-systems.md
-    - Modules:
 # moduletable
-    # - module: module.md
+    # - Modules:
+    #   - module: module.md
 # /moduletable

--- a/docs/src/extra.css
+++ b/docs/src/extra.css
@@ -11,3 +11,6 @@
 	width: 100%;
 	height: 100%;
 }
+.md-typeset table:not([class]) th {
+	min-width: 0;
+}

--- a/tools/scripts/generate_module_docs.py
+++ b/tools/scripts/generate_module_docs.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
 
     print("\nWriting module table")
     config_path = Path(repopath("docs/mkdocs.yml"))
-    modtable = "\n".join(sorted(modtable))
+    modtable = "\n".join(["    - Modules:"] + sorted(modtable))
     config = config_path.read_text()
     if extract(config, "moduletable") != modtable:
         config = replace(config, "moduletable", modtable)


### PR DESCRIPTION
Sets the minimum table width to zero to fit more of the HAL matrix table onto the homepage.

Fixes an issue with MkDocs crashing if no modules have been added.

cc @rleh 
