### PR TITLE
STM32G4 FDCAN driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✗</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✗</td>
 <td align="center">✗</td>
 <td align="center">✅</td>

--- a/examples/nucleo_g474re/can/main.cpp
+++ b/examples/nucleo_g474re/can/main.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+#include <modm/board.hpp>
+
+using namespace modm::literals;
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "CAN Test Program" << modm::endl;
+
+	MODM_LOG_INFO << "Initializing Fdcan1..." << modm::endl;
+	// Initialize Fdcan1
+	Fdcan1::connect<GpioB8::Rx, GpioB9::Tx>(Gpio::InputType::PullUp);
+	Fdcan1::initialize<Board::SystemClock, 125_kbps, 1_pct, 500_kbps>(9);
+
+	MODM_LOG_INFO << "Setting up Filter for Fdcan1..." << modm::endl;
+	// Receive every extended id message
+	Fdcan1::setExtendedFilter(0, Fdcan1::FilterConfig::Fifo0,
+			modm::can::ExtendedIdentifier(0),
+			modm::can::ExtendedMask(0));
+
+	MODM_LOG_INFO << "Initializing Fdcan2..." << modm::endl;
+	// Initialize Fdcan2
+	Fdcan2::connect<GpioB5::Rx, GpioB6::Tx>(Gpio::InputType::PullUp);
+	Fdcan2::initialize<Board::SystemClock, 125_kbps, 1_pct, 500_kbps>(12);
+
+	MODM_LOG_INFO << "Setting up Filter for Fdcan2..." << modm::endl;
+	// Receive every message
+	Fdcan2::setExtendedFilter(0, Fdcan2::FilterConfig::Fifo0,
+			modm::can::ExtendedIdentifier(0),
+			modm::can::ExtendedMask(0));
+
+	// Send a message
+	MODM_LOG_INFO << "Sending message on Fdcan1..." << modm::endl;
+	modm::can::Message msg1(1, 1);
+	msg1.setExtended(true);
+	msg1.data[0] = 0x11;
+	Fdcan1::sendMessage(msg1);
+
+	// Send a message
+	MODM_LOG_INFO << "Sending message on Fdcan2..." << modm::endl;
+	msg1.data[0] = 0x22;
+	Fdcan2::sendMessage(msg1);
+
+
+	while (true)
+	{
+		if (Fdcan1::isMessageAvailable())
+		{
+			MODM_LOG_INFO << "Fdcan1: Message is available..." << modm::endl;
+			modm::can::Message message;
+			Fdcan1::getMessage(message);
+			MODM_LOG_INFO << message << modm::endl;
+		}
+		if (Fdcan2::isMessageAvailable())
+		{
+			MODM_LOG_INFO << "Fdcan2: Message is available..." << modm::endl;
+			modm::can::Message message;
+			Fdcan2::getMessage(message);
+			MODM_LOG_INFO << message << modm::endl;
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g474re/can/project.xml
+++ b/examples/nucleo_g474re/can/project.xml
@@ -1,0 +1,15 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/can</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:can:1</module>
+    <module>modm:platform:can:2</module>
+    <module>modm:platform:can:3</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:uart:2</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/can_filter.hpp
+++ b/src/modm/architecture/interface/can_filter.hpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef MODM_CAN_FILTER_HPP
+#define MODM_CAN_FILTER_HPP
+
+#include <modm/io/iostream.hpp>
+
+namespace modm::can
+{
+
+/// CAN 2.0A 11 bit standard identifier
+/// The upper 5 bits are ignored
+/// @ingroup modm_architecture_can
+struct StandardIdentifier
+{
+	uint16_t id;
+
+	constexpr explicit operator uint16_t()
+	{
+		return id;
+	}
+};
+
+/// CAN 2.0A 11 bit standard mask
+/// The upper 5 bits are ignored
+/// @ingroup modm_architecture_can
+struct StandardMask
+{
+	uint16_t mask;
+
+	constexpr explicit operator uint16_t()
+	{
+		return mask;
+	}
+};
+
+/// CAN 2.0B 29 bit extended identifier
+/// The upper 3 bits are ignored
+/// @ingroup modm_architecture_can
+struct ExtendedIdentifier
+{
+	uint32_t id;
+
+	constexpr explicit operator uint32_t()
+	{
+		return id;
+	}
+};
+
+/// CAN 2.0B 29 bit extended mask
+/// The upper 3 bits are ignored
+/// @ingroup modm_architecture_can
+struct ExtendedMask
+{
+	uint32_t mask;
+
+	constexpr explicit operator uint32_t()
+	{
+		return mask;
+	}
+};
+
+}
+
+#endif

--- a/src/modm/architecture/interface/can_message.hpp
+++ b/src/modm/architecture/interface/can_message.hpp
@@ -113,6 +113,13 @@ public:
 				(this->flags.extended == rhs.flags.extended) and
 				std::equal(data, data + length, rhs.data));
 	}
+
+	inline bool
+	operator < (const modm::can::Message& rhs) const
+	{
+		return (this->identifier << (this->flags.extended ? 0 : 18))
+			< (rhs.identifier << (rhs.flags.extended ? 0 : 18));
+	}
 };
 
 }	// namespace modm::can

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -127,6 +127,7 @@ class Can(Module):
         env.outbasepath = "modm/src/modm/architecture"
         env.copy("interface/can.hpp")
         env.copy("interface/can.cpp")
+        env.copy("interface/can_filter.hpp")
         env.copy("interface/can_message.hpp")
 # -----------------------------------------------------------------------------
 

--- a/src/modm/board/nucleo_g474re/board.hpp
+++ b/src/modm/board/nucleo_g474re/board.hpp
@@ -112,6 +112,7 @@ struct SystemClock {
 		// update frequencies for busy-wait delay functions
 		Rcc::updateCoreFrequency<Frequency>();
 
+		Rcc::setCanClockSource(Rcc::CanClockSource::Pclk);
 		return true;
 	}
 };

--- a/src/modm/platform/can/common/can_bit_timings.hpp
+++ b/src/modm/platform/can/common/can_bit_timings.hpp
@@ -23,6 +23,16 @@
 namespace modm
 {
 
+
+struct CanBitTimingConfiguration
+{
+	uint8_t bs1;
+	uint8_t bs2;
+	uint8_t sjw;
+	uint16_t prescaler;
+	float error;
+};
+
 /**
  * CAN Bit Timing
  *
@@ -49,14 +59,6 @@ template<int32_t Clk, int32_t Bitrate, uint8_t prescaler_width = 10, uint8_t bs1
 class CanBitTiming
 {
 private:
-	struct CanBitTimingConfiguration {
-		uint8_t bs1;	// 1-16
-		uint8_t bs2;	// 1-8
-		uint8_t sjw;
-		uint16_t prescaler;
-		float minError;
-	};
-
 	static constexpr uint32_t round_uint32(float f)
 	{
 		uint32_t f_int = (uint32_t) f;
@@ -103,10 +105,16 @@ public:
 	static constexpr uint8_t getSJW() { return BestConfig.sjw; }
 	static constexpr uint8_t getPrescaler() { return BestConfig.prescaler; }
 
+	static constexpr CanBitTimingConfiguration
+	getBitTimings()
+	{
+		return BestConfig;
+	}
+
 	template<percent_t tolerance>
 	static constexpr void assertBitrateInTolerance()
 	{
-		static_assert(pct2f(tolerance) >= BestConfig.minError,
+		static_assert(pct2f(tolerance) >= BestConfig.error,
 			"The closest available bitrate exceeds the specified maximum tolerance!");
 	}
 

--- a/src/modm/platform/can/stm32-fdcan/can.cpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.cpp.in
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -11,17 +12,23 @@
 #include <queue>
 #include <array>
 #include <algorithm>
+#include <cstring>
+#include <optional>
 
 #include <modm/architecture/driver/atomic/queue.hpp>
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/architecture/interface/delay.hpp>
 #include <modm/architecture/interface/assert.hpp>
+#include <modm/architecture/interface/interrupt.hpp>
 
 #include "can_{{ id }}.hpp"
 
+namespace {
+
+using MessageRam = modm::platform::fdcan::MessageRam<{{ id - 1 }}>;
 
 %% if options["buffer.tx"] > 0
-static std::priority_queue<modm::can::Message> txQueue;
+modm::atomic::Queue<modm::can::Message, {{ options["buffer.tx"] }}> txQueue;
 %% endif
 
 struct RxMessage {
@@ -30,152 +37,31 @@ struct RxMessage {
     uint16_t timestamp;
 };
 %% if options["buffer.rx"] > 0
-static modm::atomic::Queue<RxMessage, {{ options["buffer.rx"] }}> rxQueue;
+modm::atomic::Queue<RxMessage, {{ options["buffer.rx"] }}> rxQueue;
 %% endif
 
+bool
+isHardwareTxQueueFull()
+{
+	return (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQF) != 0);
+}
+
+bool
+rxFifo0HasMessage()
+{
+	return (({{ reg }}->RXF0S & FDCAN_RXF0S_F0FL_Msk) > 0);
+}
+
+bool
+rxFifo1HasMessage()
+{
+	return (({{ reg }}->RXF1S & FDCAN_RXF1S_F1FL_Msk) > 0);
+}
 
 void
-modm::platform::Fdcan{{ id }}::initializeWithPrescaler(
-		uint16_t prescaler, uint8_t bs1, uint8_t bs2, uint8_t sjw,
-		uint16_t dataPrescaler, uint8_t dataBs1, uint8_t dataBs2, uint8_t dataSjw,
-		Preprescaler preprescaler,
-		uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun)
+acknowledgeRxFifoRead(uint8_t fifoIndex, uint8_t getIndex)
 {
-	if(!Rcc::isEnabled<Peripheral::Fdcan1>()) {
-		Rcc::enable<Peripheral::Fdcan1>();
-	}
-
-	// Enter init mode, stops all FDCAN activities
-	{{ reg }}->CCCR = FDCAN_CCCR_INIT;
-	int deadlockPreventer = 10'000; // max ~10ms
-	while ((({{ reg }}->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
-		modm::delayMicroseconds(1);
-		// Wait until the initialization mode is entered.
-	}
-	modm_assert(deadlockPreventer > 0, "can", "init", "timeout", {{ id }});
-	{{ reg }}->CCCR |= FDCAN_CCCR_CCE;
-
-	// Configure pre-prescaler (common for all three FDCAN instances)
-	// Fixme: TODO!!!!!
-	FDCAN_CONFIG->CKDIV = static_cast<uint8_t>(preprescaler);
-
-	// Configure nominal and data bitrates
-	{{ reg }}->NBTP =
-			((sjw - 1) << FDCAN_NBTP_NSJW_Pos) |
-			((bs2 - 1) << FDCAN_NBTP_NTSEG2_Pos) |
-			((bs1 - 1) << FDCAN_NBTP_NTSEG1_Pos) |
-			((prescaler - 1) << FDCAN_NBTP_NBRP_Pos);
-	{{ reg }}->DBTP =
-			((dataSjw - 1) << FDCAN_DBTP_DSJW_Pos) |
-			((dataBs2 - 1) << FDCAN_DBTP_DTSEG2_Pos) |
-			((dataBs1 - 1) << FDCAN_DBTP_DTSEG1_Pos) |
-			((dataPrescaler - 1) << FDCAN_DBTP_DBRP_Pos) |
-			FDCAN_DBTP_TDC; // enable "Transceiver Delay Compensation"
-
-
-	// Timestamp: FDCAN internal counter with prescaler=1
-	// In CAN FD mode the internal timestamp counter TCP does not provide a constant time
-	//  base due to the different CAN bit times between arbitration phase and data phase.
-	{{ reg }}->TSCC = (1 << FDCAN_TSCC_TSS_Pos);
-
-	// Set vector priority
-	NVIC_SetPriority({{ reg }}_IT0_IRQn, interruptPriority);
-	NVIC_SetPriority({{ reg }}_IT1_IRQn, interruptPriority);
-
-	// Register Interrupts at the NVIC
-	NVIC_EnableIRQ({{ reg }}_IT0_IRQn);
-	NVIC_EnableIRQ({{ reg }}_IT1_IRQn);
-
-	{{ reg }}->ILE = FDCAN_ILE_EINT1 | FDCAN_ILE_EINT0;
-	// TODO: assign interrupts to interrupt lines
-
-	{{ reg }}->RXGFC = overwriteOnOverrun ? 0 : (FDCAN_RXGFC_F1OM | FDCAN_RXGFC_F0OM); // TODO: or inverted?
-
-	// Reject frames not matching any filter
-	{{ reg }}->RXGFC |= FDCAN_RXGFC_ANFE | FDCAN_RXGFC_ANFS;
-
-	// Tx buffer: queue mode
-	{{ reg }}->TXBC = FDCAN_TXBC_TFQM;
-
-	_setMode(startupMode);
-
-	// Switch to normal operation
-	{{ reg }}->CCCR &= ~FDCAN_CCCR_INIT;
-}
-
-
-// Configure the mailbox to send a CAN message.
-// Low level function called by sendMessage and by Tx Interrupt.
-static bool
-sendMsg(const modm::can::Message& message)
-{
-	using namespace modm::platform;
-	if(!Fdcan{{ id }}::isReadyToSend()) {
-		return false;
-	}
-
-	// Retrieve the Tx queue put index
-	uint8_t putIndex = ({{ reg }}->TXFQS & FDCAN_TXFQS_TFQPI_Msk) >> FDCAN_TXFQS_TFQPI_Pos;
-
-	uint32_t* msgRam = (uint32_t*)(Fdcan{{ id }}::TxFifo + (putIndex * Fdcan{{ id }}::TxFifoElementSize));
-	*msgRam++ = ((message.isExtended() ? 1 : 0) << 30)
-		| ((message.isRemoteTransmitRequest() ? 1 : 0) << 30)
-		| (message.isExtended() ? message.getIdentifier() : (message.getIdentifier() << 18));
-	*msgRam++ = /* ((message.isLFM() ? 1 : 0) << 21) */ 0
-		/*| ((message.isFFM() ? 1 : 0) << 20)*/
-		| (message.getDLC() << 16);
-
-	// copy data (max. 64 bytes)
-	std::memcpy(msgRam, message.data, std::min(message.getLength(), uint8_t(64)));
-
-	// Activate the corresponding transmission request
-	{{ reg }}->TXBAR = ((uint32_t)1 << putIndex);
-
-	return true;
-}
-
-
-// Low level function to receive a message from mailbox.
-// Called by Rx Interrupt or by getMessage.
-static void
-readMsg(modm::can::Message& message, uint8_t* filter_id, uint16_t *timestamp)
-{
-	using namespace modm::platform;
-	uint8_t getIndex;
-	uint32_t* msgRam;
-	if(true /* fifo 0 or 1? */) {
-		getIndex = ({{ reg }}->RXF0S & FDCAN_RXF0S_F0GI_Msk) >> FDCAN_RXF0S_F0GI_Pos;
-		msgRam = (uint32_t*)(Fdcan{{ id }}::RxFifo0 + (getIndex * Fdcan{{ id }}::RxFifoElementSize));
-	}
-	else {
-		getIndex = ({{ reg }}->RXF1S & FDCAN_RXF1S_F1GI_Msk) >> FDCAN_RXF1S_F1GI_Pos;
-		msgRam = (uint32_t*)(Fdcan{{ id }}::RxFifo1 + (getIndex * Fdcan{{ id }}::RxFifoElementSize));
-	}
-
-	message.setExtended(*msgRam & (1 << 30));
-	message.setRemoteTransmitRequest(*msgRam & (1 << 29));
-	message.setIdentifier((*msgRam & ((1 << 29) - 1)) >> message.isExtended() ? 0 : 18);
-
-	msgRam++;
-
-	//message.setFilterId((*msgRam >> 24) & (1 << 7));
-	if(filter_id != nullptr) {
-		*filter_id = (*msgRam >> 24) & (1 << 7);
-	}
-	//message.setLFM(*msgRam & (1 << 21));
-	//message.setFFM(*msgRam & (1 << 20));
-	message.setDLC((*msgRam >> 16) & (1 << 20));
-	//message.setTimestamp(*msgRam & ((1 << 16) -1 ));
-	if(timestamp != nullptr) {
-		*timestamp = *msgRam & ((1 << 16) -1 );
-	}
-
-	msgRam++;
-
-	// copy data (max. 8 (64) bytes)
-	std::memcpy(message.data, msgRam, std::min(message.getLength(), uint8_t(8) /* 64 */));
-
-	if(true /* fifo 0 or 1? */) {
+	if (fifoIndex == 0) {
 		{{ reg }}->RXF0A = getIndex;
 	}
 	else {
@@ -183,123 +69,218 @@ readMsg(modm::can::Message& message, uint8_t* filter_id, uint16_t *timestamp)
 	}
 }
 
+uint8_t
+retrieveRxFifoGetIndex(uint8_t fifoIndex)
+{
+	if (fifoIndex == 0) {
+		return (({{ reg }}->RXF0S & FDCAN_RXF0S_F0GI_Msk) >> FDCAN_RXF0S_F0GI_Pos);
+	} else {
+		return (({{ reg }}->RXF1S & FDCAN_RXF1S_F1GI_Msk) >> FDCAN_RXF1S_F1GI_Pos);
+	}
+}
 
-/* Transmit Interrupt
- *
- * Generated when Transmit Mailbox 0..2 becomes empty.
- */
+uint8_t
+retrieveTxFifoPutIndex()
+{
+	return (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQPI_Msk) >> FDCAN_TXFQS_TFQPI_Pos);
+}
 
