### PR TITLE
Include r14 in delay_ns clobber list

### DIFF
--- a/src/modm/platform/core/cortex/delay_impl.hpp.in
+++ b/src/modm/platform/core/cortex/delay_impl.hpp.in
@@ -43,7 +43,7 @@ void delay_ns(uint32_t ns)
     asm volatile(
         "mov r0, %0 \n\t"
         "blx %1"
-        :: "r" (ns), "l" (platform::delay_ns) : "r0", "r1", "r2");
+        :: "r" (ns), "l" (platform::delay_ns) : "r0", "r1", "r2", "lr");
 }
 
 


### PR DESCRIPTION
I think r14 (lr) needs to be included here, because the blx instruction writes to it. 

I've been chasing some crazy optimization problems: weird behavior that went away with -O0, but cropped up unexpectedly sometimes with -O1 or higher. I was becoming more and more convinced that somehow the compiler was not respecting the volatile accesses buried in the SAMG GPIO driver, but! Then I discovered that problems went away if I used only delay_us, and sometimes the symptoms changed based on the value of the argument to delay_ns. After some digging, it seems that a) this change fixes the wrong behavior and b) I do see some instances of r14 being used for intermediate value storage.

I am still not at all clear how the delay value passed to delay_ns can affect the behavior though, as this should be written only to r0-r2, which were already in the clobber list. This makes me a little concerned that I have missed some part of the root cause here.