### PR TITLE
Fix an incorrect include path which worked in most cases

### DIFF
--- a/src/modm/platform/dac/stm32/dac.hpp.in
+++ b/src/modm/platform/dac/stm32/dac.hpp.in
@@ -17,7 +17,7 @@
 #include "../device.hpp"
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/platform/clock/rcc.hpp>
-#include <modm/src/modm/math/units.hpp>
+#include <modm/math/units.hpp>
 
 namespace modm::platform
 {


### PR DESCRIPTION
This fixes an old mistake of mine. It's been working so I hadn't noticed until I restructured my project.