### PR TITLE
[stm32] Add STM32L5

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -363,6 +363,27 @@ jobs:
           name: stm32l4-compile-all-3
           path: test/all/log
 
+  stm32l5-compile-all:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Checkout code and update modm tools
+        run: |
+          (git submodule sync && git submodule update --init --jobs 8) & pip3 install --upgrade --upgrade-strategy=eager modm & wait
+      - name: Compile HAL for all STM32L5
+        run: |
+          (cd test/all && python3 run_all.py stm32l5 --quick-remaining)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: stm32l5-compile-all
+          path: test/all/log
+
   stm32g0-compile-all:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -128,6 +128,10 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py stm32l476_discovery nucleo_l476rg nucleo_l432kc nucleo_l452re nucleo_l496zg-p)
+      - name: Examples STM32L5 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_l552ze-q)
       - name: Examples STM32G4 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3256<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3300<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->2682<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->2726<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->186<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 
@@ -99,7 +99,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <table>
 <tr>
 <th align="center"></th>
-<th align="center" colspan="12">STM32</th>
+<th align="center" colspan="13">STM32</th>
 <th align="center" colspan="3">SAM</th>
 <th align="center" colspan="3">AT</th>
 </tr><tr>
@@ -116,6 +116,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center">L0</th>
 <th align="center">L1</th>
 <th align="center">L4</th>
+<th align="center">L5</th>
 <th align="center">D21</th>
 <th align="center">G55</th>
 <th align="center">V70</th>
@@ -134,6 +135,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
@@ -156,6 +158,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -177,6 +180,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -184,6 +188,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 </tr><tr>
 <td align="left">DAC</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -204,6 +209,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">DMA</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -242,8 +248,10 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
 </tr><tr>
 <td align="left">External Interrupt</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -278,6 +286,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -302,8 +311,10 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 </tr><tr>
 <td align="left">I<sup>2</sup>C</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -339,6 +350,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -355,6 +367,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -373,6 +386,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -397,6 +411,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -404,6 +419,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Timer</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -438,12 +454,14 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
 </tr><tr>
 <td align="left">Unique ID</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -471,6 +489,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -563,13 +582,14 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-olimexino-stm32">OLIMEXINO-STM32</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-raspberrypi">Raspberry Pi</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-board-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-board-srxe">Smart Response XE</a></td>
 </tr>

