### PR TITLE
[stm32] Fix missing dependency of rcc driver on architecture:delay

### DIFF
--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -21,7 +21,7 @@ def prepare(module, options):
     if not options[":target"].has_driver("rcc:stm32*"):
         return False
 
-    module.depends(":cmsis:device", ":utils", ":platform:clock")
+    module.depends(":cmsis:device", ":utils", ":platform:clock", ":architecture:delay")
     # FIXME: Move Peripherals enum somewhere better
     module.depends(":platform:gpio")
     return True


### PR DESCRIPTION
When the FDCAN driver was merged a function was added in RCC to switch the CAN clock mux. It uses `delay_us` but doesn't depend on `architecture:delay` in lbuild. If the project doesn't include the latter the code generation fails.