### PR TITLE
[openocd] Upgrade deprecated TPIU+ITM configuration

### DIFF
--- a/examples/nucleo_f103rb/itm/main.cpp
+++ b/examples/nucleo_f103rb/itm/main.cpp
@@ -21,11 +21,8 @@ int
 main()
 {
 	Board::initialize();
+	Itm::initialize();
 	LedD13::setOutput();
-
-	// Done by OpenOCD: scons log-itm fcpu=64000000
-	// Itm::initialize<Board::SystemClock, 500_kHz>();
-	// Itm::connect<GpioB3::Traceswo>();
 
 	stream << "Hello from the SWO." << modm::endl;
 	stream << "debug"   << modm::endl;

--- a/examples/nucleo_f303re/itm/main.cpp
+++ b/examples/nucleo_f303re/itm/main.cpp
@@ -21,11 +21,8 @@ int
 main()
 {
 	Board::initialize();
+	Itm::initialize();
 	LedD13::setOutput();
-
-	// Done by OpenOCD: scons log-itm fcpu=64000000
-	// Itm::initialize<Board::SystemClock, 500_kHz>();
-	// Itm::connect<GpioB3::Traceswo>();
 
 	stream << "Hello from the SWO." << modm::endl;
 	stream << "debug"   << modm::endl;

--- a/src/modm/platform/uart/cortex/itm.cpp.in
+++ b/src/modm/platform/uart/cortex/itm.cpp.in
@@ -24,13 +24,20 @@ namespace
 namespace modm::platform
 {
 
-/* All done by OpenOCD 'tpiu config'
+void
+Itm::initialize()
+{
+	// Enable Tracing Debug Unit
+	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+%% if target.platform == "stm32"
+	// Enable the Trace SWO output
+	DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
+%% endif
+}
+
 void
 Itm::enable(uint8_t prescaler)
 {
-	// Enable the Tracing functionality
-	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-
 	// Trace Port Interface Selected Pin Protocol Register
 	TPI->ACPR = prescaler;
 
@@ -57,7 +64,6 @@ Itm::enable(uint8_t prescaler)
 	// Trace Enable Register
 	ITM->TER = 0b1;
 }
-*/
 
 void
 Itm::writeBlocking(uint8_t data)
@@ -179,3 +185,4 @@ Itm::update()
 }
 
 }	// namespace modm::platform
+

--- a/src/modm/platform/uart/cortex/itm.hpp.in
+++ b/src/modm/platform/uart/cortex/itm.hpp.in
@@ -12,8 +12,6 @@
 #pragma once
 
 #include <modm/architecture/interface/uart.hpp>
-// #include <modm/platform/gpio/connector.hpp>
-// #include <cmath>
 
 namespace modm::platform
 {
@@ -31,46 +29,8 @@ public:
 	static constexpr size_t TxBufferSize = {{ options["buffer.tx"] }};
 
 public:
-	/* Initialized by OpenOCD 'tpiu config'
-	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(2) >
 	static void
-	initialize()
-	{
-		constexpr float desired = float(SystemClock::Frequency) / baudrate;
-
-		// calculate the possible rates above and below the requested rate
-		constexpr uint32_t rate_lower = SystemClock::Frequency / std::ceil(desired);
-		constexpr uint32_t rate_upper = SystemClock::Frequency / std::floor(desired);
-
-		// calculate the half-point between the upper and lower rate
-		constexpr uint32_t rate_middle = (rate_upper + rate_lower) / 2;
-		// decide which reload value is closer to a possible rate
-		constexpr uint32_t prescaler = (1000 < rate_middle) ? std::ceil(desired) : std::floor(desired);
-
-		// check if within rate tolerance
-		constexpr uint32_t generated_rate = SystemClock::Frequency / prescaler;
-		PeripheralDriver::assertBaudrateInTolerance< generated_rate, baudrate, tolerance >();
-
-		enable(prescaler - 1);
-	}
-	*/
-
-	/* Trace pins can only be assigned by debugger on External Private Peripheral Bus
-	 * !!! THIS IS DEVICE SPECIFIC!
-	template< template<Peripheral _> class... Signals >
-	static void
-	connect()
-	{
-		using Connector = GpioConnector<Peripheral::Sys, Signals...>;
-		using Tx = typename Connector::template GetSignal< Gpio::Signal::Traceswo >;
-		static_assert(((Connector::template IsValid<Tx>) and sizeof...(Signals) == 1),
-					  "Itm::connect() requires one SWO signal!");
-
-		// Enable the Trace SWO output
-		DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
-		Connector::connect();
-	}
-	*/
+	initialize();
 
 	static void
 	writeBlocking(uint8_t data);

--- a/src/modm/platform/uart/cortex/module.lb
+++ b/src/modm/platform/uart/cortex/module.lb
@@ -33,6 +33,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/platform/itm"
+    env.substitutions = {"target": env[":target"].identifier}
     env.template("itm.hpp.in")
     env.template("itm.cpp.in")
 

--- a/src/modm/platform/uart/cortex/module.md
+++ b/src/modm/platform/uart/cortex/module.md
@@ -7,6 +7,8 @@ You can use this class as a *transmit-only* alternative for logging:
 modm::IODeviceWrapper<modm::platform::Itm,
                       modm::IOBuffer::DiscardIfFull> itm_device;
 modm::IOStream stream(itm_device);
+
+modm::platform::Itm::initialize();
 stream << "Hello World" << modm::endl;
 ```
 

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -9,12 +9,12 @@ source [find {{ openocd_user_path | modm.windowsify(escape_level=1) }}]
 source [find {{ file | modm.windowsify(escape_level=1) }}]
 %% endfor
 
-proc modm_itm_log { OUTPUT F_CPU {BAUDRATE ""} } {
-	if {$BAUDRATE eq ""} {
-		tpiu config internal $OUTPUT uart off $F_CPU
-	} else {
-		tpiu config internal $OUTPUT uart off $F_CPU $BAUDRATE
-	}
+proc modm_itm_log { OUTPUT F_CPU {BAUDRATE 2000000} } {
+	tpiu create itm.tpiu -dap [dap names] -ap-num 0 -protocol uart
+	itm.tpiu configure -traceclk $F_CPU -pin-freq $BAUDRATE -output $OUTPUT
+	itm.tpiu enable
+	tpiu init
+	itm port 0 on
 }
 
 proc modm_program { SOURCE } {


### PR DESCRIPTION
Fixes #633.

You now need to manually call `Itm::initialize()` since OpenOCD does not do it anymore.

Tested in hardware with the NUCLEO-F103RB ITM example.

cc @strongly-typed 