--- a/examples/nucleo_l552ze-q/adc_basic/main.cpp
+++ b/examples/nucleo_l552ze-q/adc_basic/main.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ * Copyright (c) 2022, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "STM32L5 ADC basic example" << modm::endl;
+	MODM_LOG_INFO << " running on Nucleo-L552ZE-Q" << modm::endl << modm::endl;
+
+	MODM_LOG_INFO << "Configuring ADC ...";
+	// max. ADC clock for STM32L552: 80 MHz
+	// 110 MHz AHB clock / 2 = 55 MHz
+	Adc1::initialize(
+		Adc1::ClockMode::SynchronousPrescaler2,
+		Adc1::ClockSource::SystemClock,
+		Adc1::Prescaler::Disabled,
+		Adc1::CalibrationMode::SingleEndedInputsMode,
+		true);
+	// GpioB1: A6
+	Adc1::connect<GpioB1::In16>();
+	Adc1::setPinChannel<GpioB1>(Adc1::SampleTime::Cycles13);
+
+	while (true)
+	{
+		Adc1::startConversion();
+		while(!Adc1::isConversionFinished)
+			;
+		const auto adcValue = Adc1::getValue();
+		MODM_LOG_INFO << "adcValue=" << adcValue;
+		const float voltage = adcValue * 3.3 / 0xfff;
+		MODM_LOG_INFO << " voltage=";
+		MODM_LOG_INFO.printf("%.3f\n", voltage);
+		Board::Leds::toggle();
+		modm::delay(500ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l552ze-q/adc_basic/project.xml
+++ b/examples/nucleo_l552ze-q/adc_basic/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-l552ze-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l552ze-q/adc_basic</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:adc:1</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_l552ze-q/blink/main.cpp
+++ b/examples/nucleo_l552ze-q/blink/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter = 0;
+
+	while (true)
+	{
+		Leds::write(counter % (1 << 3));
+		modm::delay(Button::read() ? 250ms : 500ms);
+		MODM_LOG_INFO << "loop: " << counter << modm::endl;
+		counter++;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l552ze-q/blink/project.xml
+++ b/examples/nucleo_l552ze-q/blink/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-l552ze-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l552ze-q/blink</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_l552ze-q/dac_dma/main.cpp
+++ b/examples/nucleo_l552ze-q/dac_dma/main.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+#include <numbers>
+#include <cmath>
+#include <array>
+
+using namespace Board;
+
+constexpr auto computeSinTable(float frequency = 1.f)
+{
+	std::array<uint16_t, 100> data{};
+	constexpr auto HalfOutput = ((1 << 12) - 1) / 2; // 12 bit dac
+	for (size_t i = 0; i < data.size(); ++i) {
+		constexpr auto pi = std::numbers::pi_v<float>;
+		data[i] = HalfOutput * (1 + sin(i * (2 * pi * frequency / data.size())));
+	}
+	return data;
+}
+
+constexpr auto sinTable1 = computeSinTable(1.0f);
+constexpr auto sinTable2 = computeSinTable(2.0f);
+
+// DAC1 channel 1 on GpioA4: switch between 10 kHz and 20 kHz sine signal after DMA transfer complete
+
+void setupDac()
+{
+	using Dac = Dac1Dma;
+	using DacChannel = Dac::Channel1<Dma1::Channel1>;
+
+	Dac::connect<GpioOutputA4::Out1>();
+	Dac::initialize();
+
+	DacChannel::configure(sinTable1.data(), sinTable1.size(), DmaBase::CircularMode::Disabled);
+
+	// trigger source 3: timer 4 for DAC1, see reference manual
+	DacChannel::setTriggerSource(3);
+
+	// switch between signals when transfer completed
+	static bool toggleBit = false;
+	Dma1::Channel1::setTransferCompleteIrqHandler([]() {
+		DacChannel::stopDma();
+		toggleBit = !toggleBit;
+		if (toggleBit) {
+			DacChannel::setData(sinTable1.data(), sinTable1.size());
+		} else {
+			DacChannel::setData(sinTable2.data(), sinTable2.size());
+		}
+		DacChannel::startDma();
+	});
+
+	Dma1::Channel1::enableInterruptVector();
+	Dma1::Channel1::enableInterrupt(Dma1::InterruptEnable::TransferComplete |
+									Dma1::InterruptEnable::TransferError);
+
+	DacChannel::startDma();
+	DacChannel::enableDacChannel();
+}
+
+int main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	MODM_LOG_INFO << "DAC DMA Demo" << modm::endl;
+
+	Dma1::enable();
+
+	setupDac();
+
+	// configure timer 4 as trigger for DACs
+	// 110 MHz / 110 = 1 MHz => 1 Msps DAC output
+	Timer4::enable();
+	Timer4::setMode(Timer4::Mode::UpCounter);
+	Timer4::setPrescaler(1);
+	Timer4::setOverflow(110 - 1);
+	Timer4::applyAndReset();
+	Timer4::start();
+
+	// Enable trigger out for timer 4
+	TIM4->CR2 |= TIM_CR2_MMS_1;
+
+	while (true)
+	{
+		Leds::toggle();
+		modm::delay_ms(500);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_l552ze-q/dac_dma/project.xml
+++ b/examples/nucleo_l552ze-q/dac_dma/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:nucleo-l552ze-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l552-ze/dac_dma</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:platform:dac:1</module>
+    <module>modm:platform:dma</module>
+    <module>modm:platform:timer:4</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_l552ze-q/freertos_blink/main.cpp
+++ b/examples/nucleo_l552ze-q/freertos_blink/main.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Mike Wolfram
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing/rtos.hpp>
+
+using namespace Board;
+
+class BlinkTask : modm::rtos::Thread
+{
+public:
+	BlinkTask()
+		: Thread(4, 2048, "blink")
+	{}
+
+	void
+	run()
+	{
+		Leds::setOutput();
+		while (true)
+		{
+			vTaskDelay(500 * (configTICK_RATE_HZ / 1000.0));
+			Leds::toggle();
+		}
+	}
+};
+
+BlinkTask blinkTask;
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "\n\nReboot: FreeRTOS blink example" << modm::endl;
+
+	modm::rtos::Scheduler::schedule();
+
+	// we should never get here
+	return 0;
+}

--- a/examples/nucleo_l552ze-q/freertos_blink/project.xml
+++ b/examples/nucleo_l552ze-q/freertos_blink/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-l552ze-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_l552ze-q/freertos_blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:freertos</module>
+    <module>modm:processing:rtos</module>
+  </modules>
+</library>

--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -27,7 +27,9 @@ def build(env):
     env.copy("cmsis/CMSIS/Core/Include/cmsis_version.h", "cmsis_version.h")
     env.copy("cmsis/CMSIS/Core/Include/cmsis_compiler.h", "cmsis_compiler.h")
     env.copy("cmsis/CMSIS/Core/Include/cmsis_gcc.h", "cmsis_gcc.h")
-    if core != "0": # 0+ has MPU support though!
+    if "33" in core:
+        env.copy("cmsis/CMSIS/Core/Include/mpu_armv8.h", "mpu_armv8.h")
+    elif core != "0": # 0+ has MPU support though!
         env.copy("cmsis/CMSIS/Core/Include/mpu_armv7.h", "mpu_armv7.h")
     if core == "7":
         env.copy("cmsis/CMSIS/Core/Include/cachel1_armv7.h", "cachel1_armv7.h")

--- a/ext/aws/FreeRTOSConfig.h.in
+++ b/ext/aws/FreeRTOSConfig.h.in
@@ -93,6 +93,16 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #ifndef configUSE_16_BIT_TICKS
 #	define configUSE_16_BIT_TICKS					0
 #endif
+// required for Cortex M23/M33 ports
+#ifndef configENABLE_FPU
+#	define configENABLE_FPU							{{ 1 if with_fpu else 0 }}
+#endif
+#ifndef configENABLE_MPU
+#	define configENABLE_MPU							0
+#endif
+#ifndef configENABLE_TRUSTZONE
+#	define configENABLE_TRUSTZONE					0
+#endif
 
 /* Defaulted by FreeRTOS but changed by modm */
 

--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -96,9 +96,12 @@ def build(env):
         "frequency": env.get("frequency", 1000),
         "with_debug": env.has_module(":debug"),
         "with_heap": env.has_module(":platform:heap"),
+        "with_fpu": env.get(":platform:cortex-m:float-abi", "soft") != "soft",
     }
     path = core.replace("cortex-m", "ARM_CM").replace("+", "").replace("fd", "f").upper()
     path = path.replace("CM7F", "CM7/r0p1") # use subfolder for M7
+    path = path.replace("CM33F", "CM33") # common port for FPU/non-FPU version
+    path = path.replace("CM33", "CM33_NTZ/non_secure") # no trustzone supported, use non_secure subfolder
     path = "freertos/FreeRTOS/Source/portable/GCC/{}".format(path)
 
     env.outbasepath = "modm/ext"
@@ -112,6 +115,10 @@ def build(env):
     env.copy("{}/port.c".format(path), "freertos/port.c")
     # Copy the portmacro.h file
     env.copy("{}/portmacro.h".format(path), "freertos/inc/freertos/portmacro.h")
+    # Copy the portasm.c/.h files for CM33
+    if "CM33" in path:
+        env.copy("{}/portasm.c".format(path), "freertos/portasm.c")
+        env.copy("{}/portasm.h".format(path), "freertos/inc/freertos/portasm.h")
 
     # Generate the FreeRTOSConfig.h file
     env.template("FreeRTOSConfig.h.in", "freertos/inc/freertos/FreeRTOSConfig.h")

--- a/ext/st/device.hpp.in
+++ b/ext/st/device.hpp.in
@@ -4,6 +4,7 @@
  * Copyright (c) 2009-2010, 2016, Fabian Greif
  * Copyright (c) 2012-2013, 2016, 2018 Niklas Hauser
  * Copyright (c) 2013, Kevin Laeufer
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -23,6 +24,13 @@
 #include <stdint.h>
 // Defines for example the modm_always_inline macro
 #include <modm/architecture/utils.hpp>
+
+%% if target.family == "l5"
+// Suppress verbose compiler warning '"__ARMCC_VERSION" is not defined' from device header
+// '#pragma GCC diagnostic ignored "-Wundef"' does not work here because of gcc bug:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
+#pragma GCC system_header
+%% endif
 
 // Include external device headers:
 %% for header in headers
@@ -59,7 +67,13 @@
 // the peripherals directly in GDB in any context.
 // Otherwise GDB would throw a "no symbol 'GPIO_TypeDef' in current context".
 %% for (name, type) in peripherals
+%% if type == "SAU_Type"
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+%% endif
 extern {{ type | lbuild.pad(19) }}	___{{ name | lbuild.pad(15) }};
+%% if type == "SAU_Type"
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+%% endif
 %% endfor
 /// @endcond
 

--- a/repo.lb
+++ b/repo.lb
@@ -84,7 +84,7 @@ class DevicesCache(dict):
         supported = ["stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
                      "stm32g0", "stm32g4",
                      "stm32h7",
-                     "stm32l0", "stm32l1", "stm32l4",
+                     "stm32l0", "stm32l1", "stm32l4", "stm32l5",
                      "at90", "attiny", "atmega",
                      "samd21", "samg55", "samv70",
                      "hosted"]

--- a/src/modm/architecture/detect.hpp
+++ b/src/modm/architecture/detect.hpp
@@ -215,6 +215,9 @@
 #	elif defined __ARM_ARCH_7EM__
 #		define MODM_CPU_CORTEX_M4	1
 #		define MODM_CPU_STRING		"ARM Cortex-M4"
+#	elif defined __ARM_ARCH_8M_MAIN__
+#		define MODM_CPU_CORTEX_M33	1
+#		define MODM_CPU_STRING		"ARM Cortex-M33"
 #	elif defined __ARM_ARCH_6__
 #		define MODM_CPU_CORTEX_A6	1
 #		define MODM_CPU_STRING		"ARM Cortex-A6"

--- a/src/modm/board/nucleo144_arduino_l4.hpp
+++ b/src/modm/board/nucleo144_arduino_l4.hpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
 // Nucleo144 Arduino Header Footprint for STM32L4xxZx
 // Schematic: https://www.st.com/resource/en/schematic_pack/mb1312-l4xxzx-a03_schematic.pdf
 

--- a/src/modm/board/nucleo144_arduino_l5.hpp
+++ b/src/modm/board/nucleo144_arduino_l5.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -9,28 +9,29 @@
  */
 // ----------------------------------------------------------------------------
 
-// Nucleo144 Arduino Header Footprint
+// Nucleo144 Arduino Header Footprint for STM32L5xxZx
+// Schematic: https://www.st.com/resource/en/schematic_pack/mb1361-l552zeq-c02_schematic.pdf
 
-#ifndef MODM_STM32_NUCLEO144_ARDUINO_HPP
-#define MODM_STM32_NUCLEO144_ARDUINO_HPP
+#ifndef MODM_STM32_NUCLEO144_ARDUINO_L5_HPP
+#define MODM_STM32_NUCLEO144_ARDUINO_L5_HPP
 
 // Arduino Footprint
 using A0 = GpioA3;
-using A1 = GpioC0;
+using A1 = GpioA2;
 using A2 = GpioC3;
-using A3 = GpioF3;
-using A4 = GpioF5;
-using A5 = GpioF10;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
 // Zio Footprint
 using A6 = GpioB1;
 using A7 = GpioC2;
-using A8 = GpioF4;
+using A8 = GpioA1;
 
 // Arduino Footprint
-using D0  = GpioG9;
-using D1  = GpioG14;
+using D0  = GpioD9;
+using D1  = GpioD8;
 using D2  = GpioF15;
-using D3  = GpioF13;
+using D3  = GpioE13;
 using D4  = GpioF14;
 using D5  = GpioE11;
 using D6  = GpioE9;
@@ -45,23 +46,23 @@ using D14 = GpioB9;
 using D15 = GpioB8;
 // Zio Footprint
 using D16 = GpioC6;
-using D17 = GpioB15;
+using D17 = GpioD11;
 using D18 = GpioB13;
-using D19 = GpioB12;
-using D20 = GpioA15;
-using D21 = GpioC7;
+using D19 = GpioD12;
+using D20 = GpioA4;
+using D21 = GpioB4;
 using D22 = GpioB5;
 using D23 = GpioB3;
 using D24 = GpioA4;
 using D25 = GpioB4;
-using D26 = GpioB6;
-using D27 = GpioB2;
-using D28 = GpioD13;
-using D29 = GpioD12;
-using D30 = GpioD11;
-using D31 = GpioE2;
+using D26 = GpioA2;
+using D27 = GpioB10;
+using D28 = GpioE15;
+using D29 = GpioB0;
+using D30 = GpioE12;
+using D31 = GpioE14;
 using D32 = GpioA0;
-using D33 = GpioB0;
+using D33 = GpioA8;
 using D34 = GpioE0;
 using D35 = GpioB11;
 using D36 = GpioB10;
@@ -77,8 +78,8 @@ using D45 = GpioC10;
 using D46 = GpioC11;
 using D47 = GpioC12;
 using D48 = GpioD2;
-using D49 = GpioG2;
-using D50 = GpioG3;
+using D49 = GpioF3;
+using D50 = GpioF5;
 using D51 = GpioD7;
 using D52 = GpioD6;
 using D53 = GpioD5;
@@ -99,7 +100,7 @@ using D67 = GpioD0;
 using D68 = GpioF0;
 using D69 = GpioF1;
 using D70 = GpioF2;
-using D71 = GpioA7;
-using D72 = GpioUnused;
+using D71 = GpioB6;
+using D72 = GpioB2;
 
-#endif // MODM_STM32_NUCLEO144_ARDUINO_HPP
+#endif // MODM_STM32_NUCLEO144_ARDUINO_L5_HPP

--- a/src/modm/board/nucleo32_arduino.hpp.in
+++ b/src/modm/board/nucleo32_arduino.hpp.in
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
 // Nucleo32 Arduino Header Footprint
 
 #ifndef MODM_STM32_NUCLEO32_ARDUINO_HPP

--- a/src/modm/board/nucleo64_arduino.hpp
+++ b/src/modm/board/nucleo64_arduino.hpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
 // Nucleo64 Arduino Header Footprint
 
 #ifndef MODM_STM32_NUCLEO64_ARDUINO_HPP

--- a/src/modm/board/nucleo_l496zg-p/board.hpp
+++ b/src/modm/board/nucleo_l496zg-p/board.hpp
@@ -102,14 +102,9 @@ struct SystemClock {
 		// update clock frequencies
 		Rcc::updateCoreFrequency<Frequency>();
 
-		// Enable Hsi48 clock
-		uint32_t waitCycles = 2048;
-		RCC->CRRCR |= RCC_CRRCR_HSI48ON;
-		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitCycles)
-			;
-
+		Rcc::enableInternalClockMHz48();
 		// Select Hsi48 as source for CLK48 MUX (USB, SDMMC, RNG)
-		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_CLK48SEL_Msk) | (0b00 << RCC_CCIPR_CLK48SEL_Pos);
+		Rcc::setClock48Source(Rcc::Clock48Source::Hsi48);
 
 		return true;
 	}

