### PR TITLE
[board] Add configuration version for DISCO-F469NI

### DIFF
--- a/docs/src/guide/custom-project.md
+++ b/docs/src/guide/custom-project.md
@@ -93,14 +93,16 @@ discover all of modm yet. You can now choose from two levels of customization:
 
 ## Using a Board Support Package
 
-Use lbuild to discover the specific BSP configuration you want to use:
+Use lbuild to discover the specific BSP configuration you want to use.
+Some board configurations support different hardware revisions, so check your
+hardware to select the right one:
 
 ```
  $ lbuild discover
 Parser(lbuild)
 ╰── Repository(modm @ ../../ext/modm)   modm: a barebone embedded library generator
     ├── Option(target) = REQUIRED in [stm32f469ngh6, stm32f469nih6, stm32f469vet6, ...
-    ├── Config(modm:disco-f469ni)   STM32F469IDISCOVERY
+    ├── Config(modm:disco-f469ni:b-03) in [b-01, b-03]   STM32F469IDISCOVERY
    ...
 ```
 
@@ -113,7 +115,7 @@ cannot remove any inherited modules.
 <library>
   <repositories>...</repositories>
 
-  <extends>modm:disco-f469ni</extends>
+  <extends>modm:disco-f469ni:b-03</extends>
 
   <options>...</options>
   <modules>...</modules>

