### PR TITLE
Add support for Real Time Transfer (RTT) via OpenOCD

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -85,7 +85,8 @@ supported development boards:
 [CAN](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/can/main.cpp),
 [Accelerometer](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/accelerometer/main.cpp),
 [Gyroscope](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/rotation/main.cpp),
-[TinyUSB DFU](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/usb_dfu/main.cpp).
+[TinyUSB DFU](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/usb_dfu/main.cpp),
+[Logging via RTT](https://github.com/modm-io/modm/blob/develop/examples/stm32f3_discovery/rtt/main.cpp).
 - STM32F4 Discovery:
 [Blinky](https://github.com/modm-io/modm/blob/develop/examples/stm32f4_discovery/blink/main.cpp),
 [CAN](https://github.com/modm-io/modm/blob/develop/examples/stm32f4_discovery/can/main.cpp),

--- a/examples/avr/block_device_mirror/main.cpp
+++ b/examples/avr/block_device_mirror/main.cpp
@@ -20,7 +20,7 @@ using namespace modm::platform;
 
 // Create a new UART object and configure it to a baudrate of 115200
 Uart0 uart;
-modm::IODeviceWrapper< Uart0, modm::IOBuffer::BlockIfFull > loggerDevice(uart);
+modm::IODeviceWrapper< Uart0, modm::IOBuffer::BlockIfFull > loggerDevice;
 
 // Set all four logger streams to use the UART
 modm::log::Logger modm::log::debug(loggerDevice);

--- a/examples/stm32f3_discovery/rtt/main.cpp
+++ b/examples/stm32f3_discovery/rtt/main.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+#include <modm/debug.hpp>
+
+using namespace Board;
+
+Rtt rtt(0);
+modm::IODeviceObjectWrapper< Rtt, modm::IOBuffer::DiscardIfFull > rtt_device(rtt);
+// Set all four logger streams to use RTT
+modm::log::Logger modm::log::debug(rtt_device);
+modm::log::Logger modm::log::info(rtt_device);
+modm::log::Logger modm::log::warning(rtt_device);
+modm::log::Logger modm::log::error(rtt_device);
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+/*
+
+ $ scons log-rtt
+╭───OpenOCD───> Real Time Transfer
+╰─────RTT────── stm32f303vct6
+Info : STLINK V2J16S0 (API v2) VID:PID 0483:3748
+Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
+Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Control block found at 0x20000c04
+Info : Listening on port 9090 for rtt connections
+Info
+Warning
+Error
+loop: 0
+loop: 1
+loop: 2
+loop: 3
+loop: 4
+loop: 5
+
+
+Type number 0-9, then press enter to send.
+The LED should blink slower or faster.
+
+Ctrl+D to exit
+
+*/
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_DEBUG << "Debug" << modm::endl;
+	MODM_LOG_INFO << "Info" << modm::endl;
+	MODM_LOG_WARNING << "Warning" << modm::endl;
+	MODM_LOG_ERROR << "Error" << modm::endl;
+
+	uint32_t counter(0);
+	modm::PeriodicTimer tmr(100ms);
+
+	char data;
+	while (true)
+	{
+		MODM_LOG_INFO.get(data);
+		switch(data)
+		{
+			case '0':
+				tmr.restart(1s);
+				break;
+			case '1'...'9':
+				tmr.restart(std::chrono::milliseconds((data - '0') * 100));
+				break;
+		}
+		if (tmr.execute())
+		{
+			LedNorth::toggle();
+
+			MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+		}
+	}
+
+	return 0;
+}

--- a/examples/stm32f3_discovery/rtt/project.xml
+++ b/examples/stm32f3_discovery/rtt/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:disco-f303vc</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/stm32f3_discovery/rtt</option>
+    <option name="modm:platform:rtt:buffer.rx">16</option>
+  </options>
+  <modules>
+    <module>modm:platform:rtt</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+    <module>modm:debug</module>
+  </modules>
+</library>

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -68,6 +68,7 @@ def common_memories(env):
 
       - `memories`: unfiltered memory regions
       - `regions`: memory region names
+      - `cont_ram`: largest continuous internal SRAM section
 
     :returns: dictionary of memory properties
     """
@@ -84,9 +85,19 @@ def common_memories(env):
             m["start"] = int(m["start"], 0)
             m["size"] = int(m["size"], 0)
 
+    # Find largest continuous internal SRAM section
+    cont = []
+    for m in memories:
+        if m["name"].startswith("sram") or m["name"].startswith("ram"):
+            if cont and (cont[-1]["start"] + cont[-1]["size"] == m["start"]):
+                cont[-1]["size"] += m["size"]
+            else:
+                cont.append(dict(m))
+
     properties = {
         "memories": memories,
         "regions": [m["name"] for m in memories],
+        "cont_ram": sorted(cont, key=lambda m: -m["size"])[0],
     }
     return properties
 
@@ -116,6 +127,7 @@ def common_linkerscript(env):
       - `regions`: memory region names
       - `ram_origin`: Lowest SRAM origin address
       - `ram_origin`: Total size of all SRAM regions
+      - `cont_ram`: largest continuous internal SRAM section
 
     :returns: dictionary of linkerscript properties
     """

--- a/src/modm/platform/uart/cortex/module.md
+++ b/src/modm/platform/uart/cortex/module.md
@@ -44,8 +44,8 @@ the asynchronous trace stream.
 To log the output to a file called `itm.fifo` you can call the `modm_log_itm`
 command manually.
 
-```
- $ openocd -f "modm/openocd.cfg" -c "modm_log_itm itm.fifo 64000000"
+```sh
+openocd -f modm/openocd.cfg -c "modm_log_itm itm.fifo 64000000"
 ```
 
 You can then either use `tail -f itm.fifo` to display the raw data stream
@@ -62,9 +62,8 @@ terminal
 
 ```
  $ scons log-itm fcpu=64000000
-.----OpenOCD--> Single Wire Viewer
-'------SWO----- stm32f103rbt
-
+╭───OpenOCD───> Single Wire Viewer
+╰─────SWO────── stm32f103rbt
 Hello from the SWO.
 debug
 info

--- a/src/modm/platform/uart/rtt/module.lb
+++ b/src/modm/platform/uart/rtt/module.lb
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":platform:rtt"
+    module.description = FileReader("module.md")
+
+def prepare(module, options):
+    if not options[":target"].has_driver("core:cortex-m*"):
+        return False
+
+    module.add_set_option(
+        NumericOption(name="buffer.tx", description="Transmit buffer sizes",
+            minimum=0, maximum=2**16), default=512)
+    module.add_set_option(
+        NumericOption(name="buffer.rx", description="Receive buffer sizes",
+            minimum=0, maximum=2**16), default=0)
+
+    module.depends(":architecture:uart")
+    return True
+
+def validate(env):
+    if len(env["buffer.tx"]) != len(env["buffer.rx"]):
+        raise ValidateException("There must be the same number of TX buffers as RX buffers!")
+
+def build(env):
+    env.outbasepath = "modm/src/modm/platform/rtt"
+    env.substitutions = {
+        "buffer_tx": env["buffer.tx"],
+        "buffer_rx": env["buffer.rx"],
+    }
+    env.template("rtt.hpp.in")
+    env.template("rtt.cpp.in")

--- a/src/modm/platform/uart/rtt/module.md
+++ b/src/modm/platform/uart/rtt/module.md
@@ -1,0 +1,96 @@
+# Real Time Transfer (RTT)
+
+This module implements the RTT protocol compatible with OpenOCD. RTT works by
+placing multiple ring-buffers in RAM which the debugger read and writes using
+background memory accesses via SWD. It therefore works on any Cortex-M devices
+without extra pins except for the SWDCLK and SWDIO.
+
+See https://www.segger.com/jlink-rtt.html
+
+The RTT channels are exposed as a UART interface which you can use like so:
+
+```cpp
+modm::platform::Rtt rtt(/* channel= */0);
+// Access data directly via UART interface: eg. loop back
+if (uint8_t data; rtt.read(data)) { rtt.write(data); }
+// Or wrap into an IOStream for printing
+modm::IODeviceObjectWrapper<modm::platform::Rtt,
+                            modm::IOBuffer::DiscardIfFull> rtt_device(rtt);
+modm::IOStream stream(rtt_device);
+stream << "Hello World" << modm::endl;
+// Reading is more annoying
+char data;
+stream.get(data);
+if (data != modm::IOStream::eof) { /* process new data */ }
+```
+
+You can define the number of channels and their buffer size by setting the
+`buffer.tx` and `buffer.rx` set options. Note that you can define *multiple*
+buffer sizes indexed by channel. Here is an example of three channels:
+
+```xml
+<!-- Channel0: TX only with 256B buffer -->
+<!-- Channel1: RX only with 128B buffer -->
+<!-- Channel2: TX with 512B and RX with 64B buffer -->
+<option name="modm:platform:rtt:buffer.tx">256, 0, 512</option>
+<option name="modm:platform:rtt:buffer.rx">0, 128, 64</option>
+```
+
+You can set the buffer size to `0` if you don't want to use this channel
+direction. This won't allocate a buffer and save a little RAM.
+
+
+## Accessing Data
+
+[OpenOCD has built-in support for RTT][rtt] and modm generates a config that
+opens each RTT channel as a TCP port starting at 9090 (ie. 9090=channel 0,
+9091=channel 1, etc).
+
+```sh
+openocd -f modm/openocd.cfg -c modm_rtt
+```
+
+You can also call this from inside GDB via the `monitor` command:
+
+```
+(gdb) monitor modm_rtt
+rtt: Searching for control block 'modm.rtt.modm'
+rtt: Control block found at 0x20001024
+Listening on port 9090 for rtt connections
+(gdb)
+```
+
+You can then use for example `telnet 127.0.0.1 9090` to connect to the stream.
+
+Note that this connection does not halt the target, you should therefore be able
+to use this at any point during program execution.
+
+A simple telnet client is integrated into the build system generator, however,
+it can only connect to one stream at a time (disconnect with Ctrl+D).
+
+```
+ $ scons log-rtt
+╭───OpenOCD───> Real Time Transfer
+╰─────RTT────── stm32f103rbt
+Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Control block found at 0x20000008
+Listening on port 9090 for rtt connections
+loop 51
+loop 52
+loop 53
+^D
+
+ $ make log-rtt channel=0
+Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Control block found at 0x20000008
+Listening on port 9090 for rtt connections
+loop 58
+loop 60
+loop 61
+```
+
+If you want to use this as a proper communication channel with a custom protocol
+you should implement the OpenOCD config yourself (with different ports).
+
+
+[rtt]: http://openocd.org/doc/html/General-Commands.html#Real-Time-Transfer-_0028RTT_0029

--- a/src/modm/platform/uart/rtt/rtt.cpp.in
+++ b/src/modm/platform/uart/rtt/rtt.cpp.in
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/platform/device.hpp>
+#include "rtt.hpp"
+#include <algorithm>
+
+namespace modm::platform
+{
+
+struct RttBuffer
+{
+	const char* name{nullptr};
+	uint8_t* buffer{nullptr};
+	const uint32_t size{0};
+	volatile uint32_t head{0};
+	volatile uint32_t tail{0};
+	uint32_t flags{0};
+
+	bool write(uint8_t data)
+	{
+		const uint32_t rhead{head};
+		const uint32_t rtail{tail};
+		const uint32_t rhead_next{(rhead + 1) % size};
+		if (not size or rhead_next == rtail) return false;
+		buffer[rhead] = data;
+		head = rhead_next;
+		return true;
+	}
+	bool read(uint8_t &data)
+	{
+		const uint32_t rhead{head};
+		const uint32_t rtail{tail};
+		if (not size or rtail == rhead) return false;
+		data = buffer[rtail];
+		tail = (rtail + 1) % size;
+		return true;
+	}
+	bool isEmpty() const { return (head == tail); }
+	uint32_t getSize() const
+	{
+		const uint32_t rhead{head};
+		const uint32_t rtail{tail};
+		return ((rhead >= rtail) ? 0 : size) + rhead - rtail;
+	}
+} modm_packed;
+
+%% for size in buffer_tx
+%% if size
+static uint8_t tx_data_buffer_{{loop.index0}}[{{size}}];
+%% endif
+%% endfor
+%% for size in buffer_rx
+%% if size
+static uint8_t rx_data_buffer_{{loop.index0}}[{{size}}];
+%% endif
+%% endfor
+%#
+struct RttControlBlock
+{
+	const char identifier[16]{"modm.rtt.modm"};
+	const int32_t tx_buffer_count{ {{ buffer_tx | length }} };
+	const int32_t rx_buffer_count{ {{ buffer_rx | length }} };
+	RttBuffer tx_buffers[{{ buffer_tx | length }}] = {
+%% for size in buffer_tx
+		{"tx{{loop.index0}}", {% if size %}tx_data_buffer_{{loop.index0}}{% else %}nullptr{% endif %}, {{size}} },
+%% endfor
+	};
+	RttBuffer rx_buffers[{{ buffer_rx | length }}] = {
+%% for size in buffer_rx
+		{"rx{{loop.index0}}", {% if size %}rx_data_buffer_{{loop.index0}}{% else %}nullptr{% endif %}, {{size}} },
+%% endfor
+	};
+} modm_packed;
+
+static RttControlBlock rtt_control;
+
+
+Rtt::Rtt(uint8_t channel)
+:	tx_buffer(rtt_control.tx_buffers[std::min<uint8_t>(channel, {{ buffer_tx | length - 1 }})]),
+	rx_buffer(rtt_control.rx_buffers[std::min<uint8_t>(channel, {{ buffer_rx | length - 1 }})])
+{
+}
+
+bool
+Rtt::write(uint8_t data)
+{
+	return tx_buffer.write(data);
+}
+
+std::size_t
+Rtt::write(const uint8_t *data, std::size_t length)
+{
+	std::size_t sent = 0;
+	for (; sent < length; sent++)
+		if (not write(*data++))
+			return sent;
+	return sent;
+}
+
+bool
+Rtt::isWriteFinished()
+{
+	return tx_buffer.isEmpty();
+}
+
+std::size_t
+Rtt::transmitBufferSize()
+{
+	return tx_buffer.getSize();
+}
+
+bool
+Rtt::read(uint8_t& data)
+{
+	return rx_buffer.read(data);
+}
+
+std::size_t
+Rtt::read(uint8_t *data, std::size_t length)
+{
+	uint32_t i = 0;
+	for (; i < length; ++i)
+		if (not rx_buffer.read(*data++))
+			return i;
+	return i;
+}
+
+std::size_t
+Rtt::receiveBufferSize()
+{
+	return rx_buffer.getSize();
+}
+
+
+
+}	// namespace modm::platform

--- a/src/modm/platform/uart/rtt/rtt.hpp.in
+++ b/src/modm/platform/uart/rtt/rtt.hpp.in
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <modm/architecture/interface/uart.hpp>
+
+namespace modm::platform
+{
+
+struct RttBuffer;
+
+/**
+ * Real Time Transfer (RTT) Uart Interface
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_rtt
+ */
+class Rtt : public ::modm::Uart
+{
+	RttBuffer& tx_buffer;
+	RttBuffer& rx_buffer;
+
+public:
+	Rtt(uint8_t channel);
+
+	inline void
+	writeBlocking(uint8_t data)
+	{ while(not write(data)) ; }
+
+	inline void
+	writeBlocking(const uint8_t *data, std::size_t length)
+	{ while (length--) writeBlocking(*data++); }
+
+	inline void
+	flushWriteBuffer() {}
+
+	bool
+	write(uint8_t data);
+
+	std::size_t
+	write(const uint8_t *data, std::size_t length);
+
+	bool
+	isWriteFinished();
+
+	std::size_t
+	transmitBufferSize();
+
+	inline std::size_t
+	discardTransmitBuffer()
+	{ return 0; }
+
+	bool
+	read(uint8_t &data);
+
+	std::size_t
+	read(uint8_t *data, std::size_t length);
+
+	std::size_t
+	receiveBufferSize();
+
+	inline std::size_t
+	discardReceiveBuffer()
+	{ return 0; }
+
+	inline bool
+	hasError()
+	{ return false; }
+
+	inline void
+	clearError() {}
+};
+
+}	// namespace modm::platform

--- a/tools/build_script_generator/cmake/module.md
+++ b/tools/build_script_generator/cmake/module.md
@@ -196,7 +196,7 @@ make log-itm fcpu={HCLK in Hz}
 Configures OpenOCD in tracing mode to output ITM channel 0 on SWO pin and
 displays the serial output stream.
 
-See the `:platform:itm` module for details how to use the ITM as a logging
+See the `modm:platform:itm` module for details how to use the ITM as a logging
 output.
 
 

--- a/tools/build_script_generator/cmake/resources/Makefile.in
+++ b/tools/build_script_generator/cmake/resources/Makefile.in
@@ -60,20 +60,20 @@ ui?=tui
 debug: build
 	@python3 modm/modm_tools/gdb.py -x modm/gdbinit -x modm/openocd_gdbinit \
 			-ex "dir $(dir $(realpath $(dir $(realpath $(shell which arm-none-eabi-gcc)))))" \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			openocd -f modm/openocd.cfg
 
 debug-bmp: build
 	@python3 modm/modm_tools/bmp.py -x modm/gdbinit \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			bmp -p $(port)
 
 debug-coredump: build
 	@python3 modm/modm_tools/gdb.py -x modm/gdbinit \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			crashdebug --binary-path modm/ext/crashcatcher/bins
 
 fcpu?=0
 log-itm:
-	@python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg -fcpu $(fcpu)
+	@python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg --fcpu $(fcpu)
 %% endif

--- a/tools/build_script_generator/make/module.md
+++ b/tools/build_script_generator/make/module.md
@@ -349,8 +349,32 @@ loop: 60
 loop: 61
 ```
 
-See the `:platform:itm` module for details how to use the ITM as a logging
+See the `modm:platform:itm` module for details how to use the ITM as a logging
 output.
+
+
+#### make log-rtt
+
+```
+make log-rtt [channel={int}]
+```
+
+Configures OpenOCD in RTT mode to output the chosen channel (default 0) via a
+simple telnet client. Disconnect with Ctrl+D.
+(\* *only ARM Cortex-M targets*)
+
+```
+ $ make log-rtt
+Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Control block found at 0x20000008
+loop: 57
+loop: 58
+loop: 59
+loop: 60
+loop: 61
+```
+
+See the `modm:platform:rtt` module for details how to use RTT for data transfer.
 
 
 #### make library

--- a/tools/build_script_generator/make/resources/Makefile.in
+++ b/tools/build_script_generator/make/resources/Makefile.in
@@ -135,4 +135,9 @@ fcpu?=0
 .PHONY: log-itm
 log-itm:
 	@python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg --fcpu $(fcpu)
+
+channel?=0
+.PHONY: log-rtt
+log-rtt:
+	@python3 modm/modm_tools/log.py rtt openocd -f modm/openocd.cfg --channel $(channel)
 %% endif

--- a/tools/build_script_generator/make/resources/Makefile.in
+++ b/tools/build_script_generator/make/resources/Makefile.in
@@ -114,25 +114,25 @@ ui?=tui
 debug: build
 	@python3 modm/modm_tools/gdb.py $(addprefix -x ,$(MODM_GDBINIT)) \
 			$(addprefix -x ,$(MODM_OPENOCD_GDBINIT)) \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			openocd $(addprefix -f ,$(MODM_OPENOCD_CONFIGFILES))
 
 .PHONY: debug-bmp
 debug-bmp: build
 	@python3 modm/modm_tools/bmp.py $(addprefix -x ,$(MODM_GDBINIT)) \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			bmp -p $(port)
 
 coredump?=coredump.txt
 .PHONY: debug-coredump
 debug-coredump: build
 	@python3 modm/modm_tools/gdb.py $(addprefix -x ,$(MODM_GDBINIT)) \
-			$(ELF_FILE) -ui=$(ui) \
+			$(ELF_FILE) --ui=$(ui) \
 			crashdebug --binary-path modm/ext/crashcatcher/bins \
 			--dump $(coredump)
 
 fcpu?=0
 .PHONY: log-itm
 log-itm:
-	@python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg -fcpu $(fcpu)
+	@python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg --fcpu $(fcpu)
 %% endif

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -243,6 +243,13 @@ def post_build(env):
         openocd_cfg = env.get(":build:openocd.cfg", "")
         if len(openocd_cfg):
             env.substitutions["openocd_user_path"] = env.relative_outpath(openocd_cfg)
+
+        has_rtt = env.has_module(":platform:rtt")
+        env.substitutions["has_rtt"] = has_rtt
+        if has_rtt:
+            memories = env.query(":platform:cortex-m:linkerscript", {})
+            env.substitutions["ram_size"] = memories.get("cont_ram", {}).get("size", 4096)
+            env.substitutions["rtt_channels"] = len(env.get(":platform:rtt:buffer.tx", []))
         env.template("openocd.cfg.in")
         env.template("openocd_gdbinit.in")
         env.template("gdbinit")

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -22,3 +22,16 @@ proc modm_program { SOURCE } {
 	reset run
 	shutdown
 }
+
+%% if has_rtt
+proc modm_rtt { {POLLING 1} {CHANNELS {{rtt_channels}}} } {
+	rtt setup 0x20000000 {{ram_size}} "modm.rtt.modm"
+	rtt start
+	rtt polling_interval $POLLING
+	for {set i 0} {$i < $CHANNELS} {incr i} {
+		rtt server start [expr {9090 + $i}] $i
+	}
+}
+%% endif
+
+init

--- a/tools/build_script_generator/openocd_gdbinit.in
+++ b/tools/build_script_generator/openocd_gdbinit.in
@@ -6,6 +6,3 @@ define rerun
   mon reset halt
   c
 end
-
-mon init
-mon poll on

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -101,7 +101,7 @@ def build(env):
 
     device = env.query("::device")
     if device["core"].startswith("cortex-m"):
-        tools.update({"size", "log_itm", "artifact", "openocd",
+        tools.update({"size", "log_cortex", "artifact", "openocd",
                      "openocd_remote", "bmp", "crashdebug", "dfu"})
         if device["platform"] in ["sam"]:
             tools.update({"bossac"})

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -406,8 +406,34 @@ loop: 60
 loop: 61
 ```
 
-See the `:platform:itm` module for details how to use the ITM as a logging
+See the `modm:platform:itm` module for details how to use the ITM as a logging
 output.
+
+
+#### scons log-rtt
+
+```
+scons log-rtt [channel={int}]
+```
+
+Configures OpenOCD in RTT mode to output the chosen channel (default 0) via a
+simple telnet client. Disconnect with Ctrl+D.
+(\* *only ARM Cortex-M targets*)
+
+```
+ $ scons log-rtt
+╭───OpenOCD───> Real Time Transfer
+╰─────RTT────── stm32f103rbt6
+Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Control block found at 0x20000008
+loop: 57
+loop: 58
+loop: 59
+loop: 60
+loop: 61
+```
+
+See the `modm:platform:rtt` module for details how to use RTT for data transfer.
 
 
 #### scons library

--- a/tools/build_script_generator/scons/resources/build_target.py.in
+++ b/tools/build_script_generator/scons/resources/build_target.py.in
@@ -43,6 +43,7 @@ def build_target(env, sources):
 	env.Alias("size", env.Size(chosen_program))
 	%% if core.startswith("cortex-m")
 	env.Alias("log-itm", env.LogItmOpenOcd())
+	env.Alias("log-rtt", env.LogRttOpenOcd())
 
 	env.Alias("artifact", env.CacheArtifact(program))
 		%% set artifact = ', "artifact"' if upload_with_artifact else ''

--- a/tools/build_script_generator/scons/site_tools/comstr.py
+++ b/tools/build_script_generator/scons/site_tools/comstr.py
@@ -132,6 +132,9 @@ def generate(env, **kw):
         env["ITM_OPENOCD_COMSTR"] =      "%s╭───OpenOCD───> %sSingle Wire Viewer\n" \
                                          "%s╰─────SWO────── %s$CONFIG_DEVICE_NAME%s" % install
 
+        env["RTT_OPENOCD_COMSTR"] =      "%s╭───OpenOCD───> %sReal Time Transfer\n" \
+                                         "%s╰─────RTT────── %s$CONFIG_DEVICE_NAME%s" % install
+
         env["PROGRAM_REMOTE_COMSTR"] =   "%s╭────────────── %s$SOURCE\n" \
                                          "%s╰─Rem─OpenOCD─> %s$CONFIG_DEVICE_NAME%s" % install
 

--- a/tools/modm_tools/gdb.md
+++ b/tools/modm_tools/gdb.md
@@ -8,7 +8,7 @@ The tool can be called from the command line. Here is a typical use-case using
 the openocd backend with the common configuration files:
 
 ```sh
-python3 modm/modm_tools/gdb.py path/to/project.elf -ui=tui \
+python3 modm/modm_tools/gdb.py path/to/project.elf --ui=tui \
         -x modm/gdbinit -x modm/openocd_gdbinit \
         openocd -f modm/openocd.cfg
 ```
@@ -32,7 +32,7 @@ remote backend with the `--host={ip or hostname}` via the command line:
 
 ```sh
 # Extended-Remote running remotely
-python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit -ui=tui \
+python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit --ui=tui \
         remote --host 123.45.67.89
 ```
 
@@ -40,11 +40,11 @@ Note that you can use different programmer backends to GDB:
 
 ```sh
 # Black Magic Probe
-python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit -ui=tui \
+python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit --ui=tui \
         bmp --port /dev/tty.usbserial-123
 
 # CrashDebug for Post-Mortem debugging
-python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit -ui=tui \
+python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit --ui=tui \
         crashdebug --binary-path modm/ext/crashcatcher/bins --dump coredump.txt
 ```
 
@@ -52,8 +52,8 @@ python3 modm/modm_tools/gdb.py path/to/project.elf -x modm/gdbinit -ui=tui \
 
 Currently two UIs are implemented for debugging:
 
-- `-ui=tui`: Text-based UI in your shell.
-- `-ui=web`: Web-based UI in your browser, based on [gdbgui][].
+- `--ui=tui`: Text-based UI in your shell.
+- `--ui=web`: Web-based UI in your browser, based on [gdbgui][].
 
 
 #### Text UI

--- a/tools/modm_tools/gdb.py
+++ b/tools/modm_tools/gdb.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
             metavar="ELF",
             help="The ELF files to use for debugging.")
     parser.add_argument(
-            "-ui",
+            "--ui",
             dest="ui",
             choices=["tui", "web"],
             help="Use GDB via TUI or GDBGUI.")

--- a/tools/modm_tools/log.py
+++ b/tools/modm_tools/log.py
@@ -24,7 +24,7 @@ Logging via the SWO trace pin is supported via OpenOCD and the
 `modm:platform:itm` module:
 
 ```sh
-python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg -fcpu 64000000
+python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg --fcpu 64000000
 ```
 
 (\* *only ARM Cortex-M targets*)
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # Add backends
     parser_openocd = openocd.add_subparser(subparsers)
     parser_openocd.add_argument(
-            "-fcpu",
+            "--fcpu",
             dest="fcpu",
             required=True,
             type=int,

--- a/tools/modm_tools/log.py
+++ b/tools/modm_tools/log.py
@@ -27,6 +27,15 @@ Logging via the SWO trace pin is supported via OpenOCD and the
 python3 modm/modm_tools/log.py itm openocd -f modm/openocd.cfg --fcpu 64000000
 ```
 
+#### RTT
+
+Logging via the RTT protocol is supported via OpenOCD and the
+`modm:platform:rtt` module:
+
+```sh
+python3 modm/modm_tools/log.py rtt openocd -f modm/openocd.cfg --channel 0
+```
+
 (\* *only ARM Cortex-M targets*)
 """
 
@@ -43,7 +52,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Host-side logging post-processing.')
     parser.add_argument(
             dest="type",
-            choices=["itm"],
+            choices=["itm", "rtt"],
             help="The type of log connection.")
 
     subparsers = parser.add_subparsers(title="Backend", dest="backend")
@@ -53,16 +62,23 @@ if __name__ == "__main__":
     parser_openocd.add_argument(
             "--fcpu",
             dest="fcpu",
-            required=True,
             type=int,
-            help="The devices' CPU/HCLK frequency.")
+            help="The devices' CPU/HCLK frequency (ITM only).")
     parser_openocd.add_argument(
             "-b", "--baudrate",
             dest="baudrate",
             type=int,
-            help="Set the baudrate of the log connection.")
+            help="Set the baudrate of the log connection (ITM only).")
+    parser_openocd.add_argument(
+            "--channel",
+            dest="channel",
+            type=int,
+            default=0,
+            help="The RTT channel to display (RTT only).")
 
     args = parser.parse_args()
     # FIXME: Currently hardcoded to the OpenOCD backend
-    openocd.log_itm(backend=args.backend(args),
-                    fcpu=args.fcpu, baudrate=args.baudrate)
+    if args.type == "itm":
+        openocd.log_itm(backend=args.backend(args), fcpu=args.fcpu, baudrate=args.baudrate)
+    else:
+        openocd.log_rtt(backend=args.backend(args), channel=args.channel)

--- a/tools/modm_tools/openocd.py
+++ b/tools/modm_tools/openocd.py
@@ -29,10 +29,12 @@ python3 modm/modm_tools/openocd.py -f modm/openocd.cfg --reset
 """
 
 import os
+import time
 import signal
 import tempfile
-import subprocess
 import platform
+import telnetlib
+import subprocess
 if __name__ == "__main__":
     import sys
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -114,6 +116,13 @@ def log_itm(backend, fcpu, baudrate=None):
             except KeyboardInterrupt:
                 pass
 
+def log_rtt(backend, channel=0):
+    backend.commands.append("modm_rtt")
+    # Start OpenOCD in the background
+    with bem.Scope(backend) as b:
+        time.sleep(0.5)
+        with telnetlib.Telnet("localhost", 9090+channel) as tn:
+            tn.interact()
 
 # -----------------------------------------------------------------------------
 def program(source, config=None, search=None):
@@ -121,7 +130,7 @@ def program(source, config=None, search=None):
     call(commands=commands, config=config, search=search)
 
 def reset(config=None, search=None):
-    commands = ["init", "reset", "shutdown"]
+    commands = ["reset", "shutdown"]
     call(commands=commands, config=config, search=search)
 
 # -----------------------------------------------------------------------------

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -78,7 +78,7 @@ def hal_get_modules():
 
         modules = set()
         # We only care about some modm:platform:* modules here
-        not_interested = {"bitbang", "common", "heap", "clock", "core", "fault", "cortex-m", "uart.spi", "itm"}
+        not_interested = {"bitbang", "common", "heap", "clock", "core", "fault", "cortex-m", "uart.spi", "itm", "rtt"}
         imodules = (m  for (repo, mfile) in mfiles  for m in lbuild.module.load_module_from_file(repo, mfile)
                     if m.available and m.fullname.startswith("modm:platform:") and
                     all(p not in m.fullname for p in not_interested))


### PR DESCRIPTION
[OpenOCD v0.11 added basic support for RTT](http://openocd.org/doc/html/General-Commands.html#Real-Time-Transfer-_0028RTT_0029), which is a great non-blocking alternative to semihosting and works on *any* Cortex-M target without requiring any peripheral UART drivers.

This adds a basic implementation based on [the OpenOCD implementation](http://openocd.org/doc/doxygen/html/target_2rtt_8c_source.html):

- [x] RTT control structure, channels and buffers implemented
- [x] µC -> OpenOCD tested in hardware
- [x] OpenOCD -> µC tested in hardware
- [x] Proper channel buffer config validation
- [x] Build system Integration: Better Telnet client
  - [x] SCons
  - [x] Makefile
  - [x] CMake
- [x] Documentation

cc @rleh @chris-durand 