### PR TITLE
[cortex-m] Enable FPU before startup script

### DIFF
--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -293,7 +293,7 @@ def build(env):
     env.outbasepath = "modm/src/modm/platform/core"
 
     # startup script
-    env.copy("reset_handler.sx")
+    env.template("reset_handler.sx.in")
     env.template("startup.c.in")
     env.template("vectors.c.in")
     env.collect(":build:linkflags", "-nostartfiles")

--- a/src/modm/platform/core/cortex/reset_handler.sx.in
+++ b/src/modm/platform/core/cortex/reset_handler.sx.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Niklas Hauser
+ * Copyright (c) 2019, 2021, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -16,8 +16,16 @@
 	.type	Reset_Handler, %function
 	.func   Reset_Handler
 Reset_Handler:
+	// Some bootloaders do not reset the stack pointer back to the VTOR entry
 	ldr r0,=__main_stack_top
 	mov sp,r0
+%% if with_fpu
+	// Enable FPU early so the compiler may use FPU registers for copying
+	// SCB->CPACR = ((3UL << 10*2) | (3UL << 11*2));
+	ldr r0,=0xe000ed88
+	ldr r1,=0x00f00000
+	str r1, [r0, #0]
+%% endif
 	bl __modm_initialize_platform
 	bl modm_initialize_platform
 	b __modm_startup

--- a/src/modm/platform/core/cortex/startup.c.in
+++ b/src/modm/platform/core/cortex/startup.c.in
@@ -102,11 +102,6 @@ void __modm_startup(void)
 	SCB_EnableICache();
 %% endif
 
-%% if with_fpu
-	// Enable FPU in privileged and user mode
-	SCB->CPACR |= ((3UL << 10*2) | (3UL << 11*2));
-%% endif
-
 %% if "m0" not in core
 	// Set the vector table location
 	SCB->VTOR = (uint32_t)__vector_table_{{ vector_table_location }}_start;


### PR DESCRIPTION
This allows the compiler to emit instructions that access the FPU
registers for copying.

Fixes #687.

cc @mcbridejc 