### PR TITLE
[macos] Treat /usr/local/include as a "system" include path

### DIFF
--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -138,11 +138,13 @@ env.Append(MODM_BOSSAC_OPTIONS = "{{ bossac_options }}")
 env["XPCC_SYSTEM_DESIGN"] = "$BASEPATH/modm/tools/xpcc_generator"
 %% endif
 
+%% if is_modm and family == "darwin"
+env.AppendUnique(CPPFLAGS=[
+	"-isystem", "/usr/local/include",
+])
+%% endif
 
 env.AppendUnique(CPPPATH=[
-%% if is_modm and family == "darwin"
-	"/usr/local/include",
-%% endif
 %% for path in include_paths | sort
     abspath("{{ path | relocate | modm.windowsify(escape_level=1) }}"),
 %% endfor


### PR DESCRIPTION
Modm manually adds `/usr/local/include` to the include path. However, the way it's done now means that it's treated as project-local code, and thus those headers are subject to the warnings and compiler settings you specify. Treating this path as a "system" path means it won't spew warnings or trigger errors based on your private settings.

There appear to be some minor downsides to doing this; in particular, changes to files in `/usr/local/include` won't invalidate whatever caching system SCons uses to track rebuilds. SO post linked below. You can choose whether this makes sense to accept or not.

https://stackoverflow.com/questions/2441047/how-do-i-set-scons-system-include-path