### PR TITLE
[ext] Embedded Template Library ETL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "ext/lvgl/lvgl"]
 	path = ext/lvgl/lvgl
 	url = https://github.com/modm-ext/lvgl-partial.git
+[submodule "ext/etlcpp/etl"]
+	path = ext/etlcpp/etl
+	url = https://github.com/modm-ext/etl-partial.git

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 - Integration of useful third-party software:
 	- [FreeRTOS][] and [FreeRTOS+TCP][].
 	- [CMSIS][] and [CMSIS-DSP][].
+	- [ETL][].
 	- [TinyUSB][].
 	- [FatFS][].
 	- [ROSserial][].
@@ -766,6 +767,7 @@ and [many more contributors][contributors].
 [CMSIS]:           https://www.keil.com/pack/doc/CMSIS/General/html/index.html
 [CMSIS-DSP]:       https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html
 [TinyUSB]:         https://github.com/hathach/tinyusb
+[ETL]:             https://www.etlcpp.com
 [FatFS]:           http://elm-chan.org/fsw/ff/00index_e.html
 [ROSserial]:       https://wiki.ros.org/rosserial
 [CrashCatcher]:    https://github.com/adamgreen/CrashCatcher

--- a/examples/generic/etl/main.cpp
+++ b/examples/generic/etl/main.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <etl/unordered_map.h>
+#include <numbers>
+
+using namespace std::chrono_literals;
+
+int main()
+{
+	Board::initialize();
+
+	while (true)
+	{
+		// Create an unordered_map of three strings (that map to strings)
+		etl::unordered_map<uint8_t, double, 3> u = {
+			{15, std::numbers::pi},
+			{42, std::numbers::e},
+			{87, std::numbers::sqrt2}
+		};
+
+		if (Board::Button::read()) {
+			// Access non-existant element causing an assertion
+			MODM_LOG_INFO << u[12];
+		}
+
+		MODM_LOG_INFO << "Iterate and print keys and values using structured binding (since C++17):\n";
+		for( const auto& [key, value] : u ) {
+			MODM_LOG_INFO << "Key:[" << key << "] Value:[" << value << "]\n";
+		}
+
+		modm::delay(5000ms);
+	}
+
+	return 0;
+}

--- a/examples/generic/etl/project.xml
+++ b/examples/generic/etl/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-f439zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/generic/etl</option>
+  </options>
+  <modules>
+    <module>modm:etl</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/linux/etl/main.cpp
+++ b/examples/linux/etl/main.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <etl/unordered_map.h>
+#include <numbers>
+#include <chrono>
+#include <modm/debug/logger.hpp>
+
+using namespace std::chrono_literals;
+
+int main()
+{
+	// Create an unordered_map of three strings (that map to strings)
+	etl::unordered_map<uint8_t, double, 3> u = {
+		{15, std::numbers::pi},
+		{42, std::numbers::e},
+		{87, std::numbers::sqrt2}
+	};
+
+	MODM_LOG_INFO << "Iterate and print keys and values using structured binding (since C++17):\n";
+	for( const auto& [key, value] : u ) {
+		MODM_LOG_INFO << "Key:[" << key << "] Value:[" << value << "]\n";
+	}
+
+	// Access non-existant element causing an assertion
+	MODM_LOG_INFO << u[12];
+
+	return 0;
+}

--- a/examples/linux/etl/project.xml
+++ b/examples/linux/etl/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <!-- CI: run fail -->
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/etl</option>
+  </options>
+  <modules>
+    <module>modm:etl</module>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/etlcpp/error_handler.h
+++ b/ext/etlcpp/error_handler.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2021 Niklas Hauser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_ERROR_HANDLER_EXTERNAL_INCLUDED
+#define ETL_ERROR_HANDLER_EXTERNAL_INCLUDED
+
+/* Include the original header from ETL */
+#include "error_handler_internal.h"
+
+/* Only redefine errors if necessary */
+#if !defined(ETL_NO_CHECKS) && !defined(ETL_THROW_EXCEPTIONS) && !defined(ETL_LOG_ERRORS)
+
+/* Undefine the error handlers */
+#undef ETL_ASSERT
+#undef ETL_ASSERT_AND_RETURN
+#undef ETL_ASSERT_AND_RETURN_VALUE
+#undef ETL_ALWAYS_ASSERT
+#undef ETL_ALWAYS_ASSERT_AND_RETURN
+#undef ETL_ALWAYS_ASSERT_AND_RETURN_VALUE
+#undef ETL_ERROR
+
+/* Define the error handlers to use modm_assert */
+#include <modm/architecture/interface/assert.h>
+
+#define ETL_ASSERT(b, e)                         {         modm_assert((b), "etl", (e)); }
+#define ETL_ASSERT_AND_RETURN(b, e)              { if (not modm_assert_continue_ignore((b), "etl", (e))) return; }
+#define ETL_ASSERT_AND_RETURN_VALUE(b, e, v)     { if (not modm_assert_continue_ignore((b), "etl", (e))) return (v); }
+
+#define ETL_ALWAYS_ASSERT(e)                     ETL_ASSERT(false, e)
+#define ETL_ALWAYS_ASSERT_AND_RETURN(e)          ETL_ASSERT_AND_RETURN(false, e)
+#define ETL_ALWAYS_ASSERT_AND_RETURN_VALUE(e, v) ETL_ASSERT_AND_RETURN_VALUE(false, e, v)
+
+#include <modm/architecture/utils.hpp>
+
+#if defined(ETL_VERBOSE_ERRORS)
+  #define ETL_ERROR(e) (__FILE__ ":" MODM_STRINGIFY(__LINE__) " -> \"" MODM_STRINGIFY(e) "\"")
+#else
+  #define ETL_ERROR(e) (MODM_STRINGIFY(__LINE__) " -> \"" MODM_STRINGIFY(e) "\"")
+#endif
+
+#endif /* ETL_NO_CHECKS */
+
+#endif /* ETL_ERROR_HANDLER_EXTERNAL_INCLUDED */

