### PR TITLE
[samg] Add faster transmit only method to SPI driver

### DIFF
--- a/src/modm/platform/spi/sam/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam/spi_master.cpp.in
@@ -64,6 +64,9 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 	// LSB != Bit0 ?
 	if ( !(state & Bit0) )
 	{
+		// Clear any stale rx data ready status
+		read();
+
 		// wait for previous transfer to finish
 		if (!isTransmitDataRegisterEmpty())
 			return {modm::rf::Running};
@@ -129,3 +132,19 @@ modm::platform::SpiMaster{{ id }}::transfer(
 			return {modm::rf::Stop};
 	}
 }
+
+void modm::platform::SpiMaster{{ id }}::transferBlocking(
+		const uint8_t *tx, std::size_t length)
+{
+	uint8_t index = 0;
+	while(index < length) {
+		// Wait for tx empty
+		while(!isTransmitDataRegisterEmpty());
+		// Write next byte
+		write(tx ? tx[index] : 0);
+		index++;
+	}
+	// wait for the internal shift register to be empty, indicating the transmission of the final byte is complete
+	while(!isTxEmpty());
+}
+

--- a/src/modm/platform/spi/sam/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam/spi_master.hpp.in
@@ -42,6 +42,11 @@ class SpiMaster{{ id }} : public modm::SpiMaster {
 	}
 
 	static inline bool
+	isTxEmpty() {
+		return Regs()->SPI_SR & SPI_SR_TXEMPTY;
+	}
+
+	static inline bool
 	isReceiveDataRegisterFull() {
 		return Regs()->SPI_SR & SPI_SR_RDRF;
 	}
@@ -68,12 +73,10 @@ public:
 
 		if constexpr (!std::is_void<SckPin>::value) {
 			using SckConnector = typename SckPin::template Connector<Flexcom, Flexcom::Sck>;
-			SckPin::setOutput();
 			SckConnector::connect();
 		}
 		if constexpr (!std::is_void<MisoPin>::value) {
 			using MisoConnector = typename MisoPin::template Connector<Flexcom, Flexcom::Miso>;
-			MisoPin::setOutput();
 			MisoConnector::connect();
 		}
 		if constexpr (!std::is_void<MosiPin>::value) {
@@ -124,7 +127,13 @@ public:
 
 	static void
 	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length) {
-		RF_CALL_BLOCKING(transfer(tx, rx, length));
+		// If we do not need to receive data, use a more efficient
+		// transmit-only routine to increase throughput
+		if(rx) {
+			RF_CALL_BLOCKING(transfer(tx, rx, length));
+		} else {
+			transferBlocking(tx, length);
+		}
 	}
 
 	static modm::ResumableResult<uint8_t>
@@ -143,6 +152,17 @@ public:
 			Regs()->SPI_MR &= ~SPI_MR_LLB;
 		}
 	}
+
+protected:
+	/** Perform transmit-only transaction
+	 *
+	 * A faster version of blocking transfer when transmitting only.
+	 *
+	 * If no receive is needed, the next byte can be loaded while the
+	 * current transfer is in progress.
+	 */
+	static void
+	transferBlocking(const uint8_t *tx, std::size_t length);
 };
 
 } // namespace modm::platform


### PR DESCRIPTION
Synchronous transfer is slowed down by the having to wait for a complete
transfer to read the received byte. When only transmit is required, this
method allows for writing the next transmit byte while the current byte
is being written out to increase throughput.

Also removes the 'setOutput' calls in the connect() method, as these are not necessary.