### PR TITLE
[stm32] CanFilter on devices with two bxCan peripherals

### DIFF
--- a/examples/blue_pill_f103/can/main.cpp
+++ b/examples/blue_pill_f103/can/main.cpp
@@ -41,12 +41,9 @@ main()
 
 	MODM_LOG_INFO << "CAN Test Program" << modm::endl;
 
-	MODM_LOG_INFO << "Dividing filter bank..." << modm::endl;
-	CanFilter::setStartFilterBankForCan2(14);
+	MODM_LOG_INFO << "Initializing Can..." << modm::endl;
 
-	MODM_LOG_INFO << "Initializing Can1..." << modm::endl;
-
-	// Initialize Can1
+	// Initialize Can
 	if (false) {
 		Can::connect<GpioInputA11::Rx, GpioOutputA12::Tx>(Gpio::InputType::PullUp);
 	} else {
@@ -54,7 +51,7 @@ main()
 	}
 	Can::initialize<Board::SystemClock, 125_kbps>(9);
 
-	MODM_LOG_INFO << "Setting up Filter for Can1..." << modm::endl;
+	MODM_LOG_INFO << "Setting up Filter for Can..." << modm::endl;
 	// Receive every message
 	CanFilter::setFilter(0, CanFilter::FIFO0,
 			CanFilter::ExtendedIdentifier(0),
@@ -65,7 +62,7 @@ main()
 			CanFilter::StandardFilterMask(0));
 
 	// Send a message
-	MODM_LOG_INFO << "Sending message on Can1... nn" << modm::endl;
+	MODM_LOG_INFO << "Sending message on Can... nn" << modm::endl;
 	modm::can::Message msg1(1, 1);
 	msg1.setExtended(true);
 	msg1.data[0] = 0x11;
@@ -75,7 +72,7 @@ main()
 	{
 		if (Can::isMessageAvailable())
 		{
-			MODM_LOG_INFO << "Can1: Message is available..." << modm::endl;
+			MODM_LOG_INFO << "Can: Message is available..." << modm::endl;
 			modm::can::Message message;
 			uint8_t filter_id;
 			Can::getMessage(message, &filter_id);

--- a/examples/generic/ros/can_bridge/main.cpp
+++ b/examples/generic/ros/can_bridge/main.cpp
@@ -97,9 +97,7 @@ main()
 	// Do not use it for logging because this will destroy ROS serial messages.
 	RosSerialUart::initialize<Board::SystemClock, 250_kBd>();
 
-	CanFilter::setStartFilterBankForCan2(14);
-
-	// Initialize Can1
+	// Initialize Can
 	if (false) {
 		Can::connect<GpioInputA11::Rx, GpioOutputA12::Tx>(Gpio::InputType::PullUp);
 	} else {

--- a/src/modm/platform/can/stm32/can_filter.cpp.in
+++ b/src/modm/platform/can/stm32/can_filter.cpp.in
@@ -77,14 +77,14 @@ modm::platform::CanFilter::disableFilter(uint8_t id)
 }
 
 // ----------------------------------------------------------------------------
-%% if target["family"] in ["f1", "f2", "f4"]
+%% if target_has_can2
 void
 modm::platform::CanFilter::setStartFilterBankForCan2(uint8_t startBank)
 {
 	// Initialization mode for the filter
 	{{ reg }}->FMR |= CAN_FMR_FINIT;
 
-	{{ reg }}->FMR = ({{ reg }}->FMR & ~0x3f00) | (startBank << 8);
+	{{ reg }}->FMR = ({{ reg }}->FMR & ~CAN_FMR_CAN2SB_Msk) | (startBank << CAN_FMR_CAN2SB_Pos);
 
 	// Leave the initialization mode for the filter
 	{{ reg }}->FMR &= ~CAN_FMR_FINIT;

--- a/src/modm/platform/can/stm32/can_filter.hpp.in
+++ b/src/modm/platform/can/stm32/can_filter.hpp.in
@@ -364,7 +364,7 @@ public:
 	static void
 	disableFilter(uint8_t bank);
 
-%% if target["family"] in ["f1", "f2", "f4"]
+%% if target_has_can2
 	/**
 	 * Set the first filter bank for CAN2.
 	 *

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -184,6 +184,7 @@ def build(env):
         properties["combined_isr"] = True
     else:
         properties["combined_isr"] = False
+    properties["target_has_can2"] = (("instance" in driver) and len(driver["instance"]) > 1)
 
     if "instance" not in driver:
         properties.update(get_substitutions(0, device, env))


### PR DESCRIPTION
Enable `CanFilter::setStartFilterBankForCan2(uint8_t)` for all devices with two CAN peripherals.

The code was not generated on some F0, F7 and L4 devices, e.g. STM32L496/STM32L4A6.

Previously the code was generated for all STM32F1, F2 and F4 targets, even if there is no second CAN peripheral. This (breaking) change could therefore lead to errors in some existing (incorrect) application code, as in our STM32F103 examples.