--- a/ext/etlcpp/module.lb
+++ b/ext/etlcpp/module.lb
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Raphael Lehmann
+# Copyright (c) 2021, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":etl"
+    module.description = """
+# Embedded Template Library (ETL)
+
+ETL is a MIT licensed template library which augments the STL with embedded
+friendly containers and algorithms.
+
+- https://www.etlcpp.com/
+- https://github.com/ETLCPP/etl
+
+
+## Configuration
+
+This module pre-configures ETL by adding these macros:
+
+- `ETL_TARGET_OS_FREERTOS`: if built together with the `modm:freertos` module.
+
+To add your own configuration you can [create a `<etl_profile.h>` file][config]
+which will automatically be included by ETL.
+
+
+## Debugging ETL
+
+This module reroutes ETLs assertions to `modm_assert` but only for the default
+configuration. Defining any of `ETL_NO_CHECKS`, `ETL_THROW_EXCEPTIONS` or
+`ETL_LOG_ERRORS` will use original ETL mechanism.
+
+Make sure you have implemented the `modm_abandon` handler! See the
+`modm:architecture:assert` module for details.
+
+An ETL assertion failure in release mode is fairly cryptic:
+
+```
+Assertion 'etl' failed!
+Abandoning...
+```
+
+If you run this again in debug mode, you'll note a much more detailed assertion
+description:
+
+```
+Assertion 'etl' failed!
+  modm/ext/etl/etl/ipool.h:369 -> "pool_no_allocation"
+Abandoning...
+```
+
+[config]: https://www.etlcpp.com/setup.html
+"""
+
+def prepare(module, options):
+    module.depends(":architecture:assert")
+    return True
+
+def build(env):
+    env.collect(":build:path.include", "modm/ext/etl")
+    env.outbasepath = "modm/ext/etl"
+    env.substitutions = {"with_freertos": env.has_module(":freertos")}
+
+    # Ignore the preconfigured profiles (but keep determine_ headers)
+    env.copy("etl/include/etl/", dest="etl/", ignore=env.ignore_paths(
+             "*/etl/include/etl/profiles/[a-ce-z]*", "*/doxygen.h",
+             "*/error_handler.h", "*/platform.h"))
+    # Rename the original header files
+    env.copy("etl/include/etl/error_handler.h", dest="etl/error_handler_internal.h")
+    env.copy("etl/include/etl/platform.h", dest="etl/platform_internal.h")
+    # So that we can replace them with ours but not need to reproduce them
+    env.copy("error_handler.h", dest="etl/error_handler.h")
+    env.template("platform.h.in", dest="etl/platform.h")

--- a/ext/etlcpp/platform.h.in
+++ b/ext/etlcpp/platform.h.in
@@ -1,0 +1,45 @@
+/******************************************************************************
+The MIT License(MIT)
+
+Embedded Template Library.
+https://github.com/ETLCPP/etl
+https://www.etlcpp.com
+
+Copyright(c) 2021 Niklas Hauser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files(the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+#ifndef ETL_PLATFORM_EXTERNAL_INCLUDED
+#define ETL_PLATFORM_EXTERNAL_INCLUDED
+
+/* Map modm's debug macro to ETL's debug macro */
+#ifdef MODM_DEBUG_BUILD
+#define ETL_DEBUG
+#define ETL_VERBOSE_ERRORS
+#endif
+
+/* Default modm settings */
+%% if with_freertos
+#define ETL_TARGET_OS_FREERTOS
+%% endif
+
+#include "platform_internal.h"
+
+#endif /* ETL_PLATFORM_EXTERNAL_INCLUDED */


### PR DESCRIPTION
- [x] Submodule of partial [ETLCPP/etl](https://github.com/ETLCPP/etl) repo: https://github.com/modm-ext/etl-partial
- [x] lbuild module
- [x] Minimal example
- [x] Ignore `profiles/` folder and `doxygen.h`
- [x] `ETL_ASSERT` etc should be rerouted to `modm_assert`. I think replacing the `error_handler.h` file should be enough for that.
- [x] Verify that all compatible `ETL_*` defined are defaulted, like `ETL_CPP17_SUPPORTED` etc. 
- [x] `<etl_local.h>` mechanism? => ETL uses `etl_profile.h` themselves.
- [x] Add ETL as external project to Readme