### PR TITLE
[stm32] Do not reset RCR register when configuring timer channel

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -199,9 +199,6 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 	}
 %% endif
 
-	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)
-	TIM{{ id }}->RCR = 0;
-
 	if (mode != OutputCompareMode::Inactive) {
 		TIM{{ id }}->CCER |= (TIM_CCER_CC1E) << (channel * 4);
 	}
@@ -253,10 +250,6 @@ OutputComparePreload preload)
 	}
 %% endif
 
-
-	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)
-	TIM{{ id }}->RCR = 0;
-
 	// CCER Flags (Enable/Polarity)
 	flags = (static_cast<uint32_t>(polarity_n) << 2) |
 			(static_cast<uint32_t>(out_n)      << 2) |
@@ -305,9 +298,6 @@ uint32_t modeOutputPorts)
 		}
 %% endif
 	}
-
-	// Disable Repetition Counter (FIXME has to be done here for some unknown reason)
-	TIM{{ id }}->RCR = 0;
 
 	uint32_t flags = (modeOutputPorts & (0xf)) << (channel * 4);
 	flags |= TIM{{ id }}->CCER & ~(0xf << (channel * 4));


### PR DESCRIPTION
Do not reset advanced control timer repetition counter register when configuring an output channel. It was done "for some unknown reason". In case the register is used by the application resetting it will mess up the timing and just setting it again from the application code is no option.

Fixes #794 