### PR TITLE
add **/.favorites.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ CMakeLists.txt
 
 # Codium/Code
 **/.vscode/
+# https://marketplace.visualstudio.com/items?itemName=kdcro101.favorites
+**/.favorites.json
 
 # ignore generated code in the example folder
 examples/**/modm


### PR DESCRIPTION
This seems to be the best [favorites extensions](https://marketplace.visualstudio.com/items?itemName=kdcro101.favorites) for vscode/codium.

Should not worry anyone, if we add `**/.favorites.json` to `.gitignore` !?