### PR TITLE
[core] Much longer modm::delay_ms on Cortex-M

### DIFF
--- a/src/modm/architecture/interface/delay.hpp
+++ b/src/modm/architecture/interface/delay.hpp
@@ -23,10 +23,7 @@ namespace modm
  * @warning This function is implemented as best-effort and its resolution will
  *          be very coarse especially on platforms with very slow clocks.
  *
- * @warning The maximum delay is less than 1 millisecond.
- *
- * @note In debug mode this function may raise "delay.us" if input validation
- *       fails.
+ * @warning The maximum delay is 1'000'000ns = 1 millisecond.
  *
  * @ingroup modm_architecture_delay
  */
@@ -46,7 +43,7 @@ void delay_ns(uint32_t ns);
 /**
  * Spin for microseconds.
  *
- * @warning The maximum delay is less than 10 seconds.
+ * @warning The maximum delay is 1'000'000us = 1 second. Use milliseconds for longer delays.
  *
  * @note In debug mode this function may raise "delay.us" if input validation
  *       fails.
@@ -59,11 +56,6 @@ void delay_us(uint32_t us);
 
 /**
  * Spin for milliseconds.
- *
- * @warning The maximum delay is less than 10 seconds.
- *
- * @note In debug mode this function may raise "delay.us" if input validation
- *       fails.
  *
  * @ingroup modm_architecture_delay
  */
