### PR TITLE
Fix STM32F3/G4/L4 ADC initialization

### DIFF
--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -22,8 +22,10 @@ main()
 	MODM_LOG_INFO << " running on Nucleo-G474RE" << modm::endl << modm::endl;
 
 	MODM_LOG_INFO << "Configuring ADC ...";
+	// max. ADC clock for STM32G474: 60 MHz
+	// 170 MHz AHB clock / 4 = 42.5 MHz
 	Adc1::initialize(
-		Adc1::ClockMode::SynchronousPrescaler1,
+		Adc1::ClockMode::SynchronousPrescaler4,
 		Adc1::ClockSource::SystemClock,
 		Adc1::Prescaler::Disabled,
 		Adc1::CalibrationMode::SingleEndedInputsMode,

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -65,14 +65,18 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 	ADC{{ id }}->CR |= static_cast<uint32_t>(VoltageRegulatorState::Enabled);
 	modm::delay_us(10);	// FIXME: this is ugly -> find better solution
 
-	// Clear ready flag
-	ADC{{ id }}->ISR |= ADC_ISR_ADRDY;
+	acknowledgeInterruptFlag(InterruptFlag::Ready);
 
 	calibrate(cal, true);	// blocking calibration
 
 	ADC{{ id }}->CR |= ADC_CR_ADEN;
 	if (blocking) {
-		while(not isReady());
+		// ADEN can only be set 4 ADC clock cycles after ADC_CR_ADCAL gets
+		// cleared. Setting it in a loop ensures the flag gets set for ADC
+		// clocks slower than the CPU clock.
+		while (not isReady()) {
+			ADC{{ id }}->CR |= ADC_CR_ADEN;
+		}
 		acknowledgeInterruptFlag(InterruptFlag::Ready);
 	}
 }


### PR DESCRIPTION
Two fixes, tested with Nucleo G474RE and a custom board with an STM32G473RB:

- ADC initialization hangs for larger clock prescalers
Setting ADC_CR_ADEN after calibration is only possible after 4 ADC clock
cycles have elapsed. In case the ADC clock is much slower than the CPU
clock that flag was never set and the initialization blocked infinitely
waiting for the ready flag to get set.

- The ADC clock in the Nucleo G474RE example was set to 170 MHz which exceeds the 60 MHz maximum clock.