### PR TITLE
[fiber] Stackful cooperative scheduling via Fibers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Compile AVR Unittests ATmega
         if: always()
         run: |
-          (cd test && make compile-mega-2560-pro)
+          (cd test && make compile-mega-2560-pro_A compile-mega-2560-pro_B)
       - name: Quick compile HAL for AVR Devices
         if: always()
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,18 +53,22 @@ jobs:
           git submodule update --init --jobs 8
 
       - name: Hosted Unittests
+        if: always()
         run: |
           (cd test && make run-hosted-darwin)
 
       - name: Hosted Examples
+        if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py linux)
 
       - name: Compile STM32 Examples
+        if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py nucleo_f031k6 nucleo_f103rb nucleo_f303re nucleo_f411re nucleo_f746zg)
           (cd examples && ../tools/scripts/examples_compile.py nucleo_g071rb nucleo_l031k6 nucleo_l152re nucleo_l476rg nucleo_g474re)
 
       - name: Compile AVR Examples
+        if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py avr)

--- a/.github/workflows/windows_hosted.yml
+++ b/.github/workflows/windows_hosted.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Hosted Examples
         shell: bash
         run: |
-          (cd examples && python ../tools/scripts/examples_compile.py linux/assert linux/block_device linux/build_info linux/git linux/logger linux/printf)
+          (cd examples && python ../tools/scripts/examples_compile.py linux/assert linux/block_device linux/build_info linux/git linux/logger linux/printf linux/etl linux/fiber)
 
       - name: Hosted Unittests
         if: always()

--- a/.github/workflows/windows_hosted.yml
+++ b/.github/workflows/windows_hosted.yml
@@ -59,6 +59,7 @@ jobs:
           (cd examples && python ../tools/scripts/examples_compile.py linux/assert linux/block_device linux/build_info linux/git linux/logger linux/printf)
 
       - name: Hosted Unittests
+        if: always()
         shell: bash
         run: |
           (cd test && make run-hosted-windows)

--- a/examples/avr/fiber/main.cpp
+++ b/examples/avr/fiber/main.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+using namespace std::chrono_literals;
+
+constexpr uint32_t cycles = 100'000;
+volatile uint32_t f1counter = 0, f2counter = 0;
+uint32_t total_counter=0;
+
+void
+fiber_function1()
+{
+	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+	while (++f1counter < cycles) { modm::fiber::yield(); total_counter++; }
+}
+
+void
+fiber_function2(uint32_t cyc)
+{
+	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+	while (++f2counter < cyc) { modm::fiber::yield(); total_counter++; }
+}
+
+struct Test
+{
+	void
+	fiber_function3()
+	{
+		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+		while (++f3counter < cycles) { modm::fiber::yield(); total_counter++; }
+	}
+
+	void
+	fiber_function4(uint32_t cyc)
+	{
+		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+		while (++f4counter < cyc) { modm::fiber::yield(); total_counter++; }
+	}
+
+	volatile uint32_t f3counter{0};
+	volatile uint32_t f4counter{0};
+} test;
+
+modm::fiber::Stack<128> stack1;
+modm::fiber::Stack<128> stack2;
+modm::fiber::Stack<128> stack3;
+modm::fiber::Stack<128> stack4;
+modm::Fiber fiber1(stack1, fiber_function1);
+modm::Fiber fiber2(stack2, [](){ fiber_function2(cycles); });
+modm::Fiber fiber3(stack3, [](){ test.fiber_function3(); });
+modm::Fiber fiber4(stack4, [cyc=uint32_t(cycles)]() mutable { cyc++; test.fiber_function4(cyc); });
+
+// ATmega2560@16MHz: 239996 yields in 2492668us, 96280 yields per second, 10386ns per yield
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+	MODM_LOG_INFO << "Starting fiber modm::yield benchmark..." << modm::endl;
+	MODM_LOG_INFO.flush();
+
+	const modm::PreciseTimestamp start = modm::PreciseClock::now();
+	modm::fiber::Scheduler::run();
+	const auto diff = (modm::PreciseClock::now() - start);
+
+	MODM_LOG_INFO << "Benchmark done!" << modm::endl;
+	MODM_LOG_INFO << "Executed " << total_counter << " yields in " << diff << modm::endl;
+	MODM_LOG_INFO << uint32_t((total_counter * 1'000'000ull) / std::chrono::microseconds(diff).count());
+	MODM_LOG_INFO << " yields per second, ";
+	MODM_LOG_INFO << uint32_t(std::chrono::nanoseconds(diff).count() / total_counter);
+	MODM_LOG_INFO << "ns per yield" << modm::endl;
+	MODM_LOG_INFO.flush();
+
+	while(1) ;
+	return 0;
+}

--- a/examples/avr/fiber/project.xml
+++ b/examples/avr/fiber/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:mega-2560-pro</extends>
+  <!-- <extends>modm:arduino-nano</extends> -->
+  <options>
+    <option name="modm:build:build.path">../../../build/avr/fiber</option>
+    <option name="modm:__fibers">yes</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:fiber</module>
+  </modules>
+</library>

--- a/examples/generic/fiber/main.cpp
+++ b/examples/generic/fiber/main.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+using namespace std::chrono_literals;
+
+constexpr uint32_t cycles = 1'000'000;
+volatile uint32_t f1counter = 0, f2counter = 0;
+uint32_t total_counter=0;
+
+void
+fiber_function1()
+{
+	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+	while (++f1counter < cycles) { modm::fiber::yield(); total_counter++; }
+}
+
+void
+fiber_function2(uint32_t cyc)
+{
+	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+	while (++f2counter < cyc) { modm::fiber::yield(); total_counter++; }
+}
+
+struct Test
+{
+	void
+	fiber_function3()
+	{
+		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+		while (++f3counter < cycles) { modm::fiber::yield(); total_counter++; }
+	}
+
+	void
+	fiber_function4(uint32_t cyc)
+	{
+		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
+		while (++f4counter < cyc) { modm::fiber::yield(); total_counter++; }
+	}
+
+	volatile uint32_t f3counter{0};
+	volatile uint32_t f4counter{0};
+} test;
+
+modm_faststack modm::fiber::Stack<2048> stack1;
+modm_faststack modm::fiber::Stack<2048> stack2;
+modm_faststack modm::fiber::Stack<2048> stack3;
+modm_faststack modm::fiber::Stack<2048> stack4;
+modm_fastdata  modm::Fiber fiber1(stack1, fiber_function1);
+modm_fastdata  modm::Fiber fiber2(stack2, [](){ fiber_function2(cycles); });
+modm_fastdata  modm::Fiber fiber3(stack3, [](){ test.fiber_function3(); });
+modm_fastdata  modm::Fiber fiber4(stack4, [cyc=uint32_t(0)]() mutable { cyc++; test.fiber_function4(cyc); });
+
+// Blue pill (M3 72MHz): Executed 1000000 in 1098591us (910256.88 yields per second)
+// Feather M0 (M0+ 48MHz): Executed 1000000 in 1944692us (514220.25 yields per second)
+int
+main()
+{
+	Board::initialize();
+	MODM_LOG_INFO << "Starting fiber modm::yield benchmark..." << modm::endl;
+	MODM_LOG_INFO.flush();
+
+	const modm::PreciseTimestamp start = modm::PreciseClock::now();
+	modm::fiber::Scheduler::run();
+	const auto diff = (modm::PreciseClock::now() - start);
+
+	MODM_LOG_INFO << "Benchmark done!" << modm::endl;
+	MODM_LOG_INFO << "Executed " << total_counter << " yields in " << diff << modm::endl;
+	MODM_LOG_INFO << ((total_counter * 1'000'000ull) / std::chrono::microseconds(diff).count());
+	MODM_LOG_INFO << " yields per second, ";
+	MODM_LOG_INFO << (std::chrono::nanoseconds(diff).count() / total_counter);
+	MODM_LOG_INFO << "ns per yield" << modm::endl;
+	MODM_LOG_INFO.flush();
+
+	while(1) ;
+	return 0;
+}

