### PR TITLE
[stm32] Fix linkerscript veneer offset issues

### DIFF
--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -15,24 +15,32 @@
 %% endmacro
 
 %% macro prefix()
-MEMORY
-{
-%% for memory in (memories + cont_ram_regions)
-	{{ memory.name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
-%% endfor
-{{ linkerscript_memory | indent(first=True) }}
-}
-
-%% for memory in memories
-__{{memory.name}}_start = ORIGIN({{memory.name|upper}});
-__{{memory.name}}_end = ORIGIN({{memory.name|upper}}) + LENGTH({{memory.name|upper}});
-%% endfor
-
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 ENTRY(Reset_Handler)
 
-/* the handler stack is used for main program as well as interrupts */
+MEMORY
+{
+	%% for memory in memories
+	{{ memory.name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
+	%% endfor
+	%% for memory in cont_ram_regions
+	%% if memory.cont_name != memory.name
+	{{ memory.cont_name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
+	%% endif
+	%% endfor
+	%% if linkerscript_memory
+{{ linkerscript_memory | indent(first=True) }}
+	%% endif
+}
+
+	%% for memory in memories
+__{{memory.name}}_start = ORIGIN({{memory.name|upper}});
+__{{memory.name}}_end = ORIGIN({{memory.name|upper}}) + LENGTH({{memory.name|upper}});
+	%% endfor
+	%#
+
+/* The handler stack is used for main program as well as interrupts */
 MAIN_STACK_SIZE    = {{ options[":platform:cortex-m:main_stack_size"] }};
 PROCESS_STACK_SIZE = {{ process_stack_size }};
 TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
@@ -40,22 +48,23 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_vector_rom(memory)
+	/* Read-only vector table in {{memory}} */
 	.text :
 	{
 		__vector_table_rom_start = .;
 		__vector_table_ram_load = .;
-		/* Initial stack address, Reset and NMI handler */
 		KEEP(*(.vector_rom))
+		__vector_table_rom_end = .;
 	} >{{memory}}
 %% endmacro
 
 
 %% macro section_vector_ram(memory, table_copy)
+	/* Read-Write vector table in {{memory}} */
 	%% do table_copy.append("vector_table_ram")
 	.vectors (NOLOAD) :
 	{
 		__vector_table_ram_start = .;
-		/* Vector table in RAM, only if remapped */
 		KEEP(*(.vector_ram))
 		. = ALIGN(4);
 		__vector_table_ram_end = .;
@@ -64,10 +73,11 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_stack(memory, start=None)
+	/* Main stack in {{memory}} */
 	.stack (NOLOAD) :
 	{
 	%% if start != None
-		. = {{ start }};
+		. += {{ start }};
 	%% endif
 		__stack_start = .;
 
@@ -85,6 +95,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_tables(memory, copy, zero, heap)
+	/* Memory layout configuration tables */
 	.rodata :
 	{
 		. = ALIGN(4);
@@ -104,35 +115,27 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__table_copy_intern_end = .;
 
 		__table_zero_extern_start = .;
+	%% if linkerscript_extern_zero
 {{ linkerscript_extern_zero | indent(8, first=True) }}
+	%% endif
 		__table_zero_extern_end = .;
 		__table_copy_extern_start = .;
+	%% if linkerscript_extern_copy
 {{ linkerscript_extern_copy | indent(8, first=True) }}
+	%% endif
 		__table_copy_extern_end = .;
 
-		/* SRAM properties bit mask (16-bit):
-		 *
-		 * - 0x0001: accessible via S-Bus
-		 * - 0x0002: accessible via D-Bus
-		 * - 0x0004: accessible via I-Bus
-		 * - 0x0008: accessible via DMA
-		 * - 0x0010: accessible via DMA2D
-		 *
-		 * - 0x1FE0: reserved
-		 *
-		 * - 0x2000: Fast memory (Core- or Tightly-Coupled)
-		 * - 0x4000: non-volatile (or battery backed) memory
-		 * - 0x8000: external memory
-		 */
+		/* See `modm:architecture:memory` for bitmask */
 		__table_heap_start = .;
 	%% for section in heap
 		LONG({{ section.prop }})
 		LONG(__{{ section.name }}_start)
 		LONG(__{{ section.name }}_end)
 	%% endfor
+	%% if linkerscript_extern_heap
 {{ linkerscript_extern_heap | indent(8, first=True) }}
+	%% endif
 		__table_heap_end = .;
-
 	} >{{memory}}
 %% endmacro
 
@@ -147,9 +150,9 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		. = ALIGN(4);
 		__{{name}}_end = .;
 	} >{{memory}}
-
 	%% do table_copy.extend(sections)
 	%% for section in sections
+	%#
 	.{{section}} :
 	{
 		__{{section}}_load = LOADADDR(.{{section}});
@@ -172,8 +175,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		. = ALIGN(4);
 		__{{section}}_end = .;
 	} >{{ placement if placement else memory }}
+	%#
 	%% endfor
-
 	.{{name}} (NOLOAD) :
 	{
 		. = ALIGN(4);
@@ -187,20 +190,22 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% macro all_heap_sections(table_copy, table_zero, table_heap)
 	%% for cont_region in cont_ram_regions
 		%% for region in cont_region.contains
+	/* Sections in {{ region.name|upper }} */
 			%% if region.index
-{{ section(cont_region.name|upper + " AT >FLASH", "data_"+region.name, table_copy) }}
+{{ section(cont_region.cont_name|upper + " AT >FLASH", "data_"+region.name, table_copy) }}
 				%% do table_zero.append("bss_"+region.name)
 			%% endif
-
-{{ section_heap(region.name|upper, "heap_"+region.name, cont_region.name|upper,
+{{ section_heap(region.name|upper, "heap_"+region.name, cont_region.cont_name|upper,
 				sections=(["bss_"+region.name] if region.index else []) + ["noinit_"+region.name]) }}
 			%% do table_heap.insert(region.index, {"name": "heap_"+region.name, "prop": "0x2013" if "dtcm" in region.name else "0x001f"})
+			%#
 		%% endfor
 	%% endfor
 %% endmacro
 
 
 %% macro section_rom(memory)
+	/* Read-only sections in {{memory}} */
 	.text :
 	{
 		*(.text .text.* .gnu.linkonce.t.*)
@@ -219,7 +224,6 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__init_array_end = .;
 
 		__hardware_init_start = .;
-		/* Table symbols are alphabetically sorted! */
 		KEEP(*(SORT(.hardware_init.order_*)))
 		KEEP(*(SORT(.hardware_init)))
 		. = ALIGN(4);
@@ -233,13 +237,15 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__build_id = .;
 		KEEP(*(.note.gnu.build-id))
 	} >{{memory}}
+
 	/* We do not call static destructors ever */
 	/DISCARD/ :
 	{
 		*(.fini_array .fini_array.*)
 	}
-
 	%% if with_cpp_exceptions
+	%#
+	/* C++ exception unwind tables */
 	.exidx :
 	{
 		. = ALIGN(4);
@@ -255,9 +261,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		KEEP(*(.eh_frame*))
 	} >{{memory}}
 	%% else
-	/* Unwind tables are used to unwind the stack for C++ exceptions. Even
-	 * though we disabled exceptions, pre-compiled libraries such as libstdc++
-	 * still have to raise exceptions. */
+	%#
+	/* C++ exception unwind tables are discarded */
 	/DISCARD/ :
 	{
 		*(.ARM.extab* .gnu.linkonce.armextab.*)
@@ -266,9 +271,10 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 	}
 	%% endif
 	%% if not with_heap
+	%#
+	/* Catch use of dynamic memory without `modm:platform:heap` module. */
 	/DISCARD/ :
 	{
-		/* See `modm:platform:heap` module for an explanation! */
 		*({{no_heap_section}})
 	}
 	%% endif
@@ -276,6 +282,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_ram(memory, rom, table_copy, table_zero, sections_data=[], sections_bss=[])
+	/* Read-write sections in {{memory}} */
 	%% do table_copy.append("data")
 	.data :
 	{
@@ -286,9 +293,9 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		. = ALIGN(4);
 		__data_end = .;
 	} >{{memory}} AT >{{rom}}
-
 	%% do table_copy.extend(sections_data)
 	%% for section in sections_data
+	%#
 	.{{section}} :
 	{
 		__{{section}}_load = LOADADDR(.{{section}});
@@ -298,7 +305,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{section}}_end = .;
 	} >{{memory}} AT >{{rom}}
 	%% endfor
-
+	%#
 	%% do table_zero.append("bss")
 	.bss (NOLOAD) :
 	{
@@ -307,9 +314,9 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		. = ALIGN(4);
 		__bss_end = .;
 	} >{{memory}}
-
 	%% do table_zero.extend(sections_bss)
 	%% for section in sections_bss
+	%#
 	.{{section}} (NOLOAD) :
 	{
 		__{{section}}_start = . ;
@@ -318,7 +325,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{section}}_end = .;
 	} >{{memory}}
 	%% endfor
-
+	%#
 	.noinit (NOLOAD) :
 	{
 		__noinit_start = .;

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -50,7 +50,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_vector_ram(memory)
+%% macro section_vector_ram(memory, table_copy)
+	%% do table_copy.append("vector_table_ram")
 	.vectors (NOLOAD) :
 	{
 		__vector_table_ram_start = .;
@@ -84,15 +85,10 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 
 
 %% macro section_tables(memory, copy, zero, heap)
-%% if vector_table_location == "ram"
-	%% do copy.insert(0, "vector_table_ram")
-%% endif
 	.rodata :
 	{
 		. = ALIGN(4);
 		__table_zero_intern_start = .;
-		LONG(__bss_start)
-		LONG(__bss_end)
 	%% for name in zero
 		LONG(__{{name}}_start)
 		LONG(__{{name}}_end)
@@ -100,9 +96,6 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__table_zero_intern_end = .;
 
 		__table_copy_intern_start = .;
-		LONG(__data_load)
-		LONG(__data_start)
-		LONG(__data_end)
 	%% for name in copy
 		LONG(__{{name}}_load)
 		LONG(__{{name}}_start)
@@ -143,7 +136,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 	} >{{memory}}
 %% endmacro
 
-%% macro section(memory, name, sections=[])
+%% macro section(memory, name, table_copy, sections=[])
+	%% do table_copy.append(name)
 	.{{name}} :
 	{
 		. = ALIGN(4);
@@ -151,18 +145,20 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{name}}_start = .;
 		*(.{{name}} .{{name}}.*)
 		. = ALIGN(4);
+		__{{name}}_end = .;
 	} >{{memory}}
 
+	%% do table_copy.extend(sections)
 	%% for section in sections
 	.{{section}} :
 	{
+		__{{section}}_load = LOADADDR(.{{section}});
 		__{{section}}_start = .;
 		*(.{{section}} .{{section}}.*)
 		. = ALIGN(4);
 		__{{section}}_end = .;
 	} >{{memory}}
 	%% endfor
-	__{{name}}_end = .;
 %% endmacro
 
 
@@ -192,8 +188,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 	%% for cont_region in cont_ram_regions
 		%% for region in cont_region.contains
 			%% if region.index
-{{ section(cont_region.name|upper + " AT >FLASH", "data_"+region.name) }}
-				%% do table_copy.append("data_"+region.name)
+{{ section(cont_region.name|upper + " AT >FLASH", "data_"+region.name, table_copy) }}
 				%% do table_zero.append("bss_"+region.name)
 			%% endif
 
@@ -280,7 +275,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 %% endmacro
 
 
-%% macro section_ram(memory, rom, sections_data=[], sections_bss=[])
+%% macro section_ram(memory, rom, table_copy, table_zero, sections_data=[], sections_bss=[])
+	%% do table_copy.append("data")
 	.data :
 	{
 		. = ALIGN(4);
@@ -288,8 +284,10 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__data_start = .;
 		*(.data .data.* .gnu.linkonce.d.*)
 		. = ALIGN(4);
+		__data_end = .;
 	} >{{memory}} AT >{{rom}}
 
+	%% do table_copy.extend(sections_data)
 	%% for section in sections_data
 	.{{section}} :
 	{
@@ -300,8 +298,8 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{section}}_end = .;
 	} >{{memory}} AT >{{rom}}
 	%% endfor
-	__data_end = .;
 
+	%% do table_zero.append("bss")
 	.bss (NOLOAD) :
 	{
 		__bss_start = . ;
@@ -310,6 +308,7 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__bss_end = .;
 	} >{{memory}}
 
+	%% do table_zero.extend(sections_bss)
 	%% for section in sections_bss
 	.{{section}} (NOLOAD) :
 	{
@@ -319,7 +318,6 @@ TOTAL_STACK_SIZE   = MAIN_STACK_SIZE + PROCESS_STACK_SIZE;
 		__{{section}}_end = .;
 	} >{{memory}}
 	%% endfor
-	__bss_end = .;
 
 	.noinit (NOLOAD) :
 	{

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -94,10 +94,12 @@ def common_memories(env):
             if cont and (cont[-1]["start"] + cont[-1]["size"] == m["start"]):
                 cont[-1]["size"] += m["size"]
                 cont[-1]["contains"].append({**m, "index": index})
+                if not cont[-1]["cont_name"].startswith("cont_"):
+                    cont[-1]["cont_name"] = "cont_" + cont[-1]["cont_name"]
             else:
                 cont.append(dict(m))
                 cont[-1]["contains"] = [{**m, "index": index}]
-                cont[-1]["name"] = "cont_" + cont[-1]["name"]
+                cont[-1]["cont_name"] = cont[-1]["name"]
             index += 1
 
     properties = {

--- a/src/modm/platform/core/cortex/ram.ld.in
+++ b/src/modm/platform/core/cortex/ram.ld.in
@@ -7,12 +7,9 @@
 %% set table_zero = []
 
 %% if vector_table_location == "ram"
-/* Round up the number of vector table entries to the nearest power-of-two and multiply by 8. */
-__vec_alignment = (1 << LOG2CEIL({{ highest_irq + 16 }})) * 8;
-/* compute the vector table offset from start of RAM */
-__vec_offset = ALIGN(TOTAL_STACK_SIZE, __vec_alignment);
-%% else
-__vec_offset = TOTAL_STACK_SIZE;
+/* Computes stack offset so that vector table is aligned */
+__stack_offset = ALIGN(TOTAL_STACK_SIZE, (1 << LOG2CEIL({{ highest_irq + 16 }})) * 8) - TOTAL_STACK_SIZE;
+%#
 %% endif
 
 SECTIONS
@@ -23,25 +20,29 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-
-{{ linker.section_stack(cont_ram_regions[0].name|upper, "__vec_offset - TOTAL_STACK_SIZE") }}
+{{ linker.section_stack(cont_ram_regions[0].cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram_regions[0].cont_name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+
 %% if with_crashcatcher
-	g_crashCatcherStack = . - 500;
+    %#
+    /* Bottom of crash stack for `modm:platform:fault` */
+    g_crashCatcherStack = . - 500;
+    %#
 %% endif
 
-
+%% if linkerscript_sections
 {{ linkerscript_sections | indent(first=True) }}
-
+    %#
+%% endif
 
 {{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
 

--- a/src/modm/platform/core/cortex/ram.ld.in
+++ b/src/modm/platform/core/cortex/ram.ld.in
@@ -27,10 +27,10 @@ SECTIONS
 {{ linker.section_stack(cont_ram_regions[0].name|upper, "__vec_offset - TOTAL_STACK_SIZE") }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].name|upper) }}
+{{ linker.section_vector_ram(cont_ram_regions[0].name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH",
+{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 

--- a/src/modm/platform/core/stm32/dccm.ld.in
+++ b/src/modm/platform/core/stm32/dccm.ld.in
@@ -7,12 +7,9 @@
 %% set table_zero = []
 
 %% if vector_table_location == "ram"
-/* Round up the number of vector table entries to the nearest power-of-two and multiply by 8. */
-__vec_alignment = (1 << LOG2CEIL({{ highest_irq + 16 }})) * 8;
-/* compute the vector table offset from start of RAM */
-__vec_offset = ALIGN(TOTAL_STACK_SIZE, __vec_alignment);
-%% else
-__vec_offset = TOTAL_STACK_SIZE;
+/* Computes stack offset so that vector table is aligned */
+__stack_offset = ALIGN(TOTAL_STACK_SIZE, (1 << LOG2CEIL({{ highest_irq + 16 }})) * 8) - TOTAL_STACK_SIZE;
+%#
 %% endif
 
 SECTIONS
@@ -23,41 +20,44 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-
-{{ linker.section_stack(cont_ram_regions[0].name|upper, "__vec_offset - TOTAL_STACK_SIZE") }}
+{{ linker.section_stack(cont_ram_regions[0].cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram_regions[0].cont_name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastcode", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 
-
 %% if "backup" in regions
+	/* Sections in memory region BACKUP */
 {{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
-%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
-%% do table_zero.append("bss_backup")
+	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
+	%% do table_zero.append("bss_backup")
 %% endif
 
-
+	/* Sections in memory region CCM */
 {{ linker.section("CCM AT >FLASH", "fastdata", table_copy, sections=["data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
-%% do table_heap.append({"name": "heap_ccm", "prop": "0x2002"})
-%% do table_zero.append("bss_ccm")
+	%% do table_heap.append({"name": "heap_ccm", "prop": "0x2002"})
+	%% do table_zero.append("bss_ccm")
 %% if with_crashcatcher
+	%#
+	/* Bottom of crash stack for `modm:platform:fault` */
 	g_crashCatcherStack = . - 500;
+	%#
 %% endif
 
-
+%% if linkerscript_sections
 {{ linkerscript_sections | indent(first=True) }}
-
+	%#
+%% endif
 
 {{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
 

--- a/src/modm/platform/core/stm32/dccm.ld.in
+++ b/src/modm/platform/core/stm32/dccm.ld.in
@@ -27,10 +27,10 @@ SECTIONS
 {{ linker.section_stack(cont_ram_regions[0].name|upper, "__vec_offset - TOTAL_STACK_SIZE") }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].name|upper) }}
+{{ linker.section_vector_ram(cont_ram_regions[0].name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH",
+{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastcode", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
@@ -38,8 +38,7 @@ SECTIONS
 
 
 %% if "backup" in regions
-{{ linker.section("BACKUP AT >FLASH", "data_backup") }}
-%% do table_copy.append("data_backup")
+{{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 %% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
@@ -47,8 +46,7 @@ SECTIONS
 %% endif
 
 
-{{ linker.section("CCM AT >FLASH", "fastdata", sections=["data_ccm"]) }}
-%% do table_copy.append("fastdata")
+{{ linker.section("CCM AT >FLASH", "fastdata", table_copy, sections=["data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 %% do table_heap.append({"name": "heap_ccm", "prop": "0x2002"})

--- a/src/modm/platform/core/stm32/iccm.ld.in
+++ b/src/modm/platform/core/stm32/iccm.ld.in
@@ -18,7 +18,7 @@ SECTIONS
 
 {{ linker.section_stack(cont_ram_regions[0].name|upper) }}
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH",
+{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
@@ -29,11 +29,10 @@ SECTIONS
 
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram("CCM") }}
+{{ linker.section_vector_ram("CCM", table_copy) }}
 %% endif
 
-{{ linker.section("CCM AT >FLASH", "fastcode", sections=["fastdata", "data_ccm"]) }}
-%% do table_copy.append("fastcode")
+{{ linker.section("CCM AT >FLASH", "fastcode", table_copy, sections=["fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 %% do table_heap.append({"name": "heap_ccm", "prop": "0x2006"})

--- a/src/modm/platform/core/stm32/iccm.ld.in
+++ b/src/modm/platform/core/stm32/iccm.ld.in
@@ -15,32 +15,35 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
+{{ linker.section_stack(cont_ram_regions[0].cont_name|upper) }}
 
-{{ linker.section_stack(cont_ram_regions[0].name|upper) }}
-
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 %% if with_crashcatcher
+	%#
+	/* Bottom of crash stack for `modm:platform:fault` */
 	g_crashCatcherStack = . - 500;
+	%#
 %% endif
-
 
 %% if vector_table_location == "ram"
 {{ linker.section_vector_ram("CCM", table_copy) }}
 %% endif
 
+	/* Sections in memory region CCM */
 {{ linker.section("CCM AT >FLASH", "fastcode", table_copy, sections=["fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 %% do table_heap.append({"name": "heap_ccm", "prop": "0x2006"})
 %% do table_zero.append("bss_ccm")
 
-
+%% if linkerscript_sections
 {{ linkerscript_sections | indent(first=True) }}
-
+	%#
+%% endif
 
 {{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
 

--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -17,11 +17,10 @@ SECTIONS
 
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram("ITCM") }}
+{{ linker.section_vector_ram("ITCM", table_copy) }}
 %% endif
 
-{{ linker.section("ITCM AT >FLASH", "fastcode", sections=["data_itcm"]) }}
-%% do table_copy.append("fastcode")
+{{ linker.section("ITCM AT >FLASH", "fastcode", table_copy, sections=["data_itcm"]) }}
 
 {{ linker.section_heap("ITCM", "heap_itcm", sections=["noinit_itcm"]) }}
 %% do table_heap.append({"name": "heap_itcm", "prop": "0x201f"})
@@ -29,7 +28,7 @@ SECTIONS
 
 {{ linker.section_stack("CONT_DTCM") }}
 
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH",
+{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
@@ -40,8 +39,7 @@ SECTIONS
 
 
 %% if "backup" in regions
-{{ linker.section("BACKUP AT >FLASH", "data_backup") }}
-%% do table_copy.append("data_backup")
+{{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 %% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})

--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -15,40 +15,43 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-
 %% if vector_table_location == "ram"
 {{ linker.section_vector_ram("ITCM", table_copy) }}
 %% endif
 
+	/* Sections in memory region ITCM */
 {{ linker.section("ITCM AT >FLASH", "fastcode", table_copy, sections=["data_itcm"]) }}
 
 {{ linker.section_heap("ITCM", "heap_itcm", sections=["noinit_itcm"]) }}
 %% do table_heap.append({"name": "heap_itcm", "prop": "0x201f"})
 
+{{ linker.section_stack("DTCM") }}
 
-{{ linker.section_stack("CONT_DTCM") }}
-
-{{ linker.section_ram(cont_ram_regions[0].name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
                       sections_data=["fastdata", "data_" + cont_ram_regions[0].contains[0].name],
                       sections_bss=["bss_" + cont_ram_regions[0].contains[0].name]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
 %% if with_crashcatcher
+	%#
+	/* Bottom of crash stack for `modm:platform:fault` */
 	g_crashCatcherStack = . - 500;
+	%#
 %% endif
 
-
 %% if "backup" in regions
+	/* Sections in memory region BACKUP */
 {{ linker.section("BACKUP AT >FLASH", "data_backup", table_copy) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
-%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
-%% do table_zero.append("bss_backup")
+	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
+	%% do table_zero.append("bss_backup")
 %% endif
 
-
+%% if linkerscript_sections
 {{ linkerscript_sections | indent(first=True) }}
-
+	%#
+%% endif
 
 {{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
 


### PR DESCRIPTION
There is a linkerscript bug that can cause code placed in RAM to be loaded to the wrong address because alignment is ignored. By chance the bug showed on some F0/L0 after the `delete` stub implementations were added 9 days ago.

We could reproduce the bug with the blink examples on F042, F030 and L031 devices but more devices are affected. It caused the delay to run with random durations. The instructions loading `modm::platform::delay_fcpu_MHz` from ram to a register were never executed.

This bug was most likely introduced in the last [linkerscript refactoring](https://github.com/modm-io/modm/commit/996e361d9ed9b59f0a4928bc3ddec22862d6665b) in July.

Thanks to @salkinium for coming up with the fix after it was clear what the issue was.