### PR TITLE
[sam] GPIO setOutput overrides peripheral control

### DIFF
--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -278,6 +278,7 @@ template<class... PinConfigs>
 struct PinCfgMixin
 {
 	inline static void set(uint8_t){};
+	inline static void set(uint8_t, uint8_t){};
 };
 
 template<class PinConfig, class... PinConfigs>
@@ -291,6 +292,18 @@ struct PinCfgMixin<PinConfig, PinConfigs...>
 			PORT->Group[{{loop.index0}}].PINCFG[PinConfig::pin].reg = cfg;
 %% endfor
 		PinCfgMixin<PinConfigs...>::set(cfg);
+	}
+
+	inline static void
+	set(uint8_t setBits, uint8_t clearMask)
+	{
+%% for port in ports
+		if constexpr (PinConfig::port == PortName::{{ port }}) {
+			auto& reg = PORT->Group[{{loop.index0}}].PINCFG[PinConfig::pin].reg;
+			reg = (reg & (~clearMask)) | setBits;
+		}
+%% endfor
+		PinCfgMixin<PinConfigs...>::set(setBits, clearMask);
 	}
 };
 
@@ -371,7 +384,7 @@ public:
 	configure(InputType type)
 	{
 		set(type == InputType::PullUp);
-		PinCfg::set(PORT_PINCFG_INEN | (type != InputType::Floating) << PORT_PINCFG_PULLEN_Pos);
+		PinCfg::set(PORT_PINCFG_INEN | (type != InputType::Floating) << PORT_PINCFG_PULLEN_Pos, PORT_PINCFG_PULLEN);
 	}
 
 	static void

--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -183,20 +183,26 @@ public:
 	inline static void
 	setOutput()
 	{
+		// Enable PIO control of the pin (disables peripheral control)
+		setPortReg(PIO_PER_OFFSET);
+		// Enable output driver
 		setPortReg(PIO_OER_OFFSET);
 	}
 
 	inline static void
 	setOutput(bool status)
 	{
-		setOutput();
 		set(status);
+		setOutput();
 	}
 
 	static void
 	setInput()
 	{
-		setPortReg(PIO_ODR_OFFSET); // Disable output driver
+		// Enable PIO control of the pin (disables peripheral control)
+		setPortReg(PIO_PER_OFFSET);
+		// Disable output driver
+		setPortReg(PIO_ODR_OFFSET);
 	}
 
 	static void
@@ -336,19 +342,22 @@ public:
 	setOutput()
 	{
 		setPortReg(PORT_DIRSET_OFFSET);
+		// Disable peripheral multiplexer
+		PinCfg::set(0);
 	}
 
 	inline static void
 	setOutput(bool status)
 	{
-		setOutput();
 		set(status);
+		setOutput();
 	}
 
 	static void
 	setInput()
 	{
 		setPortReg(PORT_DIRCLR_OFFSET);
+		PinCfg::set(PORT_PINCFG_INEN);
 	}
 
 	static void


### PR DESCRIPTION
Calling setOutput now overrides peripheral control of the pin, which is
consistent with the STM32 GPIO implementation. This commit also
ensures output value is set before the output drive is enabled to prevent
glitch.