-/*
-MODM_ISR({{ reg }}_TX)
+// Internal function to receive a message from an RX Fifo.
+// Called by RX interrupt or by getMessage()
+void
+readMsg(modm::can::Message& message, uint8_t fifoIndex, uint8_t* filter_id, uint16_t *timestamp)
+{
+	using namespace modm::platform;
+	using CommonHeader = MessageRam::CommonFifoHeader;
+	using RxFifoAddress = MessageRam::RxFifoAddress;
+
+	// retrieve index of next frame in RX fifo
+	const uint8_t getIndex = retrieveRxFifoGetIndex(fifoIndex);
+	const RxFifoAddress address = {fifoIndex, getIndex};
+
+	const auto [commonHeader, rxHeader] = MessageRam::readRxHeaders(address);
+
+	message.setExtended(bool(commonHeader & CommonHeader::ExtendedId));
+	message.setRemoteTransmitRequest(bool(commonHeader & CommonHeader::RemoteFrame));
+	const auto id = MessageRam::CanId_t::get(commonHeader);
+	if(message.isExtended()) {
+		message.setIdentifier(id);
+	} else {
+		message.setIdentifier(id >> 18);
+	}
+
+	if (filter_id != nullptr) {
+		*filter_id = MessageRam::FilterIndex_t::get(rxHeader);
+	}
+
+	if (timestamp != nullptr) {
+		*timestamp = MessageRam::Timestamp_t::get(rxHeader);
+	}
+
+	const uint8_t dlcValue = MessageRam::RxDlc_t::get(rxHeader);
+	// TODO: fd large frames not supported yet
+	//if (rxHeader & MessageRam::RxHeader::FdFrame)
+		//message.setDLC(dlcValue);
+	// else
+	message.setLength(std::min<uint8_t>(8u, dlcValue));
+
+	// required for optimization in MessageRam::readData()
+	static_assert((std::size(decltype(message.data){}) % 4) == 0);
+
+	MessageRam::readData(address, {&message.data[0], message.getLength()});
+	acknowledgeRxFifoRead(fifoIndex, getIndex);
+}
+
+// Internal function to send a CAN message.
+// called by sendMessage and by TX Interrupt.
+bool
+sendMsg(const modm::can::Message& message)
+{
+	using namespace modm::platform;
+
+	if (!Fdcan{{ id }}::isReadyToSend()) {
+		return false;
+	}
+
+	// TODO: for fdcan frame format with bit rate switching set:
+	// (TxFifoHeader::FdFrame | TxFifoHeader::RateSwitching)
+	MessageRam::TxFifoHeader_t txHeader{};
+
+	// TODO: large frame support
+	const uint8_t dlc = std::min<uint8_t>(8, message.getLength());
+	MessageRam::TxDlc_t::set(txHeader, dlc);
+
+	const uint8_t putIndex = retrieveTxFifoPutIndex();
+	const auto commonHeader = MessageRam::headerFromMessage(message);
+	MessageRam::writeTxHeaders(putIndex, commonHeader, txHeader);
+
+	// required for optimization in MessageRam::readData()
+	static_assert((std::size(decltype(message.data){}) % 4) == 0);
+
+	MessageRam::writeData(putIndex, {&message.data[0], message.getLength()});
+
+	// Activate the corresponding transmission request
+	{{ reg }}->TXBAR = (1u << putIndex);
+
+	return true;
+}
+
+}
+
+void
+modm::platform::Fdcan{{ id }}::initializeWithPrescaler(
+		CanBitTimingConfiguration standardTimings,
+		std::optional<CanBitTimingConfiguration> fdDataTimings,
+		uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun)
+{
+	Rcc::enable<Peripheral::Fdcan1>();
+
+	EnterInitMode init;
+
+	// Configure nominal bitrate
+	{{ reg }}->NBTP =
+		((standardTimings.sjw - 1) << FDCAN_NBTP_NSJW_Pos) |
+		((standardTimings.bs2 - 1) << FDCAN_NBTP_NTSEG2_Pos) |
+		((standardTimings.bs1 - 1) << FDCAN_NBTP_NTSEG1_Pos) |
+		((standardTimings.prescaler - 1) << FDCAN_NBTP_NBRP_Pos);
+
+	if(fdDataTimings) {
+		// Configure FD mode fast data bitrate
+		const auto& timings = *fdDataTimings;
+		{{ reg }}->DBTP =
+			((timings.sjw - 1) << FDCAN_DBTP_DSJW_Pos) |
+			((timings.bs2 - 1) << FDCAN_DBTP_DTSEG2_Pos) |
+			((timings.bs1 - 1) << FDCAN_DBTP_DTSEG1_Pos) |
+			((timings.prescaler - 1) << FDCAN_DBTP_DBRP_Pos)/* |
+			FDCAN_DBTP_TDC*/; // enable "Transceiver Delay Compensation"
+	}
+
+	// Timestamp: FDCAN internal counter with prescaler=1
+	// In CAN FD mode the internal timestamp counter TCP does not provide a constant time
+	// base due to the different CAN bit times between arbitration phase and data phase.
+	{{ reg }}->TSCC = (1 << FDCAN_TSCC_TSS_Pos);
+
+	configureInterrupts(interruptPriority);
+
+	{{ reg }}->RXGFC = overwriteOnOverrun ? (FDCAN_RXGFC_F1OM | FDCAN_RXGFC_F0OM) : 0;
+
+	// enable all filters, reject non-matching frames
+	{{ reg }}->RXGFC |= FDCAN_RXGFC_LSE | FDCAN_RXGFC_LSS | FDCAN_RXGFC_ANFE | FDCAN_RXGFC_ANFS;
+
+	// Tx buffer: queue mode
+	{{ reg }}->TXBC = FDCAN_TXBC_TFQM;
+
+	// Enable bit rate switching and CANFD frame format
+	if(fdDataTimings) {
+		{{ reg }}->CCCR |= FDCAN_CCCR_BRSE | FDCAN_CCCR_FDOE;
+	} else {
+		{{ reg }}->CCCR &= ~(FDCAN_CCCR_BRSE | FDCAN_CCCR_FDOE);
+	}
+
+	configureMode(startupMode);
+}
+
+// line 0 used as TX and error interrupt
+// generated on finished frame transmission and error state
+MODM_ISR({{ reg }}_IT0)
 {
 %% if options["buffer.tx"] > 0
-	uint32_t mailbox;
-	uint32_t tsr = {{ reg }}->TSR;
-
-	if (tsr & CAN_TSR_RQCP2) {
-		mailbox = 2;
-		{{ reg }}->TSR = CAN_TSR_RQCP2;
-	}
-	else if (tsr & CAN_TSR_RQCP1) {
-		mailbox = 1;
-		{{ reg }}->TSR = CAN_TSR_RQCP1;
-	}
-	else {
-		mailbox = 0;
-		{{ reg }}->TSR = CAN_TSR_RQCP0;
-	}
-
-	if (txQueue.isNotEmpty())
-	{
-		sendMailbox(txQueue.get(), mailbox);
+	if (txQueue.isNotEmpty()) {
+		sendMsg(txQueue.get());
 		txQueue.pop();
 	}
 %% endif
-}
-*/
 
-
-/* FIFO0 Interrupt
- *
- * Generated on a new received message, FIFO0 full condition and Overrun
- * Condition.
- */
-/*
-MODM_ISR({{ reg }}_RX0)
-{
-	if ({{ reg }}->RF0R & CAN_RF0R_FOVR0) {
-		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO0_OVERFLOW);
-
-		// release overrun flag & access the next message
-		{{ reg }}->RF0R = CAN_RF0R_FOVR0 | CAN_RF0R_RFOM0;
+	const auto callback = modm::platform::Fdcan{{ id }}::getErrorInterruptCallback();
+	if (callback) {
+		const bool hasErrorInterrupt = ({{ reg }}->IR & (FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP));
+		if (hasErrorInterrupt) {
+			callback();
+		}
 	}
+	{{ reg }}->IR = FDCAN_IR_TC | FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP;
+}
 
+
+// line 1 used as RX interrupt
+// generated on received frame
+MODM_ISR({{ reg }}_IT1)
+{
 %% if options["buffer.rx"] > 0
 	RxMessage rxMessage;
-	readMailbox(rxMessage.message, 0, &(rxMessage.filter_id));
 
-	// Release FIFO (access the next message)
-	{{ reg }}->RF0R = CAN_RF0R_RFOM0;
+	if (rxFifo0HasMessage()) {
+		readMsg(rxMessage.message, 0, &rxMessage.filter_id, &rxMessage.timestamp);
+		// acknowledge interrupt flag
+		{{ reg }}->IR = FDCAN_IR_RF0N;
 
-	if (!rxQueue.push(rxMessage)) {
-		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO0_OVERFLOW);
+		modm_assert_continue_ignore(rxQueue.push(rxMessage), "fdcan.rx.buffer",
+			"CAN receive software buffer overflowed!", {{ id }});
+	}
+
+	if (rxFifo1HasMessage()) {
+		readMsg(rxMessage.message, 1, &rxMessage.filter_id, &rxMessage.timestamp);
+		// acknowledge interrupt flag
+		{{ reg }}->IR = FDCAN_IR_RF1N;
+
+		modm_assert_continue_ignore(rxQueue.push(rxMessage), "fdcan.rx.buffer",
+			"CAN receive software buffer overflowed!", {{ id }});
 	}
 %% endif
 }
-*/
-
-
-/* FIFO1 Interrupt
- *
- * See FIFO0 Interrupt
- */
-/*
-MODM_ISR({{ reg }}_RX1)
-{
-	if ({{ reg }}->RF1R & CAN_RF1R_FOVR1) {
-		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO1_OVERFLOW);
-
-		// release overrun flag & access the next message
-		{{ reg }}->RF1R = CAN_RF1R_FOVR1 | CAN_RF1R_RFOM1;
-	}
-
-%% if options["buffer.rx"] > 0
-	RxMessage rxMessage;
-	readMailbox(rxMessage.message, 1, &(rxMessage.filter_id));
-
-	// Release FIFO (access the next message)
-	{{ reg }}->RF1R = CAN_RF1R_RFOM1;
-
-	if (!rxQueue.push(rxMessage)) {
-		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO1_OVERFLOW);
-	}
-%% endif
-}
-*/
 
 
 void
 modm::platform::Fdcan{{ id }}::setMode(Mode mode)
 {
-
-	// Enter init mode, stops all FDCAN activities
-	{{ reg }}->CCCR = FDCAN_CCCR_INIT;
-	int deadlockPreventer = 10'000; // max ~10ms
-	while ((({{ reg }}->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
-		modm::delayMicroseconds(1);
-		// Wait until the initialization mode is entered.
-	}
-	modm_assert(deadlockPreventer > 0, "can", "setmode", "timeout", {{ id }});
-	{{ reg }}->CCCR |= FDCAN_CCCR_CCE | FDCAN_CCCR_TEST;
-
-	_setMode(mode);
-
-	// Switch back to normal operation
-	{{ reg }}->CCCR &= ~FDCAN_CCCR_INIT;
+	EnterInitMode init;
+	{{ reg }}->CCCR |= FDCAN_CCCR_CCE;
+	configureMode(mode);
 }
 
+
 void
-modm::platform::Fdcan{{ id }}::_setMode(Mode mode)
+modm::platform::Fdcan{{ id }}::configureMode(Mode mode)
 {
 	// Reset all mode register bits
 	{{ reg }}->TEST = 0;
@@ -331,6 +312,34 @@ modm::platform::Fdcan{{ id }}::_setMode(Mode mode)
 
 
 void
+modm::platform::Fdcan{{ id }}::configureInterrupts(uint32_t interruptPriority)
+{
+	NVIC_SetPriority({{ reg }}_IT0_IRQn, interruptPriority);
+	NVIC_SetPriority({{ reg }}_IT1_IRQn, interruptPriority);
+
+	NVIC_EnableIRQ({{ reg }}_IT0_IRQn);
+	NVIC_EnableIRQ({{ reg }}_IT1_IRQn);
+
+	// enable both interrupts lines (0 and 1)
+	{{ reg }}->ILE = FDCAN_ILE_EINT1 | FDCAN_ILE_EINT0;
+	// assign receive interrupts to line 1
+	{{ reg }}->ILS = (FDCAN_ILS_RXFIFO0 | FDCAN_ILS_RXFIFO1);
+
+	{{ reg }}->IE = 0;
+%% if options["buffer.tx"] > 0
+	// enable transmission complete and fifo empty interrupt
+	{{ reg }}->IE |= FDCAN_IE_TCE;
+	// enable TX interrupts for all 3 buffers
+	{{ reg }}->TXBTIE |= FDCAN_TXBTIE_TIE;
+%% endif
+%% if options["buffer.rx"] > 0
+	// enable message receive interrupts for both RX FIFOs
+	{{ reg }}->IE |= (FDCAN_IE_RF0NE | FDCAN_IE_RF1NE);
+%% endif
+}
+
+
+void
 modm::platform::Fdcan{{ id }}::setAutomaticRetransmission(bool retransmission)
 {
 	if (retransmission) {
@@ -349,8 +358,7 @@ modm::platform::Fdcan{{ id }}::isMessageAvailable()
 %% if options["buffer.rx"] > 0
 	return rxQueue.isNotEmpty();
 %% else
-	// Check if there are any messages pending in the receive registers
-	return (({{ reg }}->RXF0S & FDCAN_RXF0S_F0FL_Msk) > 0 || ({{ reg }}->RXF1S & FDCAN_RXF1S_F1FL_Msk) > 0);
+	return rxFifo0HasMessage() || rxFifo1HasMessage();
 %% endif
 }
 
@@ -359,38 +367,29 @@ bool
 modm::platform::Fdcan{{ id }}::getMessage(can::Message& message, uint8_t *filter_id, uint16_t *timestamp)
 {
 %% if options["buffer.rx"] > 0
-	if (rxQueue.isEmpty())
-	{
+	if (rxQueue.isEmpty()) {
 		// no message in the receive buffer
 		return false;
-	}
-	else {
+	} else {
 		auto& rxMessage = rxQueue.get();
-		std::memcpy(&message, &rxMessage.message, sizeof(message));
-		if(filter_id != nullptr) {
+		message = rxMessage.message;
+		if (filter_id != nullptr) {
 			(*filter_id) = rxMessage.filter_id;
 		}
-		if(timestamp != nullptr) {
+		if (timestamp != nullptr) {
 			(*timestamp) = rxMessage.timestamp;
 		}
 		rxQueue.pop();
 		return true;
 	}
 %% else
-	if (({{ reg }}->RXF0S & FDCAN_RXF0S_F0FL_Msk) > 0)
-	{
-		readMsg(message, filter_id, timestamp);
-
-		// Release FIFO (access the next message)
-		{{ reg }}->RF0R = CAN_RF0R_RFOM0;
+	if (rxFifo0HasMessage()) {
+		readMsg(message, 0, filter_id, timestamp);
+		releaseRxFifo0Message();
 		return true;
-	}
-	else if (({{ reg }}->RXF1S & FDCAN_RXF1S_F1FL_Msk) > 0)
-	{
-		readMsg(message, filter_id, timestamp);
-
-		// Release FIFO (access the next message)
-		{{ reg }}->RF1R = CAN_RF1R_RFOM1;
+	} else if (rxFifo1HasMessage()) {
+		readMsg(message, 1, filter_id, timestamp);
+		releaseRxFifo1Message();
 		return true;
 	}
 	return false;
@@ -402,9 +401,9 @@ bool
 modm::platform::Fdcan{{ id }}::isReadyToSend()
 {
 %% if options["buffer.tx"] > 0
-	return txQueue.size() < {{ options["buffer.tx"] }};
+	return txQueue.isNotFull();
 %% else
-	return (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQF) != 0);
+	return isHardwareTxQueueFull();
 %% endif
 }
 
@@ -412,14 +411,9 @@ modm::platform::Fdcan{{ id }}::isReadyToSend()
 bool
 modm::platform::Fdcan{{ id }}::sendMessage(const can::Message& message)
 {
-	// This function is not reentrant. If one of the buffers is not full it
-	// means that the software buffer is empty too. Therefore the buffer
-	// will stay empty and won't be taken by an interrupt.
-	if (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQF) == 0)
-	{
-		// Buffer completely filled at the moment
+	if (isHardwareTxQueueFull()) {
 %% if options["buffer.tx"] > 0
-		if (txQueue.size() < {{ options["buffer.tx"] }}) {
+		if (txQueue.isFull()) {
 			return false;
 		}
 		txQueue.push(message);
@@ -427,8 +421,7 @@ modm::platform::Fdcan{{ id }}::sendMessage(const can::Message& message)
 %% else
 		return false;
 %% endif
-	}
-	else {
+	} else {
 		sendMsg(message);
 		return true;
 	}
@@ -444,7 +437,7 @@ modm::platform::Fdcan{{ id }}::getBusState()
 	else if ({{ reg }}->PSR & FDCAN_PSR_EP) {
 		return BusState::ErrorPassive;
 	}
-	else if ({{ reg }}->PSR & FDCAN_PSR_EP) {
+	else if ({{ reg }}->PSR & FDCAN_PSR_EW) {
 		return BusState::ErrorWarning;
 	}
 	else {
@@ -453,8 +446,144 @@ modm::platform::Fdcan{{ id }}::getBusState()
 }
 
 
-void
-modm::platform::Fdcan{{ id }}::enableStatusChangeInterrupt(uint32_t interruptEnable, uint32_t interruptPriority)
+bool
+modm::platform::Fdcan{{ id }}::setStandardFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier id,
+	modm::can::StandardMask mask)
 {
-	// TODO
+	if (standardIndex >= StandardFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Classic,
+		config, uint16_t(id), uint16_t(mask));
+
+	return true;
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::setStandardFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier id0,
+	modm::can::StandardIdentifier id1)
+{
+	if (standardIndex >= StandardFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Dual,
+		config, uint16_t(id0), uint16_t(id1));
+
+	return true;
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::setStandardRangeFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier first,
+	modm::can::StandardIdentifier last)
+{
+	if (standardIndex >= StandardFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Range,
+		config, uint16_t(first), uint16_t(last));
+
+	return true;
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::setExtendedFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier id,
+	modm::can::ExtendedMask mask)
+{
+	if (extendedIndex >= ExtendedFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(id));
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Classic, uint32_t(mask));
+
+	return true;
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::setExtendedFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier id0,
+	modm::can::ExtendedIdentifier id1)
+{
+	if (extendedIndex >= ExtendedFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(id0));
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Dual, uint32_t(id1));
+
+	return true;
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::setExtendedRangeFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier first,
+	modm::can::ExtendedIdentifier last)
+{
+	if (extendedIndex >= ExtendedFilterCount) {
+		return false;
+	}
+
+	EnterInitMode init;
+
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(first));
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Range, uint32_t(last));
+
+	return true;
+}
+
+
+void
+modm::platform::Fdcan{{ id }}::clearStandardFilters()
+{
+	EnterInitMode init;
+	for (unsigned i = 0; i < StandardFilterCount; ++i) {
+		MessageRam::setStandardFilterDisabled(i);
+	}
+}
+
+
+void
+modm::platform::Fdcan{{ id }}::clearExtendedFilters()
+{
+	EnterInitMode init;
+	for (unsigned i = 0; i < ExtendedFilterCount; ++i) {
+		MessageRam::setExtendedFilterDisabled(i);
+	}
 }

--- a/src/modm/platform/can/stm32-fdcan/can.cpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.cpp.in
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <queue>
+#include <array>
+#include <algorithm>
+
+#include <modm/architecture/driver/atomic/queue.hpp>
+#include <modm/platform/clock/rcc.hpp>
+#include <modm/architecture/interface/delay.hpp>
+#include <modm/architecture/interface/assert.hpp>
+
+#include "can_{{ id }}.hpp"
+
+
+%% if options["buffer.tx"] > 0
+static std::priority_queue<modm::can::Message> txQueue;
+%% endif
+
+struct RxMessage {
+    modm::can::Message message;
+    uint8_t filter_id;
+    uint16_t timestamp;
+};
+%% if options["buffer.rx"] > 0
+static modm::atomic::Queue<RxMessage, {{ options["buffer.rx"] }}> rxQueue;
+%% endif
+
+
+void
+modm::platform::Fdcan{{ id }}::initializeWithPrescaler(
+		uint16_t prescaler, uint8_t bs1, uint8_t bs2, uint8_t sjw,
+		uint16_t dataPrescaler, uint8_t dataBs1, uint8_t dataBs2, uint8_t dataSjw,
+		Preprescaler preprescaler,
+		uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun)
+{
+	if(!Rcc::isEnabled<Peripheral::Fdcan1>()) {
+		Rcc::enable<Peripheral::Fdcan1>();
+	}
+
+	// Enter init mode, stops all FDCAN activities
+	{{ reg }}->CCCR = FDCAN_CCCR_INIT;
+	int deadlockPreventer = 10'000; // max ~10ms
+	while ((({{ reg }}->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
+		modm::delayMicroseconds(1);
+		// Wait until the initialization mode is entered.
+	}
+	modm_assert(deadlockPreventer > 0, "can", "init", "timeout", {{ id }});
+	{{ reg }}->CCCR |= FDCAN_CCCR_CCE;
+
+	// Configure pre-prescaler (common for all three FDCAN instances)
+	// Fixme: TODO!!!!!
+	FDCAN_CONFIG->CKDIV = static_cast<uint8_t>(preprescaler);
+
+	// Configure nominal and data bitrates
+	{{ reg }}->NBTP =
+			((sjw - 1) << FDCAN_NBTP_NSJW_Pos) |
+			((bs2 - 1) << FDCAN_NBTP_NTSEG2_Pos) |
+			((bs1 - 1) << FDCAN_NBTP_NTSEG1_Pos) |
+			((prescaler - 1) << FDCAN_NBTP_NBRP_Pos);
+	{{ reg }}->DBTP =
+			((dataSjw - 1) << FDCAN_DBTP_DSJW_Pos) |
+			((dataBs2 - 1) << FDCAN_DBTP_DTSEG2_Pos) |
+			((dataBs1 - 1) << FDCAN_DBTP_DTSEG1_Pos) |
+			((dataPrescaler - 1) << FDCAN_DBTP_DBRP_Pos) |
+			FDCAN_DBTP_TDC; // enable "Transceiver Delay Compensation"
+
+
+	// Timestamp: FDCAN internal counter with prescaler=1
+	// In CAN FD mode the internal timestamp counter TCP does not provide a constant time
+	//  base due to the different CAN bit times between arbitration phase and data phase.
+	{{ reg }}->TSCC = (1 << FDCAN_TSCC_TSS_Pos);
+
+	// Set vector priority
+	NVIC_SetPriority({{ reg }}_IT0_IRQn, interruptPriority);
+	NVIC_SetPriority({{ reg }}_IT1_IRQn, interruptPriority);
+
+	// Register Interrupts at the NVIC
+	NVIC_EnableIRQ({{ reg }}_IT0_IRQn);
+	NVIC_EnableIRQ({{ reg }}_IT1_IRQn);
+
+	{{ reg }}->ILE = FDCAN_ILE_EINT1 | FDCAN_ILE_EINT0;
+	// TODO: assign interrupts to interrupt lines
+
+	{{ reg }}->RXGFC = overwriteOnOverrun ? 0 : (FDCAN_RXGFC_F1OM | FDCAN_RXGFC_F0OM); // TODO: or inverted?
+
+	// Reject frames not matching any filter
+	{{ reg }}->RXGFC |= FDCAN_RXGFC_ANFE | FDCAN_RXGFC_ANFS;
+
+	// Tx buffer: queue mode
+	{{ reg }}->TXBC = FDCAN_TXBC_TFQM;
+
+	_setMode(startupMode);
+
+	// Switch to normal operation
+	{{ reg }}->CCCR &= ~FDCAN_CCCR_INIT;
+}
+
+
+// Configure the mailbox to send a CAN message.
+// Low level function called by sendMessage and by Tx Interrupt.
+static bool
+sendMsg(const modm::can::Message& message)
+{
+	using namespace modm::platform;
+	if(!Fdcan{{ id }}::isReadyToSend()) {
+		return false;
+	}
+
+	// Retrieve the Tx queue put index
+	uint8_t putIndex = ({{ reg }}->TXFQS & FDCAN_TXFQS_TFQPI_Msk) >> FDCAN_TXFQS_TFQPI_Pos;
+
+	uint32_t* msgRam = (uint32_t*)(Fdcan{{ id }}::TxFifo + (putIndex * Fdcan{{ id }}::TxFifoElementSize));
+	*msgRam++ = ((message.isExtended() ? 1 : 0) << 30)
+		| ((message.isRemoteTransmitRequest() ? 1 : 0) << 30)
+		| (message.isExtended() ? message.getIdentifier() : (message.getIdentifier() << 18));
+	*msgRam++ = /* ((message.isLFM() ? 1 : 0) << 21) */ 0
+		/*| ((message.isFFM() ? 1 : 0) << 20)*/
+		| (message.getDLC() << 16);
+
+	// copy data (max. 64 bytes)
+	std::memcpy(msgRam, message.data, std::min(message.getLength(), uint8_t(64)));
+
+	// Activate the corresponding transmission request
+	{{ reg }}->TXBAR = ((uint32_t)1 << putIndex);
+
+	return true;
+}
+
+
+// Low level function to receive a message from mailbox.
+// Called by Rx Interrupt or by getMessage.
+static void
+readMsg(modm::can::Message& message, uint8_t* filter_id, uint16_t *timestamp)
+{
+	using namespace modm::platform;
+	uint8_t getIndex;
+	uint32_t* msgRam;
+	if(true /* fifo 0 or 1? */) {
+		getIndex = ({{ reg }}->RXF0S & FDCAN_RXF0S_F0GI_Msk) >> FDCAN_RXF0S_F0GI_Pos;
+		msgRam = (uint32_t*)(Fdcan{{ id }}::RxFifo0 + (getIndex * Fdcan{{ id }}::RxFifoElementSize));
+	}
+	else {
+		getIndex = ({{ reg }}->RXF1S & FDCAN_RXF1S_F1GI_Msk) >> FDCAN_RXF1S_F1GI_Pos;
+		msgRam = (uint32_t*)(Fdcan{{ id }}::RxFifo1 + (getIndex * Fdcan{{ id }}::RxFifoElementSize));
+	}
+
+	message.setExtended(*msgRam & (1 << 30));
+	message.setRemoteTransmitRequest(*msgRam & (1 << 29));
+	message.setIdentifier((*msgRam & ((1 << 29) - 1)) >> message.isExtended() ? 0 : 18);
+
+	msgRam++;
+
+	//message.setFilterId((*msgRam >> 24) & (1 << 7));
+	if(filter_id != nullptr) {
+		*filter_id = (*msgRam >> 24) & (1 << 7);
+	}
+	//message.setLFM(*msgRam & (1 << 21));
+	//message.setFFM(*msgRam & (1 << 20));
+	message.setDLC((*msgRam >> 16) & (1 << 20));
+	//message.setTimestamp(*msgRam & ((1 << 16) -1 ));
+	if(timestamp != nullptr) {
+		*timestamp = *msgRam & ((1 << 16) -1 );
+	}
+
+	msgRam++;
+
+	// copy data (max. 8 (64) bytes)
+	std::memcpy(message.data, msgRam, std::min(message.getLength(), uint8_t(8) /* 64 */));
+
+	if(true /* fifo 0 or 1? */) {
+		{{ reg }}->RXF0A = getIndex;
+	}
+	else {
+		{{ reg }}->RXF1A = getIndex;
+	}
+}
+
+
+/* Transmit Interrupt
+ *
+ * Generated when Transmit Mailbox 0..2 becomes empty.
+ */
+
+/*
+MODM_ISR({{ reg }}_TX)
+{
+%% if options["buffer.tx"] > 0
+	uint32_t mailbox;
+	uint32_t tsr = {{ reg }}->TSR;
+
+	if (tsr & CAN_TSR_RQCP2) {
+		mailbox = 2;
+		{{ reg }}->TSR = CAN_TSR_RQCP2;
+	}
+	else if (tsr & CAN_TSR_RQCP1) {
+		mailbox = 1;
+		{{ reg }}->TSR = CAN_TSR_RQCP1;
+	}
+	else {
+		mailbox = 0;
+		{{ reg }}->TSR = CAN_TSR_RQCP0;
+	}
+
+	if (txQueue.isNotEmpty())
+	{
+		sendMailbox(txQueue.get(), mailbox);
+		txQueue.pop();
+	}
+%% endif
+}
+*/
+
+
+/* FIFO0 Interrupt
+ *
+ * Generated on a new received message, FIFO0 full condition and Overrun
+ * Condition.
+ */
+/*
+MODM_ISR({{ reg }}_RX0)
+{
+	if ({{ reg }}->RF0R & CAN_RF0R_FOVR0) {
+		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO0_OVERFLOW);
+
+		// release overrun flag & access the next message
+		{{ reg }}->RF0R = CAN_RF0R_FOVR0 | CAN_RF0R_RFOM0;
+	}
+
+%% if options["buffer.rx"] > 0
+	RxMessage rxMessage;
+	readMailbox(rxMessage.message, 0, &(rxMessage.filter_id));
+
+	// Release FIFO (access the next message)
+	{{ reg }}->RF0R = CAN_RF0R_RFOM0;
+
+	if (!rxQueue.push(rxMessage)) {
+		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO0_OVERFLOW);
+	}
+%% endif
+}
+*/
+
+
+/* FIFO1 Interrupt
+ *
+ * See FIFO0 Interrupt
+ */
+/*
+MODM_ISR({{ reg }}_RX1)
+{
+	if ({{ reg }}->RF1R & CAN_RF1R_FOVR1) {
+		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO1_OVERFLOW);
+
+		// release overrun flag & access the next message
+		{{ reg }}->RF1R = CAN_RF1R_FOVR1 | CAN_RF1R_RFOM1;
+	}
+
+%% if options["buffer.rx"] > 0
+	RxMessage rxMessage;
+	readMailbox(rxMessage.message, 1, &(rxMessage.filter_id));
+
+	// Release FIFO (access the next message)
+	{{ reg }}->RF1R = CAN_RF1R_RFOM1;
+
+	if (!rxQueue.push(rxMessage)) {
+		modm::ErrorReport::report(modm::platform::Fdcan{{ id }}_FIFO1_OVERFLOW);
+	}
+%% endif
+}
+*/
+
+
+void
+modm::platform::Fdcan{{ id }}::setMode(Mode mode)
+{
+
+	// Enter init mode, stops all FDCAN activities
+	{{ reg }}->CCCR = FDCAN_CCCR_INIT;
+	int deadlockPreventer = 10'000; // max ~10ms
+	while ((({{ reg }}->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
+		modm::delayMicroseconds(1);
+		// Wait until the initialization mode is entered.
+	}
+	modm_assert(deadlockPreventer > 0, "can", "setmode", "timeout", {{ id }});
+	{{ reg }}->CCCR |= FDCAN_CCCR_CCE | FDCAN_CCCR_TEST;
+
+	_setMode(mode);
+
+	// Switch back to normal operation
+	{{ reg }}->CCCR &= ~FDCAN_CCCR_INIT;
+}
+
+void
+modm::platform::Fdcan{{ id }}::_setMode(Mode mode)
+{
+	// Reset all mode register bits
+	{{ reg }}->TEST = 0;
+	{{ reg }}->CCCR &= ~(FDCAN_CCCR_ASM | FDCAN_CCCR_MON | FDCAN_CCCR_CSR | FDCAN_CCCR_TEST);
+
+	// set mode
+	switch(mode) {
+		case Mode::Normal:
+			break;
+		case Mode::Restricted:
+			{{ reg }}->CCCR |= FDCAN_CCCR_ASM;
+			break;
+		case Mode::Monitoring:
+			{{ reg }}->CCCR |= FDCAN_CCCR_MON;
+			break;
+		case Mode::Sleep:
+			{{ reg }}->CCCR |= FDCAN_CCCR_CSR;
+			break;
+		case Mode::TestExternalLoopback:
+			{{ reg }}->CCCR |= FDCAN_CCCR_TEST;
+			{{ reg }}->TEST = FDCAN_TEST_LBCK;
+			break;
+		case Mode::TestInternalLoopback:
+			{{ reg }}->CCCR |= FDCAN_CCCR_TEST | FDCAN_CCCR_MON;
+			{{ reg }}->TEST = FDCAN_TEST_LBCK;
+			break;
+	}
+}
+
+
+void
+modm::platform::Fdcan{{ id }}::setAutomaticRetransmission(bool retransmission)
+{
+	if (retransmission) {
+		// Enable retransmission
+		{{ reg }}->CCCR = ({{ reg }}->CCCR & ~FDCAN_CCCR_DAR);
+	} else {
+		// Disable retransmission
+		{{ reg }}->CCCR = ({{ reg }}->CCCR | FDCAN_CCCR_DAR);
+	}
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::isMessageAvailable()
+{
+%% if options["buffer.rx"] > 0
+	return rxQueue.isNotEmpty();
+%% else
+	// Check if there are any messages pending in the receive registers
+	return (({{ reg }}->RXF0S & FDCAN_RXF0S_F0FL_Msk) > 0 || ({{ reg }}->RXF1S & FDCAN_RXF1S_F1FL_Msk) > 0);
+%% endif
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::getMessage(can::Message& message, uint8_t *filter_id, uint16_t *timestamp)
+{
+%% if options["buffer.rx"] > 0
+	if (rxQueue.isEmpty())
+	{
+		// no message in the receive buffer
+		return false;
+	}
+	else {
+		auto& rxMessage = rxQueue.get();
+		std::memcpy(&message, &rxMessage.message, sizeof(message));
+		if(filter_id != nullptr) {
+			(*filter_id) = rxMessage.filter_id;
+		}
+		if(timestamp != nullptr) {
+			(*timestamp) = rxMessage.timestamp;
+		}
+		rxQueue.pop();
+		return true;
+	}
+%% else
+	if (({{ reg }}->RXF0S & FDCAN_RXF0S_F0FL_Msk) > 0)
+	{
+		readMsg(message, filter_id, timestamp);
+
+		// Release FIFO (access the next message)
+		{{ reg }}->RF0R = CAN_RF0R_RFOM0;
+		return true;
+	}
+	else if (({{ reg }}->RXF1S & FDCAN_RXF1S_F1FL_Msk) > 0)
+	{
+		readMsg(message, filter_id, timestamp);
+
+		// Release FIFO (access the next message)
+		{{ reg }}->RF1R = CAN_RF1R_RFOM1;
+		return true;
+	}
+	return false;
+%% endif
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::isReadyToSend()
+{
+%% if options["buffer.tx"] > 0
+	return txQueue.size() < {{ options["buffer.tx"] }};
+%% else
+	return (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQF) != 0);
+%% endif
+}
+
+
+bool
+modm::platform::Fdcan{{ id }}::sendMessage(const can::Message& message)
+{
+	// This function is not reentrant. If one of the buffers is not full it
+	// means that the software buffer is empty too. Therefore the buffer
+	// will stay empty and won't be taken by an interrupt.
+	if (({{ reg }}->TXFQS & FDCAN_TXFQS_TFQF) == 0)
+	{
+		// Buffer completely filled at the moment
+%% if options["buffer.tx"] > 0
+		if (txQueue.size() < {{ options["buffer.tx"] }}) {
+			return false;
+		}
+		txQueue.push(message);
+		return true;
+%% else
+		return false;
+%% endif
+	}
+	else {
+		sendMsg(message);
+		return true;
+	}
+}
+
+
+modm::platform::Fdcan{{ id }}::BusState
+modm::platform::Fdcan{{ id }}::getBusState()
+{
+	if ({{ reg }}->PSR & FDCAN_PSR_BO) {
+		return BusState::Off;
+	}
+	else if ({{ reg }}->PSR & FDCAN_PSR_EP) {
+		return BusState::ErrorPassive;
+	}
+	else if ({{ reg }}->PSR & FDCAN_PSR_EP) {
+		return BusState::ErrorWarning;
+	}
+	else {
+		return BusState::Connected;
+	}
+}
+
+
+void
+modm::platform::Fdcan{{ id }}::enableStatusChangeInterrupt(uint32_t interruptEnable, uint32_t interruptPriority)
+{
+	// TODO
+}

--- a/src/modm/platform/can/stm32-fdcan/can.hpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.hpp.in
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -13,11 +14,12 @@
 #define MODM_STM32_FDCAN{{ id }}_HPP
 
 #include <modm/architecture/interface/can.hpp>
+#include <modm/architecture/interface/can_filter.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include "../device.hpp"
 
 #include "can_bit_timings.hpp"
-
+#include "message_ram.hpp"
 
 namespace modm::platform
 {
@@ -39,108 +41,44 @@ namespace modm::platform
  * You can set the buffer size using the `tx_buffer` and `rx_buffer` parameters.
  *
  * @author		Raphael Lehmann <raphael@rleh.de>
+ * @author		Christopher Durand <christopher.durand@rwth-aachen.de>
  * @ingroup		modm_platform_can_{{ id }}
  */
 class Fdcan{{ id }} : public ::modm::Can
 {
 public:
-/**
- * Address and offset definitions for the CAN SRAM
- */
-// if STM32G4
-	static constexpr uint32_t FilterListStandardSize		= 28;   // Filter List Standard size
-	static constexpr uint32_t FilterListStandardElementSize	= 1*4;  // Filter Standard Element Size in bytes
-	static constexpr uint32_t FilterListExtendedSize		= 8;    // Filter List Extended size
-	static constexpr uint32_t FilterListExtendedElementSize	= 2*4;  // Filter Extended Element Size in bytes
-	static constexpr uint32_t RxFifo0Size					= 3;    // RX FIFO 0 size
-	static constexpr uint32_t RxFifo1Size					= 3;    // RX FIFO 1 size
-	static constexpr uint32_t RxFifoElementSize				= 18*4; // RX FIFO 1 size
-	static constexpr uint32_t TxEventFifoSize				= 3;    // TX Event FIFO size
-	static constexpr uint32_t TxEventFifoElementSize		= 2*4;  // TX Event FIFO element size
-	static constexpr uint32_t TxFifoSize					= 3;    // TX FIFO/Queue size
-	static constexpr uint32_t TxFifoElementSize				= 18*4; // TX FIFO/Queue element size
-// endif
-// TODO: else F7 ...
-
-	static constexpr uint32_t RamSize =
-		(FilterListStandardSize * FilterListStandardElementSize)
-		+(FilterListExtendedSize * FilterListExtendedElementSize)
-		+(RxFifo0Size * RxFifoElementSize)
-		+(RxFifo1Size * RxFifoElementSize)
-		+(TxEventFifoSize * TxEventFifoElementSize)
-		+(TxFifoSize * TxFifoElementSize);
-	static constexpr uint32_t RamBase = SRAMCAN_BASE + (RamSize * {{ id - 1 }});
-	static constexpr uint32_t FilterListStandard = RamBase + 0;
-	static constexpr uint32_t FilterListExtended = FilterListStandard + (FilterListStandardSize * FilterListStandardElementSize);
-	static constexpr uint32_t RxFifo0 = FilterListExtended + (RxFifo0Size * RxFifoElementSize);
-	static constexpr uint32_t RxFifo1 = RxFifo0 + (RxFifo1Size * RxFifoElementSize);
-	static constexpr uint32_t TxEventFifo = RxFifo1 + (TxEventFifoSize * TxEventFifoElementSize);
-	static constexpr uint32_t TxFifo = TxEventFifo + (TxFifoSize * TxFifoElementSize);
-
-public:
 	enum class
 	Mode : uint32_t
 	{
-		//Configuration,
 		Normal,
 		Restricted,
 		Monitoring,
 		Sleep,
-		// various test modes:
 		TestExternalLoopback,
 		TestInternalLoopback,
 
-		// compatibility:
-		//ListenOnly = Monitoring, // no acknowledging
-		//LoopBack = TestInternalLoopback,
-		//ListenOnlyLoopBack not supported(?)
+		// for compatibility with bxCAN:
+		ListenOnly = Monitoring, // no acknowledging
+		LoopBack = TestInternalLoopback,
 
 	};
-
-	enum class
-	Preprescaler : uint8_t
-	{
-		Preprescaler1  = 0b0000,
-		Preprescaler2  = 0b0001,
-		Preprescaler4  = 0b0010,
-		Preprescaler6  = 0b0011,
-		Preprescaler8  = 0b0100,
-		Preprescaler10 = 0b0101,
-		Preprescaler12 = 0b0110,
-		Preprescaler14 = 0b0111,
-		Preprescaler16 = 0b1000,
-		Preprescaler18 = 0b1001,
-		Preprescaler20 = 0b1010,
-		Preprescaler22 = 0b1011,
-		Preprescaler24 = 0b1100,
-		Preprescaler26 = 0b1101,
-		Preprescaler28 = 0b1110,
-		Preprescaler30 = 0b1111,
-	};
-private:
-	static constexpr uint8_t
-	getPreprescalerValue(Preprescaler preprescaler)
-	{
-		if(preprescaler == Preprescaler::Preprescaler1) {
-			return 1;
-		}
-		else {
-			return static_cast<uint8_t>(preprescaler) * 2;
-		}
-	}
 
 public:
 	// Expose jinja template parameters to be checked by e.g. drivers or application
 	static constexpr size_t RxBufferSize = {{ options["buffer.rx"] }};
 	static constexpr size_t TxBufferSize = {{ options["buffer.tx"] }};
 
+	using ErrorCallback = void (*)();
+
 private:
-	/// Private Initializer with computed prescaler and timing constants
+	using MessageRam = fdcan::MessageRam<{{ id - 1 }}>;
+
+	static inline volatile ErrorCallback errorCallback_ = nullptr;
+
 	static void
 	initializeWithPrescaler(
-			uint16_t prescaler, uint8_t bs1, uint8_t bs2, uint8_t sjw,
-			uint16_t dataPrescaler, uint8_t dataBs1, uint8_t dataBs2, uint8_t dataSjw,
-			Preprescaler preprescaler,
+			CanBitTimingConfiguration standardTimings,
+			std::optional<CanBitTimingConfiguration> fdDataTimings,
 			uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun
 			);
 
@@ -155,7 +93,6 @@ public:
 		static_assert(Connector::template IsValid<Tx> and Connector::template IsValid<Rx> and sizeof...(Signals) == 2,
 					  "Can{{ id }}::connect() requires one Tx and one Rx signal!");
 
-		// Connector::disconnect();
 		Tx::setOutput(Gpio::OutputType::PushPull);
 		Rx::setInput(inputType);
 		Connector::connect();
@@ -164,10 +101,27 @@ public:
 	/**
 	 * Enables the clock for the CAN controller and resets all settings
 	 *
-	 * \param bitrate
-	 * 			CAN bitrate (defined in driver/connectivity/can/message.hpp)
+	 * \tparam SystemClock
+	 * 			System clock struct with an FDCAN{{ id }} member containing
+	 * 			the clock speed supplied to the peripheral.
+	 * 			\warning	The CAN subsystem prescaler can be configured using
+	 * 						the RCC module and must be taken into account in
+	 * 						the provided clock speed value.
+	 * \tparam bitrate
+	 * 			Nominal CAN bitrate
+	 * \tparam tolerance
+	 * 			Maximum relative deviation between requested and resulting
+	 * 			CAN bitrates. If the tolerance is exceeded a compile-time
+	 * 			assertion will be triggered.
+	 * \tparam fastDataBitrate
+	 * 			CAN bitrate for data in FD frames with bit rate switching
+	 * 			Set to 0 to disable CANFD support.
+	 *
 	 * \param interruptPriority
 	 * 			Interrupt vector priority (0=highest to 15=lowest)
+	 * \param startupMode
+	 * 			Mode of operation set after initialization
+	 * 			\see Fdcan{{ id }}::Mode
 	 * \param overwriteOnOverrun
 	 * 			Once a receive FIFO is full the next incoming message
 	 * 			will overwrite the previous one if \c true otherwise
@@ -180,44 +134,42 @@ public:
 		class SystemClock,
 		bitrate_t bitrate=kbps(125),
 		percent_t tolerance=pct(1),
-		bitrate_t dataBitrate=bitrate,
-		Preprescaler preprescaler=Preprescaler::Preprescaler16
+		bitrate_t fastDataBitrate=0 // 0: FDCAN mode disabled
 	>
 	static inline void
 	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
 				bool overwriteOnOverrun = true)
 	{
 		using Timings = CanBitTiming<
-			SystemClock::Fdcan{{ id }} / getPreprescalerValue(preprescaler),
+			SystemClock::Fdcan{{ id }},
 			bitrate,
 			9, 8, 7, 7
 		>;
 		Timings::template assertBitrateInTolerance<tolerance>();
 
-		using DataTimings = CanBitTiming<
-			SystemClock::Fdcan{{ id }} / getPreprescalerValue(preprescaler),
-			bitrate,
-			5, 5, 4, 4
-		>;
-		DataTimings::template assertBitrateInTolerance<tolerance>();
+		std::optional<CanBitTimingConfiguration> fastDataTimings = std::nullopt;
+
+		if constexpr (fastDataBitrate != 0) {
+			using DataTimings = CanBitTiming<
+				SystemClock::Fdcan{{ id }},
+				fastDataBitrate,
+				5, 5, 4, 4
+			>;
+			DataTimings::template assertBitrateInTolerance<tolerance>();
+
+			fastDataTimings = DataTimings::getBitTimings();
+		}
 
 		return initializeWithPrescaler(
-			Timings::getPrescaler(),
-			Timings::getBS1(),
-			Timings::getBS2(),
-			Timings::getSJW(),
-			DataTimings::getPrescaler(),
-			DataTimings::getBS1(),
-			DataTimings::getBS2(),
-			DataTimings::getSJW(),
-			preprescaler,
+			Timings::getBitTimings(),
+			fastDataTimings,
 			interruptPriority,
 			startupMode,
 			overwriteOnOverrun);
 	}
 
 	/**
-	 * The the operating mode.
+	 * Set the operating mode.
 	 *
 	 * Default after initialization is the normal mode.
 	 */
@@ -227,12 +179,8 @@ public:
 	static void
 	setAutomaticRetransmission(bool retransmission);
 
-private:
-	static void
-	_setMode(Mode mode);
-
 public:
-	// Can Interface Methods
+	// Can interface methods
 	static bool
 	isMessageAvailable();
 
@@ -246,6 +194,74 @@ public:
 	sendMessage(const can::Message& message);
 
 public:
+	// Can filter configuration
+
+	using FilterConfig = MessageRam::FilterConfig;
+
+	static constexpr inline uint8_t StandardFilterCount{28};
+	static constexpr inline uint8_t ExtendedFilterCount{8};
+
+	/// Set standard filter with id and mask
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier id,
+		modm::can::StandardMask mask);
+
+	/// Set standard filter with dual ids
+	/// Matches on any of both specified ids
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier id0,
+		modm::can::StandardIdentifier id1);
+
+	/// Set standard range filter
+	/// Matches the inclusive range between both specified ids
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardRangeFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier first,
+		modm::can::StandardIdentifier last);
+
+	/// Set extended filter with id and mask
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier id,
+		modm::can::ExtendedMask mask);
+
+	/// Set standard filter with dual ids
+	/// Matches on any of both specified ids
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier id0,
+		modm::can::ExtendedIdentifier id1);
+
+	/// Set standard range filter
+	/// Matches the inclusive range between both specified ids
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedRangeFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier first,
+		modm::can::ExtendedIdentifier last);
+
+	/// Disable all standard filters, receive no standard frames
+	static void
+	clearStandardFilters();
+
+	/// Disable all extended filters, receive no extended frames
+	static void
+	clearExtendedFilters();
+
+public:
 	// Extended Functionality
 	/**
 	 * Get Receive Error Counter.
@@ -257,7 +273,7 @@ public:
 	 * was higher than 128. When the counter value exceeds 127, the
 	 * CAN controller enters the error passive state.
 	 */
-	static inline uint32_t
+	static inline uint8_t
 	getReceiveErrorCounter()
 	{
 		return (({{ reg }}->ECR >> 8) & 0xFF);
@@ -267,7 +283,7 @@ public:
 	 * Get Transmit Error Counter.
 	 *
 	 */
-	static inline uint32_t
+	static inline uint8_t
 	getTransmitErrorCounter()
 	{
 		return ({{ reg }}->ECR & 0xFF);
@@ -277,48 +293,68 @@ public:
 	getBusState();
 
 	/**
-	 * Enable the error and status change interrupt.
+	 * Set the error interrupt callback.
 	 *
-	 * Can be generated by the following events:
-	 * - Error condition, for more details on error conditions please
-	 *   refer to the CAN Error Status register (CAN_ESR).
-	 * - Wakeup condition, SOF monitored on the CAN Rx signal.
-	 * - Entry into Sleep mode
+	 * It will be called on the following events:
+	 * - The FDCAN peripheral enters ERROR_PASSIVE or BUS_OFF state
+	 * - The error counter exceeds the warning limit
 	 *
-	 * You need to create you own interrupt handler for this interrupt.
-	 * The interrupt handler has a fixed name:
-	 * \code
-	 * MODM_ISR(CAN{{ id }}_SCE)
-	 * {
-	 *     ...
-	 *
-	 *     // e.g. Acknowledge interrupt
-	 *     CAN{{ id }}->MSR = CAN_MSR_ERRI;
-	 * }
-	 * \endcode
-	 *
-	 * \param interruptEnable
-	 * 			Upper 24-bit of the CAN_IER register. E.g.:
-	 * 			 - CAN_IER_BOFIE
-	 * 			 - CAN_IER_EPVIE
-	 * 			 - ...
-	 * 			See Reference Manual >> bxCAN >> CAN_IER Register
-	 * \param interruptPriority
-	 * 			Interrupt vector priority (0=highest to 15=lowest)
+	 * To disable the interrupt set the callback to nullptr.
 	 */
 	static void
-	enableStatusChangeInterrupt(uint32_t interruptEnable,
-			uint32_t interruptPriority);
+	setErrorInterruptCallback(ErrorCallback callback)
+	{
+		errorCallback_ = callback;
+		if(callback) {
+			FDCAN{{ id }}->IE |=  (FDCAN_IE_BOE | FDCAN_IE_EPE | FDCAN_IE_EWE);
+		} else {
+			FDCAN{{ id }}->IE &= ~(FDCAN_IE_BOE | FDCAN_IE_EPE | FDCAN_IE_EWE);
+		}
+	}
 
-	/**
-	 *
-	 *
-	 */
+	static ErrorCallback
+	getErrorInterruptCallback()
+	{
+		return errorCallback_;
+	}
+
 	static uint16_t
 	getCurrentTimestamp()
 	{
 		return {{ reg }}->TSCV;
 	}
+
+private:
+	static void
+	configureMode(Mode mode);
+
+	static void
+	configureInterrupts(uint32_t interruptPriority);
+
+	struct EnterInitMode
+	{
+		EnterInitMode()
+		{
+			{{ reg }}->CCCR |= FDCAN_CCCR_INIT;
+			int deadlockPreventer = 10'000; // max ~10ms
+			while ((({{ reg }}->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
+				using namespace std::literals;
+				modm::delay(1us);
+				// Wait until the initialization mode is entered.
+			}
+			modm_assert(deadlockPreventer > 0, "can.{{ id }}.init", "timeout expired");
+			{{ reg }}->CCCR |= FDCAN_CCCR_CCE;
+		}
+
+		~EnterInitMode()
+		{
+			// Switch to normal operation, automatically clears CCE flag
+			{{ reg }}->CCCR &= ~FDCAN_CCCR_INIT;
+		}
+
+		EnterInitMode(const EnterInitMode&) = delete;
+		EnterInitMode& operator=(const EnterInitMode&) = delete;
+	};
 };
 
 }	// namespace modm::platform

--- a/src/modm/platform/can/stm32-fdcan/can.hpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.hpp.in
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_FDCAN{{ id }}_HPP
+#define MODM_STM32_FDCAN{{ id }}_HPP
+
+#include <modm/architecture/interface/can.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include "../device.hpp"
+
+#include "can_bit_timings.hpp"
+
+
+namespace modm::platform
+{
+/**
+ * @brief		FDCAN{{ id }} (CAN with Flexible Data-Rate)
+ *
+ * The controller area network (CAN) subsystem consists of one CAN module,
+ * a shared Message RAM memory and a configuration block.
+ * The modules (FDCAN) are compliant with ISO 11898-1: 2015 (CAN protocol
+ * specification version 2.0 part A, B) and CAN FD protocol specification version 1.0.
+ * A 0.8 Kbyte Message RAM per FDCAN instance implements filters, receive FIFOs,
+ * transmit event FIFOs and transmit FIFOs.
+ *
+ * ## Filter
+ * Up to 28 filters can be defined for 11-bit IDs, up to 8 filters for 29-bit IDs.
+ * The filter banks are not shared between the CAN instances.
+ *
+ * ## Configuration
+ * You can set the buffer size using the `tx_buffer` and `rx_buffer` parameters.
+ *
+ * @author		Raphael Lehmann <raphael@rleh.de>
+ * @ingroup		modm_platform_can_{{ id }}
+ */
+class Fdcan{{ id }} : public ::modm::Can
+{
+public:
+/**
+ * Address and offset definitions for the CAN SRAM
+ */
+// if STM32G4
+	static constexpr uint32_t FilterListStandardSize		= 28;   // Filter List Standard size
+	static constexpr uint32_t FilterListStandardElementSize	= 1*4;  // Filter Standard Element Size in bytes
+	static constexpr uint32_t FilterListExtendedSize		= 8;    // Filter List Extended size
+	static constexpr uint32_t FilterListExtendedElementSize	= 2*4;  // Filter Extended Element Size in bytes
+	static constexpr uint32_t RxFifo0Size					= 3;    // RX FIFO 0 size
+	static constexpr uint32_t RxFifo1Size					= 3;    // RX FIFO 1 size
+	static constexpr uint32_t RxFifoElementSize				= 18*4; // RX FIFO 1 size
+	static constexpr uint32_t TxEventFifoSize				= 3;    // TX Event FIFO size
+	static constexpr uint32_t TxEventFifoElementSize		= 2*4;  // TX Event FIFO element size
+	static constexpr uint32_t TxFifoSize					= 3;    // TX FIFO/Queue size
+	static constexpr uint32_t TxFifoElementSize				= 18*4; // TX FIFO/Queue element size
+// endif
+// TODO: else F7 ...
+
+	static constexpr uint32_t RamSize =
+		(FilterListStandardSize * FilterListStandardElementSize)
+		+(FilterListExtendedSize * FilterListExtendedElementSize)
+		+(RxFifo0Size * RxFifoElementSize)
+		+(RxFifo1Size * RxFifoElementSize)
+		+(TxEventFifoSize * TxEventFifoElementSize)
+		+(TxFifoSize * TxFifoElementSize);
+	static constexpr uint32_t RamBase = SRAMCAN_BASE + (RamSize * {{ id - 1 }});
+	static constexpr uint32_t FilterListStandard = RamBase + 0;
+	static constexpr uint32_t FilterListExtended = FilterListStandard + (FilterListStandardSize * FilterListStandardElementSize);
+	static constexpr uint32_t RxFifo0 = FilterListExtended + (RxFifo0Size * RxFifoElementSize);
+	static constexpr uint32_t RxFifo1 = RxFifo0 + (RxFifo1Size * RxFifoElementSize);
+	static constexpr uint32_t TxEventFifo = RxFifo1 + (TxEventFifoSize * TxEventFifoElementSize);
+	static constexpr uint32_t TxFifo = TxEventFifo + (TxFifoSize * TxFifoElementSize);
+
+public:
+	enum class
+	Mode : uint32_t
+	{
+		//Configuration,
+		Normal,
+		Restricted,
+		Monitoring,
+		Sleep,
+		// various test modes:
+		TestExternalLoopback,
+		TestInternalLoopback,
+
+		// compatibility:
+		//ListenOnly = Monitoring, // no acknowledging
+		//LoopBack = TestInternalLoopback,
+		//ListenOnlyLoopBack not supported(?)
+
+	};
+
+	enum class
+	Preprescaler : uint8_t
+	{
+		Preprescaler1  = 0b0000,
+		Preprescaler2  = 0b0001,
+		Preprescaler4  = 0b0010,
+		Preprescaler6  = 0b0011,
+		Preprescaler8  = 0b0100,
+		Preprescaler10 = 0b0101,
+		Preprescaler12 = 0b0110,
+		Preprescaler14 = 0b0111,
+		Preprescaler16 = 0b1000,
+		Preprescaler18 = 0b1001,
+		Preprescaler20 = 0b1010,
+		Preprescaler22 = 0b1011,
+		Preprescaler24 = 0b1100,
+		Preprescaler26 = 0b1101,
+		Preprescaler28 = 0b1110,
+		Preprescaler30 = 0b1111,
+	};
+private:
+	static constexpr uint8_t
+	getPreprescalerValue(Preprescaler preprescaler)
+	{
+		if(preprescaler == Preprescaler::Preprescaler1) {
+			return 1;
+		}
+		else {
+			return static_cast<uint8_t>(preprescaler) * 2;
+		}
+	}
+
+public:
+	// Expose jinja template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = {{ options["buffer.rx"] }};
+	static constexpr size_t TxBufferSize = {{ options["buffer.tx"] }};
+
+private:
+	/// Private Initializer with computed prescaler and timing constants
+	static void
+	initializeWithPrescaler(
+			uint16_t prescaler, uint8_t bs1, uint8_t bs2, uint8_t sjw,
+			uint16_t dataPrescaler, uint8_t dataBs1, uint8_t dataBs2, uint8_t dataSjw,
+			Preprescaler preprescaler,
+			uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun
+			);
+
+public:
+	template< template<Peripheral _> class... Signals >
+	static void
+	connect(Gpio::InputType inputType = Gpio::InputType::Floating)
+	{
+		using Connector = GpioConnector<Peripheral::Fdcan{{ id }}, Signals...>;
+		using Tx = typename Connector::template GetSignal< Gpio::Signal::Tx >;
+		using Rx = typename Connector::template GetSignal< Gpio::Signal::Rx >;
+		static_assert(Connector::template IsValid<Tx> and Connector::template IsValid<Rx> and sizeof...(Signals) == 2,
+					  "Can{{ id }}::connect() requires one Tx and one Rx signal!");
+
+		// Connector::disconnect();
+		Tx::setOutput(Gpio::OutputType::PushPull);
+		Rx::setInput(inputType);
+		Connector::connect();
+	}
+
+	/**
+	 * Enables the clock for the CAN controller and resets all settings
+	 *
+	 * \param bitrate
+	 * 			CAN bitrate (defined in driver/connectivity/can/message.hpp)
+	 * \param interruptPriority
+	 * 			Interrupt vector priority (0=highest to 15=lowest)
+	 * \param overwriteOnOverrun
+	 * 			Once a receive FIFO is full the next incoming message
+	 * 			will overwrite the previous one if \c true otherwise
+	 * 			the incoming message will be discarded
+	 *
+	 * \warning	Has to called after connect(), but before any
+	 * 			other function from this class!
+	 */
+	template<
+		class SystemClock,
+		bitrate_t bitrate=kbps(125),
+		percent_t tolerance=pct(1),
+		bitrate_t dataBitrate=bitrate,
+		Preprescaler preprescaler=Preprescaler::Preprescaler16
+	>
+	static inline void
+	initialize(	uint32_t interruptPriority, Mode startupMode = Mode::Normal,
+				bool overwriteOnOverrun = true)
+	{
+		using Timings = CanBitTiming<
+			SystemClock::Fdcan{{ id }} / getPreprescalerValue(preprescaler),
+			bitrate,
+			9, 8, 7, 7
+		>;
+		Timings::template assertBitrateInTolerance<tolerance>();
+
+		using DataTimings = CanBitTiming<
+			SystemClock::Fdcan{{ id }} / getPreprescalerValue(preprescaler),
+			bitrate,
+			5, 5, 4, 4
+		>;
+		DataTimings::template assertBitrateInTolerance<tolerance>();
+
+		return initializeWithPrescaler(
+			Timings::getPrescaler(),
+			Timings::getBS1(),
+			Timings::getBS2(),
+			Timings::getSJW(),
+			DataTimings::getPrescaler(),
+			DataTimings::getBS1(),
+			DataTimings::getBS2(),
+			DataTimings::getSJW(),
+			preprescaler,
+			interruptPriority,
+			startupMode,
+			overwriteOnOverrun);
+	}
+
+	/**
+	 * The the operating mode.
+	 *
+	 * Default after initialization is the normal mode.
+	 */
+	static void
+	setMode(Mode mode);
+
+	static void
+	setAutomaticRetransmission(bool retransmission);
+
+private:
+	static void
+	_setMode(Mode mode);
+
+public:
+	// Can Interface Methods
+	static bool
+	isMessageAvailable();
+
+	static bool
+	getMessage(can::Message& message, uint8_t *filter_id=nullptr, uint16_t *timestamp=nullptr);
+
+	static bool
+	isReadyToSend();
+
+	static bool
+	sendMessage(const can::Message& message);
+
+public:
+	// Extended Functionality
+	/**
+	 * Get Receive Error Counter.
+	 *
+	 * In case of an error during reception, this counter is
+	 * incremented by 1 or by 8 depending on the error condition as
+	 * defined by the CAN standard. After every successful reception
+	 * the counter is decremented by 1 or reset to 120 if its value
+	 * was higher than 128. When the counter value exceeds 127, the
+	 * CAN controller enters the error passive state.
+	 */
+	static inline uint32_t
+	getReceiveErrorCounter()
+	{
+		return (({{ reg }}->ECR >> 8) & 0xFF);
+	}
+
+	/**
+	 * Get Transmit Error Counter.
+	 *
+	 */
+	static inline uint32_t
+	getTransmitErrorCounter()
+	{
+		return ({{ reg }}->ECR & 0xFF);
+	}
+
+	static BusState
+	getBusState();
+
+	/**
+	 * Enable the error and status change interrupt.
+	 *
+	 * Can be generated by the following events:
+	 * - Error condition, for more details on error conditions please
+	 *   refer to the CAN Error Status register (CAN_ESR).
+	 * - Wakeup condition, SOF monitored on the CAN Rx signal.
+	 * - Entry into Sleep mode
+	 *
+	 * You need to create you own interrupt handler for this interrupt.
+	 * The interrupt handler has a fixed name:
+	 * \code
+	 * MODM_ISR(CAN{{ id }}_SCE)
+	 * {
+	 *     ...
+	 *
+	 *     // e.g. Acknowledge interrupt
+	 *     CAN{{ id }}->MSR = CAN_MSR_ERRI;
+	 * }
+	 * \endcode
+	 *
+	 * \param interruptEnable
+	 * 			Upper 24-bit of the CAN_IER register. E.g.:
+	 * 			 - CAN_IER_BOFIE
+	 * 			 - CAN_IER_EPVIE
+	 * 			 - ...
+	 * 			See Reference Manual >> bxCAN >> CAN_IER Register
+	 * \param interruptPriority
+	 * 			Interrupt vector priority (0=highest to 15=lowest)
+	 */
+	static void
+	enableStatusChangeInterrupt(uint32_t interruptEnable,
+			uint32_t interruptPriority);
+
+	/**
+	 *
+	 *
+	 */
+	static uint16_t
+	getCurrentTimestamp()
+	{
+		return {{ reg }}->TSCV;
+	}
+};
+
+}	// namespace modm::platform
+
+#endif	//  MODM_STM32_FDCAN{{ id }}_HPP

--- a/src/modm/platform/can/stm32-fdcan/message_ram.hpp
+++ b/src/modm/platform/can/stm32-fdcan/message_ram.hpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2019, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_FDCAN_COMMON_HPP
+#define MODM_STM32_FDCAN_COMMON_HPP
+
+#include <cstdint>
+#include <concepts>
+#include <span>
+
+#include <modm/math/utils/bit_constants.hpp>
+#include <modm/architecture/interface/register.hpp>
+#include "../device.hpp"
+
+/// @cond
+
+namespace modm::platform::fdcan
+{
+
+/// Internal class to manage FDCAN message ram
+/// \tparam InstanceIndex index of FDCAN instance (starts at 0)
+template<uint8_t InstanceIndex>
+class MessageRam
+{
+public:
+	/// Header common to RX and TX elements
+	enum class CommonFifoHeader : uint32_t
+	{
+		ErrorIndicator 	= Bit31,
+		ExtendedId		= Bit30,
+		RemoteFrame 	= Bit29,
+		// bits 28-0: can id
+	};
+	MODM_FLAGS32(CommonFifoHeader);
+	using CanId_t = Value<CommonFifoHeader_t, 29>;
+
+	/// TX element specific header
+	enum class TxFifoHeader : uint32_t
+	{
+		// bit 31-24: message marker
+		StoreEvents		= Bit23,
+		// bit 22: reserved
+		FdFrame 		= Bit21,
+		RateSwitching	= Bit20,
+		// bit 19-16: dlc
+		// bit 15-0: reserved
+	};
+	MODM_FLAGS32(TxFifoHeader);
+	using TxDlc_t = Value<TxFifoHeader_t, 4, 16>;
+
+	/// RX element specific header
+	enum class RxFifoHeader : uint32_t
+	{
+		NonMatchingFrame	= Bit31,
+		// bit 30-24: filter index
+		StoreEvents		= Bit23,
+		// bit 22: reserved
+		FdFrame 		= Bit21,
+		RateSwitching	= Bit20,
+		// bit 19-16: dlc
+		// bit 15-0: timestamp
+	};
+	MODM_FLAGS32(RxFifoHeader);
+	using FilterIndex_t = Value<RxFifoHeader_t, 7, 24>;
+	using RxDlc_t = Value<RxFifoHeader_t, 4, 16>;
+	using Timestamp_t = Value<RxFifoHeader_t, 16>;
+
+	enum class FilterType : uint32_t
+	{
+		Range = 0,
+		Dual = (1u << 30),
+		Classic = (1u << 31)
+	};
+
+	enum class FilterConfig : uint32_t
+	{
+		/// skip filter
+		Disabled 	= 0b000u << 27,
+		/// store in RX fifo 0 if filter matches
+		Fifo0		= 0b001u << 27,
+		/// store in RX fifo 1 if filter matches
+		Fifo1		= 0b010u << 27,
+		/// reject if filter matches
+		Reject		= 0b011u << 27
+	};
+public:
+	static constexpr uint32_t StandardFilterCount 	= 28;
+	static constexpr uint32_t StandardFilterSize	= 1*4;
+	static constexpr uint32_t ExtendedFilterCount	= 8;
+	static constexpr uint32_t ExtendedFilterSize	= 2*4;
+	static constexpr uint32_t RxFifoElements		= 3;
+	static constexpr uint32_t RxFifoElementSize		= 18*4;
+	static constexpr uint32_t TxEventFifoEntries	= 3;
+	static constexpr uint32_t TxEventFifoEntrySize	= 2*4;
+	static constexpr uint32_t TxFifoElements		= 3;
+	static constexpr uint32_t TxFifoElementSize		= 18*4;
+
+	/// Total message ram size in bytes
+	static constexpr uint32_t Size =
+		(StandardFilterCount * StandardFilterSize)    +
+		(ExtendedFilterCount * ExtendedFilterSize)    +
+		(RxFifoElements      * RxFifoElementSize) * 2 +
+		(TxEventFifoEntries  * TxEventFifoEntrySize)  +
+		(TxFifoElements      * TxFifoElementSize);
+
+	static constexpr uintptr_t RamBase = SRAMCAN_BASE + (Size * InstanceIndex);
+
+	static constexpr uintptr_t FilterListStandard = RamBase + 0;
+	static constexpr uintptr_t FilterListExtended = FilterListStandard + (StandardFilterCount * StandardFilterSize);
+	static constexpr uintptr_t RxFifo0 = FilterListExtended + (ExtendedFilterCount * ExtendedFilterSize);
+	static constexpr uintptr_t RxFifo1 = RxFifo0 + (RxFifoElements * RxFifoElementSize);
+	static constexpr uintptr_t TxEventFifo = RxFifo1 + (RxFifoElements * RxFifoElementSize);
+	static constexpr uintptr_t TxFifo = TxEventFifo + (TxEventFifoEntries * TxEventFifoEntrySize);
+
+	/// Address of element in RX FIFO
+	struct RxFifoAddress
+	{
+		uint8_t fifoIndex;
+		uint8_t getIndex;
+
+		/// \returns pointer to RX fifo element
+		uint32_t* ptr()
+		{
+			uintptr_t address = RxFifo0 +
+				RxFifoElementSize * ((RxFifoElements * uint8_t(fifoIndex)) + getIndex);
+			return reinterpret_cast<uint32_t*>(address);
+		}
+	};
+
+	/// \returns pointer to element in TX queue
+	static uint32_t*
+	txFifoElement(uint8_t putIndex)
+	{
+		return reinterpret_cast<uint32_t*>(TxFifo + (putIndex * TxFifoElementSize));
+	}
+
+	/// \returns pointer to standard filter element
+	static uint32_t*
+	standardFilter(uint8_t index)
+	{
+		const auto address = FilterListStandard + (index * StandardFilterSize);
+		return reinterpret_cast<uint32_t*>(address);
+	}
+
+	/// \returns pointer to extended filter element
+	static uint32_t*
+	extendedFilter(uint8_t index)
+	{
+		const auto address = FilterListExtended + (index * ExtendedFilterSize);
+		return reinterpret_cast<uint32_t*>(address);
+	}
+public:
+	/// Write TX element headers to TX queue
+	static void
+	writeTxHeaders(uint8_t putIndex, CommonFifoHeader_t common, TxFifoHeader_t tx)
+	{
+		uint32_t* messageRam = txFifoElement(putIndex);
+		*messageRam++ = common.value;
+		*messageRam = tx.value;
+	}
+
+	/// Read RX element headers from RX fifo
+	static std::tuple<CommonFifoHeader, RxFifoHeader>
+	readRxHeaders(RxFifoAddress address)
+	{
+		const uint32_t* messageRam = address.ptr();
+		const auto commonHeader = CommonFifoHeader{*messageRam++};
+		const auto rxHeader = RxFifoHeader{*messageRam};
+		return {commonHeader, rxHeader};
+	}
+
+	/// Read message data from RX fifo
+	static void
+	readData(RxFifoAddress address, std::span<uint8_t> outData)
+	{
+		const auto size = std::min(outData.size(), 64u);
+
+		// + 2: skip 2x32 bit headers
+		const uint32_t* messageRam = address.ptr() + 2;
+		// message data must be read in 32bit accesses, memcpy on message ram does not work
+		for (auto i = 0u; i < size; i += 4) {
+			const uint32_t receivedData = *messageRam++;
+
+			// copy in 32 bit words, memcpy is optimized to single store instruction
+			// CAN message buffer must fit full multiples of 4 bytes
+			std::memcpy(&outData[i], &receivedData, 4);
+		}
+	}
+
+	/// Write message data to TX queue
+	static void
+	writeData(uint_fast8_t putIndex, std::span<const uint8_t> inData)
+	{
+		const auto size = std::min(inData.size(), 64u);
+
+		// + 2: skip 2x32 bit headers
+		uint32_t* messageRam = txFifoElement(putIndex) + 2;
+		// message data must be written in 32bit accesses, memcpy to message ram does not work
+		for (auto i = 0u; i < size; i += 4) {
+			uint32_t outputData{};
+			// copy in 32 bit words, memcpy is optimized to single store instruction
+			// CAN message buffer must fit full multiples of 4 bytes
+			std::memcpy(&outputData, &inData[i], 4);
+
+			*messageRam++ = outputData;
+		}
+	}
+
+	/// Construct common fifo header from CanMessage
+	static CommonFifoHeader_t
+	headerFromMessage(const modm::can::Message& message)
+	{
+		CommonFifoHeader_t header = (message.isExtended() ? CommonFifoHeader::ExtendedId : CommonFifoHeader(0))
+			| (message.isRemoteTransmitRequest() ? CommonFifoHeader::RemoteFrame : CommonFifoHeader(0));
+
+		const auto canId = message.isExtended() ? message.getIdentifier() : (message.getIdentifier() << 18);
+		CanId_t::set(header, canId);
+
+		return header;
+	}
+
+	static void
+	setStandardFilter(uint8_t index, FilterType type, FilterConfig config, uint16_t id1, uint16_t id2)
+	{
+		constexpr auto idMask = (1u << 11) - 1;
+		*standardFilter(index) = uint32_t(type) | uint32_t(config) |
+			(id2 & idMask) | ((id1 & idMask) << 16);
+	}
+
+	static void
+	setExtendedFilter0(uint8_t index, FilterConfig config, uint32_t id)
+	{
+		constexpr auto idMask = (1u << 29) - 1;
+		*extendedFilter(index) = (uint32_t(config) << 2) | (id & idMask);
+	}
+
+	static void
+	setExtendedFilter1(uint8_t index, FilterType type, uint32_t id)
+	{
+		constexpr auto idMask = (1u << 29) - 1;
+		*(extendedFilter(index) + 1) = uint32_t(type) | (id & idMask);
+	}
+
+	static void
+	setStandardFilterDisabled(uint8_t index)
+	{
+		*standardFilter(index) = 0;
+	}
+
+	static void
+	setExtendedFilterDisabled(uint8_t index)
+	{
+		*extendedFilter(index) = 0;
+	}
+
+};
+
+}	// namespace modm::platform::fdcan
+
+/// @endcond
+
+#endif	//  MODM_STM32_FDCAN{{ id }}_HPP

--- a/src/modm/platform/can/stm32-fdcan/module.lb
+++ b/src/modm/platform/can/stm32-fdcan/module.lb
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2018, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def load_options(module):
+    module.add_option(
+        NumericOption(
+            name="buffer.tx",
+            description="",
+            minimum=1, maximum=2 ** 16 - 2,
+            default=32))
+    module.add_option(
+        NumericOption(
+            name="buffer.rx",
+            description="",
+            minimum=1, maximum=2 ** 16 - 2,
+            default=32))
+
+class Instance(Module):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        load_options(module)
+        return True
+
+    def build(self, env):
+        device = env[":target"]
+        driver = device.get_driver("fdcan")
+
+        properties = device.properties
+        properties["target"] = target = device.identifier
+        properties["driver"] = driver
+        properties["id"] = self.instance
+        properties["reg"] = 'FDCAN{}'.format(self.instance)
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/can"
+
+        env.template("can.hpp.in", "can_{}.hpp".format(self.instance))
+        env.template("can.cpp.in", "can_{}.cpp".format(self.instance))
+
+
+def init(module):
+    module.name = ":platform:can"
+    module.description = "Controller Area Network with Flexible Data-Rate (FDCAN)"
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("fdcan:stm32"):
+        return False
+
+    module.depends(
+        ":architecture:assert",
+        ":architecture:atomic",
+        ":architecture:can",
+        ":architecture:clock",
+        ":architecture:delay",
+        ":architecture:interrupt",
+        ":cmsis:device",
+        ":debug",
+        ":platform:can.common",
+        ":platform:gpio",
+        ":platform:rcc",
+        ":utils")
+
+    driver = device.get_driver("fdcan")
+
+    for instance in listify(driver["instance"]):
+        module.add_submodule(Instance(int(instance)))
+
+    return True
+
+def build(env):
+    pass
+    #device = env[":target"]
+    #driver = device.get_driver("fdcan")
+
+    #properties = device.properties
+    #properties["target"] = device.identifier
+    #properties["driver"] = driver
+
+    #env.substitutions = properties
+    #env.outbasepath = "modm/src/modm/platform/can"
+
+    #env.copy("common.hpp")

--- a/src/modm/platform/can/stm32-fdcan/module.lb
+++ b/src/modm/platform/can/stm32-fdcan/module.lb
@@ -86,15 +86,5 @@ def prepare(module, options):
     return True
 
 def build(env):
-    pass
-    #device = env[":target"]
-    #driver = device.get_driver("fdcan")
-
-    #properties = device.properties
-    #properties["target"] = device.identifier
-    #properties["driver"] = driver
-
-    #env.substitutions = properties
-    #env.outbasepath = "modm/src/modm/platform/can"
-
-    #env.copy("common.hpp")
+    env.outbasepath = "modm/src/modm/platform/can"
+    env.copy("message_ram.hpp")

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -99,6 +99,10 @@ def build(env):
         if "Can" in all_peripherals and per == "CAN1":
             per = "CAN"
             nper = "CAN1"
+        # FDCAN
+        if "Fdcan1" in all_peripherals and per == "FDCAN":
+            per = "FDCAN1"
+            nper = "FDCAN"
         # Fix ADC vs ADC1
         if "Adc1" in all_peripherals and per == "ADC":
             per = "ADC1"

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -384,3 +384,35 @@ modm::platform::Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycle
 
 	return true;
 }
+
+
+%% if target["family"] == "g4"
+bool
+modm::platform::Rcc::setCanPrescaler(CanPrescaler prescaler)
+{
+	enable<Peripheral::Fdcan1>();
+
+	// FDCAN1 must enter initialization mode to configure common divider.
+	// This will stop operation of FDCAN1.
+	// The setting only takes effect after resetting INIT in FDCAN1_CCCR
+	if (FDCAN_CONFIG->CKDIV != uint32_t(prescaler)) {
+		FDCAN1->CCCR = FDCAN_CCCR_INIT;
+
+		// Wait until the initialization mode is entered
+		int deadlockPreventer = 10'000; // max ~10ms
+		while (((FDCAN1->CCCR & FDCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
+			modm::delay_us(1);
+		}
+
+		if(deadlockPreventer == 0) {
+			return false;
+		}
+
+		FDCAN1->CCCR |= FDCAN_CCCR_CCE;
+		FDCAN_CONFIG->CKDIV = uint32_t(prescaler);
+
+		FDCAN1->CCCR &= ~FDCAN_CCCR_INIT;
+	}
+	return true;
+}
+%% endif

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include "../device.hpp"
 #include <modm/platform/core/peripherals.hpp>
+#include <modm/architecture/interface/delay.hpp>
 
 namespace modm::platform
 {
@@ -279,6 +280,51 @@ public:
 	%% endif
 	};
 %% endif
+
+%% if target["family"] == "g4"
+	enum class
+	CanClockSource : uint32_t
+	{
+		Hse = 0,
+		PllQ = RCC_CCIPR_FDCANSEL_0,
+		Pclk = RCC_CCIPR_FDCANSEL_1,
+	};
+
+	static void
+	setCanClockSource(CanClockSource source)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_FDCANSEL) | uint32_t(source);
+	}
+
+	/// FDCAN subsystem prescaler common to all FDCAN instances
+	enum class
+	CanPrescaler : uint8_t
+	{
+		Div1  = 0b0000,
+		Div2  = 0b0001,
+		Div4  = 0b0010,
+		Div6  = 0b0011,
+		Div8  = 0b0100,
+		Div10 = 0b0101,
+		Div12 = 0b0110,
+		Div14 = 0b0111,
+		Div16 = 0b1000,
+		Div18 = 0b1001,
+		Div20 = 0b1010,
+		Div22 = 0b1011,
+		Div24 = 0b1100,
+		Div26 = 0b1101,
+		Div28 = 0b1110,
+		Div30 = 0b1111,
+	};
+
+	/// Configure CAN subsystem prescaler
+	/// \warning Configure the prescaler before enabling the CAN peripherals
+	/// \returns true if setting the prescaler was successful
+	static bool
+	setCanPrescaler(CanPrescaler prescaler);
+%% endif
+
 public:
 	// sources
 	static bool

--- a/test/Makefile
+++ b/test/Makefile
@@ -63,6 +63,12 @@ run-nucleo-l432:
 	$(call run-test,nucleo-l432,size)
 
 
+compile-nucleo-g474:
+	$(call compile-test,nucleo-g474,size)
+run-nucleo-g474:
+	$(call run-test,nucleo-g474,size)
+
+
 compile-nucleo-f103_A:
 	$(call compile-test,nucleo-f103_A,size)
 run-nucleo-f103_A:

--- a/test/config/nucleo-g474.xml
+++ b/test/config/nucleo-g474.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/nucleo-g474/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/nucleo-g474/modm-test</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>

--- a/test/modm/platform/fdcan/fdcan_test.cpp
+++ b/test/modm/platform/fdcan/fdcan_test.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fdcan_test.hpp"
+
+#include <modm/platform.hpp>
+#include <modm/board.hpp>
+
+using namespace modm::platform;
+
+void
+FdcanTest::setUp()
+{
+	Fdcan1::initialize<Board::SystemClock, 500_kbps, 1_pct>(9, Fdcan1::Mode::TestInternalLoopback);
+
+	// receive all extended messages
+	Fdcan1::setExtendedFilter(0, Fdcan1::FilterConfig::Fifo1,
+			modm::can::ExtendedIdentifier(0),
+			modm::can::ExtendedMask(0));
+}
+
+void
+FdcanTest::testSendReceive()
+{
+	modm::can::Message message{0x12345678, 7};
+	constexpr std::string_view data = "\xDE\xAD\xBE\xEF\x12\x34\x56";
+	std::copy(std::begin(data), std::begin(data) + 7, message.data);
+
+	TEST_ASSERT_FALSE(Fdcan1::isMessageAvailable());
+	TEST_ASSERT_TRUE(Fdcan1::sendMessage(message));
+
+	modm::delay_ms(1);
+
+	modm::can::Message receivedMessage;
+	TEST_ASSERT_TRUE(Fdcan1::getMessage(receivedMessage));
+	TEST_ASSERT_EQUALS(receivedMessage.getIdentifier(), 0x12345678u);
+	TEST_ASSERT_EQUALS(receivedMessage.getLength(), 7);
+	TEST_ASSERT_TRUE(receivedMessage.isExtended());
+	TEST_ASSERT_FALSE(receivedMessage.isRemoteTransmitRequest());
+	TEST_ASSERT_TRUE(std::equal(std::begin(data), std::begin(data) + 7, message.data));
+}
+
+void
+FdcanTest::testFilters()
+{
+	Fdcan1::setStandardFilter(27, Fdcan1::FilterConfig::Fifo0,
+			modm::can::StandardIdentifier(0x108),
+			modm::can::StandardMask(0x1F8));
+
+	modm::can::Message message{0x188, 0};
+	message.setExtended(false);
+	Fdcan1::sendMessage(message);
+	modm::delay_ms(1);
+	TEST_ASSERT_FALSE(Fdcan1::isMessageAvailable());
+
+	message.setIdentifier(0xF09);
+	Fdcan1::sendMessage(message);
+	modm::delay_ms(1);
+	TEST_ASSERT_TRUE(Fdcan1::isMessageAvailable());
+	TEST_ASSERT_TRUE(Fdcan1::getMessage(message));
+	TEST_ASSERT_FALSE(message.isExtended());
+}
+
+void
+FdcanTest::testBuffers()
+{
+	modm::can::Message message{0x4711, 0};
+	// send 8 messages, exceeds internal peripheral queue size
+	for (uint_fast8_t i = 0; i <= 8; ++i) {
+		message.setLength(i);
+		for (uint_fast8_t dataIndex = 0; dataIndex < i; ++dataIndex) {
+			message.data[dataIndex] = i;
+		}
+		Fdcan1::sendMessage(message);
+	}
+
+	modm::delay_ms(10);
+
+	// try to receive same messages
+	modm::can::Message receivedMessage;
+	for (uint_fast8_t i = 0; i <= 8; ++i) {
+		TEST_ASSERT_TRUE(Fdcan1::getMessage(receivedMessage));
+
+		TEST_ASSERT_EQUALS(receivedMessage.getIdentifier(), 0x4711u);
+		TEST_ASSERT_EQUALS(receivedMessage.getLength(), i);
+
+		for (uint_fast8_t dataIndex = 0; dataIndex < i; ++dataIndex) {
+			TEST_ASSERT_EQUALS(receivedMessage.data[dataIndex], i);
+		}
+	}
+	TEST_ASSERT_FALSE(Fdcan1::isMessageAvailable());
+	TEST_ASSERT_FALSE(Fdcan1::getMessage(message));
+}

--- a/test/modm/platform/fdcan/fdcan_test.hpp
+++ b/test/modm/platform/fdcan/fdcan_test.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_platform_fdcan
+class FdcanTest : public unittest::TestSuite
+{
+public:
+	void
+	setUp() override;
+
+	void
+	testSendReceive();
+
+	void
+	testFilters();
+
+	void
+	testBuffers();
+};

--- a/test/modm/platform/fdcan/module.lb
+++ b/test/modm/platform/fdcan/module.lb
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def init(module):
+    module.name = ":test:platform:fdcan"
+
+def prepare(module, options):
+    target = options[":target"]
+
+    identifier = target.identifier
+    if identifier.platform != "stm32" or identifier.family != "g4":
+        return False
+
+    module.depends(":architecture:delay", ":platform:can:1")
+    return True
+
+def build(env):
+#    env.substitutions = properties
+    env.outbasepath = "modm-test/src/modm-test/platform/fdcan_test"
+    env.copy("fdcan_test.hpp")
+    env.copy("fdcan_test.cpp")


### PR DESCRIPTION
This is a follow-up to #325 and adds an FDCAN driver working for standard CAN with an interface similar to the bxCAN driver. Do not consider this driver done, support for FDCAN features is totally missing. The intention was to provide a working implementation of standard CAN first before we start experimenting with redesigning APIs for FDCAN support. So it still has the integrated buffers like the bxCAN driver, not the concept of #294 to implement buffering outside of the driver.

This is tested in hardware on a custom board with a G473RB. ~~The Nucleo example compiles but is untested.~~ An on-target unit test for a Nucleo board using the FDCAN internal loopback mode will follow.

~~One thing that is still not solved is proper handling of the global clock prescaler which affects all instances. Configuring it is really ugly because the FDCAN1 instance needs to be put into initialization mode to reconfigure it. Right now it simply does that on initialize.~~ Solved by moving common clock settings to Rcc.

A simple but suboptimal solution could be letting the user configure it inside SystemClock and the FDCAN driver does not need to touch it at all. If your data rates are not less than 50 kbit/s standard rate (and 300 kbit/s fast data bitrate for canfd with bit rate switching) a prescaler of 1 will do anyway, even with a 170MHz peripheral clock. ~~An option is yet missing to bypass the fast bitrate assert if CANFD is not used at all.~~ Implemented now.

~~Another aspect to consider is trying to create a common interface for CAN filters for different drivers. This is not straightforward since the semantics and feature sets differ between drivers. FDCAN has 8 filters that apply to extended id messages and 28 for standard 2.0A messages. bxCAN does not have this strict distinction and treats the frame format as a bit of the id and mask. This is not supported for FDCAN. Furthermore, FDCAN filters do not consider the RTR flag. Because I didn't find an obvious solution for an easy to use API, I skipped that effort for now, ignored @rleh's `modm::can::Filter` type and went for a less ambitious hardware specific API.~~ Refactoring of CAN filters is out of scope for this PR.

If you look at the SAM E5x manual, you will find that the message RAM data structures are identical to the STM32 FDCAN implementation. I guess both vendors did some copy-paste from an automotive standard. Does anyone know more details?

- [x] Working standard CAN
- [x] CAN filter support 
- [x] Hardware unit test in loopback mode
- [x] Test hardware unit test on Nucleo board (Thanks for testing, @rleh)
- [x] Test example with Nucleo and CAN transceiver

cc @rleh @salkinium 