### PR TITLE
Enable flash driver for STM32G4

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✅</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>

--- a/examples/nucleo_g431kb/flash/main.cpp
+++ b/examples/nucleo_g431kb/flash/main.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "\n\nReboot\n";
+	if (not Flash::unlock()) {
+		MODM_LOG_INFO << "Flash unlock failed!" << modm::endl;
+	}
+
+	{
+		uint32_t err{0};
+		MODM_LOG_INFO << "Erasing sectors [32, 64)" << modm::endl;
+		MODM_LOG_INFO.flush();
+		modm::delay(1s);
+
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+
+		for (uint8_t page{32}; page < 64u; page++)
+			err |= Flash::erase(page);
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Erasing done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Erasing with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+		MODM_LOG_INFO.flush();
+	}
+
+
+	{
+		uint32_t err{0};
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+		for (uint32_t dst_addr{Flash::OriginAddr + Flash::Size/2}, src_addr{Flash::OriginAddr};
+		     src_addr < (Flash::OriginAddr + Flash::Size/2);
+		     src_addr += sizeof(Flash::MaxWordType), dst_addr += sizeof(Flash::MaxWordType))
+		{
+			err |= Flash::program(dst_addr, *(Flash::MaxWordType*)src_addr);
+		}
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Programming done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Programming with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+	}
+
+	while(1) ;
+	return 0;
+}

--- a/examples/nucleo_g431kb/flash/project.xml
+++ b/examples/nucleo_g431kb/flash/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-g431kb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g431kb/flash</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:flash</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_g431rb/flash/main.cpp
+++ b/examples/nucleo_g431rb/flash/main.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "\n\nReboot\n";
+	if (not Flash::unlock()) {
+		MODM_LOG_INFO << "Flash unlock failed!" << modm::endl;
+	}
+
+	{
+		uint32_t err{0};
+		MODM_LOG_INFO << "Erasing sectors [32, 64)" << modm::endl;
+		MODM_LOG_INFO.flush();
+		modm::delay(1s);
+
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+
+		for (uint8_t page{32}; page < 64u; page++)
+			err |= Flash::erase(page);
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Erasing done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Erasing with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+		MODM_LOG_INFO.flush();
+	}
+
+
+	{
+		uint32_t err{0};
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+		for (uint32_t dst_addr{Flash::OriginAddr + Flash::Size/2}, src_addr{Flash::OriginAddr};
+		     src_addr < (Flash::OriginAddr + Flash::Size/2);
+		     src_addr += sizeof(Flash::MaxWordType), dst_addr += sizeof(Flash::MaxWordType))
+		{
+			err |= Flash::program(dst_addr, *(Flash::MaxWordType*)src_addr);
+		}
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Programming done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Programming with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+	}
+
+	while(1) ;
+	return 0;
+}

--- a/examples/nucleo_g431rb/flash/project.xml
+++ b/examples/nucleo_g431rb/flash/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-g431rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g431rb/flash</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:flash</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_g474re/flash/main.cpp
+++ b/examples/nucleo_g474re/flash/main.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "\n\nReboot\n";
+	if (not Flash::unlock()) {
+		MODM_LOG_INFO << "Flash unlock failed!" << modm::endl;
+	}
+
+	{
+		uint32_t err{0};
+		MODM_LOG_INFO << "Erasing sectors [32, 64)" << modm::endl;
+		MODM_LOG_INFO.flush();
+		modm::delay(1s);
+
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+
+		for (uint8_t page{32}; page < 64u; page++)
+			err |= Flash::erase(page);
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Erasing done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Erasing with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+		MODM_LOG_INFO.flush();
+	}
+
+
+	{
+		uint32_t err{0};
+		const modm::PreciseTimestamp start = modm::PreciseClock::now();
+		for (uint32_t dst_addr{Flash::OriginAddr + Flash::Size/2}, src_addr{Flash::OriginAddr};
+		     src_addr < (Flash::OriginAddr + Flash::Size/2);
+		     src_addr += sizeof(Flash::MaxWordType), dst_addr += sizeof(Flash::MaxWordType))
+		{
+			err |= Flash::program(dst_addr, *(Flash::MaxWordType*)src_addr);
+		}
+
+		const auto diff = (modm::PreciseClock::now() - start);
+		MODM_LOG_INFO << "Programming done in " << diff << " with errors: " << err << modm::endl;
+		MODM_LOG_INFO << "Programming with " << (Flash::Size/2 / (diff.count() >> 10) ) << "kiB/s" << modm::endl;
+	}
+
+	while(1) ;
+	return 0;
+}

--- a/examples/nucleo_g474re/flash/project.xml
+++ b/examples/nucleo_g474re/flash/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/flash</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:flash</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/flash/stm32/flash.cpp.in
+++ b/src/modm/platform/flash/stm32/flash.cpp.in
@@ -91,7 +91,7 @@ Flash::erase(uint8_t index)
 	FLASH->CR = FLASH_CR_STRT | FLASH_CR_SER | uint32_t(size) |
 			((index << FLASH_CR_SNB_Pos) & FLASH_CR_SNB_Msk);
 %% else
-%% if family == "g0"
+%% if family in ["g0","g4"]
 	FLASH->CR = FLASH_CR_STRT | FLASH_CR_PER |
 			((index << FLASH_CR_PNB_Pos) & FLASH_CR_PNB_Msk);
 %% else
@@ -154,6 +154,7 @@ Flash::program(uintptr_t addr, MaxWordType data)
 	FLASH->CR &= ~FLASH_CR_PG;
 	return FLASH->SR & FLASH_SR_PGERR;
 %% else
+	FLASH->SR |= FLASH_SR_EOP;
 	FLASH->CR = 0;
 	return FLASH->SR & FLASH_SR_ERR;
 %% endif

--- a/src/modm/platform/flash/stm32/flash.hpp.in
+++ b/src/modm/platform/flash/stm32/flash.hpp.in
@@ -55,7 +55,6 @@ public:
 %% if not has_sectors and family == "g0"
 		Rcc::disable<Peripheral::Flash>();
 %% endif
-
 	}
 
 	static bool

--- a/src/modm/platform/flash/stm32/module.lb
+++ b/src/modm/platform/flash/stm32/module.lb
@@ -17,7 +17,7 @@ def init(module):
 
 def prepare(module, options):
     device = options[":target"]
-    if device.identifier.family not in ["g0", "f1", "f4"]:
+    if device.identifier.family not in ["g0","g4", "f1", "f4"]:
         return False
     if not device.has_driver("flash:stm32*"):
         return False
@@ -44,6 +44,10 @@ def build(env):
         block_shift = 11
         ftype = "page"
         busy_bit = "FLASH_SR_BSY1"
+    elif target.family in ["g4"]:
+        block_shift = 11
+        ftype = "page"
+        busy_bit = "FLASH_SR_BSY"
 
     env.substitutions = {
         "start": int(flash["start"], 16),


### PR DESCRIPTION
The flash implementation has been tested on STM32g474ret6. It does not implement bank selection for dual bank modes. Also it resolves and issue with g0 devices where the EOP flag should be cleared after programming.