### PR TITLE
Issues when using TinyUSB and FreeRTOS together

### DIFF
--- a/examples/nucleo_f429zi/usb_freertos/main.cpp
+++ b/examples/nucleo_f429zi/usb_freertos/main.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <tusb.h>
+
+#include <modm/board.hpp>
+#include <modm/processing/rtos.hpp>
+#include <modm/processing/timer/periodic_timer.hpp>
+
+using namespace Board;
+
+class SomeTask : modm::rtos::Thread
+{
+public:
+	SomeTask() : Thread(2, 2048, "some_task") {}
+
+	void
+	run()
+	{
+		modm::PeriodicTimer tmr{2.5s};
+		uint8_t counter{0};
+
+		while (1)
+		{
+			if (tmr.execute())
+			{
+				MODM_LOG_INFO << "SomeTask: Hello via Uart, counter=" << (counter++) << modm::endl;
+			}
+
+			vTaskDelay(1);
+		}
+
+		vTaskDelete(0);
+	}
+};
+
+class UsbTask : modm::rtos::Thread
+{
+public:
+	UsbTask() : Thread(1, 2048, "usb_task"), usb_io_device0{}, usb_stream0{usb_io_device0} {}
+
+	void
+	run()
+	{
+		MODM_LOG_INFO << "USBTask: Calling Board::initializeUsbFs() ..." << modm::endl;
+		Board::initializeUsbFs(4);
+		MODM_LOG_INFO << "USBTask: Calling tusb_init() ..." << modm::endl;
+		tusb_init();
+		MODM_LOG_INFO << "... done!" << modm::endl;
+
+		modm::PeriodicTimer tmr{2.5s};
+		uint8_t counter{0};
+
+		while (1)
+		{
+			tud_task();
+			if (tmr.execute())
+			{
+				MODM_LOG_INFO << "UsbTask: Hello via Uart, counter=" << counter << modm::endl;
+				usb_stream0 << "UsbTask: Hello via USB CDC, counter=" << counter << modm::endl;
+				counter++;
+			}
+
+			vTaskDelay(1);
+		}
+
+		vTaskDelete(0);
+	}
+
+private:
+	modm::IODeviceWrapper<UsbUart0, modm::IOBuffer::DiscardIfFull> usb_io_device0;
+	modm::IOStream usb_stream0;
+};
+
+SomeTask someTask;
+UsbTask usbTask;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+	MODM_LOG_INFO << "Nucleo-F429ZI: TinyUSB & FreeRTOS example" << modm::endl;
+
+	MODM_LOG_INFO << "WARNING!" << modm::endl;
+	MODM_LOG_INFO << "TinyUSB in modm does not currently use the FreeRTOS abstraction layer";
+	MODM_LOG_INFO << " and is not thread-safe with FreeRTOS threads." << modm::endl;
+
+	modm::rtos::Scheduler::schedule();
+
+	// we should never get here
+	return 0;
+}

--- a/examples/nucleo_f429zi/usb_freertos/project.xml
+++ b/examples/nucleo_f429zi/usb_freertos/project.xml
@@ -1,0 +1,17 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f429zi/usb_freertos</option>
+    <option name="modm:tinyusb:config">device.cdc</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:freertos</module>
+    <module>modm:processing:rtos</module>
+    <module>modm:processing:timer</module>
+    <module>modm:tinyusb</module>
+  </modules>
+  <collectors>
+    <collect name="modm:build:cppdefines">CFG_TUSB_DEBUG=2</collect>
+  </collectors>
+</library>

--- a/ext/aws/FreeRTOSConfig.h.in
+++ b/ext/aws/FreeRTOSConfig.h.in
@@ -48,7 +48,7 @@ your application. */
 #define configCPU_CLOCK_HZ                      ( SystemCoreClock )
 #define configTICK_RATE_HZ                      ( {{ frequency }} )
 /* Memory allocation related definitions. */
-#define configSUPPORT_STATIC_ALLOCATION         {{ 0 if with_heap else 1 }}
+#define configSUPPORT_STATIC_ALLOCATION         1
 #define configSUPPORT_DYNAMIC_ALLOCATION        {{ 1 if with_heap else 0 }}
 // used by modm:platform:clock for modm::Clock::increment(): vApplicationTickHook()
 #define configUSE_TICK_HOOK                     1

