### PR TITLE
[docs] Update link to Linux ARM toolchain in install guide to current version

### DIFF
--- a/.github/workflows/windows_armcortexm.yml
+++ b/.github/workflows/windows_armcortexm.yml
@@ -27,15 +27,15 @@ jobs:
         shell: powershell
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -OutFile gcc-arm-none-eabi-win32.zip https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-win32.zip
+          Invoke-WebRequest -OutFile gcc-arm-none-eabi-win32.zip https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-win32.zip
 
       - name: Install ARM Toolchain
         shell: powershell
         run: |
           Add-Type -Assembly "System.IO.Compression.Filesystem"
           [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-arm-none-eabi-win32.zip", "C:\")
-          dir C:\gcc-arm-none-eabi-10.3-2021.07
-          echo "C:\gcc-arm-none-eabi-10.3-2021.07\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          dir C:\gcc-arm-none-eabi-10.3-2021.10
+          echo "C:\gcc-arm-none-eabi-10.3-2021.10\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           rm gcc-arm-none-eabi-win32.zip
 
       - name: Show lbuild and arm-none-eabi-gcc Version Information

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -85,13 +85,13 @@ export PATH="/opt/doxypress:$PATH"
 Install the [pre-built ARM toolchain][gcc-arm-toolchain]:
 
 ```sh
-wget -O- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 | sudo tar xj -C /opt/
+wget -O- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | sudo tar xj -C /opt/
 ```
 
 Add it to your `PATH` variable in `~/.bashrc`:
 
 ```sh
-export PATH="/opt/gcc-arm-none-eabi-10-2020-q4-major/bin:$PATH"
+export PATH="/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH"
 ```
 
 !!! warning "Ubuntus 'gcc-arm-none-eabi' package"


### PR DESCRIPTION
Update the download link for the Linux ARM tool chain in the install guide to the most recent version (10.3-2021.10).

Debugging seems to be broken in the version currently provided in the guide. Two colleagues at work always got a mismatch error for the `.text` and `.data` sections in gdb even when the binary was correctly programmed to the device. Updating the toolchain on their machines resolved the issue.