### PR TITLE
Fix ADC shared interrupt generation error and fail loudly on bad IRQ names in MODM_ISR

### DIFF
--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -250,7 +250,5 @@ modm::platform::Adc{{ id }}::getInterruptFlags()
 void
 modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t flags)
 {
-	// Flags are cleared by writing a one to the flag position.
-	// Writing a zero is ignored.
-	ADC{{ per }}->SR = flags.value;
+	ADC{{ per }}->SR = ~flags.value;
 }

--- a/src/modm/platform/adc/stm32/adc_interrupt.cpp.in
+++ b/src/modm/platform/adc/stm32/adc_interrupt.cpp.in
@@ -18,7 +18,7 @@ modm::platform::AdcInterrupt{{ id }}::Handler
 modm::platform::AdcInterrupt{{ id }}::handler(modm::dummy);
 
 %% if id not in shared_irq_ids
-MODM_ISR(ADC{{ id }})
+MODM_ISR(ADC{{ irq }})
 {
     if (modm::platform::AdcInterrupt{{ id }}::getInterruptFlags()) {
         modm::platform::AdcInterrupt{{ id }}::handler();

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -49,6 +49,7 @@ class Instance(Module):
         properties["channels"] = sorted(channels)
         global props
         properties["shared_irq_ids"] = props["shared_irq_ids"]
+        properties["irq"] = "1" if target.family in ["l1"] else self.instance
         props["instances"].append(self.instance)
 
         env.substitutions = properties

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -76,7 +76,7 @@ def prepare(module, options):
     props["instances"] = []
 
     if target["family"] in ["f2", "f4", "f7"]:
-        props["shared_irqs"] = {"ADC": listify(device.get_driver("adc")["instance"])}
+        props["shared_irqs"] = {"ADC": listify([int(i) for i in device.get_driver("adc")["instance"]])}
         props["shared_irq_ids"] = props["shared_irqs"]["ADC"]
     else:
         shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -121,16 +121,16 @@ modm::platform::Can{{ id }}::initializeWithPrescaler(
 	NVIC_EnableIRQ(CEC_CAN_IRQn);
 %% else
 	// Set vector priority
-	NVIC_SetPriority({{ reg }}_RX0_IRQn, interruptPriority);
-	NVIC_SetPriority({{ reg }}_RX1_IRQn, interruptPriority);
+	NVIC_SetPriority({{ irqs.rx0 }}_IRQn, interruptPriority);
+	NVIC_SetPriority({{ irqs.rx1 }}_IRQn, interruptPriority);
 
 	// Register Interrupts at the NVIC
-	NVIC_EnableIRQ({{ reg }}_RX0_IRQn);
-	NVIC_EnableIRQ({{ reg }}_RX1_IRQn);
+	NVIC_EnableIRQ({{ irqs.rx0 }}_IRQn);
+	NVIC_EnableIRQ({{ irqs.rx1 }}_IRQn);
 
 	%% if options["buffer.tx"] > 0
-	NVIC_EnableIRQ({{ reg }}_TX_IRQn);
-	NVIC_SetPriority({{ reg }}_TX_IRQn, interruptPriority);
+	NVIC_EnableIRQ({{ irqs.tx }}_IRQn);
+	NVIC_SetPriority({{ irqs.tx }}_IRQn, interruptPriority);
 	%% endif
 %% endif
 
@@ -220,8 +220,11 @@ readMailbox(modm::can::Message& message, uint32_t mailboxId, uint8_t* filter_id)
  *
  * Generated when Transmit Mailbox 0..2 becomes empty.
  */
-
-MODM_ISR({{ reg }}_TX)
+%% if combined_isr
+void MODM_ISR_NAME({{ irqs.tx }})()
+%% else
+MODM_ISR({{ irqs.tx }})
+%% endif
 {
 %% if options["buffer.tx"] > 0
 	uint32_t mailbox;
@@ -254,7 +257,11 @@ MODM_ISR({{ reg }}_TX)
  * Generated on a new received message, FIFO0 full condition and Overrun
  * Condition.
  */
-MODM_ISR({{ reg }}_RX0)
+%% if combined_isr
+void MODM_ISR_NAME({{ irqs.rx0 }})()
+%% else
+MODM_ISR({{ irqs.rx0 }})
+%% endif
 {
 	if (not modm_assert_continue_ignore(not ({{ reg }}->RF0R & CAN_RF0R_FOVR0),
 			"can.rx.hw0", "CAN receive hardware buffer overflowed!", {{ 0 if id == '' else id }}))
@@ -280,7 +287,11 @@ MODM_ISR({{ reg }}_RX0)
  *
  * See FIFO0 Interrupt
  */
-MODM_ISR({{ reg }}_RX1)
+%% if combined_isr
+void MODM_ISR_NAME({{ irqs.rx1 }})()
+%% else
+MODM_ISR({{ irqs.rx1 }})
+%% endif
 {
 	if (not modm_assert_continue_ignore(not ({{ reg }}->RF1R & CAN_RF1R_FOVR1),
 			"can.rx.hw1", "CAN receive hardware buffer overflowed!", {{ 0 if id == '' else id }}))
@@ -301,7 +312,7 @@ MODM_ISR({{ reg }}_RX1)
 %% endif
 }
 
-%% if target["family"] == "f0"
+%% if combined_isr
 // On stm32f0, ST has decided to use only one interrupt vector for all
 // CAN interrupts. In order to avoide duplicate code, we try to determine
 // the interrupt source and call the correct interrupts function defined above.
@@ -310,15 +321,15 @@ MODM_ISR({{ reg }}_RX1)
 MODM_ISR(CEC_CAN)
 {
 	if({{ reg }}->TSR & (CAN_TSR_RQCP0 | CAN_TSR_RQCP1 | CAN_TSR_RQCP2)) {
-		MODM_ISR_CALL({{ reg }}_TX);
+		MODM_ISR_NAME({{ irqs.tx }})();
 	}
 
 	if({{ reg }}->RF0R & (CAN_RF0R_FMP0 | CAN_RF0R_FULL0 | CAN_RF0R_FOVR0)) {
-		MODM_ISR_CALL({{ reg }}_RX0);
+		MODM_ISR_NAME({{ irqs.rx0 }})();
 	}
 
 	if({{ reg }}->RF1R & (CAN_RF1R_FMP1 | CAN_RF1R_FULL1 | CAN_RF1R_FOVR1)) {
-		MODM_ISR_CALL({{ reg }}_RX1);
+		MODM_ISR_NAME({{ irqs.rx1 }})();
 	}
 
 	// TODO: we do not handle status changes at the moment.

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -84,12 +84,22 @@ def get_substitutions(instance, device, env):
     cm = can_map[target["family"]]
     is_single = (cm[instance].type == CanType.Single) or (cm[instance].associated_instance not in instances)
     other = cm[instance].associated_instance
+    cmr = cm[instance].register
+    irqs = {
+        "tx": "CAN" + cmr + "_TX",
+        "rx0": "CAN" + cmr + "_RX0",
+        "rx1": "CAN" + cmr + "_RX1",
+    }
+    if any(v["name"].startswith("USB_HP_CAN") for v in device.get_driver("core")["vector"]):
+        irqs["tx"] = "USB_HP_CAN" + cmr + "_TX"
+        irqs["rx0"] = "USB_LP_CAN" + cmr + "_RX0"
 
     subs = {
         "id": "" if instance == 0 else str(instance),
-        "own_instance": cm[instance].register,
+        "own_instance": cmr,
         "other_instance": cm[other].register if other in cm else None,
-        "reg": "CAN" + cm[instance].register,
+        "reg": "CAN" + cmr,
+        "irqs": irqs,
         "type": cm[instance].type.name if not is_single else CanType.Single.name
     }
 
@@ -115,6 +125,11 @@ class Instance(Module):
         properties = device.properties
         properties["target"] = target = device.identifier
         properties["driver"] = driver
+        if device.identifier.family == "f0":
+            properties["combined_isr"] = True
+        else:
+            properties["combined_isr"] = False
+
         properties.update(get_substitutions(self.instance, device, env))
 
         env.substitutions = properties
@@ -165,6 +180,10 @@ def build(env):
     properties = device.properties
     properties["target"] = device.identifier
     properties["driver"] = driver
+    if device.identifier.family == "f0":
+        properties["combined_isr"] = True
+    else:
+        properties["combined_isr"] = False
 
     if "instance" not in driver:
         properties.update(get_substitutions(0, device, env))

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -296,6 +296,7 @@ def build(env):
     env.template("reset_handler.sx.in")
     env.template("startup.c.in")
     env.template("vectors.c.in")
+    env.template("vectors.hpp.in")
     env.collect(":build:linkflags", "-nostartfiles")
 
     # dealing with runtime assertions

--- a/src/modm/platform/core/cortex/vectors.hpp.in
+++ b/src/modm/platform/core/cortex/vectors.hpp.in
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+#include <modm/architecture/utils.hpp>
+#include <string_view>
+
+extern "C"
+{
+
+void Reset_Handler(void);
+void NMI_Handler(void);
+void HardFault_Handler(void);
+%% for pos in range(4 - 16, highest_irq + 1)
+%% 	if pos in vector_table
+void {{vector_table[pos]}}(void);
+%%	endif
+%% endfor
+
+}
+
+namespace modm::platform::detail
+{
+
+constexpr std::string_view vectorNames[] =
+{
+	"__main_stack_top",
+	"Reset",
+	"NMI",
+	"HardFault",
+%% for pos in range(4 - 16, highest_irq)
+%% 	if pos in vector_table
+	"{{vector_table[pos] | replace('_Handler', '') | replace('_IRQHandler', '')}}",
+%% 	else
+	"Undefined",
+%% 	endif
+%% endfor
+};
+
+
+#ifndef MODM_ISR_DISABLE_VALIDATION
+#define MODM_ISR_VALIDATE(vector_str, vector) \
+	static_assert(::modm::platform::detail::validateIrqName(vector_str), \
+			"'" vector_str "' is not a valid IRQ name!\n" \
+			"  Hint: You do not need to add '_IRQHandler' to the name.\n" \
+			"  Hint: Here are all the IRQs on this device:\n" \
+%% for pos in range(0, highest_irq)
+%% if pos in vector_table
+			"    - {{vector_table[pos] | replace('_Handler', '') | replace('_IRQHandler', '')}}\n" \
+%% endif
+%% endfor
+	)
+#else
+#define MODM_ISR_VALIDATE(...)
+#endif
+
+constexpr int getIrqPosition(std::string_view name)
+{
+	for (int pos = 0; pos < {{highest_irq+16}}; pos++)
+		if (vectorNames[pos] == name) return pos;
+	return -1;
+}
+
+constexpr bool validateIrqName(std::string_view name)
+{
+	return getIrqPosition(name) != -1;
+}
+
+}	// namespace modm::platform::detail

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -58,8 +58,13 @@ public:
 		if constexpr (ID == 1)
 			Rcc::enable<Peripheral::Dma1>();
 %% if (dma.instance | length) > 1
-		else
+		else {
 			Rcc::enable<Peripheral::Dma2>();
+%% if target.string.startswith("stm32f100")
+			// TODO: Enable remap of DMA2_Channel5 IRQ
+			// AFIO->MAPR2 |= AFIO_MAPR2_MISC_REMAP;
+%% endif
+		}
 %% endif
 %% if dmaType in ["stm32-mux"]:
 		Rcc::enable<Peripheral::Dmamux1>();

--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -44,8 +44,8 @@ def prepare(module, options):
 
 
 def get_irq_list(device):
-    irqs = [v["name"] for v in device.get_driver("core")["vector"]]
-    irqs = [v for v in irqs if v.startswith("DMA") and v[3].isdigit() and not "DMA2D" in v]
+    irqs = {v["position"]: v["name"] for v in device.get_driver("core")["vector"]}
+    irqs = [v for v in irqs.values() if v.startswith("DMA") and v[3].isdigit() and not "DMA2D" in v]
 
     instance_pattern = re.compile("(DMA\d_(Ch|Channel)\d(_\d)*)")
     channel_pattern = re.compile("DMA(?P<instance>\d)_(Channel|Ch)(?P<channels>(\d(_\d)*))")


### PR DESCRIPTION
The `shared_irq_ids` was being populated with strings, e.g. `['1']`, but was being tested with integers (e.g. `if any (i in props["shared_irq_ids"] for i in props["instances"])`).

I also went ahead and included the invalid IRQ check that led me to find this. If you see any issue with that though, I can drop it from the PR. 

What's not entirely clear to me is if this worked on some platform? Perhaps on some platform the instance IDs come in as ints, either because the XML attribute is an int or something in modm-devices converts them. 

Thanks!