### PR TITLE
[board] Nucleo-L496ZG-P

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Examples STM32L4 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc nucleo_l452re)
+          (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc nucleo_l452re nucleo_l496zg-p)
       - name: Examples STM32G4 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -495,10 +495,11 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l452re">NUCLEO-L452RE</a></td>
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l476rg">NUCLEO-L476RG</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-samd21-mini">SAMD21-MINI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32f030_demo">STM32F030-DEMO</a></td>
 </tr>

--- a/examples/nucleo_l496zg-p/blink/main.cpp
+++ b/examples/nucleo_l496zg-p/blink/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter = 0;
+
+	while (true)
+	{
+		Leds::write(counter % (1 << 3));
+		modm::delay(Button::read() ? 250ms : 500ms);
+		MODM_LOG_INFO << "loop: " << counter << modm::endl;
+		counter++;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l496zg-p/blink/project.xml
+++ b/examples/nucleo_l496zg-p/blink/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-l496zg-p</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l496zg-p/blink</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo144_arduino_l4.hpp
+++ b/src/modm/board/nucleo144_arduino_l4.hpp
@@ -1,0 +1,95 @@
+// Nucleo144 Arduino Header Footprint for STM32L4xxZx
+// Schematic: https://www.st.com/resource/en/schematic_pack/mb1312-l4xxzx-a03_schematic.pdf
+
+#ifndef MODM_STM32_NUCLEO144_ARDUINO_L4_HPP
+#define MODM_STM32_NUCLEO144_ARDUINO_L4_HPP
+
+// Arduino Footprint
+using A0 = GpioA3;
+using A1 = GpioC0;
+using A2 = GpioC3;
+using A3 = GpioC1;
+using A4 = GpioC4;
+using A5 = GpioC5;
+// Zio Footprint
+using A6 = GpioB1;
+using A7 = GpioC2;
+using A8 = GpioA1;
+
+// Arduino Footprint
+using D0  = GpioD9;
+using D1  = GpioD8;
+using D2  = GpioF15;
+using D3  = GpioE13;
+using D4  = GpioF14;
+using D5  = GpioE11;
+using D6  = GpioE9;
+using D7  = GpioF13;
+using D8  = GpioF12;
+using D9  = GpioD15;
+using D10 = GpioD14;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+// Zio Footprint
+using D16 = GpioC6;
+using D17 = GpioB15;
+using D18 = GpioB13;
+using D19 = GpioB12;
+using D20 = GpioA4;
+using D21 = GpioB4;
+using D22 = GpioB5;
+using D23 = GpioB3;
+using D24 = GpioA4;
+using D25 = GpioB4;
+using D26 = GpioA2;
+using D27 = GpioB10;
+using D28 = GpioE15;
+using D29 = GpioB0;
+using D30 = GpioE12;
+using D31 = GpioE14;
+using D32 = GpioA0;
+using D33 = GpioB0;
+using D34 = GpioE0;
+using D35 = GpioUnused; // SMPSVDD12 on Nucleo-P (SMPS variants), otherwise GpioB11
+using D36 = GpioB10;
+using D37 = GpioE15;
+using D38 = GpioE14;
+using D39 = GpioE12;
+using D40 = GpioE10;
+using D41 = GpioE7;
+using D42 = GpioE8;
+using D43 = GpioC8;
+using D44 = GpioC9;
+using D45 = GpioC10;
+using D46 = GpioC11;
+using D47 = GpioC12;
+using D48 = GpioD2;
+using D49 = GpioF3;
+using D50 = GpioF5;
+using D51 = GpioD7;
+using D52 = GpioD6;
+using D53 = GpioD5;
+using D54 = GpioD4;
+using D55 = GpioD3;
+using D56 = GpioE2;
+using D57 = GpioE4;
+using D58 = GpioE5;
+using D59 = GpioE6;
+using D60 = GpioE3;
+using D61 = GpioF8;
+using D62 = GpioF7;
+using D63 = GpioF9;
+using D64 = GpioG1;
+using D65 = GpioG0;
+using D66 = GpioD1;
+using D67 = GpioD0;
+using D68 = GpioF0;
+using D69 = GpioF1;
+using D70 = GpioF2;
+using D71 = GpioB6;
+using D72 = GpioB2;
+
+#endif // MODM_STM32_NUCLEO144_ARDUINO_L4_HPP

--- a/src/modm/board/nucleo_l496zg-p/board.hpp
+++ b/src/modm/board/nucleo_l496zg-p/board.hpp
@@ -1,0 +1,182 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_L496ZG_P_HPP
+#define MODM_STM32_NUCLEO_L496ZG_P_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+
+/// @ingroup modm_board_nucleo_l496zg_p
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_l496zg_p
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32L4 running at 80MHz generated from the
+/// internal Multispeed oscillator
+
+// Dummy clock for devices
+struct SystemClock {
+	static constexpr uint32_t Frequency = 80_MHz;
+	static constexpr uint32_t Ahb  = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+	static constexpr uint32_t Apb1Timer = Apb1;
+	static constexpr uint32_t Apb2Timer = Apb2;
+
+	static constexpr uint32_t Can1 = Apb1;
+	static constexpr uint32_t Can2 = Apb1;
+
+	static constexpr uint32_t Comp1 = Apb2;
+	static constexpr uint32_t Comp2 = Apb2;
+
+	static constexpr uint32_t Dac1 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Sai1 = Apb2;
+	static constexpr uint32_t Sai2 = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static constexpr uint32_t Usart1  = Apb2;
+	static constexpr uint32_t Usart2  = Apb1;
+	static constexpr uint32_t Usart3  = Apb1;
+	static constexpr uint32_t Uart4   = Apb1;
+	static constexpr uint32_t Uart5   = Apb1;
+
+	static constexpr uint32_t Lpuart1 = Frequency; // Clock mux default: 0b00 -> PCLK
+
+	static constexpr uint32_t Usb = 48_MHz;
+	static constexpr uint32_t Rng = 48_MHz;
+	static constexpr uint32_t Sdmmc = 48_MHz;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableMultiSpeedInternalClock(Rcc::MsiFrequency::MHz16);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 2,		//   16MHz / M=2  ->   8MHz
+			.pllN = 40,		//   8MHz *  N=40 -> 320MHz
+			.pllR = 4,		// 320MHz /  R=4  ->  80MHz = F_cpu
+			.pllQ = 2,		// 320MHz /  Q=2  -> 160MHz
+		};
+		Rcc::enablePll(Rcc::PllSource::Msi, pllFactors);
+		Rcc::setFlashLatency<Frequency>();
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update clock frequencies
+		Rcc::updateCoreFrequency<Frequency>();
+
+		// Enable Hsi48 clock
+		uint32_t waitCycles = 2048;
+		RCC->CRRCR |= RCC_CRRCR_HSI48ON;
+		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitCycles)
+			;
+
+		// Select Hsi48 as source for CLK48 MUX (USB, SDMMC, RNG)
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_CLK48SEL_Msk) | (0b00 << RCC_CCIPR_CLK48SEL_Pos);
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo144_arduino_l4.hpp"
+
+using Button = GpioInputC13;
+
+using LedGreen = GpioOutputC7;	// LED1 [Green]
+using LedBlue = GpioOutputB7;	// LED2 [Blue]
+using LedRed = GpioOutputB14;	// LED3 [Red]
+using Leds = SoftwareGpioPort< LedRed, LedBlue, LedGreen >;
+
+namespace usb
+{
+using Vbus = GpioA9;
+using Id = GpioA10;
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Overcurrent = GpioInputG5;	// OTG_FS_OverCurrent
+using Power = GpioOutputG6;			// OTG_FS_PowerSwitchOn
+
+using Device = UsbFs;
+}
+
+namespace stlink
+{
+using Rx = GpioOutputG8;
+using Tx = GpioInputG7;
+using Uart = Lpuart1;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedRed::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+//	Button::setInputTrigger(Gpio::InputTrigger::RisingEdge);
+//	Button::enableExternalInterrupt();
+//	Button::enableExternalInterruptVector(12);
+}
+
+inline void
+initializeUsbFs()
+{
+	usb::Device::initialize<SystemClock>();
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
+
+	usb::Overcurrent::setInput();
+	usb::Vbus::setInput();
+}
+
+} // Board namespace
+
+#endif	// MODM_STM32_NUCLEO_L496ZG_P_HPP

