### PR TITLE
[stm32] Fix off-by-one error in exti irq handler

### DIFF
--- a/src/modm/platform/extint/stm32/exti.hpp.in
+++ b/src/modm/platform/extint/stm32/exti.hpp.in
@@ -420,7 +420,7 @@ public:
 	%% if (range | length) == 1
 				return 1ul << {{ range[0] }};
 	%% else
-				return ((1ul << {{range[-1]+1}}) - 1ul) & ~((1ul << {{range[0]+1}}) - 1ul);
+				return ((1ul << {{range[-1]+1}}) - 1ul) & ~((1ul << {{range[0]}}) - 1ul);
 	%% endif
 %% endfor
 		}


### PR DESCRIPTION
The lowest interrupt flag bit is not cleared correctly for EXTI interrupts shared between multiple pins. The controller is stuck in the interrupt forever.