### PR TITLE
[animation] add missing dependency to :processing:timer

### DIFF
--- a/src/modm/ui/animation/base.hpp
+++ b/src/modm/ui/animation/base.hpp
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <modm/architecture/interface/clock.hpp>
 #include <modm/math/utils/arithmetic_traits.hpp>
+#include <modm/processing/timer.hpp>
 #include "interpolation.hpp"
 
 namespace modm

--- a/src/modm/ui/animation/module.lb
+++ b/src/modm/ui/animation/module.lb
@@ -19,7 +19,7 @@ Various classes for animating values.
 """
 
 def prepare(module, options):
-    module.depends(":architecture:clock", ":math:utils")
+    module.depends(":architecture:clock", ":math:utils", ":processing:timer")
     return True
 
 def build(env):


### PR DESCRIPTION
I tried to add `<module>modm:ui:animation</module>` to my `project.xml` in order to use some animation code, but compiling failed with a missing defintion of `ShortTimestamp`. After some digging, I found it in `modm:processing:timer` and it looks like the animation module misses this as a dependency.

But maybe I just used it wrong? FWIW, I've added the dependency and the missing include and now I can just add `modm:ui:animation` and it works as expected.