### PR TITLE
[stm32] Add support for advanced timer channels 5,6 and TRGO2

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -37,7 +37,7 @@ modm::platform::Timer{{ id }}::disable()
 void
 modm::platform::Timer{{ id }}::setMode(Mode mode, SlaveMode slaveMode,
 		SlaveModeTrigger slaveModeTrigger, MasterMode masterMode
-%% if target["family"] in ["f3", "f7"]
+%% if advanced_extended
 		, MasterMode2 masterMode2
 %% endif
 		)
@@ -55,7 +55,7 @@ modm::platform::Timer{{ id }}::setMode(Mode mode, SlaveMode slaveMode,
 
 	// ARR Register is buffered, only Under/Overflow generates update interrupt
 	TIM{{ id }}->CR1 = TIM_CR1_ARPE | TIM_CR1_URS | static_cast<uint32_t>(mode);
-%% if target["family"] in ["f3", "f7"]
+%% if advanced_extended
 	TIM{{ id }}->CR2 = 	static_cast<uint32_t>(masterMode) |
 						static_cast<uint32_t>(masterMode2);
 %% else

--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -83,7 +83,7 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 
 	if (channel <= 1)
 	{
-		uint32_t offset = 8 * channel;
+		const uint32_t offset = 8 * channel;
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR1 & ~(0xff << offset);
@@ -97,14 +97,28 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 				TIM{{ id }}->CR2 &= ~TIM_CR2_TI1S;
 		}
 	}
+%% if advanced_extended
+	else if (channel <= 3) {
+%% else
 	else {
-		uint32_t offset = 8 * (channel - 2);
+%% endif
+		const uint32_t offset = 8 * (channel - 2);
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR2 & ~(0xff << offset);
 
 		TIM{{ id }}->CCMR2 = flags;
 	}
+%% if advanced_extended
+	else {
+		const uint32_t offset = 8 * (channel - 4);
+
+		flags <<= offset;
+		flags |= TIM{{ id }}->CCMR3 & ~(0xff << offset);
+
+		TIM{{ id }}->CCMR3 = flags;
+	}
+%% endif
 
 	TIM{{ id }}->CCER |= (TIM_CCER_CC1E | static_cast<uint32_t>(polarity)) << (channel * 4);
 }
@@ -126,21 +140,35 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 
 	if (channel <= 1)
 	{
-		uint32_t offset = 8 * channel;
+		const uint32_t offset = 8 * channel;
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR1 & ~(0xff << offset);
 
 		TIM{{ id }}->CCMR1 = flags;
 	}
+%% if advanced_extended
+	else if (channel <= 3) {
+%% else
 	else {
-		uint32_t offset = 8 * (channel - 2);
+%% endif
+		const uint32_t offset = 8 * (channel - 2);
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR2 & ~(0xff << offset);
 
 		TIM{{ id }}->CCMR2 = flags;
 	}
+%% if advanced_extended
+	else {
+		const uint32_t offset = 8 * (channel - 4);
+
+		flags <<= offset;
+		flags |= TIM{{ id }}->CCMR3 & ~(0xff << offset);
+
+		TIM{{ id }}->CCMR3 = flags;
+	}
+%% endif
 
 	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)
 	TIM{{ id }}->RCR = 0;
@@ -166,21 +194,36 @@ OutputComparePreload preload)
 
 	if (channel <= 1)
 	{
-		uint32_t offset = 8 * channel;
+		const uint32_t offset = 8 * channel;
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR1 & ~(0xff << offset);
 
 		TIM{{ id }}->CCMR1 = flags;
 	}
