### PR TITLE
Fix for ambigious gpio

### DIFF
--- a/src/modm/platform/gpio/common/unused.hpp.in
+++ b/src/modm/platform/gpio/common/unused.hpp.in
@@ -106,13 +106,13 @@ public:
 	struct BitBang
 	{
 		using Data = detail::DataUnused;
-		static constexpr Gpio::Signal Signal = Gpio::Signal::BitBang;
+		static constexpr platform::Gpio::Signal Signal = platform::Gpio::Signal::BitBang;
 	};
 %% for name in all_signals
 	struct {{ name }}
 	{
 		using Data = detail::DataUnused;
-		static constexpr Gpio::Signal Signal = Gpio::Signal::{{ name }};
+		static constexpr platform::Gpio::Signal Signal = platform::Gpio::Signal::{{ name }};
 	};
 %% endfor
 };


### PR DESCRIPTION
I've got a problem compiling basic example for blue_pill.
Compiler (`arm-none-eabi-c++ (Arch Repository) 11.1.0`) was complaning about `Gpio` struct ambiguity. The this PR fixes that ambiguity.