### PR TITLE
[core] Fix delay_ns cycle calculation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,6 +59,7 @@ jobs:
           (cd test && make compile-nucleo-l432)
           (cd test && make compile-nucleo-f103_A)
           (cd test && make compile-nucleo-f103_B)
+          (cd test && make compile-nucleo-f091)
       - name: Linux Examples
         if: always()
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Examples STM32F0 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py stm32f0_discovery stm32f072_discovery nucleo_f031k6 nucleo_f072rb nucleo_f042k6 stm32f030f4p6_demo_board)
+          (cd examples && ../tools/scripts/examples_compile.py stm32f0_discovery stm32f072_discovery nucleo_f031k6 nucleo_f072rb nucleo_f091rc nucleo_f042k6 stm32f030f4p6_demo_board)
       - name: Examples STM32F1 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -469,39 +469,41 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f042k6">NUCLEO-F042K6</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f072rb">NUCLEO-F072RB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f091rc">NUCLEO-F091RC</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f103rb">NUCLEO-F103RB</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f303k8">NUCLEO-F303K8</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f303re">NUCLEO-F303RE</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f334r8">NUCLEO-F334R8</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f334r8">NUCLEO-F334R8</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f401re">NUCLEO-F401RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f411re">NUCLEO-F411RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f429zi">NUCLEO-F429ZI</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f439zi">NUCLEO-F439ZI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f439zi">NUCLEO-F439ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f446re">NUCLEO-F446RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f446ze">NUCLEO-F446ZE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f746zg">NUCLEO-F746ZG</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-g071rb">NUCLEO-G071RB</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-g431rb">NUCLEO-G431RB</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-g474re">NUCLEO-G474RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-g474re">NUCLEO-G474RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l432kc">NUCLEO-L432KC</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l452re">NUCLEO-L452RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32f030_demo">STM32F030-DEMO</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/generic/delay/main.cpp
