### PR TITLE
[architecture] Require setting SPI config in `SpiDevice` based drivers

### DIFF
--- a/examples/nucleo_f429zi/adc_ads816x/main.cpp
+++ b/examples/nucleo_f429zi/adc_ads816x/main.cpp
@@ -36,6 +36,7 @@ main()
 
 	SpiMaster::initialize<Board::SystemClock, 10_MHz>();
 	SpiMaster::connect<Sck::Sck, Mosi::Mosi, Miso::Miso>();
+	adc.configureBus();
 
 	Rst::setOutput();
 	Cs::setOutput(true);

--- a/src/modm/architecture/interface/spi.hpp
+++ b/src/modm/architecture/interface/spi.hpp
@@ -15,6 +15,7 @@
 #ifndef MODM_INTERFACE_SPI_HPP
 #define MODM_INTERFACE_SPI_HPP
 
+#include <compare>
 #include <modm/architecture/interface/peripheral.hpp>
 
 namespace modm
@@ -43,6 +44,14 @@ struct Spi
 		MsbFirst = 0b0,
 		LsbFirst = 0b1,
 	};
+};
+
+struct SpiConfiguration
+{
+	Spi::DataMode dataMode{};
+	Spi::DataOrder dataOrder{};
+
+	constexpr auto operator<=>(const SpiConfiguration&) const = default;
 };
 
 } // namespace modm

--- a/src/modm/architecture/interface/spi.hpp
+++ b/src/modm/architecture/interface/spi.hpp
@@ -46,10 +46,11 @@ struct Spi
 	};
 };
 
+template <typename SpiMaster>
 struct SpiConfiguration
 {
-	Spi::DataMode dataMode{};
-	Spi::DataOrder dataOrder{};
+	SpiMaster::DataMode dataMode{};
+	SpiMaster::DataOrder dataOrder{};
 
 	constexpr auto operator<=>(const SpiConfiguration&) const = default;
 };

--- a/src/modm/architecture/interface/spi_device.hpp
+++ b/src/modm/architecture/interface/spi_device.hpp
@@ -27,7 +27,7 @@ namespace modm
  * @author	Niklas Hauser
  * @ingroup modm_architecture_spi_device
  */
-template < class SpiMaster >
+template < class SpiMaster, SpiConfiguration config >
 class SpiDevice
 {
 	Spi::ConfigurationHandler configuration;
@@ -44,6 +44,12 @@ public:
 		configuration = handler;
 	}
 
+	void inline
+	configureBus()
+	{
+		SpiMaster::setDataMode(config.dataMode);
+		SpiMaster::setDataOrder(config.dataOrder);
+	}
 protected:
 	bool inline
 	acquireMaster()

--- a/src/modm/architecture/interface/spi_device.hpp
+++ b/src/modm/architecture/interface/spi_device.hpp
@@ -27,7 +27,7 @@ namespace modm
  * @author	Niklas Hauser
  * @ingroup modm_architecture_spi_device
  */
-template < class SpiMaster, SpiConfiguration config >
+template < class SpiMaster, SpiConfiguration<SpiMaster> config >
 class SpiDevice
 {
 	Spi::ConfigurationHandler configuration;

--- a/src/modm/driver/adc/ads816x.hpp
+++ b/src/modm/driver/adc/ads816x.hpp
@@ -85,6 +85,8 @@ struct ads816x
 		ResultChannelStatus	= (0b10 << 4),
 		//Reserved			= (0b11 << 4),
 	};
+
+	static constexpr SpiConfiguration spiConfig{Spi::DataMode::Mode0, Spi::DataOrder::MsbFirst};
 };
 
 /**
@@ -95,7 +97,7 @@ struct ads816x
  * @ingroup modm_driver_ads816x
  */
 template <typename SpiMaster, typename Cs>
-class Ads816x : public ads816x, public modm::SpiDevice<SpiMaster>, protected modm::NestedResumable<3>
+class Ads816x : public ads816x, public modm::SpiDevice<SpiMaster, ads816x::spiConfig>, protected modm::NestedResumable<3>
 {
 public:
 	Ads816x() = default;

--- a/src/modm/driver/adc/ads816x.hpp
+++ b/src/modm/driver/adc/ads816x.hpp
@@ -85,9 +85,10 @@ struct ads816x
 		ResultChannelStatus	= (0b10 << 4),
 		//Reserved			= (0b11 << 4),
 	};
-
-	static constexpr SpiConfiguration spiConfig{Spi::DataMode::Mode0, Spi::DataOrder::MsbFirst};
 };
+
+template<typename SpiMaster>
+constexpr auto Ads816xSpiConfig = SpiConfiguration<SpiMaster>{SpiMaster::DataMode::Mode0, SpiMaster::DataOrder::MsbFirst};
 
 /**
  * @tparam	SpiMaster	SpiMaster interface
@@ -97,7 +98,9 @@ struct ads816x
  * @ingroup modm_driver_ads816x
  */
 template <typename SpiMaster, typename Cs>
-class Ads816x : public ads816x, public modm::SpiDevice<SpiMaster, ads816x::spiConfig>, protected modm::NestedResumable<3>
+class Ads816x : public ads816x,
+				public modm::SpiDevice<SpiMaster, Ads816xSpiConfig<SpiMaster>>,
+				protected modm::NestedResumable<3>
 {
 public:
 	Ads816x() = default;


### PR DESCRIPTION
PR to move the discussion about a new API for setting the SPI configuration in `SpiDevice` based device drivers to a different place.

As a first step a new `SpiConfiguration` struct is added under `architecture`. Furthermore, `modm::SpiDevice` will take that config struct as a non-type template parameter and provides a default `configureBus()` function that applies the settings to the SPI master.

EDIT: this does not work as expected, the platform-specific `SpiMaster` driver won't accept `modm::Spi::DataMode` as an argument to `SpiMaster::setDataMode()`. `modm::platform::SpiMaster::DataMode` has to be used.