### PR TITLE
Changed tilde by $HOME variable due to lack of expansion

### DIFF
--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -51,7 +51,7 @@ pip3 install gdbgui
     Add the following line to the end of your `~/.bashrc` file:
 
     ```sh
-    export PATH="~/.local/bin:$PATH"
+    export PATH="$HOME/.local/bin:$PATH"
     ```
 
 !!! warning "Ubuntu ≤ 19.10"


### PR DESCRIPTION
I am using an up to date Arch Linux distribution with a fish shell. I added the export line to the `.bashrc` before the `exec fish` line. The string is added to the `$PATH` correctly but the packages installed with pip are not found. I feel that a more resilient solution is using the `$HOME` variable so it is expanded before being added to the `$PATH`. 
With this modification I am able to call the pip packages from the console without using the full path.