--- a/examples/generic/fiber/project.xml
+++ b/examples/generic/fiber/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <!-- <extends>modm:nucleo-g071rb</extends> -->
+  <options>
+    <option name="modm:build:build.path">../../../build/generic/fiber</option>
+    <option name="modm:__fibers">yes</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+    <module>modm:processing:fiber</module>
+  </modules>
+</library>

--- a/examples/linux/fiber/main.cpp
+++ b/examples/linux/fiber/main.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/debug.hpp>
+#include <modm/processing.hpp>
+
+void hello()
+{
+	for(int ii=0; ii<10; ii++)
+	{
+		MODM_LOG_INFO << "Hello ";
+		modm::fiber::yield();
+	}
+}
+
+struct Test
+{
+	void world(const char *arg)
+	{
+		for(int ii=0; ii<10; ii++)
+		{
+			MODM_LOG_INFO << arg << modm::endl;
+			modm::fiber::yield();
+		}
+	}
+} test;
+
+modm::fiber::Stack<1024> stack1;
+modm::fiber::Stack<1024> stack2;
+modm::Fiber fiber1(stack1, hello);
+
+int
+main(void)
+{
+	const char *arg = "World";
+	modm::Fiber fiber2(stack2, [=]() { test.world(arg); });
+
+	MODM_LOG_INFO << "Start" << modm::endl;
+	modm::fiber::Scheduler::run();
+	MODM_LOG_INFO << "End" << modm::endl;
+
+	return 0;
+}

--- a/examples/linux/fiber/project.xml
+++ b/examples/linux/fiber/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <!-- CI: run -->
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../build/linux/fiber</option>
+    <option name="modm:__fibers">yes</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:core</module>
+    <module>modm:processing:fiber</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/repo.lb
+++ b/repo.lb
@@ -274,6 +274,10 @@ def init(repo):
                      description=descr_target,
                      enumeration=devices))
 
+    # Invisible option guarding the Fiber API until it is ready
+    repo.add_option(BooleanOption(name="__fibers", default=False,
+                                  description="Enable unstable fiber API."))
+
 def prepare(repo, options):
     repo.add_modules_recursive("ext", modulefile="*.lb")
     repo.add_modules_recursive("src", modulefile="*.lb")

--- a/src/modm/architecture/utils.hpp
+++ b/src/modm/architecture/utils.hpp
@@ -72,6 +72,9 @@
 	/// Marks a declaration as deprecated and displays a message.
 	#define modm_deprecated(msg)
 
+	/// Tells the compiler to not generate prologue/epilogue code for this function.
+	#define modm_naked
+
 	/// Places a function in the fastest executable memory:
 	/// instruction cache, core coupled memory or SRAM as fallback.
 	#define modm_fastcode
@@ -134,6 +137,7 @@
 	#define modm_fallthrough		__attribute__((fallthrough))
 	#define modm_noreturn			__attribute__((noreturn))
 	#define modm_warn_unused_result	__attribute__((warn_unused_result))
+	#define modm_naked				__attribute__((naked))
 
 	#ifdef MODM_COMPILER_MINGW
 	 	// FIXME: Windows Object Format PE does not support weak symbols

--- a/src/modm/architecture/utils.hpp
+++ b/src/modm/architecture/utils.hpp
@@ -81,6 +81,11 @@
 	/// @note This memory location may not be DMA-able!
 	#define modm_fastdata
 
+	/// Places an array into the fastest accessible memory *with* DMA access:
+	/// data cache, core coupled memory or SRAM as fallback.
+	/// @note This memory location is DMA-able, but uninitialized!
+	#define modm_faststack
+
 	/// This branch is more likely to execute.
 	#define modm_likely(x) (x)
 
@@ -144,10 +149,12 @@
 	#	define modm_fastcode
 	#	define modm_ramcode
 	#	define modm_fastdata
+	#	define modm_faststack
 	#else
 	#	define modm_fastcode		modm_section(".fastcode")
 	#	define modm_ramcode			modm_fastcode
 	#	define modm_fastdata		modm_section(".fastdata")
+	#	define modm_faststack		modm_section(".faststack")
 	#endif
 
 	#ifdef __cplusplus

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -119,6 +119,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 {{ linkerscript_extern_zero | indent(8, first=True) }}
 	%% endif
 		__table_zero_extern_end = .;
+
 		__table_copy_extern_start = .;
 	%% if linkerscript_extern_copy
 {{ linkerscript_extern_copy | indent(8, first=True) }}
@@ -139,17 +140,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 	} >{{memory}}
 %% endmacro
 
-%% macro section(memory, name, table_copy, sections=[])
-	%% do table_copy.append(name)
-	.{{name}} :
-	{
-		. = ALIGN(4);
-		__{{name}}_load = LOADADDR(.{{name}});
-		__{{name}}_start = .;
-		*(.{{name}} .{{name}}.*)
-		. = ALIGN(4);
-		__{{name}}_end = .;
-	} >{{memory}}
+%% macro section_load(memory, table_copy, sections)
 	%% do table_copy.extend(sections)
 	%% for section in sections
 	%#
@@ -192,7 +183,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		%% for region in cont_region.contains
 	/* Sections in {{ region.name|upper }} */
 			%% if region.index
