### PR TITLE
[stm32] Add calibration for F1 ADC

### DIFF
--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -286,10 +286,15 @@ public:
 	setRightAdjustResult();
 	// stop documentation inherited
 
-	// TODO
-	//static void
-	//calibrate();
-
+%% if target["family"] == "f1"
+	/**
+	 * Run ADC self-calibration
+	 *
+	 * @pre	The ADC must be initialized to perform the calibration
+	 */
+	static inline void
+	calibrate();
+%% endif
 
 %% if temperature_available
 	/// Switch on temperature- and V_REF measurement.

--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -76,6 +76,15 @@ modm::platform::Adc{{ id }}::setRightAdjustResult()
 	ADC{{ per }}->CR2 &= ~ADC_CR2_ALIGN;
 }
 
+%% if target["family"] == "f1"
+void
+modm::platform::Adc{{ id }}::calibrate()
+{
+	ADC{{ per }}->CR2 |= ADC_CR2_CAL;
+	while (ADC{{ per }}->CR2 & ADC_CR2_CAL);
+}
+%% endif
+
 bool
 modm::platform::Adc{{ id }}::setChannel(const Channel channel,
 									 const SampleTime sampleTime)


### PR DESCRIPTION
Add calibration function for F1 ~~, F2, F4, F7~~ ADC. Successfully tested on F105 hardware. Running the calibration improved the accuracy significantly.