--- a/src/modm/board/nucleo_l552-ze-q/board.hpp
+++ b/src/modm/board/nucleo_l552-ze-q/board.hpp
@@ -1,0 +1,172 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2021, Raphael Lehmann
+ * Copyright (c) 2022, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_L552ZE_Q_HPP
+#define MODM_STM32_NUCLEO_L552ZE_Q_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+
+/// @ingroup modm_board_nucleo_l552ze_q
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_l552ze_q
+namespace Board
+{
+using namespace modm::literals;
+
+/// STM32L5 running at 110 MHz generated from the
+/// internal Multispeed oscillator
+
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 110_MHz;
+	static constexpr uint32_t Ahb  = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+	static constexpr uint32_t Apb1Timer = Apb1;
+	static constexpr uint32_t Apb2Timer = Apb2;
+
+	static constexpr uint32_t Can1 = Apb1;
+
+	static constexpr uint32_t Comp1 = Apb2;
+	static constexpr uint32_t Comp2 = Apb2;
+
+	static constexpr uint32_t Dac1 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Sai1 = Apb2;
+	static constexpr uint32_t Sai2 = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static constexpr uint32_t Usart1  = Apb2;
+	static constexpr uint32_t Usart2  = Apb1;
+	static constexpr uint32_t Usart3  = Apb1;
+	static constexpr uint32_t Uart4   = Apb1;
+	static constexpr uint32_t Uart5   = Apb1;
+
+	static constexpr uint32_t Lpuart1 = Frequency; // Clock mux default: 0b00 -> PCLK
+
+	static constexpr uint32_t Usb = 48_MHz;
+	static constexpr uint32_t Rng = 48_MHz;
+	static constexpr uint32_t Sdmmc = 48_MHz;
+
+	static bool inline
+	enable()
+	{
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Range0);
+		Rcc::enableMultiSpeedInternalClock(Rcc::MsiFrequency::MHz4);
+		const Rcc::PllFactors pllFactors{
+			.pllM = 1,		//   4MHz /  M=1  ->   4MHz
+			.pllN = 55,		//   4MHz *  N=55 -> 220MHz
+			.pllR = 2,		// 220MHz /  R=2  -> 110MHz = F_cpu
+			.pllQ = 2,		// 220MHz /  Q=2  -> 110MHz
+		};
+		Rcc::enablePll(Rcc::PllSource::Msi, pllFactors);
+		Rcc::setFlashLatency<Frequency>();
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		// update clock frequencies
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableInternalClockMHz48();
+		// Select Hsi48 as source for CLK48 MUX (USB, SDMMC, RNG)
+		Rcc::setClock48Source(Rcc::Clock48Source::Hsi48);
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo144_arduino_l5.hpp"
+
+using Button = GpioInputC13;
+
+using LedGreen = GpioOutputC7;	// LED1 [Green]
+using LedBlue = GpioOutputB7;	// LED2 [Blue]
+using LedRed = GpioOutputA9;	// LED3 [Red]
+using Leds = SoftwareGpioPort<LedRed, LedBlue, LedGreen>;
+
+namespace usb
+{
+	using Dm = GpioA11;
+	using Dp = GpioA12;
+
+	using UcpdFlt = GpioB14;
+	using UcpdDBn = GpioB5;
+	using UcpdCc1 = GpioA15;
+	using UcpdCc2 = GpioB15;
+
+	using Device = UsbFs;
+}
+
+namespace stlink
+{
+	using Rx = GpioOutputG8;
+	using Tx = GpioInputG7;
+	using Uart = Lpuart1;
+}
+
+using LoggerDevice = modm::IODeviceWrapper<stlink::Uart, modm::IOBuffer::BlockIfFull>;
+
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedRed::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+}
+
+inline void
+initializeUsbFs()
+{
+	usb::Device::initialize<SystemClock>();
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+
+} // Board namespace
+
+#endif	// MODM_STM32_NUCLEO_L552ZE_Q_HPP