-{{ section(cont_region.cont_name|upper + " AT >FLASH", "data_"+region.name, table_copy) }}
+{{ section_load(cont_region.cont_name|upper + " AT >FLASH", table_copy, sections=["data_"+region.name]) }}
 				%% do table_zero.append("bss_"+region.name)
 			%% endif
 {{ section_heap(region.name|upper, "heap_"+region.name, cont_region.cont_name|upper,
@@ -281,7 +272,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_ram(memory, rom, table_copy, table_zero, sections_data=[], sections_bss=[])
+%% macro section_ram(memory, rom, table_copy, table_zero, sections_data=[], sections_bss=[], sections_noinit=[])
 	/* Read-write sections in {{memory}} */
 	%% do table_copy.append("data")
 	.data :
@@ -312,10 +303,21 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__bss_start = . ;
 		*(.bss .bss.* .gnu.linkonce.b.*)
 		. = ALIGN(4);
+	%% for section in sections_bss
+	} >{{memory}}
+	%#
+	.{{section}} (NOLOAD) :
+	{
+		__{{section}}_start = . ;
+		*(.{{section}} .{{section}}.*)
+		. = ALIGN(4);
+		__{{section}}_end = .;
+	%% endfor
 		__bss_end = .;
 	} >{{memory}}
-	%% do table_zero.extend(sections_bss)
-	%% for section in sections_bss
+	%#
+	%% do sections_noinit.insert(0, "noinit")
+	%% for section in sections_noinit
 	%#
 	.{{section}} (NOLOAD) :
 	{
@@ -325,14 +327,6 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{section}}_end = .;
 	} >{{memory}}
 	%% endfor
-	%#
-	.noinit (NOLOAD) :
-	{
-		__noinit_start = .;
-		*(.noinit .noinit.*)
-		. = ALIGN(4);
-		__noinit_end = .;
-	} >{{memory}}
 %% endmacro
 
 

--- a/src/modm/platform/core/cortex/ram.ld.in
+++ b/src/modm/platform/core/cortex/ram.ld.in
@@ -28,7 +28,8 @@ SECTIONS
 
 {{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
+                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+                      sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 

--- a/src/modm/platform/core/cortex/vectors.c.in
+++ b/src/modm/platform/core/cortex/vectors.c.in
@@ -31,7 +31,6 @@ typedef void (* const FunctionPointer)(void);
 
 // defined in the linkerscript
 extern uint32_t __main_stack_top[];
-extern uint32_t __process_stack_top[];
 
 // Define the vector table
 modm_section(".vector_rom")

--- a/src/modm/platform/core/sam/module.md
+++ b/src/modm/platform/core/sam/module.md
@@ -25,7 +25,6 @@ Currently only one basic linkerscript is supported.
             │  .data                 │
             │  .fastdata             │
             │  .fastcode             │
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
     RAM     │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __ram_start
 

--- a/src/modm/platform/core/sam/module.md
+++ b/src/modm/platform/core/sam/module.md
@@ -19,6 +19,7 @@ Currently only one basic linkerscript is supported.
             │  +HEAP_RAM             │
             │  .noinit_ram           │
             │  .noinit               │
+            │  .faststack            │
             │  .bss_ram              │
             │  .bss                  │
             │  .data_ram             │

--- a/src/modm/platform/core/stm32/dccm.ld.in
+++ b/src/modm/platform/core/stm32/dccm.ld.in
@@ -28,13 +28,14 @@ SECTIONS
 
 {{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastcode", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
+                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+                      sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 
 %% if "backup" in regions
 	/* Sections in memory region BACKUP */
-{{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
+{{ linker.section_load("BACKUP AT >FLASH", table_copy, sections=["data_backup"]) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
@@ -42,7 +43,7 @@ SECTIONS
 %% endif
 
 	/* Sections in memory region CCM */
-{{ linker.section("CCM AT >FLASH", "fastdata", table_copy, sections=["data_ccm"]) }}
+{{ linker.section_load("CCM AT >FLASH", table_copy, sections=["fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 	%% do table_heap.append({"name": "heap_ccm", "prop": "0x2002"})

--- a/src/modm/platform/core/stm32/iccm.ld.in
+++ b/src/modm/platform/core/stm32/iccm.ld.in
@@ -19,7 +19,8 @@ SECTIONS
 
 {{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
+                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+                      sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 %% if with_crashcatcher
@@ -34,7 +35,7 @@ SECTIONS
 %% endif
 
 	/* Sections in memory region CCM */
-{{ linker.section("CCM AT >FLASH", "fastcode", table_copy, sections=["fastdata", "data_ccm"]) }}
+{{ linker.section_load("CCM AT >FLASH", table_copy, sections=["fastcode", "fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 %% do table_heap.append({"name": "heap_ccm", "prop": "0x2006"})

--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -20,7 +20,7 @@ SECTIONS
 %% endif
 
 	/* Sections in memory region ITCM */
-{{ linker.section("ITCM AT >FLASH", "fastcode", table_copy, sections=["data_itcm"]) }}
+{{ linker.section_load("ITCM AT >FLASH", table_copy, sections=["fastcode", "data_itcm"]) }}
 
 {{ linker.section_heap("ITCM", "heap_itcm", sections=["noinit_itcm"]) }}
 %% do table_heap.append({"name": "heap_itcm", "prop": "0x201f"})
@@ -29,7 +29,8 @@ SECTIONS
 
 {{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
+                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+                      sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 %% if with_crashcatcher
@@ -41,7 +42,7 @@ SECTIONS
 
 %% if "backup" in regions
 	/* Sections in memory region BACKUP */
-{{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
+{{ linker.section_load("BACKUP AT >FLASH", table_copy, sections=["data_backup"]) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})

--- a/src/modm/platform/core/stm32/module.md
+++ b/src/modm/platform/core/stm32/module.md
@@ -66,7 +66,6 @@ SRAMs explicitly to free up the space in the lower sections.
             │  .fastdata             │
             │  .fastcode             │
             │ (.vector_ram)          │◄ only if remapped into RAM
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
    SRAM1    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __sram1_start
 
@@ -135,7 +134,6 @@ Therefore the main stack is placed into SRAM, even though it is slower than CCM.
             │  .data                 │
             │  .fastcode             │
             │ (.vector_ram)          │◄ only if remapped into RAM
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
    SRAM1    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __sram1_start
 
@@ -205,7 +203,6 @@ not DMA-able.
             │  .bss                  │
             │  .data_sram1           │
             │  .data                 │
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
    SRAM1    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __sram1_start
 
@@ -285,7 +282,6 @@ overflow into the SRAM1/2 sections.
    access   │  .data_dtcm            │
             │  .data                 │
             │  .fastdata             │
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
     DTCM    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __dtcm_start
 
@@ -391,7 +387,6 @@ placed into the 128kB DTCM, but cannot overflow into D1_SRAM section.
     only    │  .data_dtcm            │
    access   │  .data                 │
             │  .fastdata             │
-            │  +PROCESS_STACK_SIZE   │◄ __process_stack_top
     DTCM    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __dtcm_start
 

--- a/src/modm/platform/core/stm32/module.md
+++ b/src/modm/platform/core/stm32/module.md
@@ -59,6 +59,7 @@ SRAMs explicitly to free up the space in the lower sections.
             │  +HEAP_SRAM1           │
             │  .noinit_sram1         │
             │  .noinit               │
+            │  .faststack            │
             │  .bss_sram1            │
             │  .bss                  │
             │  .data_sram1           │
@@ -128,6 +129,7 @@ Therefore the main stack is placed into SRAM, even though it is slower than CCM.
             │  +HEAP_SRAM1           │
             │  .noinit_sram1         │
             │  .noinit               │
+            │  .faststack            │
             │  .bss_sram1            │
             │  .bss                  │
             │  .data_sram1           │
@@ -199,6 +201,7 @@ not DMA-able.
             │  +HEAP_SRAM1           │
             │  .noinit_sram1         │
             │  .noinit               │
+            │  .faststack            │
             │  .bss_sram1            │
             │  .bss                  │
             │  .data_sram1           │
@@ -277,6 +280,7 @@ overflow into the SRAM1/2 sections.
             │  +HEAP_DTCM            │
             │  .noinit_dtcm          │
             │  .noinit               │
+            │  .faststack            │
    D-Code   │  .bss_dtcm             │
     only    │  .bss                  │
    access   │  .data_dtcm            │
@@ -383,6 +387,7 @@ placed into the 128kB DTCM, but cannot overflow into D1_SRAM section.
             │  +HEAP_DTCM            │
             │  .noinit_dtcm          │
             │  .noinit               │
+            │  .faststack            │
    D-Code   │  .bss_dtcm             │
     only    │  .data_dtcm            │
    access   │  .data                 │

--- a/src/modm/platform/gpio/rpi/module.lb
+++ b/src/modm/platform/gpio/rpi/module.lb
@@ -17,7 +17,7 @@ def init(module):
 
 
 def prepare(module, options):
-    if not options[":target"].has_driver("gpio:rpi"):
+    if not options[":target"].has_driver("gpio:wiring-rpi"):
         return False
 
     module.depends(":architecture:gpio")

--- a/src/modm/processing/fiber.hpp
+++ b/src/modm/processing/fiber.hpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber/fiber.hpp"
+#include "fiber/scheduler.hpp"

--- a/src/modm/processing/fiber/context.h
+++ b/src/modm/processing/fiber/context.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <modm/architecture/utils.hpp>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+struct modm_context_t
+{
+	uintptr_t sp;
+	size_t stack_size;
+};
+
+/// Prepares the stack to jump into function with arg and call end on return
+modm_context_t
+modm_context_init(uintptr_t stack, uintptr_t arg, uintptr_t fn, uintptr_t end);
+
+/// Switches control from the main context to the user context.
+void
+modm_context_start(uintptr_t sp);
+
+/// Jumps from the "from" user context to the "to" user context.
+void
+modm_context_jump(uintptr_t* from_sp, uintptr_t to_sp);
+
+/// Switches control back to the main context from the user context.
+void __attribute__((noreturn))
+modm_context_end();
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/modm/processing/fiber/context_arm_m.cpp.in
+++ b/src/modm/processing/fiber/context_arm_m.cpp.in
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "context.h"
+
+/* Stack layout (growing downwards):
+ * Registers r4-r11 must be preserved across subroutine calls.
+ *
+ * LR
+%% if not cm0
+ * r11
+ * r10
+ * r9
+ * r8
+%% endif
+ * r7
+ * r6
+ * r5
+ * r4
+%% if cm0
+ * r11
+ * r10
+ * r9
+ * r8
+%% endif
+%% if with_fpu
+ * s31
+ * s30
+ * s29
+ * s28
+ * s27
+ * s26
+ * s25
+ * s24
+ * s23
+ * s22
+ * s21
+ * s20
+ * s19
+ * s18
+ * s17
+ * s16
+ *
+ * From the PCSAA:
+ * Registers s16-s31 (d8-d15, q4-q7) must be preserved across subroutine calls;
+ * registers s0-s15 (d0-d7, q0- q3) do not need to be preserved (and can be used
+ * for passing arguments or returning results in standard procedure-call
+ * variants). Registers d16-d31 (q8-q15), if present, do not need to be
+ * preserved.
+%% endif
+ */
+
+static void modm_naked
+modm_context_entry()
+{
+	asm volatile
+	(
+		"pop {r0}		\n\t"	// Loads return address
+		"mov lr, r0		\n\t"	// Set LR
+		"pop {r0, pc}	\n\t"	// Load argument and jump
+	);
+}
+
+modm_context_t
+modm_context_init(uintptr_t stack, uintptr_t arg, uintptr_t fn, uintptr_t end)
+{
+	uintptr_t* sp = (uintptr_t*)arg;
+	*--sp = fn;		// actual fiber function
+	*--sp = arg;	// r0 argument
+	*--sp = end;	// called after fn returns
+
+	*--sp = (uintptr_t) modm_context_entry;
+	sp -= 8{% if with_fpu %}+16{% endif %};		// r4-r11{% if with_fpu %}, s16-s31{% endif %}
+	return {(uintptr_t) sp, arg - stack};
+}
+
+#define MODM_PUSH_CONTEXT() \
+%% if cm0
+		"push {r4-r7, lr}		\n\t" \
+		"mov r4, r8				\n\t" \
+		"mov r5, r9				\n\t" \
+		"mov r6, r10			\n\t" \
+		"mov r7, r11			\n\t" \
+		"push {r4-r7}			\n\t"
+%% else
+		"push {r4-r11, lr}		\n\t"{% if with_fpu %} \
+		"vpush {d8-d15}			\n\t"{% endif %}
+%% endif
+%#
+#define MODM_POP_CONTEXT() \
+%% if cm0
+		"pop {r4-r7}			\n\t" \
+		"mov r8, r4				\n\t" \
+		"mov r9, r5				\n\t" \
+		"mov r10, r6			\n\t" \
+		"mov r11, r7			\n\t" \
+		"pop {r4-r7, pc}		\n\t"
+%% else
+%% if with_fpu
+		"vpop {d8-d15}			\n\t" \
+%% endif
+		"pop {r4-r11, pc}		\n\t"
+%% endif
+%#
+void modm_naked
+modm_context_start(uintptr_t)
+{
+	asm volatile
+	(
+		MODM_PUSH_CONTEXT()
+
+		"mrs r2, control		\n\t"
+%% if cm0
+		"mov r1, #2				\n\t"
+		"orr r2, r2, r1			\n\t"	// Set SPSEL
+%% else
+		"orr r2, r2, #2			\n\t"	// Set SPSEL
+%% endif
+		"msr control, r2		\n\t"
+
+		"mov sp, r0				\n\t"	// Set PSP to fiber stack (to.sp)
+
+		MODM_POP_CONTEXT()
+	);
+}
+
+void modm_naked
+modm_context_jump(uintptr_t*, uintptr_t)
+{
+	asm volatile
+	(
+		MODM_PUSH_CONTEXT()
+%#
+%% if cm0
+		"mov r2, sp				\n\t"
+		"str r2, [r0]			\n\t"	// Store the SP in "from"
+%% else
+		"str sp, [r0]			\n\t"	// Store the SP in "from"
+%% endif
+		"mov sp,  r1			\n\t"	// Restore SP from "to"
+
+		MODM_POP_CONTEXT()
+	);
+}
+
+void modm_naked
+modm_context_end()
+{
+	asm volatile
+	(
+		"mrs r0, control		\n\t"
+%% if cm0
+		"mov r1, #2				\n\t"
+		"bic r0, r0, r1			\n\t"	// Unset SPSEL
+%% else
+		"bic r0, r0, #2			\n\t"	// Unset SPSEL
+%% endif
+		"msr control, r0		\n\t"
+
+		MODM_POP_CONTEXT()
+	);
+}

--- a/src/modm/processing/fiber/context_avr.cpp
+++ b/src/modm/processing/fiber/context_avr.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "context.h"
+#include <avr/io.h>
+
+/* Stack layout (growing downwards):
+ * Only need to save callee registers: r2-r17, r28-r29
+ *
+ * return address (2-3 bytes)
+ * r2
+ * r3
+ * r4
+ * r5
+ * r6
+ * r7
+ * r8
+ * r9
+ * r10
+ * r11
+ * r12
+ * r13
+ * r14
+ * r15
+ * r16
+ * r17
+ * r28
+ * r29
+ */
+
+static void modm_naked
+modm_context_entry()
+{
+	// Load argument 1 and return to function
+	asm volatile(
+		"pop r25	\n\t"
+		"pop r24	\n\t"
+		"ret		\n\t"
+	);
+}
+
+modm_context_t
+modm_context_init(uintptr_t stack, uintptr_t arg, uintptr_t fn, uintptr_t end)
+{
+	uint8_t* sp = (uint8_t*)arg;
+
+	// Return address for fiber ret
+	*--sp = uint16_t(end);
+	*--sp = uint16_t(end) >> 8;
+#ifdef __AVR_3_BYTE_PC__
+	*--sp = 0;
+#endif
+	// return address for modm_context_entry ret
+	*--sp = uint16_t(fn);
+	*--sp = uint16_t(fn) >> 8;
+#ifdef __AVR_3_BYTE_PC__
+	*--sp = 0;
+#endif
+
+	// Argument 1
+	*--sp = uint16_t(arg);
+	*--sp = uint16_t(arg) >> 8;
+
+	// return address for jumpcontext ret
+	*--sp = uint16_t(modm_context_entry);
+	*--sp = uint16_t(modm_context_entry) >> 8;
+#ifdef __AVR_3_BYTE_PC__
+	*--sp = 0;
+#endif
+
+	// saved register context r2-r17, r28-r29, +2 for something unclear
+	sp -= 19;
+
+	return {(uintptr_t) sp, arg - stack};
+}
+
+static modm_context_t main_context;
+
+void
+modm_context_start(uintptr_t to)
+{
+	modm_context_jump(&(main_context.sp), to);
+}
+
+void modm_naked
+modm_context_jump(uintptr_t*, uintptr_t)
+{
+	asm volatile
+	(
+		// Push callee-saved registers on stack
+		".irp regs, 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,28,29	\n\t"
+		"push r\\regs 		\n\t"
+		".endr 				\n\t"
+
+		// Store the SP of current fiber
+		"in	r18, __SP_L__	\n\t"
+		"in	r19, __SP_H__	\n\t"
+		"mov ZL, r24		\n\t"
+		"mov ZH, r25		\n\t"
+		"st  Z+, r18		\n\t"
+		"st  Z,  r19		\n\t"
+
+		// Save SREG and disable interrupts
+		"in r18, __SREG__	\n\t"
+		"cli				\n\t"
+
+		// Load the SP of next fiber
+		"out __SP_L__, r22	\n\t"
+		"out __SP_H__, r23	\n\t"
+
+		// Re-enable interrupts by restoring SREG
+		"out __SREG__, r18	\n\t"
+
+		// Pop callee-saved registers from stack
+		".irp regs, 29,28,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2	\n\t"
+		"pop r\\regs		\n\t"
+		".endr				\n\t"
+
+		"ret				\n\t"
+	);
+}
+
+void
+modm_context_end()
+{
+	uintptr_t dummy;
+	modm_context_jump(&dummy, main_context.sp);
+	__builtin_unreachable();
+}

--- a/src/modm/processing/fiber/context_x86_64.cpp.in
+++ b/src/modm/processing/fiber/context_x86_64.cpp.in
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "context.h"
+#include <modm/architecture/detect.hpp>
+
+/* Stack layout (growing downwards):
+ *
+ * fc_mxcsr | fc_x87_cw
+ * SEE registers XMM6-XMM15 (for windows)
+ * rbp
+ * rbx
+ * rsi (for windows)
+ * rdi (for windows)
+ * r15
+ * r14
+ * r13
+ * r12
+ */
+
+static void modm_naked
+modm_context_entry()
+{
+	asm volatile
+	(
+%% if with_windows
+		"popq %rcx		\n\t" // Load arg1
+%% else
+		"popq %rdi		\n\t" // Load arg1
+%% endif
+		"ret			\n\t" // jump into function
+	);
+}
+
+modm_context_t
+modm_context_init(uintptr_t stack, uintptr_t arg, uintptr_t fn, uintptr_t end)
+{
+	uintptr_t* sp = (uintptr_t*)arg;
+	*--sp = end;
+	*--sp = fn;
+	*--sp = arg;
+	*--sp = (uintptr_t) modm_context_entry;
+	sp -= 0xe8/8;
+	asm volatile
+	(
+		// initialize stack with the right flags
+		"stmxcsr 0xa0(%0)	\n\t"
+		"fnstcw  0xa4(%0)	\n\t"
+		:: "r" (sp)
+	);
+	return {(uintptr_t) sp, arg - stack};
+}
+
+static modm_context_t main_context;
+
+void
+modm_context_start(uintptr_t to)
+{
+	modm_context_jump(&(main_context.sp), to);
+}
+
+void
+modm_context_end()
+{
+	uintptr_t dummy;
+	modm_context_jump(&dummy, main_context.sp);
+	__builtin_unreachable();
+}
+
+/*
+The assembly code below is adapted from the Boost Context library to work
+for Windows, Linux and macOS.
+See https://github.com/boostorg/context/tree/develop/src/asm
+- Windows: jump_x86_64_ms_pe_clang_gas.S
+- Linux: jump_x86_64_sysv_elf_gas.S
+- macOS: jump_x86_64_sysv_macho_gas.S
+
+			Copyright Oliver Kowalke 2009.
+   Distributed under the Boost Software License, Version 1.0.
+	  (See accompanying file LICENSE_1_0.txt or copy at
+			http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+void modm_naked
+modm_context_jump(uintptr_t*, uintptr_t)
+{
+	asm volatile
+	(
+		"leaq -0xe8(%rsp), %rsp		\n\t"	// move stack pointer down
+%#
+%% if with_windows
+		// save XMM storage
+		"movaps %xmm6,  0x00(%rsp)	\n\t"
+		"movaps %xmm7,  0x10(%rsp)	\n\t"
+		"movaps %xmm8,  0x20(%rsp)	\n\t"
+		"movaps %xmm9,  0x30(%rsp)	\n\t"
+		"movaps %xmm10, 0x40(%rsp)	\n\t"
+		"movaps %xmm11, 0x50(%rsp)	\n\t"
+		"movaps %xmm12, 0x60(%rsp)	\n\t"
+		"movaps %xmm13, 0x70(%rsp)	\n\t"
+		"movaps %xmm14, 0x80(%rsp)	\n\t"
+		"movaps %xmm15, 0x90(%rsp)	\n\t"
+%#
+%% endif
+		"stmxcsr 0xa0(%rsp)			\n\t"	// save MMX control- and status-word
+		"fnstcw  0xa4(%rsp)			\n\t"	// save x87 control-word
+
+		"movq %r12, 0xa8(%rsp)		\n\t"	// save R12
+		"movq %r13, 0xb0(%rsp)		\n\t"	// save R13
+		"movq %r14, 0xb8(%rsp)		\n\t"	// save R14
+		"movq %r15, 0xc0(%rsp)		\n\t"	// save R15
+%% if with_windows
+		"movq %rdi, 0xc8(%rsp)		\n\t"	// save RDI
+		"movq %rsi, 0xd0(%rsp)		\n\t"	// save RSI
+%% endif
+		"movq %rbx, 0xd8(%rsp)		\n\t"	// save RBX
+		"movq %rbp, 0xe0(%rsp)		\n\t"	// save RBP
+%#
+%% if with_windows
+		"movq %rsp, (%rcx)			\n\t"	// Store the SP in "from"
+		"movq %rdx, %rsp			\n\t"	// Restore SP from "to"
+%% else
+		"movq %rsp, (%rdi)			\n\t"	// Store the SP in "from"
+		"movq %rsi, %rsp			\n\t"	// Restore SP from "to"
+%% endif
+%% if with_windows
+%#
+		// restore XMM storage
+		"movaps 0x00(%rsp), %xmm6	\n\t"
+		"movaps 0x10(%rsp), %xmm7	\n\t"
+		"movaps 0x20(%rsp), %xmm8	\n\t"
+		"movaps 0x30(%rsp), %xmm9	\n\t"
+		"movaps 0x40(%rsp), %xmm10	\n\t"
+		"movaps 0x50(%rsp), %xmm11	\n\t"
+		"movaps 0x60(%rsp), %xmm12	\n\t"
+		"movaps 0x70(%rsp), %xmm13	\n\t"
+		"movaps 0x80(%rsp), %xmm14	\n\t"
+		"movaps 0x90(%rsp), %xmm15	\n\t"
+%% endif
+%#
+		"ldmxcsr 0xa0(%rsp)			\n\t"	// restore MMX control- and status-word
+		"fldcw   0xa4(%rsp)			\n\t"	// restore x87 control-word
+
+		"movq 0xa8(%rsp),  %r12		\n\t"	// restore R12
+		"movq 0xb0(%rsp),  %r13		\n\t"	// restore R13
+		"movq 0xb8(%rsp),  %r14		\n\t"	// restore R14
+		"movq 0xc0(%rsp),  %r15		\n\t"	// restore R15
+%% if with_windows
+		"movq 0xc8(%rsp),  %rdi		\n\t"	// restore RDI
+		"movq 0xd0(%rsp),  %rsi		\n\t"	// restore RSI
+%% endif
+		"movq 0xd8(%rsp), %rbx		\n\t"	// restore RBX
+		"movq 0xe0(%rsp), %rbp		\n\t"	// restore RBP
+
+		"leaq 0xe8(%rsp), %rsp		\n\t"	// move stack pointer up
+
+		"ret						\n\t"	// Perform the jump back
+	);
+}

--- a/src/modm/processing/fiber/fiber.hpp
+++ b/src/modm/processing/fiber/fiber.hpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include "context.h"
+#include "stack.hpp"
+#include <memory>
+
+namespace modm
+{
+
+namespace fiber
+{
+
+void yield();
+
+class Scheduler;
+class Waitable;
+template<class Data_t>
+class Channel;
+
+} // namespace fiber
+
+/**
+ * Fiber is a cooperative threading model consisting of an execution context (stack) and a
+ * function pointer representing the entry function.
+ *
+ * Fibers are scheduled in a round-robin fashion.
+ *
+ * @author Erik Henriksson
+ * @author Niklas Hauser
+ * @ingroup	modm_processing_fiber
+ */
+class Fiber
+{
+	friend class fiber::Scheduler;
+	template<class>
+	friend class fiber::Channel;
+	friend class fiber::Waitable;
+	friend void fiber::yield();
+
+public:
+	template<size_t Size>
+	Fiber(fiber::Stack<Size>& stack, void(*fn)());
+
+	template<size_t Size, class T>
+	requires requires { &std::decay_t<T>::operator(); }
+	Fiber(fiber::Stack<Size>& stack, T&& closure);
+
+protected:
+	inline void
+	jump(Fiber& other);
+
+private:
+	Fiber() = default;
+	Fiber(const Fiber&) = delete;
+
+private:
+	Fiber* next{nullptr};
+	modm_context_t ctx;
+};
+
+}	// namespace modm
+
+#include "scheduler.hpp"
+
+namespace modm
+{
+
+template<size_t Size>
+Fiber::Fiber(fiber::Stack<Size>& stack, void(*fn)())
+{
+	ctx = modm_context_init((uintptr_t) stack.memory,
+							(uintptr_t) stack.memory + stack.size,
+							(uintptr_t) fn,
+							(uintptr_t) fiber::Scheduler::deregisterFiber);
+	// register this fiber to be scheduled
+	fiber::Scheduler::registerFiber(this);
+}
+
+template<size_t Size, class T>
+requires requires { &std::decay_t<T>::operator(); }
+Fiber::Fiber(fiber::Stack<Size>& stack, T&& closure)
+{
+	// Find a suitable aligned area at the top of stack to allocate the closure
+	uintptr_t ptr = uintptr_t(stack.memory) + stack.size;
+	if constexpr (sizeof(std::decay_t<T>))
+	{
+		ptr -= sizeof(std::decay_t<T>);
+		ptr &= ~(std::max(sizeof(void*), alignof(std::decay_t<T>)) - 1u);
+		// construct closure in place
+		::new ((void*)ptr) std::decay_t<T>{std::forward<T>(closure)};
+	}
+	// Encapsulate the proper ABI function call into a simpler function
+	auto function = (uintptr_t) +[](std::decay_t<T>* closure) { (*closure)(); };
+	// format the stack below the allocated closure
+	ctx = modm_context_init((uintptr_t) stack.memory, ptr, function,
+							(uintptr_t) fiber::Scheduler::deregisterFiber);
+	// register this fiber to be scheduled
+	fiber::Scheduler::registerFiber(this);
+}
+
+void
+Fiber::jump(Fiber& other)
+{
+	fiber::Scheduler::current = &other;
+	modm_context_jump(&(ctx.sp), other.ctx.sp);
+}
+
+}	// namespace modm

--- a/src/modm/processing/fiber/module.lb
+++ b/src/modm/processing/fiber/module.lb
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Erik Henriksson
+# Copyright (c) 2021, Christopher Durand
+# Copyright (c) 2021, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":processing:fiber"
+    module.description = FileReader("module.md")
+
+
+def prepare(module, options):
+    core = options[":target"].get_driver("core")["type"]
+    return ((core.startswith("cortex-m") or
+             core.startswith("avr") or
+             "x86_64" in core) and
+            options[":__fibers"])
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/processing/fiber"
+    env.copy("../fiber.hpp")
+
+    env.copy("fiber.hpp")
+    env.copy("scheduler.hpp")
+
+    env.copy("context.h")
+
+    core = env[":target"].get_driver("core")["type"]
+    env.substitutions = {
+        "cm0": core.startswith("cortex-m0"),
+        "core": core,
+        "with_fpu": env.get(":platform:cortex-m:float-abi", "soft") != "soft",
+        "with_windows": env[":target"].identifier.family == "windows",
+        "target": env[":target"].identifier,
+    }
+
+    env.template("stack.hpp.in")
+
+    if core.startswith("cortex-m"):
+        env.template("context_arm_m.cpp.in")
+
+    elif core.startswith("avr"):
+        env.copy("context_avr.cpp")
+
+    elif "x86_64" in core:
+        env.template("context_x86_64.cpp.in")

--- a/src/modm/processing/fiber/module.md
+++ b/src/modm/processing/fiber/module.md
@@ -1,0 +1,69 @@
+# Fibers
+
+!!! warning "Experimental and Work In Progress"
+	This module will be have an unstable API until it is finalized in 2022.
+	A lot of missing functionality will also be added until then.
+
+This module provides a lightweight stackful fiber implementation including a
+round-robin scheduler and several important OS primitives.
+
+You can create a fiber like this:
+
+```cpp
+void hello()
+{
+	for(int ii=0; ii<10; ii++)
+	{
+		MODM_LOG_INFO << "Hello ";
+		modm::fiber::yield();
+	}
+}
+
+struct Test
+{
+	void world(void *arg)
+	{
+		for(int ii=0; ii<10; ii++)
+		{
+			MODM_LOG_INFO << (char*)arg << modm::endl;
+			modm::fiber::yield();
+		}
+	}
+} test;
+
+modm::fiber::Stack<1024> stack1;
+modm::fiber::Stack<1024> stack2;
+// create fibers out of a void fn(void) signature
+modm::Fiber fiber1(stack1, hello);
+
+int
+main(void)
+{
+	// more complex functions with arguments can be called by lambda closure
+	const char *arg = "World";
+	modm::Fiber fiber2(stack2, [arg]() { test.world(arg); });
+
+	// The scheduler returns after all fibers finished
+	modm::fiber::scheduler.run();
+
+	return 0;
+}
+```
+
+Note: If `yield()` is called outside of a fiber it returns immediately.
+
+
+## AVR
+
+On AVRs the fiber stack is shared with the currently active interrupt.
+This requires the fiber stack size to include the worst case stack size of all
+interrupts. Fortunately on AVRs interrupts cannot be nested.
+
+
+## Arm Cortex-M
+
+On Cortex-M, the main function is entered using the MSP in Handler mode. After
+calling `modm::fiber::Scheduler::run()` the PSP is used as a Fiber stack pointer
+in Thread mode. Therefore all interrupts are using the main stack whose size is
+defined by the `modm:platform:cortex-m:main_stack_size` option and will not
+increase the fiber stack size at all.

--- a/src/modm/processing/fiber/scheduler.hpp
+++ b/src/modm/processing/fiber/scheduler.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+
+namespace modm::fiber
+{
+
+void yield();
+
+class Scheduler
+{
+	friend class ::modm::Fiber;
+	friend class Waitable;
+	friend void yield();
+	Scheduler(const Scheduler&) = delete;
+	Scheduler() = delete;
+
+protected:
+	/// Last fiber in the ready queue.
+	static inline Fiber* last{nullptr};
+	/// Current running fiber
+	static inline Fiber* current{nullptr};
+
+public:
+	// Should be called by the main() function.
+	static inline bool
+	run()
+	{
+		if (empty()) return false;
+		current = last->next;
+		modm_context_start(current->ctx.sp);
+		return true;
+	}
+
+	static inline bool
+	empty()
+	{
+		return last == nullptr;
+	}
+
+	static inline Fiber*
+	removeCurrent()
+	{
+		if (current == last) last = nullptr;
+		else last->next = current->next;
+		current->next = nullptr;
+		return current;
+	}
+
+	static inline void
+	runNext(Fiber* fiber)
+	{
+		fiber->next = current->next;
+		current->next = fiber;
+	}
+
+	static inline void
+	runLast(Fiber* fiber)
+	{
+		fiber->next = last->next;
+		last->next = fiber;
+		last = fiber;
+	}
+
+protected:
+	static inline void
+	registerFiber(Fiber* fiber)
+	{
+		if (last == nullptr)
+		{
+			fiber->next = fiber;
+			last = fiber;
+			return;
+		}
+		runLast(fiber);
+	}
+
+	static inline void
+	deregisterFiber()
+	{
+		Fiber* next = current->next;
+		removeCurrent();
+		if (empty())
+		{
+			current = nullptr;
+			modm_context_end();
+		}
+		current->jump(*next);
+	}
+};
+
+inline void
+yield()
+{
+	if (Scheduler::current == nullptr) return;
+	Fiber* next = Scheduler::current->next;
+	if (next == Scheduler::current) return;
+	Scheduler::last = Scheduler::current;
+	Scheduler::current->jump(*next);
+}
+
+}  // namespace modm::fiber

--- a/src/modm/processing/fiber/stack.hpp.in
+++ b/src/modm/processing/fiber/stack.hpp.in
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <modm/architecture/utils.hpp>
+
+namespace modm
+{
+
+class Fiber;
+
+namespace fiber
+{
+
+class Scheduler;
+/**
+ * Stack captures a memory area used as fiber stack.
+ *
+ * @author	Erik Henriksson
+ * @ingroup	modm_processing_fiber
+ */
+template<size_t Size>
+class Stack
+{
+%% if core.startswith("avr")
+	%% set alignment = 1
+	static_assert(Size >= 15*sizeof(void*), "Stack size must be ≥30B!");
+
+%% elif core.startswith("cortex-m")
+	%% set alignment = 8
+	static_assert(Size % 4 == 0, "Stack size must be multiple of 4.");
+%% if with_fpu
+	static_assert(Size >= 28*sizeof(void*), "Stack size must be ≥112B!");
+%% else
+	static_assert(Size >= 12*sizeof(void*), "Stack size must be ≥48B!");
+%% endif
+
+%% elif "x86_64" in core
+	%% set alignment = 16
+	static_assert(Size % 8 == 0, "Stack size must be multiple of 8.");
+	static_assert(Size >= 33*sizeof(void*), "Stack size must be ≥264B!");
+%% endif
+%#
+	friend class ::modm::Fiber;
+	friend class Scheduler;
+
+public:
+	constexpr Stack() = default;
+	Stack(const Stack&) = delete;
+
+private:
+	static constexpr size_t size = Size;
+	modm_aligned({{alignment}}) uintptr_t memory[size / sizeof(uintptr_t)];
+};
+
+} // namespace fiber
+
+}	// namespace modm

--- a/test/Makefile
+++ b/test/Makefile
@@ -133,7 +133,11 @@ run-arduino-nano_H:
 	$(call run-test,arduino-nano_H,size)
 
 
-compile-mega-2560-pro:
-	$(call compile-test,mega-2560-pro,size)
-run-mega-2560-pro:
-	$(call run-test,mega-2560-pro,size)
+compile-mega-2560-pro_A:
+	$(call compile-test,mega-2560-pro_A,size)
+run-mega-2560-pro_A:
+	$(call run-test,mega-2560-pro_A,size)
+compile-mega-2560-pro_B:
+	$(call compile-test,mega-2560-pro_B,size)
+run-mega-2560-pro_B:
+	$(call run-test,mega-2560-pro_B,size)

--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -9,6 +9,7 @@
     <option name="modm:build:info.build">True</option>
     <option name="modm:build:info.git">Info+Status</option>
     <option name="modm:build:scons:cache_dir">$cache</option>
+    <option name="modm:__fibers">yes</option>
   </options>
   <modules>
     <module>modm:build:scons</module>

--- a/test/config/mega-2560-pro_A.xml
+++ b/test/config/mega-2560-pro_A.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:mega-2560-pro</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro_A/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/mega-2560-pro_A/modm-test</option>
+    <option name="modm:build:info.git">Disabled</option>
+    <option name="modm:io:with_float">True</option>
+    <option name="modm:io:with_long_long">True</option>
+    <option name="modm:io:with_printf">True</option>
+  </options>
+
+  <modules>
+    <module>modm-test:test:architecture</module>
+    <module>modm-test:test:communication:sab</module>
+    <module>modm-test:test:communication:xpcc</module>
+    <module>modm-test:test:container</module>
+    <module>modm-test:test:driver</module>
+    <module>modm-test:test:stdc++</module>
+    <module>modm-test:test:io</module>
+
+    <!-- <module>modm-test:test:platform:**</module>
+    <module>modm-test:test:processing</module>
+    <module>modm-test:test:ui</module>
+    <module>modm-test:test:math</module> -->
+  </modules>
+</library>

--- a/test/config/mega-2560-pro_B.xml
+++ b/test/config/mega-2560-pro_B.xml
@@ -2,8 +2,8 @@
 <library>
   <extends>modm:mega-2560-pro</extends>
   <options>
-    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro/</option>
-    <option name="modm:build:unittest.source">../../build/generated-unittest/mega-2560-pro/modm-test</option>
+    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro_B/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/mega-2560-pro_B/modm-test</option>
     <option name="modm:build:info.git">Disabled</option>
     <option name="modm:io:with_float">True</option>
     <option name="modm:io:with_long_long">True</option>
@@ -11,27 +11,16 @@
   </options>
 
   <modules>
-    <module>modm-test:test:architecture</module>
-    <!-- <module>modm-test:test:communication:sab</module> -->
-
-
-    <!-- <module>modm-test:test:communication:xpcc</module> -->
-
-
+    <!-- <module>modm-test:test:architecture</module>
+    <module>modm-test:test:communication:sab</module>
+    <module>modm-test:test:communication:xpcc</module>
     <module>modm-test:test:container</module>
-
-
     <module>modm-test:test:driver</module>
     <module>modm-test:test:stdc++</module>
+    <module>modm-test:test:io</module> -->
 
-
-    <module>modm-test:test:io</module>
     <module>modm-test:test:platform:**</module>
-
-
     <module>modm-test:test:processing</module>
-
-
     <module>modm-test:test:ui</module>
     <module>modm-test:test:math</module>
   </modules>

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber_test.hpp"
+
+#include <array>
+#include <modm/debug/logger.hpp>
+#include <modm/processing/fiber.hpp>
+
+namespace
+{
+
+enum State
+{
+	INVALID,
+	F1_START,
+	F1_END,
+	F2_START,
+	F2_END,
+	F3_START,
+	F3_END,
+	SUBROUTINE_START,
+	SUBROUTINE_END,
+	CONSUMER_START,
+	CONSUMER_END,
+	PRODUCER_START,
+	PRODUCER_END,
+};
+
+std::array<State, 6> states = {};
+size_t states_pos = 0;
+
+#define ADD_STATE(state) states[states_pos++] = state;
+
+void
+f1()
+{
+	ADD_STATE(F1_START);
+	modm::fiber::yield();
+	ADD_STATE(F1_END);
+}
+
+void
+f2()
+{
+	ADD_STATE(F2_START);
+	modm::fiber::yield();
+	ADD_STATE(F2_END);
+}
+
+modm::fiber::Stack<1024> stack1, stack2;
+
+}  // namespace
+
+__attribute__((noinline)) void
+subroutine()
+{
+	ADD_STATE(SUBROUTINE_START);
+	modm::fiber::yield();
+	ADD_STATE(SUBROUTINE_END);
+}
+
+void
+FiberTest::testOneFiber()
+{
+	states_pos = 0;
+	modm::Fiber fiber(stack1, f1);
+	modm::fiber::Scheduler::run();
+	TEST_ASSERT_EQUALS(states_pos, 2u);
+	TEST_ASSERT_EQUALS(states[0], F1_START);
+	TEST_ASSERT_EQUALS(states[1], F1_END);
+}
+
+void
+FiberTest::testTwoFibers()
+{
+	states_pos = 0;
+	modm::Fiber fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Scheduler::run();
+	TEST_ASSERT_EQUALS(states_pos, 4u);
+	TEST_ASSERT_EQUALS(states[0], F1_START);
+	TEST_ASSERT_EQUALS(states[1], F2_START);
+	TEST_ASSERT_EQUALS(states[2], F1_END);
+	TEST_ASSERT_EQUALS(states[3], F2_END);
+}
+
+namespace
+{
+
+void
+f3()
+{
+	ADD_STATE(F3_START);
+	subroutine();
+	ADD_STATE(F3_END);
+}
+
+}  // namespace
+
+void
+FiberTest::testYieldFromSubroutine()
+{
+	states_pos = 0;
+	modm::Fiber fiber1(stack1, f1), fiber2(stack2, f3);
+	modm::fiber::Scheduler::run();
+	TEST_ASSERT_EQUALS(states_pos, 6u);
+	TEST_ASSERT_EQUALS(states[0], F1_START);
+	TEST_ASSERT_EQUALS(states[1], F3_START);
+	TEST_ASSERT_EQUALS(states[2], SUBROUTINE_START);
+	TEST_ASSERT_EQUALS(states[3], F1_END);
+	TEST_ASSERT_EQUALS(states[4], SUBROUTINE_END);
+	TEST_ASSERT_EQUALS(states[5], F3_END);
+}

--- a/test/modm/processing/fiber/fiber_test.hpp
+++ b/test/modm/processing/fiber/fiber_test.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_architecture
+class FiberTest : public unittest::TestSuite
+{
+public:
+
+	void
+	subroutine();
+
+	void
+	testOneFiber();
+
+	void
+	testTwoFibers();
+
+	void
+	testYieldFromSubroutine();
+};

--- a/test/modm/processing/module.lb
+++ b/test/modm/processing/module.lb
@@ -25,9 +25,14 @@ def prepare(module, options):
         "modm:processing:timer",
         "modm:processing:scheduler",
         ":mock:clock")
+    if options["modm:__fibers"]:
+        module.depends("modm:processing:fiber")
     return True
 
 
 def build(env):
     env.outbasepath = "modm-test/src/modm-test/processing"
-    env.copy('.')
+    if env["modm:__fibers"]:
+        env.copy('.')
+    else:
+        env.copy('.', ignore=env.ignore_files("fiber_test*"))

--- a/tools/devices/hosted/darwin.xml
+++ b/tools/devices/hosted/darwin.xml
@@ -4,11 +4,9 @@
   <device platform="hosted" family="darwin">
     <naming-schema>{platform}-{family}</naming-schema>
 
-    <attribute-core value="x86"/>
-
     <driver name="can" type="hosted"/>
     <driver name="can" type="canusb"/>
-    <driver name="core" type="hosted"/>
+    <driver name="core" type="hosted-x86_64"/>
     <driver name="gpio" type="hosted"/>
     <driver name="uart" type="hosted"/>
   </device>

--- a/tools/devices/hosted/linux.xml
+++ b/tools/devices/hosted/linux.xml
@@ -4,11 +4,9 @@
   <device platform="hosted" family="linux">
     <naming-schema>{platform}-{family}</naming-schema>
 
-    <attribute-core value="x86"/>
-
     <driver name="can" type="socketcan"/>
     <driver name="can" type="canusb"/>
-    <driver name="core" type="hosted"/>
+    <driver name="core" type="hosted-x86_64"/>
     <driver name="graphics" type="hosted"/>
     <driver name="gpio" type="hosted"/>
     <driver name="uart" type="hosted"/>

--- a/tools/devices/hosted/rpi.xml
+++ b/tools/devices/hosted/rpi.xml
@@ -4,8 +4,8 @@
   <device platform="hosted" family="rpi">
     <naming-schema>{platform}-{family}</naming-schema>
 
-    <driver name="core" type="rpi"/>
-    <driver name="gpio" type="rpi"/>
+    <driver name="core" type="hosted-arm64"/>
+    <driver name="gpio" type="wiring-rpi"/>
     <driver name="uart" type="hosted"/>
   </device>
 </modm>

--- a/tools/devices/hosted/windows.xml
+++ b/tools/devices/hosted/windows.xml
@@ -4,9 +4,7 @@
   <device platform="hosted" family="windows">
     <naming-schema>{platform}-{family}</naming-schema>
 
-    <attribute-core value="x86"/>
-
-    <driver name="core" type="hosted"/>
+    <driver name="core" type="hosted-x86_64"/>
     <driver name="graphics" type="hosted"/>
     <driver name="gpio" type="hosted"/>
   </device>


### PR DESCRIPTION
This continues the work in #439. The changes/additions so far:

### Main function

The main function is not a fiber anymore, the developer has to manually start the scheduler. `modm::fiber::yield()` will return if scheduler is not running, therefore looping in the main functions. This will most likely work fine for interrupt/flags driven peripheral access like I2C, SPI and UART, however, won't work for any class that requires an update() function to be polled (but that didn't work with `RF_CALL_BLOCKING` either).

The `scheduler::run()` function will return to the main function if all fibers stop running (or if all functions have yielded). This can be used for sleeping and idle thread functionality.

This also treats the main function consistently across all platforms and carries no performance overhead if not using fibers.

I've also moved all classes into the `modm::fiber` namespace, since I'm worried about compatiblity with FreeRTOS and I don't want people believing that `modm::yield()` makes their code magically reentrant or something stupid like that. In general users should not have to manually yield, but rather use some higher-level primitive or modm API anyways.

### Cortex-M Context Switch

I've optimized the context switch assembly by using the push LR, pop PC pair correctly. This significantly speeds up the context switch. For FPU enabled devices, we only need to store the upper 16 floating point registers, since the lower ones are not saved across subfunction calls according to the EABI. This does double the switching time, perhaps in future we can investigate optimizations via the FPU flags register.

Fibers run on the PSP, while the main function and the interrupts use the MSP whose size is defined by the existing lbuild option `modm:platform:cortex-m:main_stack_size`.

### Guard Option

There is an invisible guard option `modm:__fibers` which prevents the fibers from being shown in modm.io modules and the doxygen docs until it is ready. This is particularly important for adding new peripheral drivers that may use a completely different API *without* resumable functions and shouldn't be exposed to the users right now.

### Stack Placement

On STM32F4 with CCM, the main stack has been moved into RAM, since the CCM is not DMA-able. On all other STM32 the main and `modm_faststack` are placed in the fastest DMA-able memory. We will have to see how well the Cortex-M7 DTCM is really accessible for DMA, we'll deal with that later.


TODO:

- ~Integrate [puncover](https://github.com/memfault/puncover) to get max stack size analysis.~ not trivial, will investigate later
- [x] AVR support
- [x] Cortex-M0 support
- [x] Cortex-M3 support
- [x] Cortex-M4/7 support
- [x] x86 support for Linux/macOS
- [x] x86 support for Windows
- ~ARM64 support~ Cannot test it, delegating to future
- [x] Guard option to hide fibers from users right now
- [x] Move all stacks (main + fibers) into the fastest DMA-able memory
- [x] Passing a lambda function and copying the lambda capture onto the stack
  - [x] Cortex-M
  - [x] AVR
  - [x] x86