--- a/ext/aws/freertos.md
+++ b/ext/aws/freertos.md
@@ -26,7 +26,7 @@ these settings:
 - `configCPU_CLOCK_HZ` implemented with CMSIS `SystemCoreClock`.
 - `configTICK_RATE_HZ` set to `modm:freertos:frequency` or 1kHz on Cortex-M0.
 - `configSUPPORT_DYNAMIC_ALLOCATION = 1` only if used with `modm:platform:heap`.
-- `configSUPPORT_STATIC_ALLOCATION = 1` only if used without `modm:platform:heap`.
+- `configSUPPORT_STATIC_ALLOCATION = 1` always.
 - `configUSE_TICK_HOOK = 1` used by `modm:platform:clock` to provide `modm::Clock`.
 
 In addition we define these overwritable default settings:

--- a/ext/aws/modm_port.cpp.in
+++ b/ext/aws/modm_port.cpp.in
@@ -65,7 +65,8 @@ void vPortFree(void *pv)
 		traceFREE(pv, 0);
 	}
 }
-%% else
+%% endif
+
 #if configUSE_TIMERS == 1
 static StaticTask_t timers_task_storage;
 static StackType_t timers_task_stack_storage[configTIMER_TASK_STACK_DEPTH];
@@ -91,7 +92,6 @@ void vApplicationGetIdleTaskMemory(StaticTask_t** ppxIdleTaskTCBBuffer,
 	*ppxIdleTaskStackBuffer = idle_task_stack_storage;
 	*pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
-%% endif
 
 %% if with_debug
 #include <modm/debug.hpp>

--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -20,11 +20,12 @@ def init(module):
     module.description = FileReader("module.md")
 
 def prepare(module, options):
-    if not (options[":target"].has_driver("usb") or
-            options[":target"].has_driver("usb_otg_fs") or
-            options[":target"].has_driver("usb_otg_hs") or
-            options[":target"].has_driver("udp") or
-            options[":target"].has_driver("uhp")):
+    device = options[":target"]
+    if not (device.has_driver("usb") or
+            device.has_driver("usb_otg_fs") or
+            device.has_driver("usb_otg_hs") or
+            device.has_driver("udp") or
+            device.has_driver("uhp")):
         return False
 
     configs = {"device.cdc", "device.msc", "device.vendor", "device.midi", "device.dfu"}
@@ -42,12 +43,15 @@ def prepare(module, options):
                               dependencies=lambda vs:
                                     [":tinyusb:{}".format(v.replace(".", ":")) for v in vs]))
 
-    if options[":target"].has_driver("usb_otg_hs"):
+    # Most devices only have FS=usb, some STM32 have FS/HS=usb_otg_fs/usb_otg_hs
+    # and some STM32 only have HS=usb_otg_hs, so we only define this option if
+    # there is a choice and default this to FS by default.
+    if device.has_driver("usb_otg_hs") and device.has_driver("usb_otg_fs"):
         module.add_option(
                 EnumerationOption(name="speed",
                                   description="USB Port Speed",
                                   enumeration={"full": "fs", "high": "hs"},
-                                  default="high" if options[":target"].has_driver("usb_otg_hs") else "full",
+                                  default="full",
                                   dependencies=lambda s: ":platform:usb:{}s".format(s[0])))
 
     module.add_submodule(TinyUsbDeviceModule())
@@ -121,7 +125,9 @@ def build(env):
 
     has_device = env.has_module(":tinyusb:device")
     has_host = env.has_module(":tinyusb:host")
-    speed = env.get("speed", "fs")
+    # On STM32 with both speeds, the option decides, otherwise we must default
+    # to HS for the few STM32 with *only* usb_otg_hs, all other devices are FS.
+    speed = env.get("speed", "hs" if env[":target"].has_driver("usb_otg_hs") else "fs")
     port = 0 if speed == "fs" else 1
 
     mode = None

--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -113,11 +113,16 @@ def build(env):
             tusb_config["CFG_TUSB_MCU"] = "OPT_MCU_RP2040"
             env.copy("tinyusb/src/portable/raspberrypi/rp2040/", "portable/raspberrypi/rp2040/")
 
