### PR TITLE
[core] Improve micro- and nanosecond delays

### DIFF
--- a/examples/generic/delay/project.xml
+++ b/examples/generic/delay/project.xml
@@ -1,19 +1,24 @@
 <library>
-  <!-- <extends>modm:nucleo-l152re</extends> -->
-  <!-- <extends>modm:nucleo-f103rb</extends> -->
-  <!-- <extends>modm:nucleo-f401re</extends> -->
-  <!-- <extends>modm:nucleo-f411re</extends> -->
-  <!-- <extends>modm:nucleo-f446re</extends> -->
-  <extends>modm:nucleo-f334r8</extends>
-  <!-- <extends>modm:nucleo-f303k8</extends> -->
-  <!-- <extends>modm:nucleo-l476rg</extends> -->
+  <!-- <extends>modm:disco-f469ni</extends> -->
   <!-- <extends>modm:disco-f746ng</extends> -->
-  <!-- <extends>modm:nucleo-g071rb</extends> -->
+  <!-- <extends>modm:mega-2560-pro</extends> -->
   <!-- <extends>modm:nucleo-f072rb</extends> -->
   <!-- <extends>modm:nucleo-f091rc</extends> -->
+  <!-- <extends>modm:nucleo-f103rb</extends> -->
+  <!-- <extends>modm:nucleo-f303k8</extends> -->
+  <!-- <extends>modm:nucleo-f334r8</extends> -->
+  <!-- <extends>modm:nucleo-f401re</extends> -->
+  <!-- <extends>modm:nucleo-f411re</extends> -->
+  <!-- <extends>modm:nucleo-f429zi</extends> -->
+  <!-- <extends>modm:nucleo-f446re</extends> -->
+  <!-- <extends>modm:nucleo-g071rb</extends> -->
+  <extends>modm:nucleo-l152re</extends>
+  <!-- <extends>modm:nucleo-l432kc</extends> -->
+  <!-- <extends>modm:nucleo-l476rg</extends> -->
   <!-- <extends>modm:samd21-mini</extends> -->
   <options>
     <option name="modm:build:build.path">../../../build/generic/delay</option>
+    <option name="modm:io:with_printf">true</option>
     <!-- <option name="modm:tinyusb:config">device.cdc</option> -->
   </options>
   <modules>

--- a/src/modm/platform/core/avr/delay_impl.hpp.in
+++ b/src/modm/platform/core/avr/delay_impl.hpp.in
@@ -28,12 +28,8 @@ delay_ns(uint32_t ns)
 		const uint32_t cycles = uint32_t(ceil(fabs((F_CPU * double(ns)) / 1e9)));
 		__builtin_avr_delay_cycles(cycles);
 	}) : ({
-		const auto _ns = uint16_t(ns);
-		// overhead of checking + loop setup is ~5-10 instructions
-		if (_ns < uint16_t(7*3e9/F_CPU)) return; // if below, don't bother
-		// 3 cycles per loop => ns per loop = 3e9/F_CPU, round up to next power of two
-		const uint8_t loops = uint16_t(ns) >> {{ shift }};
-		if (loops) _delay_loop_1(loops);
+		const uint16_t loops = ns >> {{ shift }};
+		if (loops) _delay_loop_2(loops);
 	});
 }
 modm_always_inline void
@@ -46,12 +42,12 @@ delay_us(uint32_t us)
 	}) : ({
 %% if f_cpu <= 6000000
 		constexpr int32_t cycles = (F_CPU / 1e6);
-		for (int16_t _us = us; _us > 0; _us -= cycles)
+		for (int32_t _us = us; _us > 0; _us -= cycles)
 			__builtin_avr_delay_cycles(1);
 %% else
 		constexpr int32_t cycles = (F_CPU / 1e6) - 6;
-		for (uint16_t _us = us; _us; _us--)
-			__builtin_avr_delay_cycles(cycles > 0 ? cycles : 0);
+		for (uint32_t _us = us; _us; _us--)
+			__builtin_avr_delay_cycles(cycles);
 %% endif
 	});
 }

--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -41,7 +41,7 @@ def build(env):
         "target": target.identifier,
         "core": target.get_driver("core")["type"],
         "f_cpu": env["f_cpu"],
-        "shift": int(3e9/env["f_cpu"]).bit_length() - 1,
+        "shift": int(4e9/env["f_cpu"]).bit_length(),
     }
     env.outbasepath = "modm/src/modm/platform/core"
 

--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -32,10 +32,7 @@ namespace platform
 extern uint16_t delay_ns_per_loop;
 extern uint16_t delay_fcpu_MHz;
 
