### PR TITLE
[stm32] Fix noisy compiler warnings in uart driver for g4

### DIFF
--- a/src/modm/platform/uart/stm32/uart_base.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_base.hpp.in
@@ -29,7 +29,7 @@
 #define	USART_BRR_DIV_FRACTION	USART_BRR_DIV_Fraction
 #endif
 %% endif
-%% if tcbgt
+%% if tcbgt and target.family != "g4"
 #define USART_CR1_TXEIE   USART_CR1_TXEIE_TXFNFIE
 #define USART_CR1_RXNEIE  USART_CR1_RXNEIE_RXFNEIE
 #define USART_ISR_RXNE    USART_ISR_RXNE_RXFNE


### PR DESCRIPTION
Some macros in the uart driver to fix broken ST headers are not required for G4 and cause a lot of noisy warnings:
```
In file included from modm/src/modm/platform/uart/uart_2.hpp:22,
                 from modm/src/modm/platform.hpp:80,
                 from modm/src/modm/board/board.hpp:14,
                 from modm/src/modm/board/board.cpp:12:
modm/src/modm/platform/uart/uart_base.hpp:26: warning: "USART_ISR_TXE" redefined
   26 | #define USART_ISR_TXE     USART_ISR_TXE_TXFNF
      | 
```