### PR TITLE
Add drawBitmap method to ColorGraphicsDisplay interface

### DIFF
--- a/src/modm/ui/display/color_graphic_display.hpp
+++ b/src/modm/ui/display/color_graphic_display.hpp
@@ -51,6 +51,21 @@ public:
 		return backgroundColor;
 	}
 
+	/**
+	 * Draw a bitmap with 16-bit 565 colored pixels.
+	 *
+	 * \p data is series of pixel color values
+	 */
+	virtual void drawBitmap(
+		glcd::Point upperLeft,
+		uint16_t width,
+		uint16_t height,
+		modm::accessor::Flash<uint8_t> data)
+	{
+		modm_assert(false, "noDrawBitmap",
+			"drawBitmap method is not implemented on ColorGraphicsDisplay implementation");
+	};
+
 protected:
 	color::Rgb565 foregroundColor;
 	color::Rgb565 backgroundColor;


### PR DESCRIPTION
Hey want to solicit thoughts on this change, or something like it, @TomSaw, @salkinium.

The [ILI9341](https://github.com/modm-io/modm/blob/develop/src/modm/driver/display/ili9341.hpp#L283) driver offers a drawBitmap method, which can take a an Rgb565 bitmap as input, but this is not in the ColorGraphicsDisplay interface, and that's a problem because the ILI9341 has many template arguments so it's awkward to pass a reference to it.

Should we just add this virtual method to ColorGraphicsDisplay?