@@ -81,6 +73,31 @@ void delay_ms(uint32_t ms);
 
 namespace modm
 {
+
+// Forward everything to specialized functions
+template< class Rep >
+void
+delay(std::chrono::duration<Rep, std::nano> ns_)
+{
+    const auto ns{std::chrono::duration_cast<std::chrono::nanoseconds>(ns_)};
+    delay_ns(ns.count());
+}
+
+template< class Rep >
+void
+delay(std::chrono::duration<Rep, std::micro> us_)
+{
+    const auto us{std::chrono::duration_cast<std::chrono::microseconds>(us_)};
+    delay_us(us.count());
+}
+
+template< class Rep >
+void
+delay(std::chrono::duration<Rep, std::milli> ms_)
+{
+    const auto ms{std::chrono::duration_cast<std::chrono::milliseconds>(ms_)};
+    delay_ms(ms.count());
+}
 
 // Everything else is cast to milliseconds
 template<class Rep, class Period>

--- a/src/modm/architecture/interface/delay.hpp
+++ b/src/modm/architecture/interface/delay.hpp
@@ -82,10 +82,10 @@ void delay_ms(uint32_t ms);
 namespace modm
 {
 
-// Everything else is cast to microseconds
+// Everything else is cast to milliseconds
 template<class Rep, class Period>
 inline void delay(std::chrono::duration<Rep, Period> time)
-{ delay(std::chrono::duration_cast<std::chrono::microseconds>(time)); }
+{ delay(std::chrono::duration_cast<std::chrono::milliseconds>(time)); }
 
 // The old methods are deprecated
 [[deprecated("Use `modm::delay_ns(uint32_t ns)` instead!")]]

--- a/src/modm/architecture/interface/delay.md
+++ b/src/modm/architecture/interface/delay.md
@@ -23,6 +23,7 @@ using namespace std::chrono_literals;
 modm::delay(100ns);
 modm::delay(200us);
 modm::delay(300ms);
+modm::delay(400s);
 ```
 
 In order to not require wild casting around of values, there are also three
@@ -44,8 +45,11 @@ hardware-init time.
 
 The main limitations are accuracy and length of delay. The only guarantee given
 to you is to delay for _at least_ the specified time. Note that invocation of
-interrupts during spinning may add delay too. For additional limitations also
-check the description of the `modm:platform:core` modules.
+interrupts during spinning may add delay too.
+
+- `modm::delay(ns)` guarantees at most 1'000'000ns = 1ms delay.
+- `modm::delay(us)` guarantees at most 1'000'000µs = 1s delay.
+- `modm::delay(ms)` is limited to 49 days.
 
 Please note that the delay these functions provide is defined as the time from
 invocation to the time of execution return. Obviously no delay beyond that is
@@ -64,3 +68,6 @@ You should always prefer Software Timers (see `modm:processing:timer`) over
 these *blocking* delay functions. However, when `modm::Clock` is not set up yet,
 or when you need very small delays (for example to bit-bang a protocol), you
 need to use these delay functions.
+
+For the technical details on the delay implementations you can [read "Accurate
+Micro- and Nanosecond Delay in modm"](https://blog.salkinium.com/modm-delay).

--- a/src/modm/platform/core/avr/delay_impl.hpp.in
+++ b/src/modm/platform/core/avr/delay_impl.hpp.in
@@ -63,30 +63,5 @@ delay_ms(uint32_t ms)
 	});
 }
 
-// Forward everything to specialized functions
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::nano> ns_)
-{
-	const auto ns{std::chrono::duration_cast<std::chrono::nanoseconds>(ns_)};
-	delay_ns(ns.count());
-}
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::micro> us_)
-{
-	const auto us{std::chrono::duration_cast<std::chrono::microseconds>(us_)};
-	delay_us(us.count());
-}
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::milli> ms_)
-{
-	const auto ms{std::chrono::duration_cast<std::chrono::milliseconds>(ms_)};
-	delay_ms(ms.count());
-}
-
 }   // namespace modm
 /// @endcond

--- a/src/modm/platform/core/avr/module.md
+++ b/src/modm/platform/core/avr/module.md
@@ -30,22 +30,21 @@ fairly accurate.
 
 For delays with a dynamic time, the following limitations apply for nanoseconds:
 
-- The input is limited to 16-bit nanoseconds, so ~65 microseconds.
-- The minimum delay is between 5-10 cycles, so even at the fastest clock rate of
-  32MHz a delay below ~250ns is not possible. At 8MHz delays less than 1us are
+- The input is limited to 26-bit nanoseconds, so ~67 milliseconds.
+- The minimum delay is between 8-16 cycles, so even at the fastest clock rate of
+  32MHz a delay below ~500ns is not possible. At 8MHz delays less than 2us are
   not possible.
-- For longer delays, the 3-cycle `_delay_loop_1(loops)` is used and the number
+- For longer delays, the 4-cycle `_delay_loop_2(loops)` is used and the number
   of loops should be calculated by dividing the input value by `ns_per_loop =
-  3e9/F_CPU`. However, division is prohibitively slow and thus very coarsly
+  4e9/F_CPU`. However, division is prohibitively slow and thus very coarsly
   approximated by shifting the input: `ns >> ceil(log_2(ns_per_loop))`. This is
-  only accurate for `3e9/2^7` = 23.4MHz, 11.7MHz, 5.8MHz, etc. For all other
+  only accurate for `4e9/2^8` = 15.6MHz, 7.8MHz, 3.9MHz, etc. For all other
   clock speeds the error is bound by a factor of 2, so the delay is at most
   twice as long as expected.
 
 For micro- and milliseconds delays with dynamic time:
 
-- Microseconds delay is implemented fairly accurately in 1us steps with a
-  maximum time delay of 65ms for clocks larger than 6MHz.
+- Microseconds delay is implemented fairly accurately in 1us steps.
 - Millisecond delay is implemented fairly accurately in 1ms steps on 32-bits of
   input time.
 

--- a/src/modm/platform/core/cortex/delay.cpp.in
+++ b/src/modm/platform/core/cortex/delay.cpp.in
@@ -19,12 +19,16 @@ modm::delay_us(uint32_t us)
 	const uint32_t start = DWT->CYCCNT;
 	asm inline ("" ::: "memory");
 %% if with_assert
+#ifdef MODM_DEBUG_BUILD
 	unsigned int unshifted_cycles;
 	modm_assert_continue_fail_debug(
 		not __builtin_umul_overflow(platform::delay_fcpu_MHz, us, &unshifted_cycles),
-		"delay.us", "modm::delay(us) has overflowed at the current frequency!");
-%% else
+		"delay.us", "modm::delay(us) can only delay ~1s! Use modm::delay(ms) for longer durations.");
+#else
+%% endif
 	const uint32_t unshifted_cycles = platform::delay_fcpu_MHz * us;
+%% if with_assert
+#endif
 %% endif
 	const uint32_t cycles = unshifted_cycles >> platform::delay_fcpu_MHz_shift;
 	while (true)

--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -61,34 +61,5 @@ inline void delay_ms(uint32_t ms)
     }
 }
 
