### PR TITLE
[docs] Add workaround for doxypress crash for mcp7941x driver

### DIFF
--- a/src/modm/driver/rtc/mcp7941x.hpp
+++ b/src/modm/driver/rtc/mcp7941x.hpp
@@ -7,7 +7,6 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * chip datasheet available at http://ww1.microchip.com/downloads/en/DeviceDoc/22266A.pdf
  */
 // ----------------------------------------------------------------------------
 
@@ -24,6 +23,7 @@
 namespace modm
 {
 
+/// @ingroup modm_driver_mcp7941x
 struct mcp7941x
 {
 	/// days, months, etc. are decoded (BCD) in this struct
@@ -45,7 +45,7 @@ struct mcp7941x
  * @author	Raphael Lehmann
  */
 template < class I2cMaster >
-class Mcp7941x :	public modm::mcp7941x,
+class Mcp7941x :	public mcp7941x,
 					public modm::I2cDevice<I2cMaster, 2>
 {
 public:

--- a/src/modm/driver/rtc/mcp7941x.lb
+++ b/src/modm/driver/rtc/mcp7941x.lb
@@ -17,6 +17,9 @@ def init(module):
 # MCP79410/MCP79411/MCP79412
 
 Battery-Backed I2C Real-Time Clock/Calendar with SRAM, EEPROM and Protected EEPROM
+
+[MCP7941x datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/22266A.pdf)
+
 """
 
 

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -189,7 +189,10 @@ def create_target(argument):
         builder.build(output_dir, modules)
 
         print('Executing: (cd {}/modm/docs/ && doxypress doxypress.json)'.format(output_dir))
-        os.system('(cd {}/modm/docs/ && doxypress doxypress.json > /dev/null 2>&1)'.format(output_dir))
+        retval = os.system('(cd {}/modm/docs/ && doxypress doxypress.json > /dev/null 2>&1)'.format(output_dir))
+        if retval != 0:
+            print("Error {} generating documentation for device {}.".format(retval, output_dir))
+            return False
         print("Finished generating documentation for device {}.".format(output_dir))
 
         srcdir = (tempdir / output_dir / "modm/docs/html")


### PR DESCRIPTION
Fix docs generator crash caused by the mcp7941x driver in the Q4 release (see #797)