+    # TinyUSB has a OS abstraction layer for FreeRTOS, but it is causes problems with modm
+    # if env.has_module(":freertos"):
+    #    tusb_config["CFG_TUSB_OS"] = "OPT_OS_FREERTOS"
+    #    env.copy("tinyusb/src/osal/osal_freertos.h", "osal/osal_freertos.h")
+
     if env.has_module(":freertos"):
-        tusb_config["CFG_TUSB_OS"] = "OPT_OS_FREERTOS"
-        env.copy("tinyusb/src/osal/osal_freertos.h", "osal/osal_freertos.h")
-    else:
-        env.copy("tinyusb/src/osal/osal_none.h", "osal/osal_none.h")
+        env.log.warning("TinyUSB in modm does not currently use the FreeRTOS abstraction layer"
+                        " and is not thread-safe with FreeRTOS threads.")
+
+    env.copy("tinyusb/src/osal/osal_none.h", "osal/osal_none.h")
 
     if env.has_module(":debug"):
         tusb_config["CFG_TUSB_DEBUG_PRINTF"] = "tinyusb_debug_printf"

--- a/ext/hathach/tusb_descriptors.c.in
+++ b/ext/hathach/tusb_descriptors.c.in
@@ -162,7 +162,7 @@ string_desc_arr[] =
 %% endfor
 };
 
-static uint16_t _desc_str[32];
+static uint16_t _desc_str[33];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long

--- a/src/modm/board/black_pill_f103/board.hpp
+++ b/src/modm/board/black_pill_f103/board.hpp
@@ -115,9 +115,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
 

--- a/src/modm/board/black_pill_f411/board.hpp
+++ b/src/modm/board/black_pill_f411/board.hpp
@@ -116,9 +116,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 	usb::Id::configure(Gpio::InputType::PullUp);
 

--- a/src/modm/board/blue_pill_f103/board.hpp
+++ b/src/modm/board/blue_pill_f103/board.hpp
@@ -116,9 +116,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
 

--- a/src/modm/board/disco_f072rb/board.hpp
+++ b/src/modm/board/disco_f072rb/board.hpp
@@ -141,9 +141,9 @@ initializeL3g()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
 

--- a/src/modm/board/disco_f303vc/board.hpp
+++ b/src/modm/board/disco_f303vc/board.hpp
@@ -200,9 +200,9 @@ initializeLsm3()
 
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
 

--- a/src/modm/board/disco_f407vg/board.hpp
+++ b/src/modm/board/disco_f407vg/board.hpp
@@ -215,9 +215,9 @@ initializeMp45()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/disco_f469ni/board.hpp
+++ b/src/modm/board/disco_f469ni/board.hpp
@@ -228,9 +228,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/disco_f746ng/board.hpp
+++ b/src/modm/board/disco_f746ng/board.hpp
@@ -195,7 +195,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
 	usb_fs::Device::initialize<SystemClock>();
 	usb_fs::Device::connect<usb_fs::Dm::Dm, usb_fs::Dp::Dp, usb_fs::Id::Id>();

--- a/src/modm/board/disco_l476vg/board.hpp
+++ b/src/modm/board/disco_l476vg/board.hpp
@@ -121,9 +121,9 @@ initialize()
 
 /// You must take out the LCD screen and close SB24 and SB25 for USB to work
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/feather_m0/board.hpp
+++ b/src/modm/board/feather_m0/board.hpp
@@ -115,9 +115,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	modm::platform::Usb::initialize<Board::SystemClock>();
+	modm::platform::Usb::initialize<Board::SystemClock>(priority);
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
 

--- a/src/modm/board/nucleo_f429zi/board.hpp
+++ b/src/modm/board/nucleo_f429zi/board.hpp
@@ -150,9 +150,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/nucleo_f446ze/board.hpp
+++ b/src/modm/board/nucleo_f446ze/board.hpp
@@ -152,9 +152,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/nucleo_h743zi/board.hpp
+++ b/src/modm/board/nucleo_h743zi/board.hpp
@@ -189,9 +189,9 @@ initialize()
 
 /// FIXME: USB does not work on this board.
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 	usb::Id::configure(Gpio::InputType::Floating);
 

--- a/src/modm/board/nucleo_l496zg-p/board.hpp
+++ b/src/modm/board/nucleo_l496zg-p/board.hpp
@@ -160,9 +160,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
 
 	usb::Overcurrent::setInput();

