### PR TITLE
[cortex] Fix overflow in millisecond delay

### DIFF
--- a/src/modm/platform/core/sam/module.lb
+++ b/src/modm/platform/core/sam/module.lb
@@ -33,19 +33,22 @@ def build(env):
     env.template("startup_platform.c.in")
 
     # delay code that must be tuned for each family
-    # (cycles per loop, setup cost in loops, us shift)
+    # (cycles per loop, setup cost in loops, max cpu frequency)
     tuning = {
-        "d": (3, 4, 5), # CM0 tested on D21 in RAM
-        "g": (6, 4, 5), # G55
-        "v": (4, 4, 3), # V70
-    }.get(target.family, (4, 4, 5))
+        "d": (3, 4,  48), # CM0 tested on D21 in RAM
+        "g": (6, 4, 120), # G55
+        "v": (4, 4, 300), # V70
+    }[target.family]
+
+    # us_shift is an optimization to limit error via fractional math
+    us_shift = 32 - math.ceil(math.log2(tuning[2] * 1e6))
 
     env.substitutions.update({
         "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
         "with_cm7": env[":target"].has_driver("core:cortex-m7*"),
         "loop": tuning[0],
         "shift": int(math.log2(tuning[1])),
-        "us_shift": tuning[2],
+        "us_shift": us_shift,
         "with_assert": env.has_module(":architecture:assert")
     })
     env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -33,30 +33,34 @@ def build(env):
     env.template("startup_platform.c.in")
 
     # delay code that must be tuned for each family
-    # (cycles per loop, setup cost in loops, max us shift)
+    # (cycles per loop, setup cost in loops)
     tuning = {
-        "g4": (3,  4, 5), # CM4  tested on G476 in RAM
-        "l0": (3,  4, 6), # CM0+ tested on L031 in RAM
-        "g0": (3,  4, 5), # CM0+ tested on G072 in RAM
-        "f7": (4,  4, 4), # CM7  tested on F767 in ITCM
-        "h7": (4,  4, 3), # CM7  tested on H743 in ITCM
-        "l4": (3,  4, 5), # CM4  tested on L476 in SRAM2
-        "f3": (3,  4, 5), # CM4  tested on F334, F303 in CCM RAM
+        "g4": (3,  4), # CM4  tested on G476 in RAM
+        "l0": (3,  4), # CM0+ tested on L031 in RAM
+        "g0": (3,  4), # CM0+ tested on G072 in RAM
+        "f7": (4,  4), # CM7  tested on F767 in ITCM
+        "h7": (4,  4), # CM7  tested on H743 in ITCM
+        "l4": (3,  4), # CM4  tested on L476 in SRAM2
+        "f3": (3,  4), # CM4  tested on F334, F303 in CCM RAM
 
         # Defaults of (4, 4) for these families:
-        "l1": (4,  4, 6), # CM3  tested on L152 in RAM
-        "f0": (4,  4, 6), # CM3  tested on F071 in RAM
-        "f1": (4,  4, 5), # CM3  tested on F103 in RAM
-        "f4": (4,  4, 4), # CM4  tested on F401, F411, F446 in RAM
-        "f2": (4,  4, 4), # CM3  guessed based on documentation
+        "l1": (4,  4), # CM3  tested on L152 in RAM
+        "f0": (4,  4), # CM3  tested on F071 in RAM
+        "f1": (4,  4), # CM3  tested on F103 in RAM
+        "f4": (4,  4), # CM4  tested on F401, F411, F446 in RAM
+        "f2": (4,  4), # CM3  guessed based on documentation
     }[target.family]
+
+    # us_shift is an optimization to limit error via fractional math
+    frequency = int(env[":target"].get_driver("rcc")["max-frequency"][0])
+    us_shift = 32 - math.ceil(math.log2(frequency))
 
     env.substitutions.update({
         "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
         "with_cm7": env[":target"].has_driver("core:cortex-m7*"),
         "loop": tuning[0],
         "shift": int(math.log2(tuning[1])),
-        "us_shift": tuning[2],
+        "us_shift": us_shift,
         "with_assert": env.has_module(":architecture:assert")
     })
     env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")


### PR DESCRIPTION
The current implementation of Cortex-M millisecond delay assumes calling `delay_us` with a delay of 1s is allowed. This is not true for all supported targets. The worst case right now are STM32G4 at 170 MHz for which a delay of 790 ms overflows.
The limit is `max_us_delay = (2^32-1) / (core_clock_MHz * 2^us_shift)`. [For G4 the shift is 5, for H7 3.](https://github.com/modm-io/modm/blob/6e9f000e0ce22bc66af4e42f60255d041ed6234a/src/modm/platform/core/stm32/module.lb#L38)

~~With this fix delay_ms will call `delay_us(500'000)` instead of `delay_us(1'000'000)` to implement long delays.
Tested in hardware on Nucleo H723ZG at 550 MHz and Nucleo G474RE at 170 MHz.~~

`us shift` will be reduced for G4 and H7 to allow for a maximum us delay of at least 1s.