### PR TITLE
[c++] Remove unnecessary atexit implementation

### DIFF
--- a/ext/gcc/cabi_cortex.c
+++ b/ext/gcc/cabi_cortex.c
@@ -19,3 +19,17 @@ void _exit(int status)
 	modm_assert(false, "libc.exit",
 			"The libc exit(status) function was called!", status);
 }
+
+extern void abort(void);
+void abort(void)
+{
+    modm_assert(false, "libc.abort",
+            "The libc abort() function was called!");
+}
+
+extern int atexit(void (*fn)(void));
+int atexit(void (*fn)(void))
+{
+    (void) fn;
+    return 0;
+}

--- a/ext/gcc/cxxabi.cpp.in
+++ b/ext/gcc/cxxabi.cpp.in
@@ -22,16 +22,6 @@ void __cxa_pure_virtual()
 void __cxa_deleted_virtual()
 { modm_assert(0, "virt.del", "A deleted virtual function was called!"); }
 
-void* __dso_handle = (void*) &__dso_handle;
-%% if core.startswith("avr")
-int __cxa_atexit(void (*)(void *), void *, void *)
-%% else
-// ARM EABI specifies __aeabi_atexit instead of __cxa_atexit
-int __aeabi_atexit(void (*)(void *), void *, void *)
-%% endif
-{
-	return 0;
-}
 }
 
 %% if with_threadsafe_statics

--- a/ext/gcc/module_c++.lb
+++ b/ext/gcc/module_c++.lb
@@ -93,7 +93,7 @@ def build(env):
         env.copy("libstdc++", ignore=env.ignore_files("*.lb", "*.md", "*.in", "examples"))
         env.template("assert.cpp.in", "assert.cpp")
 
-    env.collect(":build:cxxflags", "-fuse-cxa-atexit")
+    env.collect(":build:cxxflags", "-fno-use-cxa-atexit")
     # Threadsafe statics
     if not with_threadsafe_statics:
         env.collect(":build:cxxflags", "-fno-threadsafe-statics")

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -222,13 +222,6 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		KEEP(*(.init_array))
 		. = ALIGN(4);
 		__init_array_end = .;
-	%% if 0
-		__fini_array_start = .;
-		KEEP(*(.fini_array))
-		KEEP(*(SORT(.fini_array.*)))
-		. = ALIGN(4);
-		__fini_array_end = .;
-	%% endif
 
 		__hardware_init_start = .;
 		/* Table symbols are alphabetically sorted! */
@@ -245,6 +238,11 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__build_id = .;
 		KEEP(*(.note.gnu.build-id))
 	} >{{memory}}
+	/* We do not call static destructors ever */
+	/DISCARD/ :
+	{
+		*(.fini_array .fini_array.*)
+	}
 
 	%% if with_cpp_exceptions
 	.exidx :

--- a/tools/build_script_generator/scons/site_tools/size.py
+++ b/tools/build_script_generator/scons/site_tools/size.py
@@ -27,14 +27,14 @@
 
 from SCons.Script import *
 
-def show_size(env, source, alias='__size'):
-    if env.has_key('CONFIG_DEVICE_MEMORY'):
+def show_size(env, source, alias="__size"):
+    if "CONFIG_DEVICE_MEMORY" in env:
         def size_action(target, source, env):
             from modm_tools import size
-            print(size.format(source[0].abspath, env['CONFIG_DEVICE_MEMORY']))
+            print(size.format(source[0].abspath, env["CONFIG_DEVICE_MEMORY"]))
             return 0
         action = Action(size_action, cmdstr="$SIZECOMSTR")
-    elif env.has_key('CONFIG_DEVICE_NAME'):
+    elif "CONFIG_DEVICE_NAME" in env:
         # AVR devices use avr-objdump -Pmem-usage via ELF file
         action = Action("$OBJDUMP -Pmem-usage {}".format(source[0].path),
                         cmdstr="$SIZECOMSTR")
@@ -45,7 +45,7 @@ def show_size(env, source, alias='__size'):
     return env.AlwaysBuild(env.Alias(alias, source, action))
 
 def generate(env, **kw):
-    env.AddMethod(show_size, 'Size')
+    env.AddMethod(show_size, "Size")
 
 def exists(env):
     return True


### PR DESCRIPTION
This manages a code bloat issues I recently discovered:

`-fuse-cxa-atexit` forces the compiler to register all static destructors via `__aeabi_atexit()`, which we provided empty, however in projects with a lot of constructors this call adds ~8B per constructor which can add up to a few kB of code.

If we use `-fno-use-cxa-atexit`, then the static destructors get placed into the `.fini_array` which we can discard in the linkerscript, HOWEVER, static variables are constructed at runtime **on demand**, and thus the compiler generates a call to `atexit` to register the destructor dynamically.

The [`atexit()` function family is provided by Newlib](https://embeddedartistry.com/blog/2019/04/17/exploring-startup-implementations-newlib-arm/) and is very expensively implemented (depends on malloc too). This overwrites the atexit function with an empty stub which prevents all that code getting pulled in.

This also overwrites the `abort()` function, which is called by GCC unwinding code when using exceptions and also pulls in a lot of unnecessary code.

I'm a bit sceptical that this works, since neither the `atexit()` nor the `abort()` functions are marked as weak symbols in the `libc.a` or `libc_nano.a`, so I'm assuming the ability to overwrite this from `libmodm.a` comes from using `--start-group` and `--whole-archive` linkflags which interacts somehow favorably with the `--specs=nosys.specs` and `--specs=nano.specs` linkflags, which also use `--start-group` to resolve symbols.

In general, using Newlib requires too much magic knowledge and workarounds and it still is a terrible libc implementation (just think of printf). We need to replace it with a custom compiled Picolibc, but we need to wait for fixes in GCC11's stdlibc++ to make the switch.