-constexpr uint8_t delay_fcpu_MHz_shift{3};
-// 400 MHz is the maximum for binary scaling
-static_assert(400 * (1ul << delay_fcpu_MHz_shift) < 65535);
-
+constexpr uint8_t delay_fcpu_MHz_shift({{us_shift}});
 constexpr uint16_t computeDelayMhz(uint32_t hz)
 { return std::round(hz / 1'000'000.f * (1ul << delay_fcpu_MHz_shift)); }
 }

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -300,8 +300,8 @@ def build(env):
     if env.has_module(":architecture:delay"):
         if not env.substitutions["core"].startswith("cortex-m0"):
             env.template("delay.cpp.in")
-        env.template("delay_impl.hpp.in")
-        # Must be done by :platform:core module due to 'loop' knowledge
+        # Must be done by :platform:core module due to tuning
+        # env.template("delay_impl.hpp.in")
         # env.template("delay_ns.hpp.in")
         # env.template("delay_ns.cpp.in")
 

--- a/src/modm/platform/core/sam/module.lb
+++ b/src/modm/platform/core/sam/module.lb
@@ -37,19 +37,21 @@ def build(env):
     env.template("startup_platform.c.in")
 
     # delay code that must be tuned for each family
-    # (cycles per loop, setup cost in loops)
+    # (cycles per loop, setup cost in loops, us shift)
     tuning = {
-        "d": (3,  4), # CM0 tested on D21 in RAM
-    }.get(target.family, (4, 4))
+        "d": (3,  4, 5), # CM0 tested on D21 in RAM
+    }.get(target.family, (4, 4, 5))
 
     env.substitutions.update({
         "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
         "loop": tuning[0],
         "shift": int(math.log2(tuning[1])),
+        "us_shift": tuning[2],
         "with_assert": env.has_module(":architecture:assert")
     })
     env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
     env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
+    env.template("../cortex/delay_impl.hpp.in", "delay_impl.hpp")
 
 
 def post_build(env):

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -36,31 +36,33 @@ def build(env):
     env.template("startup_platform.c.in")
 
     # delay code that must be tuned for each family
-    # (cycles per loop, setup cost in loops)
+    # (cycles per loop, setup cost in loops, max us shift)
     tuning = {
-        "g4": (3,  4), # CM4  guessed based on documentation
-        "l0": (3,  4), # CM0+ guessed based on documentation
-        "g0": (3,  4), # CM0+ tested on G072 in RAM
-        "f7": (1, 16), # CM7  tested on F767 in ITCM
-        "l4": (3,  4), # CM4  tested on L476 in SRAM2
-        "f3": (3,  4), # CM4  tested on F334, F303 in CCM RAM
+        "g4": (3,  4, 5), # CM4  tested on G476 in RAM
+        "l0": (3,  4, 6), # CM0+ tested on L031 in RAM
+        "g0": (3,  4, 5), # CM0+ tested on G072 in RAM
+        "f7": (1, 16, 4), # CM7  tested on F767 in ITCM
+        "l4": (3,  4, 5), # CM4  tested on L476 in SRAM2
+        "f3": (3,  4, 5), # CM4  tested on F334, F303 in CCM RAM
 
         # Defaults of (4, 4) for these families:
-        # - l1: CM3  tested on L152 in RAM
-        # - f0: CM3  tested on F071 in RAM
-        # - f1: CM3  tested on F103 in RAM
-        # - f4: CM4  tested on F401, F411, F446 in RAM
-        # - f2: CM3  guessed based on documentation
-    }.get(target.family, (4, 4))
+        "l1": (4,  4, 6), # CM3  tested on L152 in RAM
+        "f0": (4,  4, 6), # CM3  tested on F071 in RAM
+        "f1": (4,  4, 5), # CM3  tested on F103 in RAM
+        "f4": (4,  4, 4), # CM4  tested on F401, F411, F446 in RAM
+        "f2": (4,  4, 4), # CM3  guessed based on documentation
+    }[target.family]
 
     env.substitutions.update({
         "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
         "loop": tuning[0],
         "shift": int(math.log2(tuning[1])),
+        "us_shift": tuning[2],
         "with_assert": env.has_module(":architecture:assert")
     })
     env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
     env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
+    env.template("../cortex/delay_impl.hpp.in", "delay_impl.hpp")
 
 
 def post_build(env):


### PR DESCRIPTION
I wrote [a blog post about micro- and nanosecond delay](https://blog.salkinium.com/modm-delay/) and did some more measurements incl. on AVR and discovered a better way to doing nanosecond delay @ 16MHz.

- [x] Better accuracy for nanosecond delay on AVRs @ 16MHz.
- [x] better accuracy of delay_us by choosing the largest possible `delay_fcpu_MHz_shift`.
- ~I think STM32L4 is not using it's instruction CCM RAM, which is SRAM2. It should be the same performance as STM32F3, but it differs.~ Nope, it uses CCM RAM.

@chris-durand Could you do me a favor and run the example on STM32L0 and STM32G4 again (when you have time)? I would like to include more detailed results in my measurement graphs.