### PR TITLE
[stm32] G4 / L4+ core voltage boost mode

### DIFF
--- a/src/modm/board/nucleo_g431kb/board.hpp
+++ b/src/modm/board/nucleo_g431kb/board.hpp
@@ -95,6 +95,7 @@ struct SystemClock {
 		};
 		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Boost); // recommended for >150 MHz
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);

--- a/src/modm/board/nucleo_g431rb/board.hpp
+++ b/src/modm/board/nucleo_g431rb/board.hpp
@@ -90,6 +90,7 @@ struct SystemClock {
 		};
 		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Boost); // recommended for >150 MHz
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);

--- a/src/modm/board/nucleo_g474re/board.hpp
+++ b/src/modm/board/nucleo_g474re/board.hpp
@@ -103,6 +103,7 @@ struct SystemClock {
 		};
 		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
 		Rcc::setFlashLatency<Frequency>();
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Boost); // recommended for >150 MHz
 		// switch system clock to PLL output
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -66,6 +66,8 @@ def build(env):
         ((target["family"] == "f4") and target["name"] in ["27", "29", "37", "39", "46", "69", "79"])
     properties["vos0_overdrive"] = (target["family"] == "h7") and \
         target["name"] in ["42", "43", "45", "47", "50", "53", "55", "57"]
+    properties["has_r1mode"] = (target["family"] == "g4") or \
+        (target["family"] == "l4" and target["name"][0] in ["p", "q", "r", "s"])
     properties["pllsai_p_usb"] = (target["family"] == "f7") or \
         ((target["family"] == "f4") and target["name"] in ["46", "69", "79"])
     properties["cfgr1"] = ("CDCFGR1" if target.name in ["a0", "a3", "b0", "b3"] else "D1CFGR") \

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -358,6 +358,30 @@ Rcc::enableOverdriveMode(uint32_t waitCycles)
 }
 %% endif
 
+%% if has_r1mode
+bool
+Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
+{
+	const auto currentSetting = PWR->CR1 & PWR_CR1_VOS;
+	if (voltage == VoltageScaling::Boost) {
+		PWR->CR5 &= ~PWR_CR5_R1MODE;
+	} else {
+		PWR->CR5 |= PWR_CR5_R1MODE;
+	}
+	if (voltage != VoltageScaling::Scale2) {
+		if(static_cast<VoltageScaling>(currentSetting) == VoltageScaling::Scale2) {
+			PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | PWR_CR1_VOS_0;
+			while (PWR->SR2 & PWR_SR2_VOSF)
+				if (--waitCycles == 0) return false;
+		}
+	} else {
+		PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | PWR_CR1_VOS_1;
+	}
+
+	return true;
+}
+%% endif
+
 %% if target.family == "h7"
 bool
 Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -796,12 +796,24 @@ public:
 %% endif
 	};
 
-	static bool
-	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 2048);
-
 	/// Configure power source, has to be called exactly once early on start-up
 	static bool
 	configurePowerSource(PowerSource source, uint32_t waitCycles = 2048);
+%% endif
+
+%% if has_r1mode
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Boost = 0,
+		Scale1 = PWR_CR1_VOS_0,
+		Scale2 = PWR_CR1_VOS_1
+	};
+%% endif
+
+%% if target.family == "h7" or has_r1mode
+	static bool
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 2048);
 %% endif
 
 public:

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -57,10 +57,17 @@ __modm_initialize_platform(void)
 	PWR->CR1 |= PWR_CR1_DBP;
 	// Enable Data Tighly Coupled Memory (DTCM) and backup SRAM (BKPSRAM)
 	RCC->AHB1ENR |= RCC_AHB1ENR_DTCMRAMEN | RCC_AHB1ENR_BKPSRAMEN;
-%% elif target.family in ["g0", "l4", "l5"]
+%% elif target.family in ["g0", "g4", "l4", "l5"]
+%% if target.family in ["l4", "g4"]
+	RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+%% else
+#ifdef PWR_CR2_IOSV
+	RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
+#endif
+%% endif
+
 #ifdef PWR_CR2_IOSV
 	// Enable VDDIO2
-	RCC->APB1ENR1 |= RCC_APB1ENR1_PWREN;
 	PWR->CR2 |= PWR_CR2_IOSV;
 #endif
 %% endif


### PR DESCRIPTION
For reliable operation at full frequency of G4 and L4+ devices ST recommends enabling the core voltage scaling boost mode. The setting is added to the clock driver and implements a logic equivalent to ST's G4 CubeHAL. The present G4 examples are adapted to set the mode accordingly.

The change has been tested on a Nucleo G474RE.