--- a/src/modm/board/nucleo_l552-ze-q/board.xml
+++ b/src/modm/board/nucleo_l552-ze-q/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32l552zet6q</option>
+    <option name="modm:platform:uart:lpuart1:buffer.tx">2048</option>
+  </options>
+
+  <modules>
+    <module>modm:board:nucleo-l552ze-q</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_l552-ze-q/module.lb
+++ b/src/modm/board/nucleo_l552-ze-q/module.lb
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Raphael Lehmann
+# Copyright (c) 2022, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-l552ze-q"
+    module.description = """\
+# NUCLEO-L552ZE-Q
+
+[Nucleo kit for STM32L552ZE-Q](https://www.st.com/en/evaluation-tools/nucleo-l552ze-q.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32l552zet6q"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:lpuart1",
+        ":platform:usb")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo144_arduino_l5.hpp", "nucleo144_arduino_l5.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_l5.cfg")

--- a/src/modm/driver/gpio/gpio_sampler.lb
+++ b/src/modm/driver/gpio/gpio_sampler.lb
@@ -34,9 +34,12 @@ def prepare(module, options):
 
 def build(env):
     exti_vectors = [v["name"] for v in env[":target"].get_driver("core")["vector"] if "EXTI" in v["name"]]
-    # These are all exti possible vectors: 0, 0_1, 1, 15_10, 2, 2_3, 2_TSC, 3, 4, 4_15, 9_5
+    # These are all exti possible vectors: 0..15, 0_1, 15_10, 2_3, 2_TSC, 4_15, 9_5
     extimap = {
         "0": [0], "1": [1], "2": [2], "3": [3], "4": [4],
+        "5": [5], "6": [6], "7": [7], "8": [8], "9": [9],
+        "10": [10], "11": [11], "12": [12], "13": [13], "14": [14],
+        "15" : [15],
         "0_1": [0,1],
         "2_TSC": [2],
         "2_3": [2,3],

--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -62,12 +62,16 @@ public:
 %% elif target["family"] in ["l4", "g4"]
 		Temperature = 17,
 		BatDiv3     = 18,
+%% elif target["family"] in ["l5"]
+		InternalReference = 0,
+		Temperature = 17,
+		BatDiv3     = 18,
 %% endif
 %% elif id == 2
 %% if target["family"] in ["f3"]
 		Opamp2 = 17,
 		InternalReference = 18,
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4", "l5", "g4"]
 		Dac1 = 17,
 		Dac2 = 18,
 %% endif
@@ -107,16 +111,18 @@ public:
 		NoClock = 0, // No clock selected.
 %% if target["family"] in ["g4"]
 %% if id in [1, 2]
-		Pll = RCC_CCIPR_ADC12SEL_0, // PLL “P” clock selected as ADC clock
-		SystemClock = RCC_CCIPR_ADC12SEL_1 , // System clock selected as ADCs clock
+		Pll = RCC_{{ ccipr }}_ADC12SEL_0, // PLL “P” clock selected as ADC clock
+		SystemClock = RCC_{{ ccipr }}_ADC12SEL_1 , // System clock selected as ADCs clock
 %% elif id in [3, 4, 5]
-		Pll = RCC_CCIPR_ADC345SEL_0, // PLL “P” clock selected as ADC clock
-		SystemClock = RCC_CCIPR_ADC345SEL_1 , // System clock selected as ADCs clock
+		Pll = RCC_{{ ccipr }}_ADC345SEL_0, // PLL “P” clock selected as ADC clock
+		SystemClock = RCC_{{ ccipr }}_ADC345SEL_1 , // System clock selected as ADCs clock
 %% endif
 %% else
-		PllSai1 = RCC_CCIPR_ADCSEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
-		PllSai2 = RCC_CCIPR_ADCSEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
-		SystemClock = RCC_CCIPR_ADCSEL_1 | RCC_CCIPR_ADCSEL_0, // System clock selected as ADCs clock
+		PllSai1 = RCC_{{ ccipr }}_ADCSEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
+%% if target["family"] != "l5"
+		PllSai2 = RCC_{{ ccipr }}_ADCSEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
+%% endif
+		SystemClock = RCC_{{ ccipr }}_ADCSEL_1 | RCC_{{ ccipr }}_ADCSEL_0, // System clock selected as ADCs clock
 %% endif
 	};
 %% endif
@@ -139,7 +145,7 @@ public:
 		Div128 				= RCC_CFGR2_{{ adc_pre }}_DIV128,
 		Div256 				= RCC_CFGR2_{{ adc_pre }}_DIV256,
 		Div256AllBits 		= RCC_CFGR2_{{ adc_pre }},	// for bit clear
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4", "l5", "g4"]
 		Div1 				= 0,
 		Div2 				= ADC_CCR_PRESC_0,
 		Div4 				= ADC_CCR_PRESC_1,
@@ -156,7 +162,7 @@ public:
 %% endif
 	};
 
-%% if target["family"] in ["l4", "g4"]
+%% if target["family"] in ["l4", "l5", "g4"]
 	enum class SampleTime : uint8_t	// TODO: What is the best type?
 	{
 		Cycles2 	= 0b000,	//!   1.5 ADC clock cycles
@@ -190,7 +196,7 @@ public:
 
 	enum class VoltageRegulatorState : uint32_t
 	{
-%% if target["family"] in ["l4", "g4"]
+%% if target["family"] in ["l4", "l5", "g4"]
 		Enabled 		= ADC_CR_ADVREGEN,
 %% elif target["family"] in ["f3"]
 		// Intermediate state is needed to move from enabled to disabled

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -29,7 +29,7 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 	uint32_t tmp = 0;
 
 	// enable clock
-%% if target["family"] in ["f3", "g4"]
+%% if target["family"] in ["f3", "g4", "l5"]
 	RCC->{{ ahb }}ENR |= RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
 %% elif target["family"] in ["l4"]
 	Rcc::enable<Peripheral::Adc1>();
@@ -37,10 +37,10 @@ modm::platform::Adc{{ id }}::initialize(const ClockMode clk,
 
 %% if clock_mux
 	// select clock source
-	RCC->CCIPR |= static_cast<uint32_t>(clk_src);
+	RCC->{{ ccipr }} |= static_cast<uint32_t>(clk_src);
 %% endif
 
-%% if target["family"] in ["l4", "g4"]
+%% if target["family"] in ["l4", "l5", "g4"]
 	// Disable deep power down
 	ADC{{ id }}->CR &= ~ADC_CR_DEEPPWD;
 %% endif
@@ -90,7 +90,7 @@ modm::platform::Adc{{ id }}::disable(const bool blocking)
 		while(ADC{{ id }}->CR & ADC_CR_ADDIS);
 	}
 	// disable clock
-%% if target["family"] in ["f3", "g4"]
+%% if target["family"] in ["f3", "g4", "l5"]
 	RCC->{{ ahb }}ENR &= ~RCC_{{ ahb }}ENR_ADC{{ id_common }}EN;
 %% elif target["family"] in ["l4"]
 	Rcc::disable<Peripheral::Adc1>();
@@ -106,7 +106,7 @@ modm::platform::Adc{{ id }}::setPrescaler(const Prescaler pre)
 	tmp &= ~static_cast<uint32_t>(Prescaler::Div256AllBits);
 	tmp |=  static_cast<uint32_t>(pre);
 	RCC->CFGR2 = tmp;
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4", "l5", "g4"]
 	tmp  = ADC{{ id_common_u }}->CCR;
 	tmp &= ~static_cast<uint32_t>(Prescaler::Div256AllBits);
 	tmp |=  static_cast<uint32_t>(pre);

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -36,7 +36,7 @@ class Instance(Module):
             if target["family"] == "f3":
                 # 13-14 reserved
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,15,16,17,18]
-            elif target["family"] == "l4":
+            elif target["family"] in ["l4", "l5"]:
                 # ADC1 is connected to 16 external channels + 3 internal channels
                 channels = range(1,17)
             elif target["family"] == "g4":
@@ -51,6 +51,9 @@ class Instance(Module):
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,17,18]
             elif target["family"] == "g4":
                 # ADC2 is connected to 16 external channels + 2 internal channels
+                channels = range(1,17)
+            elif target["family"] == "l5":
+                # ADC1 is connected to 16 external channels + 2 internal channels
                 channels = range(1,17)
             else:
                 # ADC2 is connected to 16 external channels + 2 internal channels
@@ -99,6 +102,7 @@ class Instance(Module):
             properties["clock_mux"] = False
         elif target["family"] == "l4":
             properties["adc_ccr"] = "ADC_CCR"
+            properties["ccipr"] = "CCIPR"
             if len(driver["instance"]) == 1 and "q5a" not in target.string:
                 properties["id_common"] = "1"
                 properties["id_common_u"] = "1_COMMON"
@@ -109,9 +113,17 @@ class Instance(Module):
                 properties["id_common"] = "123"
                 properties["id_common_u"] = "123_COMMON"
             properties["clock_mux"] = (target["name"] not in ("12", "22"))
+        elif target["family"] == "l5":
+            properties["adc_ccr"] = "ADC_CCR"
+            properties["ccipr"] = "CCIPR1"
+            properties["ahb"] = "AHB2"
+            properties["id_common"] = ""
+            properties["id_common_u"] = "12_COMMON"
+            properties["clock_mux"] = True
         elif target["family"] == "g4":
             properties["ahb"] = "AHB2"
             properties["adc_ccr"] = "ADC_CCR"
+            properties["ccipr"] = "CCIPR"
             if instance_id in [1, 2]:
                 properties["id_common"] = "12"
                 properties["id_common_u"] = "12_COMMON"

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -65,7 +65,9 @@ def build(env):
     properties["pllprediv2"] = False    # FIXME: not sure what value this should have
     properties["pll_hse_prediv2"] = target["family"] == "f1" and target["name"] in ["01", "02", "03"]
     properties["hsi48"] = \
-        target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]
+        (target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]) or \
+        (target["family"] == "l4" and target["name"][0] not in ["7", "8"]) or \
+        (target["family"] == "l5")
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")
     properties["overdrive"] = (target["family"] == "f7") or \
         ((target["family"] == "f4") and target["name"] in ["27", "29", "37", "39", "46", "69", "79"])

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -48,6 +48,11 @@ def build(env):
         properties["lsi_frequency"] = 37
         properties["msi_frequency"] = 2.097
         properties["boot_frequency"] = properties["msi_frequency"]
+    elif target["family"] in ["l5"]:
+        properties["hsi_frequency"] = 16
+        properties["lsi_frequency"] = 32
+        properties["msi_frequency"] = 4
+        properties["boot_frequency"] = properties["msi_frequency"]
     else:
         properties["hsi_frequency"] = 16
         properties["lsi_frequency"] = 32
@@ -84,6 +89,7 @@ def build(env):
     properties["pll_ids"] = ["1", "2", "3"] if target.family == "h7" else [""]
     properties["has_smps"] = target["family"] == "h7" and (target["name"] in ["25", "35", "45", "47", "55", "57"] or \
         (target["name"] in ["30", "a3", "b0", "b3"] and target["variant"] == "q"))
+    properties["ccipr1"] = "CCIPR1" if target.family == "l5" else "CCIPR"
 
     flash_latencies = {}
     for vcore in device.get_driver("flash")["latency"]:
@@ -153,7 +159,8 @@ def build(env):
             per = "USB"+per
         if "Usbotgfs" in all_peripherals and per.startswith("USB"):
             per = per.replace("USB1", "USB").replace("USB2", "USB")
-            # print(per, mode)
+        if target.family == "l5" and per == "USBFS":
+            per = "Usb"
         if per.capitalize() not in all_peripherals:
             continue
         if "EN" in mode:

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -40,6 +40,17 @@ Rcc::enableInternalClockMHz14(uint32_t waitCycles)
 %% endif
 
 %% if hsi48
+%% if target.family in ["l4", "l5"]
+bool
+Rcc::enableInternalClockMHz48(uint32_t waitCycles)
+{
+	bool retval;
+	RCC->CRRCR |= RCC_CRRCR_HSI48ON;
+	while (not ((retval = RCC->CRRCR & RCC_CRRCR_HSI48RDY)) and --waitCycles)
+		;
+	return retval;
+}
+%% else
 bool
 Rcc::enableInternalClockMHz48(uint32_t waitCycles)
 {
@@ -49,6 +60,7 @@ Rcc::enableInternalClockMHz48(uint32_t waitCycles)
 		;
 	return retval;
 }
+%% endif
 %% endif
 
 bool

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -61,7 +61,7 @@ Rcc::enableInternalClock(uint32_t waitCycles)
 	return retval;
 }
 
-%% if target.family in ["l0", "l1", "l4"]
+%% if target.family in ["l0", "l1", "l4", "l5"]
 bool
 Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, uint32_t waitCycles)
 {
@@ -194,7 +194,7 @@ Rcc::enablePll{{id}}(PllSource source, const PllFactors& pllFactors, uint32_t wa
 		;
 
 	return tmp;
-%% elif target.family in ["g0", "l4", "g4"]
+%% elif target.family in ["g0", "l4", "l5", "g4"]
 	// Read reserved values and clear all other values
 	uint32_t tmp = RCC->PLLCFGR & ~(
 			RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN |
@@ -380,6 +380,23 @@ Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
 
 	return true;
 }
+%% elif target.family == "l5"
+bool
+Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
+{
+	// TODO: check if low power mode is active and reject changing range if active
+	// Implemented according to STHAL HAL_PWREx_ControlVoltageScaling()
+	// TODO: The reference manual describes a more complicated procedure
+	// but the CubeHal also does not implement that ...
+	const auto currentSetting = PWR->CR1 & PWR_CR1_VOS;
+	if (voltage == static_cast<VoltageScaling>(currentSetting)) {
+		return true;
+	}
+	PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | uint32_t(voltage);
+	while (PWR->SR2 & PWR_SR2_VOSF)
+		if (--waitCycles == 0) return false;
+	return true;
+}
 %% endif
 
 %% if target.family == "h7"
@@ -469,7 +486,7 @@ Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
 }
 
 
-%% if target.family == "g4"
+%% if target.family in ["g4", "l5"]
 bool
 Rcc::setCanPrescaler(CanPrescaler prescaler)
 {

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -83,8 +83,18 @@ public:
 		InternalClock = Hsi16,
 		/// High speed external clock
 		Hse = RCC_CFGR_PLLSRC,
+%% elif target.family == "l5"
+		/// High speed internal clock (16 MHz)
+		Hsi = RCC_PLLCFGR_PLLSRC_1,
+		Hsi16 = Hsi,
+		InternalClock = Hsi16,
+		/// High speed external clock
+		Hse = RCC_PLLCFGR_PLLSRC_1 | RCC_PLLCFGR_PLLSRC_0,
+		/// Multi speed internal clock
+		Msi = RCC_PLLCFGR_PLLSRC_0,
+		MultiSpeedInternalClock = Msi,
 %% endif
-%% if hsi48
+%% if hsi48 and target.family not in ["l4", "l5"]
 		/// High speed internal clock (48 MHz)
 		Hsi48 = RCC_CFGR_PLLSRC_HSI48_PREDIV,
 		InternalClockMHz48 = Hsi48,
@@ -116,12 +126,19 @@ public:
 	enum class
 	SystemClockSource : uint32_t
 	{
+%% if target.family == "l5"
+		Msi = 0,
+		Hsi = RCC_CFGR_SW_0,
+		Hsi16 = Hsi,
+		Hse = RCC_CFGR_SW_1,
+		Pll = RCC_CFGR_SW_1 | RCC_CFGR_SW_0,
+%% else
 		Hsi = RCC_CFGR_SW_HSI,
 %% if target.family == "l0"
 		Hsi16 = Hsi,
 %% endif
 		Hse = RCC_CFGR_SW_HSE,
-%% if hsi48
+%% if hsi48 and target.family != "l4"
 		Hsi48 = RCC_CFGR_SW_HSI48,
 		InternalClockMHz48 = Hsi48,
 %% endif
@@ -137,6 +154,7 @@ public:
 		Pll1P = RCC_CFGR_SW_PLL1,
 %% else
 		Pll = RCC_CFGR_SW_PLL,
+%% endif
 %% endif
 	};
 
@@ -163,6 +181,17 @@ public:
 	enum class
 	AhbPrescaler : uint32_t
 	{
+%% if target.family == "l5"
+		Div1   = 0b0000 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div2   = 0b1000 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div4   = 0b1001 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div8   = 0b1010 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div16  = 0b1011 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div64  = 0b1100 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div128 = 0b1101 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div256 = 0b1110 << RCC_{{cfgr1}}_HPRE_Pos,
+		Div512 = 0b1111 << RCC_{{cfgr1}}_HPRE_Pos
+%% else
 		Div1   = RCC_{{cfgr1}}_HPRE_DIV1,
 		Div2   = RCC_{{cfgr1}}_HPRE_DIV2,
 		Div4   = RCC_{{cfgr1}}_HPRE_DIV4,
@@ -172,6 +201,7 @@ public:
 		Div128 = RCC_{{cfgr1}}_HPRE_DIV128,
 		Div256 = RCC_{{cfgr1}}_HPRE_DIV256,
 		Div512 = RCC_{{cfgr1}}_HPRE_DIV512
+%% endif
 	};
 
 %% if target.family in ["f0", "g0"]
@@ -188,21 +218,37 @@ public:
 	enum class
 	Apb1Prescaler : uint32_t
 	{
+%% if target.family == "l5"
+		Div1   = 0b000 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
+		Div2   = 0b101 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
+		Div4   = 0b110 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
+		Div8   = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
+		Div16  = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos
+%% else
 		Div1   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV1,
 		Div2   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV2,
 		Div4   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV4,
 		Div8   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV8,
 		Div16  = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV16
+%% endif
 	};
 
 	enum class
 	Apb2Prescaler : uint32_t
 	{
+%% if target.family == "l5"
+		Div1   = 0b000 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
+		Div2   = 0b101 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
+		Div4   = 0b110 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
+		Div8   = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
+		Div16  = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos
+%% else
 		Div1   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV1,
 		Div2   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV2,
 		Div4   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV4,
 		Div8   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV8,
 		Div16  = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV16
+%% endif
 	};
 %% endif
 
@@ -278,13 +324,13 @@ public:
 		Pll = RCC_CFGR_MCO2_1 | RCC_CFGR_MCO2_0,
 	};
 	%% endif
-%% elif target.family in ["l0", "l1", "l4", "g0", "g4"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
 	enum class
 	ClockOutputSource : uint32_t
 	{
 		Disable = 0,
 		SystemClock = (1 << RCC_CFGR_MCOSEL_Pos), // SYSCLK
-	%% if target.family in ["l4"]
+	%% if target.family in ["l4", "l5"]
 		MultiSpeedInternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // MSI
 	%% endif
 	%% if target.family in ["l0", "l1"]
@@ -298,6 +344,9 @@ public:
 		Pll = (5 << RCC_CFGR_MCOSEL_Pos), // Main PLL
 		LowSpeedInternalClock = (6 << RCC_CFGR_MCOSEL_Pos), // LSI
 		LowSpeedExternalClock = (7 << RCC_CFGR_MCOSEL_Pos), // LSE
+	%% if target.family == "l5"
+		Hsi48 = (8 << RCC_CFGR_MCOSEL_Pos), // HSI48
+	%% endif
 	};
 %% else
 	enum class
@@ -321,19 +370,23 @@ public:
 	};
 %% endif
 
-%% if target.family == "g4"
+%% if target.family in ["g4", "l5"]
 	enum class
 	CanClockSource : uint32_t
 	{
 		Hse = 0,
-		PllQ = RCC_CCIPR_FDCANSEL_0,
-		Pclk = RCC_CCIPR_FDCANSEL_1,
+		PllQ = RCC_{{ccipr1}}_FDCANSEL_0,
+%% if target.family == "g4"
+		Pclk = RCC_{{ccipr1}}_FDCANSEL_1,
+%% elif target.family == "l5"
+		PllSai1P = RCC_{{ccipr1}}_FDCANSEL_1,
+%% endif
 	};
 
 	static void
 	setCanClockSource(CanClockSource source)
 	{
-		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_FDCANSEL) | uint32_t(source);
+		RCC->{{ccipr1}} = (RCC->{{ccipr1}} & ~RCC_{{ccipr1}}_FDCANSEL) | uint32_t(source);
 	}
 
 	/// FDCAN subsystem prescaler common to all FDCAN instances
@@ -380,7 +433,7 @@ public:
 	enableInternalClockMHz48(uint32_t waitCycles = 2048);
 %% endif
 
-%% if target.family in ["l0", "l1", "l4"]
+%% if target.family in ["l0", "l1", "l4", "l5"]
 	enum class
 	MsiFrequency : uint32_t
 	{
@@ -405,6 +458,19 @@ public:
 		MHz24  = RCC_CR_MSIRANGE_9,
 		MHz32  = RCC_CR_MSIRANGE_10,
 		MHz48  = RCC_CR_MSIRANGE_11,
+%% elif target.family in ["l5"]
+		kHz100 = 0b0000 << RCC_CR_MSIRANGE_Pos,
+		kHz200 = 0b0001 << RCC_CR_MSIRANGE_Pos,
+		kHz400 = 0b0010 << RCC_CR_MSIRANGE_Pos,
+		kHz800 = 0b0011 << RCC_CR_MSIRANGE_Pos,
+		MHz1   = 0b0100 << RCC_CR_MSIRANGE_Pos,
+		MHz2   = 0b0101 << RCC_CR_MSIRANGE_Pos,
+		MHz4   = 0b0110 << RCC_CR_MSIRANGE_Pos,
+		MHz8   = 0b0111 << RCC_CR_MSIRANGE_Pos,
+		MHz16  = 0b1000 << RCC_CR_MSIRANGE_Pos,
+		MHz24  = 0b1001 << RCC_CR_MSIRANGE_Pos,
+		MHz32  = 0b1010 << RCC_CR_MSIRANGE_Pos,
+		MHz48  = 0b1011 << RCC_CR_MSIRANGE_Pos,
 %% endif
 	};
 
@@ -437,10 +503,10 @@ public:
 		uint8_t pllQ;
 		uint8_t pllR;
 		uint16_t pllFrac = 0;
-%% elif target.family in ["f2", "f4", "f7", "l4", "g0", "g4"]
+%% elif target.family in ["f2", "f4", "f7", "l4", "l5", "g0", "g4"]
 		uint8_t pllM;
 		uint16_t pllN;
-	%% if target.family in ["l4", "g0", "g4"]
+	%% if target.family in ["l4", "l5", "g0", "g4"]
 		uint8_t pllR;
 	%% else
 		uint8_t pllP;
@@ -672,7 +738,7 @@ public:
 	}
 	%% endif
 
-%% elif target.family in ["l0", "l1", "l4", "g0", "g4"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
 	enum class
 	ClockOutputPrescaler : uint32_t
 	{
@@ -809,9 +875,17 @@ public:
 		Scale1 = PWR_CR1_VOS_0,
 		Scale2 = PWR_CR1_VOS_1
 	};
+%% elif target.family == "l5"
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Range0 = 0,
+		Range1 = PWR_CR1_VOS_0,
+		Range2 = PWR_CR1_VOS_1
+	};
 %% endif
 
-%% if target.family == "h7" or has_r1mode
+%% if target.family in ["h7", "l5"] or has_r1mode
 	static bool
 	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 2048);
 %% endif

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -302,6 +302,19 @@ public:
 		PllSaiP = RCC_DCKCFGR2_CK48MSEL
 	%% endif
 	};
+%% elif target.family in ["g4", "l4", "l5", "u5"]
+	enum class Clock48Source
+	{
+%% set sel48="MSEL" if target.family in ["l5", "u5"] else "SEL"
+%% if target.family == "l4" and target.name[0] in ["7", "8"]
+		None = 0,
+%% else
+		Hsi48 = 0,
+%% endif
+		PllSai1Q = RCC_{{ccipr1}}_CLK48{{sel48}}_0,
+		PllQ = RCC_{{ccipr1}}_CLK48{{sel48}}_1,
+		Msi = RCC_{{ccipr1}}_CLK48{{sel48}}_1 | RCC_{{ccipr1}}_CLK48{{sel48}}_0
+	};
 %% endif
 
 %% if target.family in ["f2", "f4", "f7", "h7"]
@@ -700,7 +713,14 @@ public:
 		RCC->DCKCFGR2 = (RCC->DCKCFGR2 & ~RCC_DCKCFGR2_CK48MSEL) | uint32_t(source);
 	%% endif
 	}
+%% elif target.family in ["g4", "l4", "l5", "u5"]
+	static inline void
+	setClock48Source(Clock48Source source)
+	{
+		RCC->{{ccipr1}} = (RCC->{{ccipr1}} & ~RCC_{{ccipr1}}_CLK48{{sel48}}_Msk) | uint32_t(source);
+	}
 %% endif
+
 %% if target.family == "h7"
 	enum class
 	UsbClockSource : uint32_t

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -77,7 +77,7 @@ Rcc::setFlashLatency()
 %% elif target["family"] == "l0"
 	// enable flash prefetch and pre-read
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_PRE_READ;
-%% elif target["family"] != "h7"
+%% elif target["family"] not in ["h7", "l5"]
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTBE;
 %% endif

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -360,6 +360,7 @@ def build(env):
     if "f" in fpu:
         fpu_spec = {
             "4f": "-mfpu=fpv4-sp-d16",
+            "33f": "-mfpu=fpv4-sp-d16",
             "7f": "-mfpu=fpv5-sp-d16",
             "7fd": "-mfpu=fpv5-d16",
         }[fpu]

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -53,6 +53,7 @@ def build(env):
         "f7": (4,  4), # CM7  tested on F767 in ITCM
         "h7": (4,  4), # CM7  tested on H743 in ITCM
         "l4": (3,  4), # CM4  tested on L476 in SRAM2
+        "l5": (3,  4), # CM33 tested on L552 in RAM
         "f3": (3,  4), # CM4  tested on F334, F303 in CCM RAM
 
         # Defaults of (4, 4) for these families:

--- a/src/modm/platform/dma/stm32/dma_hal.hpp.in
+++ b/src/modm/platform/dma/stm32/dma_hal.hpp.in
@@ -226,7 +226,11 @@ public:
 	{
 		DMA_Channel_TypeDef *Base = (DMA_Channel_TypeDef *) CHANNEL_BASE;
 %% if dmaType in ["stm32-channel-request", "stm32-channel", "stm32-mux"]
+%% if target["family"] == "l5"
+		Base->CM0AR = address;
+%% else
 		Base->CMAR = address;
+%% endif
 %% elif dmaType in ["stm32-stream-channel", "stm32-mux-stream"]
 		Base->M0AR = address;
 %% endif

--- a/src/modm/platform/extint/stm32/module.lb
+++ b/src/modm/platform/extint/stm32/module.lb
@@ -25,9 +25,12 @@ def prepare(module, options):
 
 extimap = {}
 def validate(env):
-    # These are all exti possible vectors: 0, 0_1, 1, 15_10, 2, 2_3, 2_TSC, 3, 4, 4_15, 9_5
+    # These are all exti possible vectors: 0..15, 0_1, 15_10, 2_3, 2_TSC, 4_15, 9_5
     all_exti = {
         "0": [0], "1": [1], "2": [2], "3": [3], "4": [4],
+        "5": [5], "6": [6], "7": [7], "8": [8], "9": [9],
+        "10": [10], "11": [11], "12": [12], "13": [13], "14": [14],
+        "15" : [15],
         "0_1": [0,1],
         "2_TSC": [2],
         "2_3": [2,3],
@@ -44,12 +47,12 @@ def validate(env):
 def build(env):
     target = env[":target"].identifier
 
-    separate_flags = target.family in ["g0"]
-    extended = target.family in ["l4", "g4", "h7"]
+    separate_flags = target.family in ["g0", "l5"]
+    extended = target.family in ["l4", "l5", "g4", "h7"]
     if separate_flags: extended = target.name in ["b1", "c1"]
 
     exti_reg = "SYSCFG"
-    if target.family in ["g0"]: exti_reg = "EXTI"
+    if target.family in ["g0", "l5"]: exti_reg = "EXTI"
     if target.family in ["f1"]: exti_reg = "AFIO"
 
     global extimap

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -26,7 +26,7 @@ modm_gpio_enable(void)
 %% elif target.family in ["f1"]
 %%	set clock_tree = "APB2"
 %%	set prefix = "IOP"
-%% elif target.family in ["l4", "g4"]
+%% elif target.family in ["l4", "l5", "g4"]
 %%  set clock_tree = 'AHB2'
 %% elif target.family in ["g0", "l0"]
 %%  set clock_tree = 'IOP'

--- a/src/modm/platform/uart/cortex/itm.cpp.in
+++ b/src/modm/platform/uart/cortex/itm.cpp.in
@@ -61,7 +61,11 @@ Itm::enable(uint8_t prescaler)
 	ITM->TPR  = 0;
 
 	// Trace Control Register
+%% if target.platform == "stm32" and target.family == "l5"
+	ITM->TCR  = (1 << ITM_TCR_TRACEBUSID_Pos) |
+%% else
 	ITM->TCR  = (1 << ITM_TCR_TraceBusID_Pos) |
+%% endif
 				(1 << ITM_TCR_DWTENA_Pos)     |
 				(1 << ITM_TCR_ITMENA_Pos);
 

--- a/src/modm/platform/uart/stm32/uart_base.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_base.hpp.in
@@ -29,7 +29,7 @@
 #define	USART_BRR_DIV_FRACTION	USART_BRR_DIV_Fraction
 #endif
 %% endif
-%% if tcbgt and target.family != "g4"
+%% if tcbgt and target.family not in ["g4", "l5"]
 #define USART_CR1_TXEIE   USART_CR1_TXEIE_TXFNFIE
 #define USART_CR1_RXNEIE  USART_CR1_RXNEIE_RXFNEIE
 #define USART_ISR_RXNE    USART_ISR_RXNE_RXFNE

--- a/test/Makefile
+++ b/test/Makefile
@@ -69,6 +69,12 @@ run-nucleo-l432:
 	$(call run-test,nucleo-l432,size)
 
 
+compile-nucleo-l552:
+	$(call compile-test,nucleo-l552,size)
+run-nucleo-l552:
+	$(call run-test,nucleo-l552,size)
+
+
 compile-nucleo-g474:
 	$(call compile-test,nucleo-g474,size)
 run-nucleo-g474:

--- a/test/config/nucleo-l552.xml
+++ b/test/config/nucleo-l552.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-l552ze-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/nucleo-l552/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/nucleo-l552/modm-test</option>
+    <option name="modm:platform:exti:with_handlers">false</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>


### PR DESCRIPTION
Add STM32 L5 devices

- [x] Update device files
- [x] Add STM32L5 / Cortex-M33 support
- [x] Port RCC driver
- [x] Nucleo-L552ZE-Q BSP 
- [x] DMA
- [x] ADC
- [x] ~~Port fibers to Cortex-M33~~, just works
- [x] Fix freertos
- [x] Add CI jobs
- [x] Add and test Nucleo-L552ZE-Q examples
   - [x] blink
   - [x] freertos
   - [x] DMA
   - [x] ADC