-// ----------------------------------------------------------------------------
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::nano> ns)
-{
-	const auto ns_{std::chrono::duration_cast<std::chrono::nanoseconds>(ns)};
-%% if with_assert
-	modm_assert_continue_fail_debug(0 <= ns_.count() and ns_.count() <= 1'000'000,
-		"delay.ns", "modm::delay(ns) can only delay a (positive) maximum of ~1 millisecond!");
-%% endif
-	delay_ns(ns_.count());
-}
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::micro> us)
-{
-	const auto us_{std::chrono::duration_cast<std::chrono::microseconds>(us)};
-	delay_us(us_.count());
-}
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::milli> ms)
-{
-    const auto ms_{std::chrono::duration_cast<std::chrono::milliseconds>(ms)};
-    delay_ms(ms_.count());
-}
-
 }
 /// @endcond

--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -48,7 +48,18 @@ void delay_ns(uint32_t ns)
 
 
 void delay_us(uint32_t us);
-inline void delay_ms(uint32_t ms) { delay_us(ms * 1000); }
+inline void delay_ms(uint32_t ms)
+{
+    while(1)
+    {
+        if (ms <= 1000) {
+            delay_us(ms * 1000);
+            break;
+        }
+        delay_us(1'000'000);
+        ms -= 1000;
+    }
+}
 
 // ----------------------------------------------------------------------------
 template< class Rep >
@@ -75,8 +86,8 @@ template< class Rep >
 void
 delay(std::chrono::duration<Rep, std::milli> ms)
 {
-	const auto us{std::chrono::duration_cast<std::chrono::microseconds>(ms)};
-	delay_us(us.count());
+    const auto ms_{std::chrono::duration_cast<std::chrono::milliseconds>(ms)};
+    delay_ms(ms_.count());
 }
 
 }

--- a/src/modm/platform/core/cortex/delay_ns.cpp.in
+++ b/src/modm/platform/core/cortex/delay_ns.cpp.in
@@ -38,12 +38,16 @@ void modm_fastcode
 delay_us(uint32_t us)
 {
 %% if with_assert
+#ifdef MODM_DEBUG_BUILD
 	unsigned int unshifted_cycles;
 	modm_assert_continue_fail_debug(
 		not __builtin_umul_overflow(platform::delay_fcpu_MHz, us, &unshifted_cycles),
-		"delay.us", "modm::delay(us) has overflowed at the current frequency!");
-%% else
+		"delay.us", "modm::delay(us) can only delay ~1s! Use modm::delay(ms) for longer durations.");
+#else
+%% endif
 	const uint32_t unshifted_cycles = platform::delay_fcpu_MHz * us;
+%% if with_assert
+#endif
 %% endif
 	const uint32_t cycles = unshifted_cycles >> platform::delay_fcpu_MHz_shift;
 	asm volatile (

--- a/src/modm/platform/core/hosted/delay_impl.hpp.in
+++ b/src/modm/platform/core/hosted/delay_impl.hpp.in
@@ -44,31 +44,7 @@ inline void delay_ns(uint32_t ns) { Sleep(ns / 1000'000ul); }
 inline void delay_us(uint32_t us) { Sleep(us / 1000ul); }
 inline void delay_ms(uint32_t ms) { Sleep(ms); }
 
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::milli> ms_)
-{
-	const auto ms{std::chrono::duration_cast<std::chrono::milliseconds>(ms_)};
-	delay_ms(ms.count());
-}
-
 %% endif
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::nano> ns_)
-{
-	const auto ns{std::chrono::duration_cast<std::chrono::nanoseconds>(ns_)};
-	delay_ns(ns.count());
-}
-
-template< class Rep >
-void
-delay(std::chrono::duration<Rep, std::micro> us_)
-{
-	const auto us{std::chrono::duration_cast<std::chrono::microseconds>(us_)};
-	delay_us(us.count());
-}
 
 }	// namespace modm
 /// @endcond


### PR DESCRIPTION
There is a duration limitation due to accuracy in the cycle computation on `modm::delay_us` to at least 1s. This makes `modm::delay_ms` count ms and therefore has a 2^32/1000 seconds duration, which… uhm should be enough (49 days?).

- [x] Improve interface documentation
- [x] Fix delay_ns assertion?
- [x] Fix delay_ms limitations
- AVR already implements ms counting, so it's not limited.

Closes #650.

cc @chris-durand 