### PR TITLE
[c++] Make operators `new` and `delete` weak symbols by default

### DIFF
--- a/examples/nucleo_g071rb/custom_allocator/main.cpp
+++ b/examples/nucleo_g071rb/custom_allocator/main.cpp
@@ -34,6 +34,10 @@ extern "C" void* _sbrk_r(struct _reent *,  ptrdiff_t size)
     }
     return (void*) heap;
 }
+extern "C" void operator_delete(void* ptr)
+{
+	free(ptr);
+}
 
 // ----------------------------------------------------------------------------
 int main()
@@ -47,7 +51,7 @@ int main()
 							 traits.value, start, end, size);
 	}
 
-	void* ptr;
+	uint8_t* ptr;
 	size_t counter{0};
 	while (true)
 	{
@@ -55,9 +59,13 @@ int main()
 		modm::delay(200ms);
 
 		// leak memory until heap is exhausted
-		ptr = malloc(1024);
-		if (ptr) counter++;
+		ptr = new uint8_t[1024];
+		if (ptr) {
+			ptr[0] = counter;
+			counter++;
+		}
 		MODM_LOG_INFO << "Allocated " << counter << "kb of heap!" << modm::endl;
+		// delete ptr;
 	}
 
 	return 0;

--- a/ext/gcc/module_c++.lb
+++ b/ext/gcc/module_c++.lb
@@ -31,7 +31,7 @@ or:
 
 ## AVR
 
-A partial port of GCC 8 libstdc++ is provided:
+A partial port of GCC libstdc++ is provided:
 See https://github.com/modm-io/avr-libstdcpp.
 """
 
@@ -82,6 +82,7 @@ def build(env):
         "with_exceptions": with_exceptions,
         "with_threadsafe_statics": with_threadsafe_statics,
         "with_memory_traits": env.has_module(":architecture:memory"),
+        "with_heap": env.has_module(":platform:heap"),
         "is_avr": is_avr,
     }
     env.outbasepath = "modm/ext/gcc"

--- a/ext/gcc/new_delete.cpp.in
+++ b/ext/gcc/new_delete.cpp.in
@@ -78,26 +78,40 @@ new_assert(size_t size)
 }
 
 // ----------------------------------------------------------------------------
+modm_weak
 void* operator new  (std::size_t size) { return new_assert<false>(size); }
+modm_weak
 void* operator new[](std::size_t size) { return new_assert<false>(size); }
 
+modm_weak
 void* operator new  (std::size_t size, const std::nothrow_t&) noexcept { return malloc(size); }
+modm_weak
 void* operator new[](std::size_t size, const std::nothrow_t&) noexcept { return malloc(size); }
 
 %% if with_memory_traits
+modm_weak
 void* operator new  (std::size_t size, modm::MemoryTraits traits) { return new_assert<true>(size, traits); }
+modm_weak
 void* operator new[](std::size_t size, modm::MemoryTraits traits) { return new_assert<true>(size, traits); }
 
+modm_weak
 void* operator new  (std::size_t size, modm::MemoryTraits traits, const std::nothrow_t&) noexcept { return malloc_traits(size, traits.value); }
+modm_weak
 void* operator new[](std::size_t size, modm::MemoryTraits traits, const std::nothrow_t&) noexcept { return malloc_traits(size, traits.value); }
 %% endif
 
 // ----------------------------------------------------------------------------
+modm_weak
 void operator delete  (void *ptr) noexcept { free(ptr); }
+modm_weak
 void operator delete[](void* ptr) noexcept { free(ptr); }
 
+modm_weak
 void operator delete  (void* ptr, std::size_t) noexcept { free(ptr); }
+modm_weak
 void operator delete[](void* ptr, std::size_t) noexcept { free(ptr); }
 
+modm_weak
 void operator delete  (void* ptr, const std::nothrow_t&) noexcept { free(ptr); }
+modm_weak
 void operator delete[](void* ptr, const std::nothrow_t&) noexcept { free(ptr); }

--- a/ext/gcc/new_delete.cpp.in
+++ b/ext/gcc/new_delete.cpp.in
@@ -101,17 +101,28 @@ void* operator new[](std::size_t size, modm::MemoryTraits traits, const std::not
 %% endif
 
 // ----------------------------------------------------------------------------
-modm_weak
-void operator delete  (void *ptr) noexcept { free(ptr); }
-modm_weak
-void operator delete[](void* ptr) noexcept { free(ptr); }
+extern "C" modm_weak
+void operator_delete(modm_unused void* ptr)
+{
+%% if with_heap
+	free(ptr);
+%% else
+	modm_assert_continue_fail_debug(0, "delete",
+		"operator delete was called without heap implementation!", ptr);
+%% endif
+}
 
 modm_weak
-void operator delete  (void* ptr, std::size_t) noexcept { free(ptr); }
+void operator delete  (void* ptr) noexcept { operator_delete(ptr); }
 modm_weak
-void operator delete[](void* ptr, std::size_t) noexcept { free(ptr); }
+void operator delete[](void* ptr) noexcept { operator_delete(ptr); }
 
 modm_weak
-void operator delete  (void* ptr, const std::nothrow_t&) noexcept { free(ptr); }
+void operator delete  (void* ptr, std::size_t) noexcept { operator_delete(ptr); }
 modm_weak
-void operator delete[](void* ptr, const std::nothrow_t&) noexcept { free(ptr); }
+void operator delete[](void* ptr, std::size_t) noexcept { operator_delete(ptr); }
+
+modm_weak
+void operator delete  (void* ptr, const std::nothrow_t&) noexcept { operator_delete(ptr); }
+modm_weak
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept { operator_delete(ptr); }

--- a/src/modm/platform/heap/cortex/module.md
+++ b/src/modm/platform/heap/cortex/module.md
@@ -180,6 +180,22 @@ extern "C" void* _sbrk_r(struct _reent *,  ptrdiff_t size)
 ```
 
 
+### Providing operator delete
+
+Unfortunately virtual C++ destructors can emit a call to `operator delete` even
+for classes with static allocation and also in program without a single call to
+`operator new` or `malloc`. Therefore if this module is not included, calls to
+`operator delete` are ignored and you must overwrite this behavior with this
+function that only points to `free`.
+
+```cpp
+extern "C" void operator_delete(void* ptr)
+{
+    free(ptr);
+}
+```
+
+
 ### Wrapping malloc
 
 To use a completely custom allocator, you need to replace the newlib allocator


### PR DESCRIPTION
This change makes operators `new` and `delete` weak symbols by default. See #746 