### PR TITLE
[tinyusb] Fix speed option default for STM32

### DIFF
--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -45,7 +45,7 @@ def prepare(module, options):
                 EnumerationOption(name="speed",
                                   description="USB Port Speed",
                                   enumeration={"full": "fs", "high": "hs"},
-                                  default="full",
+                                  default="high" if options[":target"].has_driver("usb_otg_hs") else "full",
                                   dependencies=lambda s: ":platform:usb:{}s".format(s[0])))
 
     module.add_submodule(TinyUsbDeviceModule())


### PR DESCRIPTION
Some H7 only have a HS USB peripheral (which can also do FS, but our modm-devices doesn't know that yet).

Fixes the broken docs.modm.io build.

- [x] Add better short test for the docs build script to the CI, we cannot have this happen everytime we add a new family.