### PR TITLE
[scons] Emit explicit error when chosen gcc isn't found on PATH

### DIFF
--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -37,7 +37,15 @@ env.Append(toolpath=[
 %% for tool in tools | sort
 env.Tool("{{tool}}")
 %% endfor
-env["GCC_PATH"] = dirname(dirname(realpath(shutil.which(env["CC"]))))
+
+c_compiler_name = env["CC"]
+c_compiler_path = shutil.which(c_compiler_name)
+
+if c_compiler_path is None:
+    print(f'Selected compiler "{c_compiler_name}" not found on PATH. Please add its installation directory to the PATH environment variable.')
+    exit(1)
+
+env["GCC_PATH"] = dirname(dirname(realpath(c_compiler_path)))
 
 %% macro generate_flags_for_profile(name, profile, append=False)
 env{% if append %}.Append({{name | upper}}{% else %}["{{name | upper}}"]{% endif %} = [


### PR DESCRIPTION
Previously, if the compiler was not on PATH, shutil.which would return
None and the error from "realpath" would be:

    TypeError: expected str, bytes or os.PathLike object, not NoneType


Someone else should probably test this. I made these edits via copy-paste from elsewhere and haven't run this particular commit (but _have_ confirmed it worked in a separate working copy).