+%% if advanced_extended
+	else if (channel <= 3) {
+%% else
 	else {
-		uint32_t offset = 8 * (channel - 2);
+%% endif
+		const uint32_t offset = 8 * (channel - 2);
 
 		flags <<= offset;
 		flags |= TIM{{ id }}->CCMR2 & ~(0xff << offset);
 
 		TIM{{ id }}->CCMR2 = flags;
 	}
+%% if advanced_extended
+	else {
+		const uint32_t offset = 8 * (channel - 4);
+
+		flags <<= offset;
+		flags |= TIM{{ id }}->CCMR3 & ~(0xff << offset);
+
+		TIM{{ id }}->CCMR3 = flags;
+	}
+%% endif
+
 
 	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)
 	TIM{{ id }}->RCR = 0;
@@ -210,7 +253,11 @@ uint32_t modeOutputPorts)
 			flags |= TIM{{ id }}->CCMR1 & ~(TIM_CCMR1_OC1M << offset);
 			TIM{{ id }}->CCMR1 = flags;
 		}
+%% if advanced_extended
+		else if (channel <= 3) {
+%% else
 		else {
+%% endif
 			uint32_t offset = 8 * (channel - 2);
 
 			flags <<= offset;
@@ -218,6 +265,16 @@ uint32_t modeOutputPorts)
 
 			TIM{{ id }}->CCMR2 = flags;
 		}
+%% if advanced_extended
+		else {
+			uint32_t offset = 8 * (channel - 4);
+
+			flags <<= offset;
+			flags |= TIM{{ id }}->CCMR3 & ~(TIM_CCMR1_OC1M << offset);
+
+			TIM{{ id }}->CCMR3 = flags;
+		}
+%% endif
 	}
 
 	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -360,7 +360,17 @@ public:
 	static inline void
 	setCompareValue(uint32_t channel, uint16_t value)
 	{
+%% if advanced_extended
+		if(channel <= 4) {
+			*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
+		} else if(channel == 5) {
+			TIM{{ id }}->CCR5 = value;
+		} else if(channel == 6) {
+			TIM{{ id }}->CCR6 = value;
+		}
+%% else
 		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
+%% endif
 	}
 
 	static inline uint16_t

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -107,7 +107,7 @@ public:
 			SlaveMode slaveMode = SlaveMode::Disabled,
 			SlaveModeTrigger slaveModeTrigger = SlaveModeTrigger::Internal0,
 			MasterMode masterMode = MasterMode::Reset
-%% if target["family"] in ["f3", "f7"]
+%% if advanced_extended
 			, MasterMode2 masterMode2 = MasterMode2::Reset
 %% endif
 			);

--- a/src/modm/platform/timer/stm32/advanced_base.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced_base.hpp.in
@@ -66,7 +66,7 @@ public:
 		SetComgOrRisingTrigEdge = TIM_CR2_CCUS
 	};
 
-%% if (target["family"] == "f3" and target["name"] not in ["73", "78"]) or target["family"] == "f7"
+%% if advanced_extended
 	enum class MasterMode2 : uint32_t
 	{
 		Reset			= 0,							//0b0000
@@ -128,7 +128,7 @@ public:
 
 	enum class Event : uint32_t
 	{
-%% if (target["family"] == "f3" and target["name"] not in ["73", "78"]) or target["family"] == "f7"
+%% if advanced_extended
 		Break2 						= TIM_EGR_B2G,
 %% endif
 		Break 						= TIM_EGR_BG,

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -107,8 +107,11 @@ def prepare(module, options):
 
     global props
     device = options[":target"]
-    props["target"] = device.identifier
+    props["target"] = target = device.identifier
     props["types"] = set()
+    # extended advanced control timer with 6 channels and trigger out 2
+    props["advanced_extended"] = target.family not in ["f0", "f1", "f2", "f4", "l0", "l1"] or \
+            target.family == "f3" and target.name not in ["73", "78"]
 
     props["timer_vectors"] = tim_vectors = defaultdict(list)
     vectors = [v["name"] for v in device.get_driver("core")["vector"] if "TIM" in v["name"]]


### PR DESCRIPTION
This adds advanced control timer channels 5 and 6 and trigger out 2 for all STM32 supporting these functions.

The STM32 timer API really needs refactoring but I don't have time to do it right now …