### PR TITLE
Initial support for Smart Response XE

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Examples AVR Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno arduino_nano)
+          (cd examples && ../tools/scripts/examples_compile.py avr arduino_uno arduino_nano srxe)
       - name: Compile AVR Unittests AT90CAN
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3138<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3166<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->2593<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->2621<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->163<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->382<!--/avrcount--> devices.
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3166<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3172<!--/allcount--> devices of these vendors:
 
 - STMicroelectronics STM32: <!--stmcount-->2621<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->163<!--/samcount--> devices.
-- Microchip AVR: <!--avrcount-->382<!--/avrcount--> devices.
+- Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 
 Here is a table with all device families and the peripheral drivers they support:
 

--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ We have out-of-box support for many development boards including documentation.
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32f030_demo">STM32F030-DEMO</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-srxe">Smart Response XE</a></td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/srxe/blink/main.cpp
+++ b/examples/srxe/blink/main.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, Tomasz Wasilczyk
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+int
+main()
+{
+	Board::initialize();
+
+	while (true)
+	{
+		Board::LedDebug::toggle();
+		modm::delay(1s);
+	}
+}

--- a/examples/srxe/blink/project.xml
+++ b/examples/srxe/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:srxe</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/srxe/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/srxe/board.hpp
+++ b/src/modm/board/srxe/board.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Tomasz Wasilczyk
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_srxe
+namespace Board {
+
+using namespace modm::literals;
+
+using SystemClock = modm::platform::SystemClock;
+
+using LedDebug = GpioB0;
+using Leds = SoftwareGpioPort<LedDebug>;
+
+namespace Display {
+
+using DC = GpioD6;
+using CS = GpioE7;
+using RST = GpioG2;
+
+}  // namespace Display
+
+inline void
+initialize() {
+	SystemClock::enable();
+
+	LedDebug::setOutput();
+
+	enableInterrupts();
+}
+
+}  // namespace Board

--- a/src/modm/board/srxe/board.xml
+++ b/src/modm/board/srxe/board.xml
@@ -1,0 +1,15 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">atmega128rfa1-zu</option>
+    <option name="modm:platform:core:f_cpu">16000000</option>
+  </options>
+  <modules>
+    <module>modm:board:srxe</module>
+  </modules>
+</library>

--- a/src/modm/board/srxe/module.lb
+++ b/src/modm/board/srxe/module.lb
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Tomasz Wasilczyk
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:srxe"
+    module.description = """
+# Smart Response XE
+
+Smart Response XE is an obsolete classroom clicker, sold for as little as 5 USD on well known online auction site.
+It's a compelling platform that's fully reverse engineered and ready to hack out of box, featuring:
+ - ATmega128RFA1 MCU
+ - 384x160 LCD display
+ - QWERTY keyboard
+ - External 1M SPI flash
+ - Exposed ISP and JTAG headers
+ - ZigBee transciever w/ antennas
+ - Powered by 4 AAA batteries
+ - Optional (unpopulated):
+   - RS232
+   - Debug LED
+   - Buzzer
+   - Accelerometer
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("atmega128rfa1"):
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":architecture:interrupt",
+        ":debug",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:uart:0")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.copy('.')
+    env.collect(":build:default.avrdude.programmer", "usbasp");

--- a/src/modm/platform/clock/avr/module.lb
+++ b/src/modm/platform/clock/avr/module.lb
@@ -35,7 +35,8 @@ def prepare(module, options):
     target = options[":target"].identifier
     if target.family in {"tiny"} and target.name in {"861", "88"}:
         return False
-    if target.family in {"mega"} and target.name in {"8", "16", "32", "64", "128"}:
+    if (target.family in {"mega"} and target.name in {"8", "16", "32", "64", "128"}
+            and target.type not in {"rfa1"}):
         return False
 
     module.depends(":architecture:atomic", ":architecture:clock")

--- a/test/all/ignored.txt
+++ b/test/all/ignored.txt
@@ -20,7 +20,6 @@ at90usb646
 at90usb647
 at90usb82
 atmega1284rfr2
-atmega128rfa1
 atmega128rfr2
 atmega162
 atmega165a

--- a/tools/scripts/synchronize_docs.py
+++ b/tools/scripts/synchronize_docs.py
@@ -52,6 +52,7 @@ def name(raw_name):
                    .replace("ARDUINO-UNO", "Arduino UNO")\
                    .replace("ARDUINO-NANO", "Arduino NANO")\
                    .replace("RASPBERRYPI", "Raspberry Pi")\
+                   .replace("SRXE", "Smart Response XE")\
                    .replace("GENERIC", "Generic")\
                    .replace("LINUX", "Linux")\
                    .replace("WINDOWS", "Windows")\


### PR DESCRIPTION
This change requires merging https://github.com/modm-io/modm-devices/pull/68 first.