--- a/src/modm/board/nucleo_l496zg-p/board.xml
+++ b/src/modm/board/nucleo_l496zg-p/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32l496zgt6p</option>
+    <option name="modm:platform:uart:lpuart1:buffer.tx">2048</option>
+  </options>
+
+  <modules>
+    <module>modm:board:nucleo-l496zg-p</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_l496zg-p/module.lb
+++ b/src/modm/board/nucleo_l496zg-p/module.lb
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-l496zg-p"
+    module.description = """\
+# NUCLEO-L496ZG-P
+
+[Nucleo kit for STM32L496ZG-P](https://www.st.com/en/evaluation-tools/nucleo-l496zg-p.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32l496zgt6p"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:lpuart1",
+        ":platform:usb:fs")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo144_arduino_l4.hpp", "nucleo144_arduino_l4.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_l4.cfg")

--- a/src/modm/driver/touch/touch2046.hpp
+++ b/src/modm/driver/touch/touch2046.hpp
@@ -17,6 +17,9 @@
 #include <modm/architecture/interface/gpio.hpp>
 #include <modm/processing/resumable.hpp>
 
+#include <array>
+#include <tuple>
+
 namespace modm
 {
 

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Sascha Schade
  * Copyright (c) 2016-2017, Fabian Greif
  * Copyright (c) 2016-2017, 2019, Niklas Hauser
+ * Copyright (c) 2021, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -54,5 +55,11 @@ __modm_initialize_platform(void)
 	PWR->CR1 |= PWR_CR1_DBP;
 	// Enable Data Tighly Coupled Memory (DTCM) and backup SRAM (BKPSRAM)
 	RCC->AHB1ENR |= RCC_AHB1ENR_DTCMRAMEN | RCC_AHB1ENR_BKPSRAMEN;
+%% elif target.family in ["g0", "l4", "l5"]
+#ifdef PWR_CR2_IOSV
+	// Enable VDDIO2
+	RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+	PWR->CR2 |= PWR_CR2_IOSV;
+#endif
 %% endif
 }

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2016-2018, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2021, Raphael Lehmann
 #
 # This file is part of the modm project.
 #
@@ -19,7 +20,10 @@ class Instance(Module):
         self.instance = int(instance)
 
     def init(self, module):
-        module.name = str(self.instance)
+        if self.driver["name"] == "lpuart":
+            module.name = "lpuart" + str(self.instance)
+        else:
+            module.name = str(self.instance)
         module.description = "Instance {}".format(self.instance)
 
     def prepare(self, module, options):
@@ -46,20 +50,27 @@ class Instance(Module):
         props["id"] = self.instance
         props["driver"] = self.driver
         props["features"] = self.driver["feature"] if "feature" in self.driver else []
-        props["uart_name"] = self.driver["name"].capitalize()
+        props["uart_type"] = self.driver["name"].capitalize()
+        props["name"] = self.driver["name"].capitalize() + str(self.instance)
+        props["hal"] = self.driver["name"].capitalize() + "Hal" + str(self.instance)
         props["buffered"] = env["buffer.tx"] or env["buffer.rx"]
 
         env.substitutions = props
         env.outbasepath = "modm/src/modm/platform/uart"
 
-        env.template("uart_hal.hpp.in", "uart_hal_{}.hpp".format(self.instance))
-        env.template("uart_hal_impl.hpp.in", "uart_hal_{}_impl.hpp".format(self.instance))
-        env.template("uart.hpp.in", "uart_{}.hpp".format(self.instance))
-        env.template("uart.cpp.in", "uart_{}.cpp".format(self.instance))
+        if self.driver["name"] == "lpuart":
+            uart = "lpuart"
+        else:
+            uart = "uart"
 
-        props["instances"].append(self.instance)
+        env.template("uart_hal.hpp.in", "{}_hal_{}.hpp".format(uart, self.instance))
+        env.template("uart_hal_impl.hpp.in", "{}_hal_{}_impl.hpp".format(uart, self.instance))
+        env.template("uart.hpp.in", "{}_{}.hpp".format(uart, self.instance))
+        env.template("uart.cpp.in", "{}_{}.cpp".format(uart, self.instance))
+
+        #props["instances"].append(props["name"])
         if props["buffered"]:
-            props["buffered_instances"].append(self.instance)
+            props["buffered_instances"].append(props["name"])
 
 
 def init(module):
@@ -68,7 +79,9 @@ def init(module):
 
 def prepare(module, options):
     device = options[":target"]
-    if not (device.has_driver("uart:stm32*") or device.has_driver("usart:stm32*")):
+    if not (device.has_driver("uart:stm32*")
+            or device.has_driver("usart:stm32*")
+            or device.has_driver("lpuart:stm32*")):
         return False
 
     module.depends(
@@ -82,7 +95,7 @@ def prepare(module, options):
         ":platform:rcc")
 
     global props
-    drivers = (device.get_all_drivers("uart") + device.get_all_drivers("usart"))
+    drivers = (device.get_all_drivers("uart") + device.get_all_drivers("usart") + device.get_all_drivers("lpuart"))
     props["extended_driver"] = ("extended" in drivers[0]["type"])
     props["over8"] = ("feature" in drivers[0]) and ("over8" in drivers[0]["feature"])
     props["tcbgt"] = ("feature" in drivers[0]) and ("tcbgt" in drivers[0]["feature"])
@@ -93,14 +106,28 @@ def prepare(module, options):
         for instance in driver["instance"]:
             module.add_submodule(Instance(driver, instance))
 
+    shared_irqs_new = dict()
     shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
-    shared_irqs = [v for v in shared_irqs if v.startswith("USART") and "_" in v]
-    if len(shared_irqs):
-        props["shared_irq"] = name = shared_irqs[0]
-        parts = name[5:].split("_")
-        props["shared_irq_ids"] = range(int(parts[0]), int(parts[1]) + 1)
-    else:
-        props["shared_irq_ids"] = []
+    shared_irqs = [v for v in shared_irqs if ("USART" in v or "UART" in v or "LPUART" in v) and "_" in v]
+    for shared_irq in shared_irqs:
+        uart_type = ""
+        import re
+        for s in re.findall(r"L?P?US?ART[\d_]+", shared_irq):
+            if "LPUART" in s:
+                uart_type = "Lpuart"
+            elif "UART" in s:
+                uart_type = "Uart"
+            elif "USART" in s:
+                uart_type = "Usart"
+            else:
+                # use type from previous irq id
+                pass
+            irq_ids = re.findall(r"\d+", s)
+            if len(irq_ids) == 2:
+                irq_ids = range(int(irq_ids[0]), int(irq_ids[1])+1)
+            for irq_id in irq_ids:
+                shared_irqs_new[uart_type + str(irq_id)] = shared_irq
+    props["shared_irqs"] = shared_irqs_new
 
     props["target"] = device.identifier
 
@@ -113,5 +140,17 @@ def build(env):
     env.substitutions = props
     env.outbasepath = "modm/src/modm/platform/uart"
     env.template("uart_base.hpp.in")
-    if any(i in props["shared_irq_ids"] for i in props["buffered_instances"]):
+
+    props["uart_shared_irqs_data"] = dict()
+    for name in props["buffered_instances"]:
+        if name in props["shared_irqs"].keys():
+            irq = props["shared_irqs"][name]
+            if irq not in props["uart_shared_irqs_data"]:
+                props["uart_shared_irqs_data"][irq] = list()
+            props["uart_shared_irqs_data"][irq].append({
+                "name": name,
+                "id": name[-1],
+                "type": name[:-1],
+            })
+    if len(props["uart_shared_irqs_data"]):
         env.template("uart_shared.cpp.in")

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -6,6 +6,7 @@
  * Copyright (c) 2013, 2016, Kevin Läufer
  * Copyright (c) 2013-2017, Niklas Hauser
  * Copyright (c) 2018, Lucas Mösch
+ * Copyright (c) 2021, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -15,12 +16,12 @@
  */
 // ----------------------------------------------------------------------------
 
-%% set name = uart_name ~ id
-%% set hal = uart_name ~ "Hal" ~ id
-
 #include "../device.hpp"
-#include "uart_hal_{{ id }}.hpp"
+%% if "Lpuart" in uart_type
+#include "lpuart_{{ id }}.hpp"
+%% else
 #include "uart_{{ id }}.hpp"
+%%endif
 
 %% if buffered
 #include <modm/architecture/interface/atomic_lock.hpp>
@@ -235,7 +236,7 @@ void
 }	// namespace modm::platform
 
 %% if buffered
-%% if id in shared_irq_ids
+%% if name in shared_irqs.keys()
 void
 modm::platform::{{ name }}::irq()
 %% else

--- a/src/modm/platform/uart/stm32/uart.hpp.in
+++ b/src/modm/platform/uart/stm32/uart.hpp.in
@@ -5,6 +5,7 @@
  * Copyright (c) 2011, 2013-2017, Niklas Hauser
  * Copyright (c) 2012, Sascha Schade
  * Copyright (c) 2013, 2016, Kevin Läufer
+ * Copyright (c) 2021, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -14,22 +15,28 @@
  */
 // ----------------------------------------------------------------------------
 
-%% set hal = uart_name ~ "Hal" ~ id
-%% set name = uart_name ~ id
-
+%% if "Lpuart" in uart_type
+#ifndef MODM_STM32_LPUART_{{ id }}_HPP
+#define MODM_STM32_LPUART_{{ id }}_HPP
+%% else
 #ifndef MODM_STM32_UART_{{ id }}_HPP
 #define MODM_STM32_UART_{{ id }}_HPP
+%%endif
 
 #include <modm/architecture/interface/uart.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include "uart_base.hpp"
+%% if "Lpuart" in uart_type
+#include "lpuart_hal_{{ id }}.hpp"
+%% else
 #include "uart_hal_{{ id }}.hpp"
+%%endif
 
 namespace modm::platform
 {
 
 /**
- * Universal asynchronous receiver transmitter ({{ uart_name | upper ~ id }})
+ * Universal asynchronous receiver transmitter ({{ name }})
  *
  * @author		Kevin Laeufer
  * @author		Niklas Hauser
@@ -121,7 +128,7 @@ public:
 	static void
 	clearError();
 
-%% if id in shared_irq_ids
+%% if name in shared_irqs.keys()
 	static void
 	irq();
 %% endif

--- a/src/modm/platform/uart/stm32/uart_hal.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal.hpp.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2013, Sascha Schade
  * Copyright (c) 2013-2014, 2016, Kevin Läufer
  * Copyright (c) 2013-2017, 2021, Niklas Hauser
+ * Copyright (c) 2021, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -11,8 +12,13 @@
  */
 // ----------------------------------------------------------------------------
 
+%% if "Lpuart" in uart_type
+#ifndef MODM_STM32_LPUARTHAL_{{ id }}_HPP
+#define MODM_STM32_LPUARTHAL_{{ id }}_HPP
+%% else
 #ifndef MODM_STM32_UARTHAL_{{ id }}_HPP
 #define MODM_STM32_UARTHAL_{{ id }}_HPP
+%%endif
 
 #include <stdint.h>
 #include "../device.hpp"
@@ -24,7 +30,7 @@ namespace modm::platform
 {
 
 /**
- * Universal asynchronous receiver transmitter ({{ uart_name ~ "Hal" ~ id }})
+ * Universal asynchronous receiver transmitter ({{ hal }})
  *
  * Not available on the low- and medium density devices.
  *
@@ -34,7 +40,7 @@ namespace modm::platform
  * @author		Kevin Laeufer
  * @ingroup		modm_platform_uart
  */
-class {{ uart_name ~ "Hal" ~ id }} : public UartBase
+class {{ hal }} : public UartBase
 {
 public:
 	static constexpr bool isExtended = {{ extended_driver | lower }};
@@ -61,7 +67,7 @@ public:
 	static inline void
 	initialize(Parity parity, WordLength length);
 
-%% if uart_name == "Usart"
+%% if uart_type == "Usart"
 	%% if extended_driver
 	/// @warning You must call `disableOperations()` before this function!
 	%% endif
@@ -133,6 +139,10 @@ public:
 
 }	// namespace modm::platform
 
+%% if "Lpuart" in uart_type
+#include "lpuart_hal_{{ id }}_impl.hpp"
+%% else
 #include "uart_hal_{{ id }}_impl.hpp"
+%%endif
 
-#endif // MODM_STM32_UARTHAL_{{ id }}_HPP
+#endif

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -5,6 +5,7 @@
  * Copyright (c) 2017, Sascha Schade
  * Copyright (c) 2018, Christopher Durand
  * Copyright (c) 2018, Lucas Mösch
+ * Copyright (c) 2021, Raphael Lehmann
  *
  * This file is part of the modm project.
  *
@@ -14,12 +15,18 @@
  */
 // ----------------------------------------------------------------------------
 
-%% set name = uart_name ~ "Hal" ~ id
-%% set peripheral = uart_name | upper ~ id
+%% set peripheral = uart_type | upper ~ id
 
+%% if "Lpuart" in uart_type
+#ifndef MODM_STM32_LPUARTHAL_{{ id }}_HPP
+#	error 	"Don't include this file directly, use lpuart_hal_{{ id }}.hpp instead!"
+#endif
+%% else
 #ifndef MODM_STM32_UARTHAL_{{ id }}_HPP
 #	error 	"Don't include this file directly, use uart_hal_{{ id }}.hpp instead!"
 #endif
+%%endif
+
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
 
@@ -28,45 +35,56 @@ namespace modm::platform
 
 // ----------------------------------------------------------------------------
 void
-{{ name }}::enable()
+{{ hal }}::enable()
 {
-	Rcc::enable<Peripheral::{{ uart_name ~ id }}>();
+	Rcc::enable<Peripheral::{{ name }}>();
 }
 
 void
-{{ name }}::disable()
+{{ hal }}::disable()
 {
 	// TX, RX, Uart, etc. Disable
 	{{ peripheral }}->CR1 = 0;
-	Rcc::disable<Peripheral::{{ uart_name ~ id }}>();
+	Rcc::disable<Peripheral::{{ name }}>();
 }
 
 void
-{{ name }}::enableOperation()
+{{ hal }}::enableOperation()
 {
 	{{ peripheral }}->CR1 |= USART_CR1_UE;
 }
 
 void
-{{ name }}::disableOperation()
+{{ hal }}::disableOperation()
 {
 	{{ peripheral }}->CR1 &= ~USART_CR1_UE;
 }
 
 template< class SystemClock, modm::baudrate_t baudrate, modm::percent_t tolerance >
 void
-{{ name }}::initialize(Parity parity, WordLength length)
+{{ hal }}::initialize(Parity parity, WordLength length)
 {
 	enable();
 	disableOperation();
 
 %% if over8
-	constexpr uint32_t scalar = (baudrate * 16l > SystemClock::{{ uart_name ~ id }}) ? 8 : 16;
+	constexpr uint32_t scalar = (baudrate * 16 > SystemClock::{{ name }}) ? 8 : 16;
 	constexpr uint32_t max = ((scalar == 16) ? (1ul << 16) : (1ul << 15)) - 1ul;
+	constexpr auto result = Prescaler::from_range(SystemClock::{{ name }}, baudrate, 1, max);
+%% elif uart_type == "Lpuart"
+	static_assert(SystemClock::{{ name }} >= baudrate * 3,
+		"fck must be in the range [3 x baud rate, 4096 x baud rate].");
+	static_assert(SystemClock::{{ name }} <= uint64_t(baudrate) * 4096,
+		"fck must be in the range [3 x baud rate, 4096 x baud rate].");
+	constexpr uint32_t max = (1ul << 20) - 1ul;
+	constexpr auto result = GenericPrescaler<uint64_t>::from_range(
+		uint64_t(SystemClock::{{ name }}) * 256,
+		baudrate,
+		0x300, max);
 %% else
 	constexpr uint32_t max = (1ul << 16) - 1ul;
+	constexpr auto result = Prescaler::from_range(SystemClock::{{ name }}, baudrate, 1, max);
 %% endif
-	constexpr auto result = Prescaler::from_range(SystemClock::{{ uart_name ~ id }}, baudrate, 1, max);
 	modm::PeripheralDriver::assertBaudrateInTolerance< result.frequency, baudrate, tolerance >();
 
 	uint32_t cr1 = {{ peripheral }}->CR1;
@@ -102,9 +120,9 @@ void
 	{{ peripheral }}->CR1 = cr1;
 }
 
-%% if uart_name == "Usart"
+%% if uart_type == "Usart"
 void
-{{ name }}::setSpiClock(SpiClock clk, LastBitClockPulse pulse)
+{{ hal }}::setSpiClock(SpiClock clk, LastBitClockPulse pulse)
 {
 	uint32_t cr2 = {{ peripheral }}->CR2;
 	cr2 &= ~(USART_CR2_LBCL | USART_CR2_CLKEN);
@@ -113,7 +131,7 @@ void
 }
 
 void
-{{ name }}::setSpiDataMode(SpiDataMode mode)
+{{ hal }}::setSpiDataMode(SpiDataMode mode)
 {
 	uint32_t cr2 = {{ peripheral }}->CR2;
 	cr2 &= ~(USART_CR2_CPOL | USART_CR2_CPHA);
@@ -123,7 +141,7 @@ void
 %% endif
 
 void
-{{ name }}::write(uint16_t data)
+{{ hal }}::write(uint16_t data)
 {
 %% if extended_driver
 	{{ peripheral }}->TDR = data;
@@ -133,7 +151,7 @@ void
 }
 
 void
-{{ name }}::read(uint8_t &data)
+{{ hal }}::read(uint8_t &data)
 {
 %% if extended_driver
 	data = {{ peripheral }}->RDR;
@@ -143,7 +161,7 @@ void
 }
 
 void
-{{ name }}::read(uint16_t &data)
+{{ hal }}::read(uint16_t &data)
 {
 %% if extended_driver
 	data = {{ peripheral }}->RDR;
@@ -153,7 +171,7 @@ void
 }
 
 void
-{{ name }}::setTransmitterEnable(bool enable)
+{{ hal }}::setTransmitterEnable(bool enable)
 {
 	if (enable) {
 		{{ peripheral }}->CR1 |=  USART_CR1_TE;
@@ -163,7 +181,7 @@ void
 }
 
 void
-{{ name }}::setReceiverEnable(bool enable)
+{{ hal }}::setReceiverEnable(bool enable)
 {
 	if (enable) {
 		{{ peripheral }}->CR1 |=  USART_CR1_RE;
@@ -173,7 +191,7 @@ void
 }
 
 bool
-{{ name }}::isReceiveRegisterNotEmpty()
+{{ hal }}::isReceiveRegisterNotEmpty()
 {
 %% if extended_driver
 	return {{ peripheral }}->ISR & USART_ISR_RXNE;
@@ -183,7 +201,7 @@ bool
 }
 
 bool
-{{ name }}::isTransmitRegisterEmpty()
+{{ hal }}::isTransmitRegisterEmpty()
 {
 %% if extended_driver
 	return {{ peripheral }}->ISR & USART_ISR_TXE;
@@ -193,10 +211,10 @@ bool
 }
 
 void
-{{ name }}::enableInterruptVector(bool enable, uint32_t priority)
+{{ hal }}::enableInterruptVector(bool enable, uint32_t priority)
 {
-%% if id in shared_irq_ids
-	%% set irq = shared_irq
+%% if name in shared_irqs.keys()
+	%% set irq = shared_irqs[name]
 %% else
 	%% set irq = peripheral
 %% endif
@@ -213,25 +231,25 @@ void
 }
 
 void
-{{ name }}::setInterruptPriority(uint32_t priority)
+{{ hal }}::setInterruptPriority(uint32_t priority)
 {
 	NVIC_SetPriority({{ irq }}_IRQn, priority);
 }
 
 void
-{{ name }}::enableInterrupt(Interrupt_t interrupt)
+{{ hal }}::enableInterrupt(Interrupt_t interrupt)
 {
 	{{ peripheral }}->CR1 |= interrupt.value;
 }
 
 void
-{{ name }}::disableInterrupt(Interrupt_t interrupt)
+{{ hal }}::disableInterrupt(Interrupt_t interrupt)
 {
 	{{ peripheral }}->CR1 &= ~interrupt.value;
 }
 
-{{ name }}::InterruptFlag_t
-{{ name }}::getInterruptFlags()
+{{ hal }}::InterruptFlag_t
+{{ hal }}::getInterruptFlags()
 {
 %% if extended_driver
 	return InterruptFlag_t( {{ peripheral }}->ISR );
@@ -241,7 +259,7 @@ void
 }
 
 void
-{{ name }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
+{{ hal }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
 {
 %% if extended_driver
 	// Flags are cleared by writing a one to the flag position.

--- a/src/modm/platform/uart/stm32/uart_shared.cpp.in
+++ b/src/modm/platform/uart/stm32/uart_shared.cpp.in
@@ -10,13 +10,23 @@
 // ----------------------------------------------------------------------------
 
 #include "../device.hpp"
-%% for id in buffered_instances if id in shared_irq_ids
-#include "uart_{{ id }}.hpp"
+
+%% for irq, uarts in uart_shared_irqs_data.items()
+%% for uart in uarts
+%% if "Lpuart" in uart.type
+#include "lpuart_{{ uart["id"] }}.hpp"
+%%else
+#include "uart_{{ uart["id"] }}.hpp"
+%%endif
+%% endfor
 %% endfor
 
-MODM_ISR({{ shared_irq }})
+
+%% for irq, uarts in uart_shared_irqs_data.items()
+MODM_ISR({{ irq }})
 {
-%% for id in buffered_instances if id in shared_irq_ids
-    modm::platform::Usart{{ id }}::irq();
+%% for uart in uarts
+    modm::platform::{{ uart.name }}::irq();
 %% endfor
 }
+%% endfor


### PR DESCRIPTION
ST decided to use a different pinout for the Zio/Arduino connectors on this Nucleo-L144 board, see [schematic](https://www.st.com/resource/en/schematic_pack/mb1312-l4xxzx-a03_schematic.pdf).

The ST-Link serial lines are only connected to LpUart1 which is not yet supported by modm; thus the logger is disabled 😒.
I will have a look at the LpUart in the next days...