+++ b/examples/generic/delay/main.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+#ifdef CFG_TUSB_MCU
+#include <modm/debug.hpp>
+modm::IODeviceWrapper<UsbUart0, modm::IOBuffer::DiscardIfFull> usb_io_device;
+modm::log::Logger modm::log::info(usb_io_device);
+#endif
+
+static void
+run_delay_ns(uint32_t ns)
+{
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+	uint32_t start, stop;
+	{
+		modm::atomic::Lock _;
+#ifdef DWT
+		start = DWT->CYCCNT;
+#else
+		SysTick->CTRL = SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_CLKSOURCE_Msk;
+		SysTick->LOAD = (1ul << 23);
+		SysTick->VAL = 0;
+		stop = SysTick->VAL;
+#endif
+		modm::delay_ns(ns);
+#ifdef DWT
+		stop = DWT->CYCCNT;
+#else
+		start = SysTick->VAL;
+#endif
+	}
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+	const uint32_t cycles = (stop - start) - 4;
+	const uint32_t expected = uint64_t(SystemCoreClock) * ns / 1'000'000'000ull;
+	const uint32_t real = cycles * 1'000'000'000ull / SystemCoreClock;
+	MODM_LOG_INFO.printf("%8lu | %7lu | %7lu | %8lu      %c\n", ns, expected, cycles, real,
+	    (cycles < expected*1.2f ? (cycles > expected*0.8f ? ' ' : '<') : '>')) << modm::flush;
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+}
+
+static void
+run_delay_us(uint32_t us)
+{
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+	uint32_t start, stop;
+	{
+		modm::atomic::Lock _;
+#ifdef DWT
+		start = DWT->CYCCNT;
+#else
+		SysTick->CTRL = SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_CLKSOURCE_Msk;
+		SysTick->LOAD = (1ul << 23);
+		SysTick->VAL = 0;
+		stop = SysTick->VAL;
+#endif
+		modm::delay_us(us);
+#ifdef DWT
+		stop = DWT->CYCCNT;
+#else
+		start = SysTick->VAL;
+#endif
+	}
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+	const uint32_t cycles = (stop - start) - 4;
+	const uint32_t expected = uint64_t(SystemCoreClock) * us / 1'000'000ull;
+	const uint32_t real = cycles * 1'000'000ull / SystemCoreClock;
+	MODM_LOG_INFO.printf("%8lu | %8lu | %8lu | %8lu      %c\n", us, expected, cycles, real,
+	    (cycles < expected*1.2f ? (cycles > expected*0.8f ? ' ' : '<') : '>')) << modm::flush;
+#ifdef CFG_TUSB_MCU
+	tud_task();
+#endif
+}
+
+static void
+run_test_ns(bool short_test=false)
+{
+	MODM_LOG_INFO << "\nmodm::delay_ns for system clock = " << SystemCoreClock << modm::endl;
+	MODM_LOG_INFO << "    expected       |      measured\n";
+	MODM_LOG_INFO << "      ns |  cycles |  cycles |       ns\n";
+
+	if (short_test)
+	{
+		run_delay_ns(       100);
+		run_delay_ns(     1'000);
+		run_delay_ns(    10'000);
+		run_delay_ns(   100'000);
+		run_delay_ns( 1'000'000);
+		run_delay_ns(10'000'000);
+	}
+	else
+	{
+		run_delay_ns(1);
+		run_delay_ns(5);
+		run_delay_ns(10);
+		for (uint32_t ii=  50; ii <   1000; ii +=   50) run_delay_ns(ii);
+		for (uint32_t ii=1000; ii <   2000; ii +=  100) run_delay_ns(ii);
+		for (uint32_t ii=2000; ii <= 10000; ii += 1000) run_delay_ns(ii);
+		run_delay_ns(100'000);
+		run_delay_ns(1'000'000);
+		run_delay_ns(10'000'000);
+	}
+}
+
+static void
+run_test_us(bool short_test=false)
+{
+	MODM_LOG_INFO << "\nmodm::delay_us for boot clock = " << SystemCoreClock << modm::endl;
+	MODM_LOG_INFO << "     expected       |       measured\n";
+	MODM_LOG_INFO << "      us |  cycles  |  cycles  |       us\n";
+
+	if (short_test)
+	{
+		run_delay_us(1);
+		run_delay_us(5);
+		for (uint32_t ii=10; ii < 100; ii += 10) run_delay_us(ii);
+		run_delay_us(1'000);
+	}
+	else
+	{
+		run_delay_us(      1);
+		run_delay_us(      5);
+		run_delay_us(     10);
+		run_delay_us(    100);
+		run_delay_us(  1'000);
+		run_delay_us( 10'000);
+		run_delay_us(100'000);
+	}
+}
+
+#ifndef CFG_TUSB_MCU
+// STM32 device
+struct BootClock
+{
+	// It may be necessary to scale these, due to clock prescalers != 1
+	static constexpr uint32_t Usart1 = Rcc::BootFrequency;
+	static constexpr uint32_t Usart2 = Rcc::BootFrequency;
+	static constexpr uint32_t Usart3 = Rcc::BootFrequency;
+	static constexpr uint32_t Usart4 = Rcc::BootFrequency;
+	static constexpr uint32_t Usart5 = Rcc::BootFrequency;
+};
+int main()
+{
+	Board::stlink::Uart::connect<Board::stlink::Tx::Tx>();
+	Board::stlink::Uart::initialize<BootClock, 115200_Bd, 5_pct>();
+
+	run_test_ns(true);
+	run_test_us(true);
+
+	Board::initialize();
+
+	run_test_ns();
+	run_test_us();
+
+	while(true) {}
+	return 0;
+}
+
+#else
+// SAMD21
+int main()
+{
+	Board::initialize();
+	Board::initializeUsbFs();
+	tusb_init();
+
+	MODM_LOG_INFO << "Hello World\n";
+
+	static int32_t counter{0};
+	while (true)
+	{
+		tud_task();
+
+		if (counter-- < 0)
+		{
+			Leds::toggle();
+			counter = 1'000'000;
+			MODM_LOG_INFO << modm::platform::delay_ns_per_loop << modm::endl;
+			run_test_ns();
+			run_test_us(true);
+		}
+	}
+	return 0;
+}
+
+#endif

--- a/examples/generic/delay/project.xml
+++ b/examples/generic/delay/project.xml
@@ -1,0 +1,24 @@
+<library>
+  <!-- <extends>modm:nucleo-l152re</extends> -->
+  <!-- <extends>modm:nucleo-f103rb</extends> -->
+  <!-- <extends>modm:nucleo-f401re</extends> -->
+  <!-- <extends>modm:nucleo-f411re</extends> -->
+  <!-- <extends>modm:nucleo-f446re</extends> -->
+  <extends>modm:nucleo-f334r8</extends>
+  <!-- <extends>modm:nucleo-f303k8</extends> -->
+  <!-- <extends>modm:nucleo-l476rg</extends> -->
+  <!-- <extends>modm:disco-f746ng</extends> -->
+  <!-- <extends>modm:nucleo-g071rb</extends> -->
+  <!-- <extends>modm:nucleo-f072rb</extends> -->
+  <!-- <extends>modm:nucleo-f091rc</extends> -->
+  <!-- <extends>modm:samd21-mini</extends> -->
+  <options>
+    <option name="modm:build:build.path">../../../build/generic/delay</option>
+    <!-- <option name="modm:tinyusb:config">device.cdc</option> -->
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:debug</module>
+    <!-- <module>modm:tinyusb</module> -->
+  </modules>
+</library>

--- a/examples/nucleo_f091rc/blink/main.cpp
+++ b/examples/nucleo_f091rc/blink/main.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+	modm::ShortPeriodicTimer timer(1s);
+
+	while (true)
+	{
+		if (timer.execute())
+		{
+			LedD13::toggle();
+
+			MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f091rc/blink/project.xml
+++ b/examples/nucleo_f091rc/blink/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-f091rc</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f091rc/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/delay.md
+++ b/src/modm/architecture/interface/delay.md
@@ -47,9 +47,20 @@ to you is to delay for _at least_ the specified time. Note that invocation of
 interrupts during spinning may add delay too. For additional limitations also
 check the description of the `modm:platform:core` modules.
 
+Please note that the delay these functions provide is defined as the time from
+invocation to the time of execution return. Obviously no delay beyond that is
+considered, which may require you to use shorter delays to compensate for the
+overhead of your code:
+
+```cpp
+do // GpioA4 toggling takes longer than 500ns because:
+{
+    modm::delay_ns(500); // takes ~500ns
+    GpioA4::toggle();    // takes a few cycles
+} while(1);              // jump back to loop also takes a few cycles
+```
+
 You should always prefer Software Timers (see `modm:processing:timer`) over
 these *blocking* delay functions. However, when `modm::Clock` is not set up yet,
 or when you need very small delays (for example to bit-bang a protocol), you
 need to use these delay functions.
-
-

--- a/src/modm/architecture/utils.hpp
+++ b/src/modm/architecture/utils.hpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2011, Georgi Grinshpun
  * Copyright (c) 2011, Martin Rosekeit
  * Copyright (c) 2011-2012, Fabian Greif
- * Copyright (c) 2012, 2014-2017, Niklas Hauser
+ * Copyright (c) 2012, 2014-2017, 2021, Niklas Hauser
  * Copyright (c) 2013, Kevin Läufer
  * Copyright (c) 2015, Sascha Schade
  * Copyright (c) 2016, Tarik TIRE
@@ -72,11 +72,13 @@
 	/// Marks a declaration as deprecated and displays a message.
 	#define modm_deprecated(msg)
 
-	/// Specifies that a function is placed in fastest executable memory.
-	/// @note This is not always SRAM, since Flash accelerators can be faster.
+	/// Places a function in the fastest executable memory:
+	/// instruction cache, core coupled memory or SRAM as fallback.
 	#define modm_fastcode
 
-	/// Specifies that a variable is placed in fastest accessible memory.
+	/// Places a variable in the fastest accessible memory:
+	/// data cache, core coupled memory or SRAM as fallback.
+	/// @note This memory location may not be DMA-able!
 	#define modm_fastdata
 
 	/// This branch is more likely to execute.
@@ -144,7 +146,7 @@
 	#	define modm_fastdata
 	#else
 	#	define modm_fastcode		modm_section(".fastcode")
-	#	define modm_ramcode			modm_section(".ramcode")
+	#	define modm_ramcode			modm_fastcode
 	#	define modm_fastdata		modm_section(".fastdata")
 	#endif
 

--- a/src/modm/board/nucleo_f091rc/board.hpp
+++ b/src/modm/board/nucleo_f091rc/board.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016-2018, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_f091rc
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_f091rc
+namespace Board
+{
+	using namespace modm::literals;
+
+/// STM32F091RC running at 48MHz generated from the internal 8MHz crystal
+// Dummy clock for devices
+struct SystemClock
+{
+	static constexpr int Frequency = 48_MHz;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Adc   = Apb;
+	static constexpr uint32_t Can   = Apb;
+
+	static constexpr uint32_t Spi1   = Apb;
+	static constexpr uint32_t Spi2   = Apb;
+
+	static constexpr uint32_t Usart1 = Apb;
+	static constexpr uint32_t Usart2 = Apb;
+	static constexpr uint32_t Usart3 = Apb;
+	static constexpr uint32_t Usart4 = Apb;
+
+	static constexpr uint32_t I2c1   = Apb;
+	static constexpr uint32_t I2c2   = Apb;
+
+	static constexpr uint32_t Timer1  = Apb;
+	static constexpr uint32_t Timer2  = Apb;
+	static constexpr uint32_t Timer3  = Apb;
+	static constexpr uint32_t Timer6  = Apb;
+	static constexpr uint32_t Timer7  = Apb;
+	static constexpr uint32_t Timer14 = Apb;
+	static constexpr uint32_t Timer15 = Apb;
+	static constexpr uint32_t Timer16 = Apb;
+	static constexpr uint32_t Timer17 = Apb;
+
+	static constexpr uint32_t Usb = 48_MHz;
+
+	static bool inline
+	enable()
+	{
+		// Enable the internal 48MHz clock
+		Rcc::enableInternalClockMHz48();
+		// set flash latency for 48MHz
+		Rcc::setFlashLatency<Frequency>();
+		// Switch to the 48MHz clock
+		Rcc::enableSystemClock(Rcc::SystemClockSource::InternalClockMHz48);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Uno Footprint
+#include "nucleo64_arduino.hpp"
+
+using Button = GpioInverted<GpioInputC13>;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+
+
+namespace stlink
+{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = Usart2;
+}
+
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+}
+
+}

--- a/src/modm/board/nucleo_f091rc/board.xml
+++ b/src/modm/board/nucleo_f091rc/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f091rct6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f091rc</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f091rc/module.lb
+++ b/src/modm/board/nucleo_f091rc/module.lb
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-f091rc"
+    module.description = """\
+# NUCLEO-F091RC
+
+[Nucleo kit for STM32F091RC](https://www.st.com/en/evaluation-tools/nucleo-f091rc.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f091rct"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock", ":architecture:clock")
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert"),
+        "has_gpio_c14_c15": False
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino.hpp", "nucleo64_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_f0.cfg")

--- a/src/modm/platform/clock/sam/gclk.cpp.in
+++ b/src/modm/platform/clock/sam/gclk.cpp.in
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2013-2014, Kevin Läufer
- * Copyright (c) 2014-2017, Niklas Hauser
+ * Copyright (c) 2020-2021, Niklas Hauser
  * Copyright (c) 2020, Erik Henriksson
  *
  * This file is part of the modm project.
@@ -13,109 +12,111 @@
 
 #include "../device.hpp"
 #include "gclk.hpp"
-#include "modm/math/units.hpp"
+#include <modm/math/units.hpp>
 
 // CMSIS Core compliance
-uint32_t modm_fastdata SystemCoreClock(1'000'000);
+constinit uint32_t modm_fastdata SystemCoreClock(modm::platform::GenericClockController::BootFrequency);
 modm_weak void SystemCoreClockUpdate() { /* Nothing to update */ }
 
 namespace modm::platform
 {
-uint16_t modm_fastdata delay_fcpu_MHz(1);
-uint16_t modm_fastdata delay_ns_per_loop({{ loops * 1000 }});
+constinit uint16_t modm_fastdata delay_fcpu_MHz(computeDelayMhz(GenericClockController::BootFrequency));
+constinit uint16_t modm_fastdata delay_ns_per_loop(computeDelayNsPerLoop(GenericClockController::BootFrequency));
+
+bool
+GenericClockController::initOsc8MHz(uint32_t waitCycles)
+{
+	SYSCTRL->OSC8M.bit.PRESC = 0x0;
+	SYSCTRL->OSC8M.bit.ONDEMAND = true;
+	SYSCTRL->OSC8M.bit.RUNSTDBY = false;
+	SYSCTRL->OSC8M.bit.ENABLE = true;
+	while (!SYSCTRL->PCLKSR.bit.OSC8MRDY && --waitCycles);
+	return waitCycles;
 }
 
 bool
-modm::platform::GenericClockController::initOsc8MHz(
-  uint32_t waitCycles)
+GenericClockController::initExternalCrystal(uint32_t waitCycles)
 {
-  SYSCTRL->OSC8M.bit.PRESC = 0x0;
-  SYSCTRL->OSC8M.bit.ONDEMAND = true;
-  SYSCTRL->OSC8M.bit.RUNSTDBY = false;
-  SYSCTRL->OSC8M.bit.ENABLE = true;
-  while (!SYSCTRL->PCLKSR.bit.OSC8MRDY && --waitCycles);
-  return waitCycles;
+	// Enable external crystal.
+	SYSCTRL->XOSC32K.reg =
+		SYSCTRL_XOSC32K_STARTUP( 0x6u ) |
+		SYSCTRL_XOSC32K_XTALEN |
+		SYSCTRL_XOSC32K_RUNSTDBY |
+		SYSCTRL_XOSC32K_EN32K;
+	// separate call, as described in chapter 15.6.3
+	SYSCTRL->XOSC32K.bit.ENABLE = 1;
+	while (!SYSCTRL->PCLKSR.bit.XOSC32KRDY and --waitCycles) ;
+
+	// Write Generic Clock Generator configuration
+	GCLK->GENCTRL.reg =
+		GCLK_GENCTRL_ID(uint32_t(ClockGenerator::ExternalCrystal32K)) |
+		GCLK_GENCTRL_SRC_XOSC32K |
+		GCLK_GENCTRL_IDC |
+		GCLK_GENCTRL_GENEN;
+	// Wait for synchronization.
+	while (GCLK->STATUS.bit.SYNCBUSY and --waitCycles) ;
+
+	return waitCycles;
 }
 
 bool
-modm::platform::GenericClockController::initExternalCrystal(
-  uint32_t waitCycles)
+GenericClockController::initDFLL48MHz(uint32_t waitCycles)
 {
-  // Enable external crystal.
-  SYSCTRL->XOSC32K.reg =
-      SYSCTRL_XOSC32K_STARTUP( 0x6u ) |
-      SYSCTRL_XOSC32K_XTALEN |
-      SYSCTRL_XOSC32K_RUNSTDBY |
-      SYSCTRL_XOSC32K_EN32K;
-  // separate call, as described in chapter 15.6.3
-  SYSCTRL->XOSC32K.bit.ENABLE = 1;
-  while (!SYSCTRL->PCLKSR.bit.XOSC32KRDY and --waitCycles);
+	// Put ExternalCrystal as source for the PLL
+	GCLK->CLKCTRL.reg =
+		GCLK_CLKCTRL_ID(uint32_t(ClockMux::DFLL48M)) |
+		GCLK_CLKCTRL_GEN(uint32_t(ClockGenerator::ExternalCrystal32K)) |
+		GCLK_CLKCTRL_CLKEN;
+	// Wait for synchronization.
+	while (GCLK->STATUS.bit.SYNCBUSY and --waitCycles) ;
 
-  // Write Generic Clock Generator configuration
-  GCLK->GENCTRL.reg =
-      GCLK_GENCTRL_ID(uint32_t(ClockGenerator::ExternalCrystal32K)) |
-      GCLK_GENCTRL_SRC_XOSC32K |
-      GCLK_GENCTRL_IDC |
-      GCLK_GENCTRL_GENEN;
-  // Wait for synchronization.
-  while (GCLK->STATUS.bit.SYNCBUSY and --waitCycles);
-  return waitCycles;
+	// Errata 1.2.1: Disable the OnDemand mode
+	SYSCTRL->DFLLCTRL.bit.ONDEMAND = 0;
+	// Wait for synchronization.
+	while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles) ;
+
+	SYSCTRL->DFLLMUL.reg =
+		SYSCTRL_DFLLMUL_CSTEP( 31 ) |
+		SYSCTRL_DFLLMUL_FSTEP( 511 ) |
+		SYSCTRL_DFLLMUL_MUL(48_MHz / 32'768_Hz);
+	// Wait for synchronization.
+	while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles) ;
+
+	// Write full configuration to DFLL control register
+	SYSCTRL->DFLLCTRL.reg |=
+		SYSCTRL_DFLLCTRL_MODE | // Enable the closed loop mode
+		SYSCTRL_DFLLCTRL_WAITLOCK | // No output until DFLL is locked.
+		SYSCTRL_DFLLCTRL_QLDIS ; // Disable Quick lock
+	// Wait for synchronization.
+	while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles) ;
+
+	// Enable the DFLL
+	SYSCTRL->DFLLCTRL.bit.ENABLE = true;
+	// Wait for locks flags
+	while (
+		not (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKC) or
+		not (SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKF));
+	// Wait for synchronization.
+	while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles) ;
+
+	return waitCycles;
 }
 
 bool
-modm::platform::GenericClockController::initDFLL48MHz(
-  uint32_t waitCycles)
+GenericClockController::setSystemClock(ClockSource source, uint32_t waitCycles)
 {
-  // // Put ExternalCrystal as source for the PLL
-  GCLK->CLKCTRL.reg =
-      GCLK_CLKCTRL_ID(uint32_t(ClockMux::DFLL48M)) |
-      GCLK_CLKCTRL_GEN(uint32_t(ClockGenerator::ExternalCrystal32K)) |
-      GCLK_CLKCTRL_CLKEN;
-  // Wait for synchronization.
-  while (GCLK->STATUS.bit.SYNCBUSY and --waitCycles);
+	GCLK->GENDIV.reg =
+		GCLK_GENDIV_ID(uint32_t(ClockGenerator::System)) |
+		GCLK_GENDIV_DIV(0u);
+	GCLK->GENCTRL.reg =
+		GCLK_GENCTRL_ID(uint32_t(ClockGenerator::System)) |
+		GCLK_GENCTRL_SRC(uint32_t(source)) |
+		GCLK_GENCTRL_IDC |
+		GCLK_GENCTRL_GENEN;
+	// Wait for synchronization.
+	while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) ;
 
-  // Errata 1.2.1: Disable the OnDemand mode
-  SYSCTRL->DFLLCTRL.bit.ONDEMAND = 0;
-  // Wait for synchronization.
-  while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles);
-
-  SYSCTRL->DFLLMUL.reg =
-      SYSCTRL_DFLLMUL_CSTEP( 31 ) |
-      SYSCTRL_DFLLMUL_FSTEP( 511 ) |
-      SYSCTRL_DFLLMUL_MUL(48_MHz / 32'768_Hz);
-  // Wait for synchronization.
-  while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles);
-  // Write full configuration to DFLL control register
-  SYSCTRL->DFLLCTRL.reg |=
-      SYSCTRL_DFLLCTRL_MODE | // Enable the closed loop mode
-      SYSCTRL_DFLLCTRL_WAITLOCK | // No output until DFLL is locked.
-      SYSCTRL_DFLLCTRL_QLDIS ; // Disable Quick lock
-  // Wait for synchronization.
-  while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles);
-  // Enable the DFLL
-  SYSCTRL->DFLLCTRL.bit.ENABLE = true;
-  // Wait for locks flags
-  while (
-    !(SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKC) ||
-    !(SYSCTRL->PCLKSR.reg & SYSCTRL_PCLKSR_DFLLLCKF));
-  // Wait for synchronization.
-  while (!SYSCTRL->PCLKSR.bit.DFLLRDY and --waitCycles);
-  return waitCycles;
+	return waitCycles;
 }
 
-bool
-modm::platform::GenericClockController::setSystemClock(
-  ClockSource source, uint32_t waitCycles)
-{
-  GCLK->GENDIV.reg =
-      GCLK_GENDIV_ID(uint32_t(ClockGenerator::System)) |
-      GCLK_GENDIV_DIV(0u);
-  GCLK->GENCTRL.reg =
-				GCLK_GENCTRL_ID(uint32_t(ClockGenerator::System)) |
-				GCLK_GENCTRL_SRC(uint32_t(source)) |
-				GCLK_GENCTRL_IDC |
-				GCLK_GENCTRL_GENEN;
-  // Wait for synchronization.
-  while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY);
-  return waitCycles;
 }

--- a/src/modm/platform/clock/sam/gclk.hpp
+++ b/src/modm/platform/clock/sam/gclk.hpp
@@ -14,6 +14,7 @@
 
 #include <stdint.h>
 #include "../device.hpp"
+#include <modm/architecture/interface/delay.hpp>
 
 namespace modm::platform
 {
@@ -86,6 +87,8 @@ enum class ClockPeripheral : uint32_t {
 class GenericClockController
 {
 public:
+	static constexpr uint32_t BootFrequency = 1'000'000;
+
 	template< uint32_t Core_Hz>
 	static uint32_t
 	setFlashLatency();

--- a/src/modm/platform/clock/sam/gclk_impl.hpp.in
+++ b/src/modm/platform/clock/sam/gclk_impl.hpp.in
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019, Ethan Slattery
  * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -11,23 +12,19 @@
 // ----------------------------------------------------------------------------
 
 #include <cmath>
-#include "modm/math/units.hpp"
+#include <modm/math/units.hpp>
 
 namespace modm::platform
 {
-/// @cond
-extern uint16_t delay_fcpu_MHz;
-extern uint16_t delay_ns_per_loop;
 extern "C" uint32_t SystemCoreClock;
-/// @endcond
 
 template< uint32_t Core_Hz >
 void
 GenericClockController::updateCoreFrequency()
 {
 	SystemCoreClock = Core_Hz;
-	delay_fcpu_MHz = Core_Hz / 1'000'000;
-	delay_ns_per_loop = ::round({{loops}}000.f / (Core_Hz / 1'000'000));
+	delay_fcpu_MHz = computeDelayMhz(Core_Hz);
+	delay_ns_per_loop = computeDelayNsPerLoop(Core_Hz);
 }
 
 template< uint32_t Core_Hz >
@@ -35,7 +32,7 @@ uint32_t
 GenericClockController::setFlashLatency()
 {
 	// See table 41.11 (NVM Characteristics) in the datasheet
-	if (Core_Hz > 24_MHz) {
+	if constexpr (Core_Hz > 24_MHz) {
 		NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_HALF_Val;
 	} else {
 		NVMCTRL->CTRLB.bit.RWS = NVMCTRL_CTRLB_RWS_SINGLE_Val;
@@ -43,15 +40,15 @@ GenericClockController::setFlashLatency()
 	return Core_Hz;
 }
 
-	template< ClockPeripheral peripheral >
-	void
-	GenericClockController::connect(ClockGenerator clockGen)
-	{
-		GCLK->CLKCTRL.reg =
-				GCLK_CLKCTRL_CLKEN |
-				GCLK_CLKCTRL_GEN(uint32_t(clockGen)) |
-				GCLK_CLKCTRL_ID(uint32_t(peripheral));
-	}
+template< ClockPeripheral peripheral >
+void
+GenericClockController::connect(ClockGenerator clockGen)
+{
+	GCLK->CLKCTRL.reg =
+		GCLK_CLKCTRL_CLKEN |
+		GCLK_CLKCTRL_GEN(uint32_t(clockGen)) |
+		GCLK_CLKCTRL_ID(uint32_t(peripheral));
+}
 
 }
 

--- a/src/modm/platform/clock/sam/module.lb
+++ b/src/modm/platform/clock/sam/module.lb
@@ -19,21 +19,10 @@ def prepare(module, options):
     if not options[":target"].has_driver("gclk:sam"):
         return False
 
-    module.depends(":cmsis:device")
+    module.depends(":cmsis:device", ":architecture:delay")
     return True
 
 def build(env):
-    device = env[":target"]
-    core = device.get_driver("core")["type"]
-
-    if "m0" in core:
-        loops = 4
-    elif "m7" in core:
-        loops = 1
-    else:
-        loops = 3
-
-    env.substitutions = {"loops": loops}
     env.outbasepath = "modm/src/modm/platform/clock"
     env.copy("gclk.hpp")
     env.template("gclk.cpp.in")

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -35,23 +35,19 @@ def build(env):
     properties["partname"] = device.partname
     properties["core"] = core = device.get_driver("core")["type"]
 
-    if target["family"] in ["f1", "f3", "f4"]:
+    if target["family"] in ["f1", "f3"]:
         properties["hsi_frequency"] = 8
         properties["lsi_frequency"] = 40
-    elif target["family"] in ["l1"]:
-        properties["hsi_frequency"] = 2.097
+        properties["boot_frequency"] = properties["hsi_frequency"]
+    elif target["family"] in ["l0", "l1"]:
+        properties["hsi_frequency"] = 16
         properties["lsi_frequency"] = 37
+        properties["msi_frequency"] = 2.097
+        properties["boot_frequency"] = properties["msi_frequency"]
     else:
         properties["hsi_frequency"] = 16
         properties["lsi_frequency"] = 32
-
-    if core == "cortex-m0":
-        loops = 4
-    elif core.startswith("cortex-m7"):
-        loops = 1
-    else:
-        loops = 3
-    properties["loops"] = loops
+        properties["boot_frequency"] = properties["hsi_frequency"]
 
     # TODO: Move this data into the device files
     properties["usbprescaler"] = device.has_driver("usb") and target.family in ["f0", "f1", "f3"]

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2009-2012, Fabian Greif
  * Copyright (c) 2011, Georgi Grinshpun
  * Copyright (c) 2012, 2016, Sascha Schade
- * Copyright (c) 2012, 2014-2019, Niklas Hauser
+ * Copyright (c) 2012, 2014-2019, 2021, Niklas Hauser
  * Copyright (c) 2013-2014, Kevin Läufer
  * Copyright (c) 2018, 2021, Christopher Durand
  *
@@ -18,19 +18,18 @@
 #include "rcc.hpp"
 
 // CMSIS Core compliance
-uint32_t modm_fastdata SystemCoreClock({{ "{0:,}".format((1000000 * hsi_frequency)|int).replace(',', "'") }});
+constinit uint32_t modm_fastdata SystemCoreClock(modm::platform::Rcc::BootFrequency);
 modm_weak void SystemCoreClockUpdate() { /* Nothing to update */ }
 
 namespace modm::platform
 {
-uint16_t modm_fastdata delay_fcpu_MHz({{ hsi_frequency }});
-uint16_t modm_fastdata delay_ns_per_loop({{ "{0:,}".format((loops * 1000.0 / hsi_frequency)|int).replace(',', "'") }});
-}
+constinit uint16_t modm_fastdata delay_fcpu_MHz(computeDelayMhz(Rcc::BootFrequency));
+constinit uint16_t modm_fastdata delay_ns_per_loop(computeDelayNsPerLoop(Rcc::BootFrequency));
 
 // ----------------------------------------------------------------------------
 %% if target["family"] == "f0"
 bool
-modm::platform::Rcc::enableInternalClockMHz14(uint32_t waitCycles)
+Rcc::enableInternalClockMHz14(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CR2 |= RCC_CR2_HSI14ON;
@@ -42,7 +41,7 @@ modm::platform::Rcc::enableInternalClockMHz14(uint32_t waitCycles)
 
 %% if hsi48
 bool
-modm::platform::Rcc::enableInternalClockMHz48(uint32_t waitCycles)
+Rcc::enableInternalClockMHz48(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CR2 |= RCC_CR2_HSI48ON;
@@ -53,7 +52,7 @@ modm::platform::Rcc::enableInternalClockMHz48(uint32_t waitCycles)
 %% endif
 
 bool
-modm::platform::Rcc::enableInternalClock(uint32_t waitCycles)
+Rcc::enableInternalClock(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CR |= RCC_CR_HSION;
@@ -64,7 +63,7 @@ modm::platform::Rcc::enableInternalClock(uint32_t waitCycles)
 
 %% if target["family"] in ["l0", "l1", "l4"]
 bool
-modm::platform::Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, uint32_t waitCycles)
+Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, uint32_t waitCycles)
 {
 	bool retval;
 %% if target["family"] in ["l0", "l1"]
@@ -81,7 +80,7 @@ modm::platform::Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, u
 %% endif
 
 bool
-modm::platform::Rcc::enableExternalClock(uint32_t waitCycles)
+Rcc::enableExternalClock(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
@@ -91,7 +90,7 @@ modm::platform::Rcc::enableExternalClock(uint32_t waitCycles)
 }
 
 bool
-modm::platform::Rcc::enableExternalCrystal(uint32_t waitCycles)
+Rcc::enableExternalCrystal(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
@@ -101,7 +100,7 @@ modm::platform::Rcc::enableExternalCrystal(uint32_t waitCycles)
 }
 
 bool
-modm::platform::Rcc::enableLowSpeedInternalClock(uint32_t waitCycles)
+Rcc::enableLowSpeedInternalClock(uint32_t waitCycles)
 {
 	bool retval;
 	RCC->CSR |= RCC_CSR_LSION;
@@ -111,7 +110,7 @@ modm::platform::Rcc::enableLowSpeedInternalClock(uint32_t waitCycles)
 }
 
 bool
-modm::platform::Rcc::enableLowSpeedExternalClock(uint32_t waitCycles)
+Rcc::enableLowSpeedExternalClock(uint32_t waitCycles)
 {
 	bool retval;
 %% if target["family"] in ["l0", "l1"]
@@ -126,7 +125,7 @@ modm::platform::Rcc::enableLowSpeedExternalClock(uint32_t waitCycles)
 }
 
 bool
-modm::platform::Rcc::enableLowSpeedExternalCrystal(uint32_t waitCycles)
+Rcc::enableLowSpeedExternalCrystal(uint32_t waitCycles)
 {
 	bool retval;
 %% if target["family"] in ["l0", "l1"]
@@ -141,7 +140,7 @@ modm::platform::Rcc::enableLowSpeedExternalCrystal(uint32_t waitCycles)
 }
 
 bool
-modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, uint32_t waitCycles)
+Rcc::enablePll(PllSource source, const PllFactors& pllFactors, uint32_t waitCycles)
 {
 %% if target["family"] in ["f2", "f4", "f7"]
 	// Read reserved values and clear all other values
@@ -292,7 +291,7 @@ modm::platform::Rcc::enablePll(PllSource source, const PllFactors& pllFactors, u
 
 %% if pllsai_p_usb
 bool
-modm::platform::Rcc::enablePllSai(const PllSaiFactors& pllFactors, uint32_t waitCycles)
+Rcc::enablePllSai(const PllSaiFactors& pllFactors, uint32_t waitCycles)
 {
 	// Read reserved values and clear all other values
 	uint32_t tmp = RCC->PLLSAICFGR & ~(
@@ -326,7 +325,7 @@ modm::platform::Rcc::enablePllSai(const PllSaiFactors& pllFactors, uint32_t wait
 
 %% if overdrive
 bool
-modm::platform::Rcc::enableOverdriveMode(uint32_t waitCycles)
+Rcc::enableOverdriveMode(uint32_t waitCycles)
 {
 	RCC->APB1ENR |= RCC_APB1ENR_PWREN;
 
@@ -354,7 +353,7 @@ modm::platform::Rcc::enableOverdriveMode(uint32_t waitCycles)
 
 %% if target["family"] == "l0"
 bool
-modm::platform::Rcc::setHsiPredivider4Enabled(bool divideBy4, uint32_t waitCycles)
+Rcc::setHsiPredivider4Enabled(bool divideBy4, uint32_t waitCycles)
 {
 	const uint32_t enableFlag = divideBy4 ? RCC_CR_HSIDIVEN : 0;
 	RCC->CR = (RCC->CR & ~RCC_CR_HSIDIVEN) | enableFlag;
@@ -370,7 +369,7 @@ modm::platform::Rcc::setHsiPredivider4Enabled(bool divideBy4, uint32_t waitCycle
 
 // ----------------------------------------------------------------------------
 bool
-modm::platform::Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
+Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
 {
 	RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | uint32_t(src);
 
@@ -388,7 +387,7 @@ modm::platform::Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycle
 
 %% if target["family"] == "g4"
 bool
-modm::platform::Rcc::setCanPrescaler(CanPrescaler prescaler)
+Rcc::setCanPrescaler(CanPrescaler prescaler)
 {
 	enable<Peripheral::Fdcan1>();
 
@@ -416,3 +415,5 @@ modm::platform::Rcc::setCanPrescaler(CanPrescaler prescaler)
 	return true;
 }
 %% endif
+
+}

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -38,6 +38,8 @@ namespace modm::platform
 class Rcc
 {
 public:
+	static constexpr uint32_t BootFrequency = {{ "{0:,}".format((1000000 * boot_frequency)|int).replace(',', "'") }};
+
 	enum class
 	PllSource : uint32_t
 	{

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Niklas Hauser
+ * Copyright (c) 2019, 2021 Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -9,14 +9,8 @@
  */
 // ----------------------------------------------------------------------------
 
-#include <cmath>
-
 namespace modm::platform
 {
-/// @cond
-extern uint16_t delay_fcpu_MHz;
-extern uint16_t delay_ns_per_loop;
-/// @endcond
 
 constexpr Rcc::flash_latency
 Rcc::computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV)
@@ -99,8 +93,8 @@ void
 Rcc::updateCoreFrequency()
 {
 	SystemCoreClock = Core_Hz;
-	delay_fcpu_MHz = Core_Hz / 1'000'000;
-	delay_ns_per_loop = std::round({{loops}}000.f / (Core_Hz / 1'000'000));
+	delay_fcpu_MHz = computeDelayMhz(Core_Hz);
+	delay_ns_per_loop = computeDelayNsPerLoop(Core_Hz);
 }
 
 constexpr bool

--- a/src/modm/platform/core/avr/module.md
+++ b/src/modm/platform/core/avr/module.md
@@ -45,7 +45,7 @@ For delays with a dynamic time, the following limitations apply for nanoseconds:
 For micro- and milliseconds delays with dynamic time:
 
 - Microseconds delay is implemented fairly accurately in 1us steps with a
-  maximum time delay of 65ms for clocks larger than 6MHz, or .
+  maximum time delay of 65ms for clocks larger than 6MHz.
 - Millisecond delay is implemented fairly accurately in 1ms steps on 32-bits of
   input time.
 

--- a/src/modm/platform/core/cortex/delay.cpp.in
+++ b/src/modm/platform/core/cortex/delay.cpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, Niklas Hauser
+ * Copyright (c) 2015-2016, 2021, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -13,47 +13,39 @@
 #include "hardware_init.hpp"
 #include "delay_impl.hpp"
 
-namespace modm
+void
+modm::delay_us(uint32_t us)
 {
-
-void modm_fastcode
-delay_us(uint32_t us)
-{
+	const uint32_t start = DWT->CYCCNT;
+	asm inline ("" ::: "memory");
 %% if with_assert
-	modm_assert_continue_fail_debug(us <= 10'000'000ul,
-		"delay.us", "modm::delay(us) can only delay a maximum of ~10 seconds!");
-%% endif
-	if (us == 0) return;    // 1 cycle, or 2 when taken
-
-%% if core.startswith("cortex-m0") or core.startswith("cortex-m7")
-	asm volatile (
-		".syntax unified"       "\n\t"
-		"muls.n	%0, %0, %1"     "\n\t"  // get number of cycles by us * fcpu_MHz:               1-2 cycles on cm3, up to 32 cycles on cm0
-	"1:  subs.n	%0, %0, #{{loop}}"     "\n\t"  // subtract the loop cycles from the input:             1 cycle
-		"bpl.n	1b"             "\n\t"  // keep doing that while result is still positive:      2 cycles (when taken)
-	:: "r" (us), "r" (platform::delay_fcpu_MHz));
+	unsigned int unshifted_cycles;
+	modm_assert_continue_fail_debug(
+		not __builtin_umul_overflow(platform::delay_fcpu_MHz, us, &unshifted_cycles),
+		"delay.us", "modm::delay(us) has overflowed at the current frequency!");
 %% else
-	uint32_t start = DWT->CYCCNT;
-	// prefer this for cores with fast hardware multiplication
-	int32_t delay = int32_t(platform::delay_fcpu_MHz) * us - {{ overhead }};
-
-	while (int32_t(DWT->CYCCNT - start) < delay)
-		;
+	const uint32_t unshifted_cycles = platform::delay_fcpu_MHz * us;
 %% endif
+	const uint32_t cycles = unshifted_cycles >> platform::delay_fcpu_MHz_shift;
+	while (true)
+	{
+		const uint32_t now = DWT->CYCCNT;
+		if (now - start >= cycles) break;
+	}
 }
 
-}
-
-%% if not (core.startswith("cortex-m0") or core.startswith("cortex-m7"))
 void
 modm_dwt_enable(void)
 {
 	// Enable Tracing Debug Unit
 	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+%% if core.startswith("cortex-m7")
+	// Unlock key
+	DWT->LAR = 0xC5ACCE55;
+%% endif
+	// Reset counter to 0
 	DWT->CYCCNT = 0;
 	// Enable CPU cycle counter
 	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 }
-
 MODM_HARDWARE_INIT_ORDER(modm_dwt_enable, 100);
-%% endif

--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2009-2011, Fabian Greif
  * Copyright (c) 2010, Georgi Grinshpun
  * Copyright (c) 2012, 2014, Sascha Schade
- * Copyright (c) 2012, 2014-2016, Niklas Hauser
+ * Copyright (c) 2012, 2014-2016, 2019-2021 Niklas Hauser
  * Copyright (c) 2014, Kevin Läufer
  *
  * This file is part of the modm project.
@@ -15,7 +15,9 @@
 // ----------------------------------------------------------------------------
 
 #pragma once
+#include <cmath>
 #include <chrono>
+#include "delay_ns.hpp"
 %% if with_assert
 #include <modm/architecture/interface/assert.hpp>
 %% endif
@@ -29,44 +31,47 @@ namespace platform
 {
 extern uint16_t delay_ns_per_loop;
 extern uint16_t delay_fcpu_MHz;
+
+constexpr uint8_t delay_fcpu_MHz_shift{3};
+// 400 MHz is the maximum for binary scaling
+static_assert(400 * (1ul << delay_fcpu_MHz_shift) < 65535);
+
+constexpr uint16_t computeDelayMhz(uint32_t hz)
+{ return std::round(hz / 1'000'000.f * (1ul << delay_fcpu_MHz_shift)); }
 }
 
-inline void modm_fastcode delay_ns(uint32_t ns)
+modm_always_inline
+void delay_ns(uint32_t ns)
 {
-	volatile uint32_t cycles;
-	// ns_per_loop = nanoseconds per cycle times cycles per loop ({{loop}} cycles)
-	asm volatile (
-		".syntax unified \n\t"
-		".align 4 \n\t"
-		"muls.n	%[cyc], %[cyc], %[dnpl] \n\t"	// multiply the overhead cycles with the ns per cycle:  1-2 cycles on cm3, up to 32 cycles on cm0
-		"subs.n	%[cyc], %[cyc], %[ovhd] \n\t"	// subtract the overhead in ns from the input:          1 cycle
-	"1:  subs.n	%[cyc], %[cyc], %[dnpl] \n\t"	// subtract the ns per loop from the input:             1 cycle
-		"bpl.n	1b"								// keep doing that while result is still positive:      2 cycles (when taken)
-	: [cyc] "=l" (cycles) : "0" (ns), [dnpl] "l" (platform::delay_ns_per_loop), [ovhd] "l" ({{(overhead / loop) | int}}));
-	// => loop is {{loop}} cycles long
+    asm volatile(
+        "mov r0, %0 \n\t"
+        "blx %1"
+        :: "r" (ns), "l" (platform::delay_ns) : "r0", "r1", "r2");
 }
+
+
 void delay_us(uint32_t us);
 inline void delay_ms(uint32_t ms) { delay_us(ms * 1000); }
 
 // ----------------------------------------------------------------------------
 template< class Rep >
 void
-delay(std::chrono::duration<Rep, std::nano> ns_)
+delay(std::chrono::duration<Rep, std::nano> ns)
 {
-	const auto ns{std::chrono::duration_cast<std::chrono::nanoseconds>(ns_)};
+	const auto ns_{std::chrono::duration_cast<std::chrono::nanoseconds>(ns)};
 %% if with_assert
-	modm_assert_continue_fail_debug(0 <= ns.count() and ns.count() <= 1'000'000,
+	modm_assert_continue_fail_debug(0 <= ns_.count() and ns_.count() <= 1'000'000,
 		"delay.ns", "modm::delay(ns) can only delay a (positive) maximum of ~1 millisecond!");
 %% endif
-	delay_ns(ns.count());
+	delay_ns(ns_.count());
 }
 
 template< class Rep >
 void
-delay(std::chrono::duration<Rep, std::micro> us_)
+delay(std::chrono::duration<Rep, std::micro> us)
 {
-	const auto us{std::chrono::duration_cast<std::chrono::microseconds>(us_)};
-	delay_us(us.count());
+	const auto us_{std::chrono::duration_cast<std::chrono::microseconds>(us)};
+	delay_us(us_.count());
 }
 
 template< class Rep >

--- a/src/modm/platform/core/cortex/delay_ns.cpp.in
+++ b/src/modm/platform/core/cortex/delay_ns.cpp.in
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015-2016, 2021 Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "../device.hpp"
+#include "hardware_init.hpp"
+#include "delay_impl.hpp"
+
+namespace modm
+{
+
+// Only call via modm::delay_ns wrapper, since this function clobbers r0, r1, r2!!!
+void __attribute__((naked, aligned(4))) modm_fastcode
+platform::delay_ns(uint32_t)
+{
+	// ns_per_loop = nanoseconds per cycle times cycles per loop
+	asm volatile (
+		".syntax unified"		"\n\t"
+		"ldr.n  r2, =_ZN4modm8platform17delay_ns_per_loopE" "\n\t"
+		"ldrh.n r2, [r2, #0]"	"\n\t"
+		"lsls.n	r1, r2, #{{shift}}"	"\n\t"	// multiply the overhead cycles with the ns per cycle:  1 cycle
+		"subs.n	r0, r0, r1"		"\n\t"	// subtract the overhead in ns from the input:          1 cycle
+	"1:  subs.n	r0, r0, r2"		"\n\t"	// subtract the ns per loop from the input:             1 cycle
+		"bpl.n	1b"				"\n\t"	// keep doing that while result is still positive:      2 cycles (when taken)
+		"bx lr"
+	);
+}
+
+%% if with_cm0
+void modm_fastcode
+delay_us(uint32_t us)
+{
+%% if with_assert
+	unsigned int unshifted_cycles;
+	modm_assert_continue_fail_debug(
+		not __builtin_umul_overflow(platform::delay_fcpu_MHz, us, &unshifted_cycles),
+		"delay.us", "modm::delay(us) has overflowed at the current frequency!");
+%% else
+	const uint32_t unshifted_cycles = platform::delay_fcpu_MHz * us;
+%% endif
+	const uint32_t cycles = unshifted_cycles >> platform::delay_fcpu_MHz_shift;
+	asm volatile (
+		".syntax unified"			"\n\t"
+		".align 4"					"\n\t"
+	"1:  subs.n	%0, %0, #{{loop}}"		"\n\t"	// subtract the loop cycles from the input:             1 cycle
+		"bpl.n	1b"							// keep doing that while result is still positive:      2 cycles (when taken)
+	:: "l" (cycles));
+}
+%% endif
+
+}

--- a/src/modm/platform/core/cortex/delay_ns.hpp.in
+++ b/src/modm/platform/core/cortex/delay_ns.hpp.in
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <cmath>
+
+/// @cond
+namespace modm::platform
+{
+
+void delay_ns(uint32_t ns);
+
+constexpr uint16_t
+computeDelayNsPerLoop(uint32_t hz)
+{
+	return std::round({{loop}}'000'000'000.0 / hz);
+}
+
+}
+/// @endcond
+
+

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -2,7 +2,7 @@
 %% macro copyright()
 /*
  * Copyright (c) 2011-2012, 2019, Fabian Greif
- * Copyright (c) 2012, 2015-2019, Niklas Hauser
+ * Copyright (c) 2012, 2015-2021, Niklas Hauser
  * Copyright (c) 2013, Sascha Schade
  * Copyright (c) 2013, 2015, Kevin Läufer
  *
@@ -108,9 +108,6 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		LONG(__data_load)
 		LONG(__data_start)
 		LONG(__data_end)
-		LONG(__fastdata_load)
-		LONG(__fastdata_start)
-		LONG(__fastdata_end)
 	%% for section in sections
 		LONG(__{{section}}_load)
 		LONG(__{{section}}_start)
@@ -167,12 +164,19 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section(memory, name)
+%% macro section(memory, name, additions=None)
 	.{{name}} : ALIGN(4)
 	{
 		__{{name}}_load = LOADADDR(.{{name}});
 		__{{name}}_start = .;
 		*(.{{name}})
+%% if additions
+%% for addition in additions
+		__{{addition}}_start = .;
+		*(.{{ addition }})
+		__{{addition}}_end = .;
+%% endfor
+%% endif
 		. = ALIGN(4);
 		__{{name}}_end = .;
 	} >{{memory}}
@@ -280,19 +284,20 @@ TOTAL_STACK_SIZE = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_ram(memory, rom)
+%% macro section_ram(memory, rom, additions=None)
 	/* initialized variables */
 	.data : ALIGN(4)
 	{
 		__data_load = LOADADDR(.data);
 		__data_start = .;
+%% if additions
+%% for addition in additions
+		__{{addition}}_start = .;
+		*(.{{ addition }})
+		__{{addition}}_end = .;
+%% endfor
+%% endif
 		*(.data .data.* .gnu.linkonce.d.*)
-	} >{{memory}} AT >{{rom}}
-
-	/* code routines in RAM */
-	.ramcode : ALIGN(4)
-	{
-		*(.ramcode .ramcode*)
 		__data_end = .;
 	} >{{memory}} AT >{{rom}}
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2016-2021, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
 #
 # This file is part of the modm project.
@@ -298,29 +298,12 @@ def build(env):
 
     # busy-waiting delays
     if env.has_module(":architecture:delay"):
-        core = env.substitutions["core"]
-        if core == "cortex-m0":
-            loop = 4
-        elif core.startswith("cortex-m7"):
-            # Cortex-M7 is superscalar with dual issue ALU and a 6-stage pipeline
-            # _and_ branches in 1 cycle => The entire loop is in the pipeline.
-            loop = 1
-        else:
-            loop = 3
-        env.substitutions["loop"] = loop
-        # FIXME: Move out of this modules, maybe remove completely
-        # TODO: These numbers were measured from a few example applications.
-        #       A statistical analysis of the average overhead cycles is required!
-        target = env.substitutions["target"]
-        if target.family in ["f4"]:
-            overhead = 25
-        elif target.family in ["f1"]:
-            overhead = 12
-        else:
-            overhead = 30
-        env.substitutions["overhead"] = overhead
-        env.template("delay.cpp.in")
+        if not env.substitutions["core"].startswith("cortex-m0"):
+            env.template("delay.cpp.in")
         env.template("delay_impl.hpp.in")
+        # Must be done by :platform:core module due to 'loop' knowledge
+        # env.template("delay_ns.hpp.in")
+        # env.template("delay_ns.cpp.in")
 
     # GNU Build ID
     env.collect(":build:linkflags", "-Wl,--build-id=sha1")

--- a/src/modm/platform/core/cortex/module.md
+++ b/src/modm/platform/core/cortex/module.md
@@ -293,14 +293,15 @@ env.collect(":platform:cortex-m:linkerscript.table_extern.heap", linkerscript_he
 ## Blocking Delay
 
 The delay functions as defined by `modm:architecture:delay` are implemented via
-software loop or hardware cycle counter (via DWT->CYCCNT, not available on
-ARMv6-M devices) and have the following limitations:
+software loop (ARMv6-M devices) or hardware cycle counter (via `DWT->CYCCNT` on
+ARMv7-M device) and have the following limitations expressed in cycles, which
+depends on the configured CPU frequency:
 
-- nanosecond delay is implemented as a tight loop with better than 100ns
-  resolution and accuracy at any CPU frequency.
-- microsecond delay has a maximum delay of 10 seconds.
+- nanosecond delay is implemented as a tight loop with a minimum delay of <20
+  cycles, a resolution of 1-4 cycles and a maximum delay of 32-bit cycles.
+- microsecond delay has a maximum delay of 32-bit cycles.
 - millisecond delay is implemented via `modm::delay_us(ms * 1000)`, thus also
-  has a maximum delay of 10 seconds.
+  has a maximum delay of 32-bit cycles.
 
 
 ## Compiler Options

--- a/src/modm/platform/core/sam/linkerscript/sam_ram.ld.in
+++ b/src/modm/platform/core/sam/linkerscript/sam_ram.ld.in
@@ -24,11 +24,7 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section("FLASH", "fastcode") }}
-
-{{ linker.section_ram("RAM", "FLASH") }}
-
-{{ linker.section("RAM AT >FLASH", "fastdata") }}
+{{ linker.section_ram("RAM", "FLASH", ["fastdata", "fastcode"]) }}
 
 {{ linker.section_heap("RAM", "heap1") }}
 

--- a/src/modm/platform/core/sam/module.lb
+++ b/src/modm/platform/core/sam/module.lb
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2019, Ethan Slattery
+# Copyright (c) 2021, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -9,6 +10,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
+
+import math
 
 def init(module):
     module.name = ":platform:core"
@@ -27,10 +30,26 @@ def prepare(module, options):
 
 
 def build(env):
-    env.substitutions = {"target": env[":target"].identifier}
+    target = env[":target"].identifier
+    env.substitutions = {"target": target}
     env.outbasepath = "modm/src/modm/platform/core"
     # startup helper code
     env.template("startup_platform.c.in")
+
+    # delay code that must be tuned for each family
+    # (cycles per loop, setup cost in loops)
+    tuning = {
+        "d": (3,  4), # CM0 tested on D21 in RAM
+    }.get(target.family, (4, 4))
+
+    env.substitutions.update({
+        "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
+        "loop": tuning[0],
+        "shift": int(math.log2(tuning[1])),
+        "with_assert": env.has_module(":architecture:assert")
+    })
+    env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
+    env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
 
 
 def post_build(env):

--- a/src/modm/platform/core/stm32/linkerscript/stm32_dccm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_dccm.ld.in
@@ -14,6 +14,7 @@ SECTIONS
 
 {{ linker.section_stack("CCM") }}
 
+	/* CCM can only be accessed by D-Bus, do not place .fastcode here! */
 {{ linker.section("CCM AT >FLASH", "fastdata") }}
 
 {{ linker.section_heap("CCM", "heap0") }}
@@ -26,9 +27,7 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section("FLASH", "fastcode") }}
-
-{{ linker.section_ram("RAM", "FLASH") }}
+{{ linker.section_ram("RAM", "FLASH", ["fastcode"]) }}
 
 {{ linker.section_heap("SRAM1", "heap1", "RAM") }}
 
@@ -48,7 +47,7 @@ SECTIONS
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 {{ linker.section_table_zero("FLASH") }}
 
-%% set copy_table = []
+%% set copy_table = ["fastdata"]
 %% if "backup" in regions
 	%% do copy_table.append("backup")
 %% endif

--- a/src/modm/platform/core/stm32/linkerscript/stm32_iccm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_iccm.ld.in
@@ -12,9 +12,7 @@ SECTIONS
 
 {{ linker.section_vector_ram("CCM") }}
 
-{{ linker.section("CCM AT >FLASH", "fastcode") }}
-
-{{ linker.section("CCM AT >FLASH", "fastdata") }}
+{{ linker.section("CCM AT >FLASH", "fastcode", ["fastdata"]) }}
 
 {{ linker.section_heap("CCM", "heap4") }}
 %% if with_crashcatcher

--- a/src/modm/platform/core/stm32/linkerscript/stm32_idtcm.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_idtcm.ld.in
@@ -44,7 +44,7 @@ SECTIONS
 	/* TABLES! TABLES! ALL THE TABLES YOU COULD EVER WANT! TABLES! */
 {{ linker.section_table_zero("FLASH") }}
 
-{{ linker.section_table_copy("FLASH", ["fastcode"]) }}
+{{ linker.section_table_copy("FLASH", ["fastdata", "fastcode"]) }}
 
 {{ linker.section_table_extern("FLASH") }}
 

--- a/src/modm/platform/core/stm32/linkerscript/stm32_ram.ld.in
+++ b/src/modm/platform/core/stm32/linkerscript/stm32_ram.ld.in
@@ -24,11 +24,7 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section("FLASH", "fastcode") }}
-
-{{ linker.section_ram("RAM", "FLASH") }}
-
-{{ linker.section("RAM AT >FLASH", "fastdata") }}
+{{ linker.section_ram("RAM", "FLASH", ["fastdata", "fastcode"]) }}
 
 {{ linker.section_heap("SRAM1", "heap1", "RAM") }}
 

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Niklas Hauser
+# Copyright (c) 2019-2021 Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -9,6 +9,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
+
+import math
 
 def init(module):
     module.name = ":platform:core"
@@ -27,10 +29,38 @@ def prepare(module, options):
 
 
 def build(env):
-    env.substitutions = {"target": env[":target"].identifier}
+    target = env[":target"].identifier
+    env.substitutions = {"target": target}
     env.outbasepath = "modm/src/modm/platform/core"
     # startup helper code
     env.template("startup_platform.c.in")
+
+    # delay code that must be tuned for each family
+    # (cycles per loop, setup cost in loops)
+    tuning = {
+        "g4": (3,  4), # CM4  guessed based on documentation
+        "l0": (3,  4), # CM0+ guessed based on documentation
+        "g0": (3,  4), # CM0+ tested on G072 in RAM
+        "f7": (1, 16), # CM7  tested on F767 in ITCM
+        "l4": (3,  4), # CM4  tested on L476 in SRAM2
+        "f3": (3,  4), # CM4  tested on F334, F303 in CCM RAM
+
+        # Defaults of (4, 4) for these families:
+        # - l1: CM3  tested on L152 in RAM
+        # - f0: CM3  tested on F071 in RAM
+        # - f1: CM3  tested on F103 in RAM
+        # - f4: CM4  tested on F401, F411, F446 in RAM
+        # - f2: CM3  guessed based on documentation
+    }.get(target.family, (4, 4))
+
+    env.substitutions.update({
+        "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
+        "loop": tuning[0],
+        "shift": int(math.log2(tuning[1])),
+        "with_assert": env.has_module(":architecture:assert")
+    })
+    env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
+    env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
 
 
 def post_build(env):

--- a/src/unittest/harness.cpp
+++ b/src/unittest/harness.cpp
@@ -22,6 +22,7 @@ namespace unittest
 	FLASH_STORAGE_STRING(stringDiffer) = " != ";
 	FLASH_STORAGE_STRING(stringNotInRange) = " not in range ";
 	FLASH_STORAGE_STRING(stringNotTrue) = "true == false\n";
+	FLASH_STORAGE_STRING(stringDelta) = " ±";
 }
 
 bool

--- a/src/unittest/harness.hpp
+++ b/src/unittest/harness.hpp
@@ -31,6 +31,7 @@ namespace unittest
 	EXTERN_FLASH_STORAGE_STRING(stringNotInRange);
 	EXTERN_FLASH_STORAGE_STRING(stringNotTrue);
 	EXTERN_FLASH_STORAGE_STRING(stringNotFalse);
+	EXTERN_FLASH_STORAGE_STRING(stringDelta);
 }
 
 #ifdef	UNITTEST_RETURN_ON_FAIL
@@ -94,7 +95,9 @@ namespace unittest
 		}
 		else {
 			TEST_REPORTER_.reportFailure(line)
-				<< a << modm::accessor::asFlash(unittest::stringEqual) << b << '\n';
+				<< a << modm::accessor::asFlash(unittest::stringEqual)
+				<< b << modm::accessor::asFlash(unittest::stringDelta)
+				<< delta << '\n';
 			return false;
 		}
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,6 +33,12 @@ run-hosted-windows:
 	$(call compile-test,hosted,run,-D":target=hosted-windows")
 
 
+compile-nucleo-f091:
+	$(call compile-test,nucleo-f091,size)
+run-nucleo-f091:
+	$(call run-test,nucleo-f091,size)
+
+
 compile-nucleo-f401:
 	$(call compile-test,nucleo-f401,size)
 run-nucleo-f401:

--- a/test/config/nucleo-f091.xml
+++ b/test/config/nucleo-f091.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-f091rc</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/nucleo-f091/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/nucleo-f091/modm-test</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>

--- a/test/modm/platform/delay/delay_test.cpp
+++ b/test/modm/platform/delay/delay_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "delay_test.hpp"
+
+#include <modm/platform.hpp>
+
+using namespace modm::platform;
+
+static uint32_t cyclesMs(uint32_t ms) { return uint64_t(SystemCoreClock) * ms / 1'000ul; }
+static uint32_t cyclesUs(uint32_t us) { return uint64_t(SystemCoreClock) * us / 1'000'000ul; }
+static uint32_t cyclesNs(uint32_t ns)
+{
+	const uint32_t cycles = uint64_t(SystemCoreClock) * ns / 1'000'000'000ul;
+	return cycles ? cycles : 1;
+}
+
+static void
+run_delay_ns(uint32_t ns, uint32_t lower=5, uint32_t upper=15)
+{
+	uint32_t start, stop;
+	{
+		modm::atomic::Lock _;
+#ifdef DWT
+		start = DWT->CYCCNT;
+#else
+		SysTick->VAL = 0;
+		stop = SysTick->VAL;
+#endif
+		modm::delay_ns(ns);
+#ifdef DWT
+		stop = DWT->CYCCNT;
+#else
+		start = SysTick->VAL;
+#endif
+	}
+	const uint32_t cycles = (stop - start) - 4;
+	TEST_ASSERT_EQUALS_RANGE(cycles, cyclesNs(ns * lower / 10), cyclesNs(ns * upper / 10));
+}
+
+static void
+run_delay_us(uint32_t us, uint32_t lower=8, uint32_t upper=15)
+{
+	uint32_t start, stop;
+	{
+		modm::atomic::Lock _;
+#ifdef DWT
+		start = DWT->CYCCNT;
+#else
+		SysTick->VAL = 0;
+		stop = SysTick->VAL;
+#endif
+		modm::delay_us(us);
+#ifdef DWT
+		stop = DWT->CYCCNT;
+#else
+		start = SysTick->VAL;
+#endif
+	}
+	const uint32_t cycles = (stop - start) - 4;
+	TEST_ASSERT_EQUALS_RANGE(cycles, cyclesUs(us * lower / 10), cyclesUs(us * upper / 10));
+}
+
+static void
+run_delay_ms(uint32_t ms, uint32_t lower=8, uint32_t upper=15)
+{
+	uint32_t start, stop;
+	{
+		modm::atomic::Lock _;
+#ifdef DWT
+		start = DWT->CYCCNT;
+#else
+		SysTick->VAL = 0;
+		stop = SysTick->VAL;
+#endif
+		modm::delay_ms(ms);
+#ifdef DWT
+		stop = DWT->CYCCNT;
+#else
+		start = SysTick->VAL;
+#endif
+	}
+	const uint32_t cycles = (stop - start) - 4;
+	TEST_ASSERT_EQUALS_RANGE(cycles, cyclesMs(ms * lower / 10), cyclesMs(ms * upper / 10));
+}
+
+void
+DelayTest::setUp()
+{
+#ifndef DWT
+	SysTick->CTRL = SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_CLKSOURCE_Msk;
+	SysTick->LOAD = (1ul << 23);
+#endif
+}
+
+void
+DelayTest::testDelayMs()
+{
+	run_delay_ms(1, 10, 20);
+	run_delay_ms(5);
+	run_delay_ms(10);
+	run_delay_ms(50);
+	run_delay_ms(100);
+	// run_delay_ms(500);
+	// run_delay_ms(1000);
+}
+
+void
+DelayTest::testDelayUs()
+{
+	run_delay_us(1, 8, 20);
+	run_delay_us(5, 8, 20);
+	run_delay_us(10);
+	run_delay_us(50);
+	run_delay_us(100);
+	run_delay_us(500);
+	run_delay_us(1000);
+}
+
+void
+DelayTest::testDelayNs()
+{
+	run_delay_ns(1, 10, 10000);
+	run_delay_ns(5, 10, 10000);
+	run_delay_ns(10, 10, 10000);
+	run_delay_ns(50, 10, 1000);
+	run_delay_ns(100, 10, 100);
+	run_delay_ns(500);
+	run_delay_ns(1000);
+	run_delay_ns(10'000);
+	run_delay_ns(100'000);
+	run_delay_ns(1'000'000);
+}
+
+

--- a/test/modm/platform/delay/delay_test.hpp
+++ b/test/modm/platform/delay/delay_test.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_platform_delay
+class DelayTest : public unittest::TestSuite
+{
+public:
+	void
+	setUp();
+
+	void
+	testDelayNs();
+
+	void
+	testDelayUs();
+
+	void
+	testDelayMs();
+};

--- a/test/modm/platform/delay/module.lb
+++ b/test/modm/platform/delay/module.lb
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def init(module):
+    module.name = ":test:platform:delay"
+
+def prepare(module, options):
+    module.depends(":architecture:delay")
+    return options[":target"].get_driver("core")["type"].startswith("cortex-m")
+
+def build(env):
+    env.outbasepath = "modm-test/src/modm-test/platform/delay"
+    env.copy("delay_test.hpp")
+    env.copy("delay_test.cpp")


### PR DESCRIPTION
There's [a massive error in the algorithm since we muliply the nanoseconds with `modm::platform::delay_ns_per_loop` first for some reason](https://github.com/modm-io/modm/issues/641#issuecomment-860099236). I'm honestly shocked at just how wrong this is?

- [x] Fix loop count for all STM32
- [x] Fix overhead computation for <1000ns
- [x] Fix inlining of delay_ns function
- [x] Some automatic or semiautomatic testing of cycles via `DWT->CYCCNT` or `SysTick->VAL`
- [x] Tested in hardware
- [x] Enable DWT for Cortex-M7 (missing unlock key)
- [x] Extend `CYCCNT` use to 32-bit instead of just 31-bit.
- [x] Better accuracy for `modm::delay_us` by using binary scaling for `modm::platform::delay_fcpu_MHz`
- [x] Smaller linkerscripts with fewer copy table entries by reusing sections
- [x] Simplify `.fastcode` section placement to always be in RAM or instruction cache
- [x] Add Cortex-M0 unit test into CI to check delay on systems without `DWT->CYCCNT`.

Fixes #641.
cc @XDjackieXD