--- a/docs/src/guide/discover.md
+++ b/docs/src/guide/discover.md
@@ -20,7 +20,7 @@ format. The `modm/repo.lb` file must be declared to find all modm modules:
 Parser(lbuild)
 ╰── Repository(modm @ .)   modm: a barebone embedded library generator
     ├── Option(target) = REQUIRED in [stm32f469ngh6, stm32f469nih6, stm32f469vet6, ...
-    ├── Config(modm:disco-f469ni)   STM32F469IDISCOVERY
+    ├── Config(modm:disco-f469ni:b-03) in [b-01, b-03]   STM32F469IDISCOVERY
    ...
 ```
 
@@ -54,7 +54,7 @@ modules for this specific target. We will choose the `stm32f469nih6` device:
 Parser(lbuild)
 ╰── Repository(modm @ .)   modm: a barebone embedded library generator
     ├── Option(target) = stm32f469nih6 in [stm32f407vgt6, stm32f469nih6, ...
-    ├── Config(modm:disco-f469ni)   STM32F469IDISCOVERY
+    ├── Config(modm:disco-f469ni:b-03) in [b-01, b-03]   STM32F469IDISCOVERY
    ...
     ├── Module(modm:board)   Board Support Packages
     │   ╰── Module(modm:board:disco-f469ni)   STM32F469IDISCOVERY

--- a/examples/stm32f469_discovery/game_of_life/main.cpp
+++ b/examples/stm32f469_discovery/game_of_life/main.cpp
@@ -36,7 +36,7 @@ constexpr modm::MemoryTraits traits = SCALE >= 4 ? modm::MemoryFastData : modm::
 void read_touch()
 {
 	static Touch::Data touchData;
-	static Touch touchSensor(touchData);
+	static Touch touchSensor(touchData, TouchAddress);
 	static bool initialized = false;
 	if (not initialized) {
 		// Configure the touchscreen to sample with 60Hz in active and monitor mode.

--- a/examples/stm32f469_discovery/lvgl/main.cpp
+++ b/examples/stm32f469_discovery/lvgl/main.cpp
@@ -32,7 +32,7 @@ static lv_color_t* buf;
 static constexpr size_t buf_size = LV_HOR_RES_MAX * LV_VER_RES_MAX;
 
 Touch::Data touchData;
-Touch touch{touchData};
+Touch touch{touchData, TouchAddress};
 
 void my_touchpad_read(lv_indev_drv_t*, lv_indev_data_t* data)
 {

--- a/examples/stm32f469_discovery/touchscreen/main.cpp
+++ b/examples/stm32f469_discovery/touchscreen/main.cpp
@@ -20,7 +20,7 @@ class LineDrawer : public modm::pt::Protothread
 {
 public:
 	LineDrawer() :
-		touch(touchData),
+		touch(touchData, TouchAddress),
 		display{Board::getDisplay()},
 		px{-1, -1}, py{-1, -1},
 		c{modm::color::html::White, modm::color::html::White}

--- a/repo.lb
+++ b/repo.lb
@@ -24,7 +24,7 @@ from os.path import normpath
 
 # Check for miminum required lbuild version
 import lbuild
-min_lbuild_version = "1.20.0"
+min_lbuild_version = "1.21.0"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))
@@ -224,15 +224,19 @@ def init(repo):
     repo.add_ignore_patterns("*/*.lb", "*/board.xml")
 
     # Add the board configuration files as their module name aliases
-    for config in Path(repopath("src/modm/board")).glob("*/board.xml"):
-        name = re.search(r"<module>modm:board:(.*?)</module>", config.read_text()).group(1)
-        if (config.parent / "module.md").exists():
-            description = FileReader(str(config.parent / "module.md"))
+    for module in Path(repopath("src/modm/board")).glob("*/module.lb"):
+        module_text = module.read_text()
+        name = re.search(r"\.name += +\".*?:board:(.*?)\"", module_text).group(1)
+        if (module.parent / "module.md").exists():
+            description = FileReader(str(module.parent / "module.md"))
         else:
             description = re.search(r'\.description += +(""".*?"""|".*?")',
-                            (config.parent / "module.lb").read_text(), flags=re.S|re.M)
+                                    module_text, flags=re.S|re.M)
             description = description.group(1).strip('"\\') if description else None
-        repo.add_configuration(name, config, description)
+        versions = re.search(r"#+ +[Rr]evisions? += +\[(.*)\]", module_text)
+        versions = versions.group(1).split(",") if versions is not None else [""]
+        config = {v.strip(): (module.parent / "board.xml") for v in versions}
+        repo.add_configuration(Configuration(name, description, config, versions[0].strip()))
 
     # Backwards compatible move, remove this in 2022.
     repo.add_alias(Alias(name="blue-pill", destination=":blue-pill-f103",

--- a/src/modm/board/disco_f469ni/board.hpp.in
+++ b/src/modm/board/disco_f469ni/board.hpp.in
@@ -164,6 +164,7 @@ using Scl = GpioB8;
 using Sda = GpioB9;
 using I2cMaster = I2cMaster1;
 using Touch = modm::Ft6x06< I2cMaster >;
+constexpr uint8_t TouchAddress = {{touch_address}};
 }
 
 namespace usb

--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -14,6 +14,7 @@
 def init(module):
     module.name = ":board:disco-f469ni"
     module.description = FileReader("module.md")
+    # Revisions = [b-03, b-01]
 
 def prepare(module, options):
     if not options[":target"].partname.startswith("stm32f469nih"):
@@ -39,10 +40,16 @@ def build(env):
     env.outbasepath = "modm/src/modm/board"
     env.substitutions = {
         "with_logger": True,
-        "with_assert": env.has_module(":architecture:assert")
+        "with_assert": env.has_module(":architecture:assert"),
+        "touch_address": 0x38 if env[":disco-f469ni"] == "b-03" else 0x2a,
     }
     env.template("../board.cpp.in", "board.cpp")
-    env.copy('.')
+    env.copy("board_display.cpp")
+    env.copy("board_dsi.cpp")
+    env.copy("board_init.cpp")
+    env.copy("board_otm8009a.cpp")
+    env.copy("board_sdram.cpp")
+    env.template("board.hpp.in")
     env.collect(":build:openocd.source", "board/stm32f469discovery.cfg")
 
     env.collect(":platform:cortex-m:linkerscript.memory", linkerscript_memory)

--- a/src/modm/board/disco_f469ni/module.md
+++ b/src/modm/board/disco_f469ni/module.md
@@ -26,3 +26,17 @@ Access to the capacitive touchscreen is provided in the `Board::ft6` namespace.
 Call `Board::initializeTouchscreen()` to setup the peripherals.
 
 [Product Link](https://www.st.com/en/evaluation-tools/32f469idiscovery.html)
+
+
+## Hardware Revisions
+
+The revision B-03 has a different touch sensor address from B-01, which is
+provided as `Board::ft6::TouchAddress`:
+
+```cpp
+Board::ft6::Touch::Data data;
+Board::ft6::Touch touchSensor(data, Board::ft6::TouchAddress);
+```
+
+If you have an earlier revision, you can extend your configuration from
+`modm:disco-f469ni:b-01`.


### PR DESCRIPTION
This adds configuration versions for the DISCO-F469NI board `<extends>modm:disco-f469ni:b-03</extends>` to fix the different I2C address of the touch sensor.
See https://github.com/modm-io/modm/issues/818#issuecomment-1030415850.

Fixes #818.

- [x] Depends on https://github.com/modm-io/lbuild/pull/73
- [x] Update documentation
- [x] Test in hardware

cc @rleh