--- a/src/modm/board/nucleo_l552-ze-q/board.hpp
+++ b/src/modm/board/nucleo_l552-ze-q/board.hpp
@@ -161,9 +161,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
 

--- a/src/modm/board/rp_pico/board.hpp
+++ b/src/modm/board/rp_pico/board.hpp
@@ -90,9 +90,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	usb::Device::initialize<SystemClock>();
+	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<>();
 }
 /// @}

--- a/src/modm/board/samd21_mini/board.hpp
+++ b/src/modm/board/samd21_mini/board.hpp
@@ -103,9 +103,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsbFs(uint8_t priority=3)
 {
-	modm::platform::Usb::initialize<Board::SystemClock>();
+	modm::platform::Usb::initialize<Board::SystemClock>(priority);
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
 

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -217,7 +217,10 @@ MAIN_STACK_SIZE = {{ options[":platform:cortex-m:main_stack_size"] }};
 		KEEP(*(.assertion))
 		. = ALIGN(4);
 		__assertion_table_end = .;
+	} >{{memory}}
 
+	.build_id :
+	{
 		__build_id = .;
 		KEEP(*(.note.gnu.build-id))
 	} >{{memory}}

--- a/tools/modm_tools/size.py
+++ b/tools/modm_tools/size.py
@@ -109,7 +109,8 @@ def format(source, device_memories):
 
             if is_in_memory("rom"):
                 totals["rom"] += s["size"]
-                sections["rom"].append(s["name"])
+                if not ".build_id" in s["name"]:
+                    sections["rom"].append(s["name"])
             if is_in_memory("ram"):
                 totals["static"] += s["size"]
                 sections["static"].append(s["name"])

--- a/tools/modm_tools/size.py
+++ b/tools/modm_tools/size.py
@@ -116,7 +116,7 @@ def format(source, device_memories):
                 sections["static"].append(s["name"])
 
     # create lists of the used sections for Flash and RAM
-    sections["rom"] = sorted(sections["rom"])
+    sections["rom"] = sorted(list(set(sections["rom"])))
     sections["ram"] = sorted(list(set(sections["static"] + sections["stack"])))
     sections["heap"] = sorted(sections["heap"])
 


### PR DESCRIPTION
I guess this is a bug in our TinyUSB port or a version incompatability between our FreeRTOS and the FreeRTOS version expected by TinyUSB.

But could also be a bug with local setup, let's see if the example fails in CI...

```
$ cd examples/nucleo_f429zi/usb_freetros/
$ lbuild build
$ scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
Compiling C++·· release/main.o
In file included from modm/ext/tinyusb/osal/osal.h:53,
                 from modm/ext/tinyusb/tusb.h:38,
                 from main.cpp:12:
modm/ext/tinyusb/osal/osal_freertos.h: In function 'QueueDefinition* osal_semaphore_create(osal_semaphore_def_t*)':
modm/ext/tinyusb/osal/osal_freertos.h:56:10: error: 'xSemaphoreCreateBinaryStatic' was not declared in this scope; did you mean 'xSemaphoreCreateBinary'?
   56 |   return xSemaphoreCreateBinaryStatic(semdef);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          xSemaphoreCreateBinary
modm/ext/tinyusb/osal/osal_freertos.h: In function 'QueueDefinition* osal_mutex_create(osal_mutex_def_t*)':
modm/ext/tinyusb/osal/osal_freertos.h:99:10: error: 'xSemaphoreCreateMutexStatic' was not declared in this scope; did you mean 'xSemaphoreCreateMutex'?
   99 |   return xSemaphoreCreateMutexStatic(mdef);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          xSemaphoreCreateMutex
modm/ext/tinyusb/osal/osal_freertos.h: In function 'QueueDefinition* osal_queue_create(osal_queue_def_t*)':
modm/ext/tinyusb/osal/osal_freertos.h:134:10: error: 'xQueueCreateStatic' was not declared in this scope; did you mean 'xQueueCreateSet'?
  134 |   return xQueueCreateStatic(qdef->depth, qdef->item_sz, (uint8_t*) qdef->buf, &qdef->sq);
      |          ^~~~~~~~~~~~~~~~~~
      |          xQueueCreateSet
scons: *** [.../build/nucleo_f429zi/usb_freetros/scons-release/main.o] Error 1
scons: building terminated because of errors.
```

cc @salkinium @chris-durand 