### PR TITLE
[hal] Support 16bit transfers for I2c

### DIFF
--- a/src/modm/architecture/interface/i2c_device.hpp
+++ b/src/modm/architecture/interface/i2c_device.hpp
@@ -40,7 +40,7 @@ namespace modm
  * @author	Niklas Hauser
  * @ingroup modm_architecture_i2c_device
  */
-template < class I2cMaster, uint8_t NestingLevels = 10, class Transaction = I2cWriteReadTransaction >
+template < class I2cMaster, uint8_t NestingLevels = 10, class Transaction = I2cWriteReadTransaction<uint8_t> >
 class I2cDevice : protected modm::NestedResumable< NestingLevels + 1 >
 {
 public:

--- a/src/modm/architecture/interface/i2c_transaction.hpp
+++ b/src/modm/architecture/interface/i2c_transaction.hpp
@@ -238,6 +238,7 @@ protected:
  * @author	Niklas Hauser
  * @ingroup	modm_architecture_i2c
  */
+template <std::unsigned_integral T = uint8_t>
 class I2cWriteReadTransaction : public I2cTransaction
 {
 public:
@@ -406,6 +407,7 @@ protected:
  * @author	Niklas Hauser
  * @ingroup	modm_architecture_i2c
  */
+template <std::unsigned_integral T = uint8_t>
 class I2cWriteTransaction : public I2cTransaction
 {
 public:
@@ -481,6 +483,7 @@ protected:
  * @author	Niklas Hauser
  * @ingroup	modm_architecture_i2c
  */
+template <std::unsigned_integral T = uint8_t>
 class I2cReadTransaction : public I2cTransaction
 {
 public:


### PR DESCRIPTION
I like the idea of moving 16bit treatment from drivers to Hal. Dozens of I2c-drivers contain endian sanities (more or less any call of 'modm::BigEndian()' in src/modm/driver/** ) before or after talking to I2c.

point_right In addition to cleaner code we gain slightly shrinked compilate and slightly improved performance because data >> 8 in Hal is cheaper than modm::fromBigendian(data) in Drivers.

Same currently happens with Spi #690
I2c is a little more tricky so i postpone this and concentrate on merging #665 first.