### PR TITLE
[samg] Make Adc::getPinChannel consistent with STM32 interface

### DIFF
--- a/src/modm/platform/adc/samg/adc.hpp
+++ b/src/modm/platform/adc/samg/adc.hpp
@@ -161,7 +161,7 @@ public:
 	static inline constexpr uint8_t
 	getPinChannel()
 	{
-		using Connector = typename Pin::template Connector<Peripherals::Adc, Peripherals::Adc::Ad>;
+		using Connector = typename Pin::Ad::template Connector<Peripherals::Adc, Peripherals::Adc::Ad>;
 		static_assert(Connector::PinSignal::AdcChannel >= 0, "Pin cannot be used as ADC input");
 		return Connector::PinSignal::AdcChannel;
 	}


### PR DESCRIPTION
Previously, you pass GpioA17::Ad as the template argument, but in the
stm32 driver you pass just GpioA17. This makes the SAMG driver
consistent with that.