### PR TITLE
Bug fixes for SAMG family

### DIFF
--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -412,9 +412,19 @@ public:
 	read()
 	{
 %% if target["family"] in ["g", "v"]
-		return Base::readPortReg<PinConfig::port>(PIO_PDSR_OFFSET);
+		return Base::template readPortReg<PinConfig::port>(PIO_PDSR_OFFSET);
 %% else
-		return Base::readPortReg<PinConfig::port>(PORT_IN_OFFSET);
+		return Base::template readPortReg<PinConfig::port>(PORT_IN_OFFSET);
+%% endif
+	}
+
+	inline static bool
+	isSet()
+	{
+%% if target["family"] in ["g", "v"]
+		return Base::template readPortReg<PinConfig::port>(PIO_ODSR_OFFSET);
+%% else
+		return Base::template readPortReg<PinConfig::port>(PORT_OUT_OFFSET);
 %% endif
 	}
 

--- a/src/modm/platform/spi/sam/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam/spi_master.hpp.in
@@ -96,7 +96,7 @@ public:
 		assertBaudrateInTolerance< result.frequency, baudrate, tolerance >();
 
 		Regs()->SPI_CSR[0] = SPI_CSR_SCBR(result.prescaler);
-		Regs()->SPI_MR = SPI_MR_MSTR;
+		Regs()->SPI_MR = SPI_MR_MSTR | SPI_MR_MODFDIS;
 		Regs()->SPI_CR |= SPI_CR_SPIEN;
 	}
 


### PR DESCRIPTION
- Adds missing isSet method, and fixes an error in read() for GPIO
driver
- Disables mode fault detection in spi driver

The driver does not use the hardware controlled chip select, so mode
fault doesn't make sense, and leads to failures depending on the state
of the CS pin.