### PR TITLE
Add STM32U5

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -526,6 +526,32 @@ jobs:
           name: stm32l5-compile-all
           path: test/all/log
 
+  stm32u5-compile-all:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager modm
+      - name: Compile HAL for all STM32U5
+        run: |
+          (cd test/all && python3 run_all.py stm32u5 --quick-remaining)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: stm32u5-compile-all
+          path: test/all/log
+
   stm32g0-compile-all:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,6 +166,10 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py nucleo_l552ze-q)
+      - name: Examples STM32U5 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_u575zi-q)
       - name: Examples STM32G4 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3534<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3607<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->2729<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->2802<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->416<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 - Raspberry Pi: <!--rpicount-->1<!--/rpicount--> device.
@@ -103,7 +103,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <table>
 <tr>
 <th align="center"></th>
-<th align="center" colspan="13">STM32</th>
+<th align="center" colspan="14">STM32</th>
 <th align="center" colspan="4">SAM</th>
 <th align="center" colspan="1">RP</th>
 <th align="center" colspan="3">AT</th>
@@ -122,6 +122,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center">L1</th>
 <th align="center">L4</th>
 <th align="center">L5</th>
+<th align="center">U5</th>
 <th align="center">D1x<br/>D2x<br/>DAx</th>
 <th align="center">D5x<br/>E5x</th>
 <th align="center">E7x<br/>S7x<br/>V7x</th>
@@ -147,6 +148,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -166,6 +168,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
@@ -194,6 +197,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -201,6 +205,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 </tr><tr>
 <td align="left">DAC</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -240,6 +245,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
@@ -261,6 +267,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✕</td>
@@ -270,6 +277,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">External Interrupt</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -305,7 +313,8 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
-<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -337,8 +346,10 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 </tr><tr>
 <td align="left">I<sup>2</sup>C</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -379,6 +390,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -396,6 +408,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
@@ -421,6 +434,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
@@ -449,11 +463,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Timer</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -497,9 +513,11 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 </tr><tr>
 <td align="left">Unique ID</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -530,6 +548,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/README.md
+++ b/README.md
@@ -647,20 +647,21 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-raspberrypi">Raspberry Pi</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 </tr>
 </table>

--- a/examples/nucleo_u575zi-q/blink/main.cpp
+++ b/examples/nucleo_u575zi-q/blink/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter = 0;
+
+	while (true)
+	{
+		Leds::write(counter % (1 << 3));
+		modm::delay(Button::read() ? 250ms : 500ms);
+		MODM_LOG_INFO << "loop: " << counter << modm::endl;
+		counter++;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_u575zi-q/blink/project.xml
+++ b/examples/nucleo_u575zi-q/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-u575zi-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_u575zi-q/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -126,7 +126,7 @@ def common_header_file(env):
     define = None
 
     content = Path(localpath(folder, family_header)).read_text(encoding="utf-8", errors="replace")
-    match = re.findall(r"if defined\((?P<define>STM32[FLGH][\w\d]+)\)", content)
+    match = re.findall(r"if defined\((?P<define>STM32[FGHLU][\w\d]+)\)", content)
     define = getDefineForDevice(device.identifier, match)
     if define is None or match is None:
         raise ValidateException("No device define found for '{}'!".format(device.partname))

--- a/repo.lb
+++ b/repo.lb
@@ -85,6 +85,7 @@ class DevicesCache(dict):
                      "stm32g0", "stm32g4",
                      "stm32h7",
                      "stm32l0", "stm32l1", "stm32l4", "stm32l5",
+                     "stm32u5",
                      "at90", "attiny", "atmega",
                      "samd21", "samg55",
                      "same70", "sams70", "samv70", "samv71",

--- a/src/modm/board/nucleo144_arduino_u5.hpp
+++ b/src/modm/board/nucleo144_arduino_u5.hpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022, Christopher Durand
+ * Copyright (c) 2022, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+// Nucleo144 Arduino Header Footprint for STM32U575/... ('NUCLEO144_Q (int-SMPS)', MB1549)
+// Schematic: https://www.st.com/resource/en/schematic_pack/mb1549-u575ziq-c03_schematic.pdf
+
+#ifndef MODM_STM32_NUCLEO144_ARDUINO_U5_HPP
+#define MODM_STM32_NUCLEO144_ARDUINO_U5_HPP
+
+// Arduino Footprint
+using A0 = GpioA3;
+using A1 = GpioA2;
+using A2 = GpioC3;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+// Zio Footprint
+using A6 = GpioB1;
+using A7 = GpioC2;
+using A8 = GpioA1;
+
+// Arduino Footprint
+using D0  = GpioG8;
+using D1  = GpioG7;
+using D2  = GpioF15;
+using D3  = GpioE13;
+using D4  = GpioF14;
+using D5  = GpioE11;
+using D6  = GpioE9;
+using D7  = GpioF13;
+using D8  = GpioF12;
+using D9  = GpioD15;
+using D10 = GpioD14;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+// Zio Footprint
+using D16 = GpioC6;
+using D17 = GpioD11;
+using D18 = GpioB13;
+using D19 = GpioD12;
+using D20 = GpioA4;
+using D21 = GpioB4;
+using D22 = GpioB5;
+using D23 = GpioB3;
+using D24 = GpioA4;
+using D25 = GpioB4;
+using D26 = GpioA2;
+using D27 = GpioB10;
+using D28 = GpioE15;
+using D29 = GpioB0;
+using D30 = GpioE12;
+using D31 = GpioE14;
+using D32 = GpioA0;
+using D33 = GpioA8;
+using D34 = GpioE0;
+using D35 = GpioB11;
+using D36 = GpioB10;
+using D37 = GpioE15;
+using D38 = GpioE14;
+using D39 = GpioE12;
+using D40 = GpioE10;
+using D41 = GpioE7;
+using D42 = GpioE8;
+using D43 = GpioC8;
+using D44 = GpioC9;
+using D45 = GpioC10;
+using D46 = GpioC11;
+using D47 = GpioC12;
+using D48 = GpioD2;
+using D49 = GpioF3;
+using D50 = GpioF5;
+using D51 = GpioD7;
+using D52 = GpioD6;
+using D53 = GpioD5;
+using D54 = GpioD4;
+using D55 = GpioD3;
+using D56 = GpioE2;
+using D57 = GpioE4;
+using D58 = GpioE5;
+using D59 = GpioE6;
+using D60 = GpioE3;
+using D61 = GpioF8;
+using D62 = GpioF7;
+using D63 = GpioF9;
+using D64 = GpioG1;
+using D65 = GpioG0;
+using D66 = GpioD1;
+using D67 = GpioD0;
+using D68 = GpioF0;
+using D69 = GpioF1;
+using D70 = GpioF2;
+using D71 = GpioB6;
+using D72 = GpioB2;
+
+#endif // MODM_STM32_NUCLEO144_ARDUINO_U5_HPP

--- a/src/modm/board/nucleo_u575zi-q/board.hpp
+++ b/src/modm/board/nucleo_u575zi-q/board.hpp
@@ -1,0 +1,189 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2022, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_NUCLEO_U575ZI_Q_HPP
+#define MODM_STM32_NUCLEO_U575ZI_Q_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+
+/// @ingroup modm_board_nucleo_u575zi_q
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+namespace Board
+{
+/// @ingroup modm_board_nucleo_u575zi_q
+/// @{
+using namespace modm::literals;
+
+/// STM32U5 running at 160 MHz generated from the internal HSI16 oscillator
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 160_MHz;
+	static constexpr uint32_t Ahb  = Frequency;
+	static constexpr uint32_t Apb1 = Frequency;
+	static constexpr uint32_t Apb2 = Frequency;
+	static constexpr uint32_t Apb3 = Frequency;
+	static constexpr uint32_t Apb1Timer = Apb1;
+	static constexpr uint32_t Apb2Timer = Apb2;
+
+	static constexpr uint32_t Hsi48 = 48_MHz;
+	static constexpr uint32_t Pll1P = 160_MHz;
+	static constexpr uint32_t Pll1Q = 160_MHz;
+
+	static constexpr uint32_t Adc1 = Frequency;
+	static constexpr uint32_t Adc4 = Frequency;
+
+	static constexpr uint32_t Comp1 = Apb2;
+	static constexpr uint32_t Comp2 = Apb2;
+
+	static constexpr uint32_t Dac1 = Frequency;
+
+	static constexpr uint32_t Fdcan1 = Pll1Q;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb3;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb3;
+
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static constexpr uint32_t Usart1  = Apb2;
+	static constexpr uint32_t Usart2  = Apb1;
+	static constexpr uint32_t Usart3  = Apb1;
+	static constexpr uint32_t Uart4   = Apb1;
+	static constexpr uint32_t Uart5   = Apb1;
+	static constexpr uint32_t Lpuart1 = Apb3;
+
+	static constexpr uint32_t Usb = Hsi48;
+	static constexpr uint32_t Rng = Hsi48;
+	static constexpr uint32_t Sdmmc = Pll1P;
+
+	static bool inline
+	enable()
+	{
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Range1);
+		Rcc::enableInternalClock(); // HSI16
+		const Rcc::PllFactors pllFactors{
+			.range = Rcc::PllInputRange::MHz8_16,
+			.pllM = 2,		//  16MHz / M ->   8MHz
+			.pllN = 40,		//   8MHz * N -> 320MHz
+			.pllP = 2,		// 320MHz / P -> 160MHz
+			.pllQ = 2,		// 320MHz / Q -> 160MHz
+			.pllR = 2,		// 320MHz / R -> 160MHz = F_cpu
+			.epodPrescaler = Rcc::EpodBoosterPrescaler::Div1,
+		};
+		Rcc::enablePll1(Rcc::PllSource::Hsi16, pllFactors);
+		Rcc::setFlashLatency<Frequency>();
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
+		Rcc::setApb3Prescaler(Rcc::Apb3Prescaler::Div1);
+		// update clock frequencies
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::setCanClockSource(Rcc::CanClockSource::Pll1Q);
+
+		Rcc::enableInternalClockMHz48();
+		// Select Hsi48 as source for CLK48 MUX (USB)
+		Rcc::setClock48Source(Rcc::Clock48Source::Hsi48);
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo144_arduino_u5.hpp"
+
+using Button = GpioInputC13;
+
+using LedGreen = GpioOutputC7;	// LED1 [Green]
+using LedBlue = GpioOutputB7;	// LED2 [Blue]
+using LedRed = GpioOutputG2;	// LED3 [Red]
+using Leds = SoftwareGpioPort<LedRed, LedBlue, LedGreen>;
+/// @}
+
+namespace usb
+{
+/// @ingroup modm_board_nucleo_u575zi_q
+/// @{
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using UcpdFlt = GpioB14;
+using UcpdDBn = GpioB5;
+using UcpdCc1 = GpioA15;
+using UcpdCc2 = GpioB15;
+
+using Device = UsbFs;
+/// @}
+}
+
+namespace stlink
+{
+/// @ingroup modm_board_nucleo_u575zi_q
+/// @{
+using Rx = GpioOutputA10;
+using Tx = GpioInputA9;
+using Uart = Usart1;
+/// @}
+}
+
+/// @ingroup modm_board_nucleo_u575zi_q
+/// @{
+using LoggerDevice = modm::IODeviceWrapper<stlink::Uart, modm::IOBuffer::BlockIfFull>;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	LedGreen::setOutput(modm::Gpio::Low);
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedRed::setOutput(modm::Gpio::Low);
+
+	Button::setInput();
+}
+
+inline void
+initializeUsbFs(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+/// @}
+
+} // Board namespace
+
+#endif	// MODM_STM32_NUCLEO_U575ZI_Q_HPP

--- a/src/modm/board/nucleo_u575zi-q/board.xml
+++ b/src/modm/board/nucleo_u575zi-q/board.xml
@@ -1,0 +1,16 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32u575zit6q</option>
+    <option name="modm:platform:uart:1:buffer.tx">2048</option>
+  </options>
+
+  <modules>
+    <module>modm:board:nucleo-u575zi-q</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_u575zi-q/module.lb
+++ b/src/modm/board/nucleo_u575zi-q/module.lb
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-u575zi-q"
+    module.description = """\
+# NUCLEO-U575ZI-Q
+
+[Nucleo kit for STM32U575ZI-Q](https://www.st.com/en/evaluation-tools/nucleo-u575zi-q.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32u575zit6q"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:1",
+        ":platform:usb:fs")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo144_arduino_u5.hpp", "nucleo144_arduino_u5.hpp")
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/st_nucleo_u5.cfg"), "st_nucleo_u5.cfg")
+    env.collect(":build:openocd.source", "modm/board/st_nucleo_u5.cfg")

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -79,6 +79,9 @@ def prepare(module, options):
     if target["family"] in ["f2", "f4", "f7"]:
         props["shared_irqs"] = {"ADC": listify([int(i) for i in device.get_driver("adc")["instance"]])}
         props["shared_irq_ids"] = props["shared_irqs"]["ADC"]
+    elif target["family"] in ["u5"]:
+        # STM32U5 is not yet supported with any ADC implementation im modm
+        return False
     else:
         shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
         shared_irqs = [v for v in shared_irqs if v.startswith("ADC") and "_" in v]

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -67,7 +67,14 @@ def build(env):
     properties["hsi48"] = \
         (target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]) or \
         (target["family"] == "l4" and target["name"][0] not in ["7", "8"]) or \
-        (target["family"] == "l5")
+        (target["family"] == "l5") or \
+        (target["family"] == "u5")
+    if target["family"] in ["l4", "l5"]:
+        properties["hsi48_cr"] = "CRRCR"
+    elif target["family"] in ["u5"]:
+        properties["hsi48_cr"] = "CR"
+    else:
+        properties["hsi48_cr"] = "CR2"
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")
     properties["overdrive"] = (target["family"] == "f7") or \
         ((target["family"] == "f4") and target["name"] in ["27", "29", "37", "39", "46", "69", "79"])
@@ -77,21 +84,38 @@ def build(env):
         (target["family"] == "l4" and target["name"][0] in ["p", "q", "r", "s"])
     properties["pllsai_p_usb"] = (target["family"] == "f7") or \
         ((target["family"] == "f4") and target["name"] in ["46", "69", "79"])
-    properties["cfgr1"] = ("CDCFGR1" if target.name in ["a0", "a3", "b0", "b3"] else "D1CFGR") \
-                           if target.family == "h7" else "CFGR"
+
+    if target.family in ["h7"]:
+        if target.name in ["a0", "a3", "b0", "b3"]:
+            properties["cfgr_prescaler"] = "CDCFGR1"
+        else:
+            properties["cfgr_prescaler"] = "D1CFGR"
+    elif target.family in ["u5"]:
+        properties["cfgr_prescaler"] = "CFGR2"
+    else:
+        properties["cfgr_prescaler"] = "CFGR"
+
+    if target.family in ["h7"]:
+        if target.name in ["a0", "a3", "b0", "b3"]:
+            properties["cfgr2"] = "CDCFGR2"
+        else:
+            properties["cfgr2"] = "D2CFGR"
+    elif target.family in ["u5"]:
+        properties["cfgr2"] = "CFGR2"
+    else:
+        properties["cfgr2"] = "CFGR"
+
     properties["d1"] = ("CD" if target.name in ["a0", "a3", "b0", "b3"] else "D1") \
                         if target.family == "h7" else ""
-    properties["cfgr2"] = ("CDCFGR2" if target.name in ["a0", "a3", "b0", "b3"] else "D2CFGR") \
-                           if target.family == "h7" else "CFGR"
     properties["d2"] = ("CD" if target.name in ["a0", "a3", "b0", "b3"] else "D2") \
                         if target.family == "h7" else ""
     properties["cfgr3"] = ("SRDCFGR" if target.name in ["a0", "a3", "b0", "b3"] else "D3CFGR")
     properties["d3"] = ("SRD" if target.name in ["a0", "a3", "b0", "b3"] else "D3")
     properties["bdcr"] = "CSR" if target.family in ["l0", "l1"] else "BDCR"
-    properties["pll_ids"] = ["1", "2", "3"] if target.family == "h7" else [""]
+    properties["pll_ids"] = ["1", "2", "3"] if target.family in ["h7", "u5"] else [""]
     properties["has_smps"] = target["family"] == "h7" and (target["name"] in ["25", "35", "45", "47", "55", "57"] or \
         (target["name"] in ["30", "a3", "b0", "b3"] and target["variant"] == "q"))
-    properties["ccipr1"] = "CCIPR1" if target.family == "l5" else "CCIPR"
+    properties["ccipr1"] = "CCIPR1" if target.family in ["l5", "u5"] else "CCIPR"
 
     flash_latencies = {}
     for vcore in device.get_driver("flash")["latency"]:
@@ -156,8 +180,11 @@ def build(env):
         if "Eth" in all_peripherals and per == "ETHMAC":
             per = "Eth"
         # Fix USBOTG OTG
+        if target.family == "u5" and per == "OTG":
+            per = "Usbotgfs"
         if "Usbotgfs" in all_peripherals and per.startswith("OTG"):
-            if per == "OTGH": per = "OTGHS";
+            if per == "OTGH":
+                per = "OTGHS"
             per = "USB"+per
         if "Usbotgfs" in all_peripherals and per.startswith("USB"):
             per = per.replace("USB1", "USB").replace("USB2", "USB")

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -40,27 +40,15 @@ Rcc::enableInternalClockMHz14(uint32_t waitCycles)
 %% endif
 
 %% if hsi48
-%% if target.family in ["l4", "l5"]
 bool
 Rcc::enableInternalClockMHz48(uint32_t waitCycles)
 {
 	bool retval;
-	RCC->CRRCR |= RCC_CRRCR_HSI48ON;
-	while (not ((retval = RCC->CRRCR & RCC_CRRCR_HSI48RDY)) and --waitCycles)
+	RCC->{{hsi48_cr}} |= RCC_{{hsi48_cr}}_HSI48ON;
+	while (not (retval = (RCC->{{hsi48_cr}} & RCC_{{hsi48_cr}}_HSI48RDY)) and --waitCycles)
 		;
 	return retval;
 }
-%% else
-bool
-Rcc::enableInternalClockMHz48(uint32_t waitCycles)
-{
-	bool retval;
-	RCC->CR2 |= RCC_CR2_HSI48ON;
-	while (not (retval = (RCC->CR2 & RCC_CR2_HSI48RDY)) and --waitCycles)
-		;
-	return retval;
-}
-%% endif
 %% endif
 
 bool
@@ -91,6 +79,31 @@ Rcc::enableMultiSpeedInternalClock(MsiFrequency msi_frequency, uint32_t waitCycl
 }
 %% endif
 
+%% if target.family in ["u5"]
+// MSIxRANGE can be modified when MSIx is OFF (MSISON = 0) or when MSIx is
+// ready (MSIxRDY = 1). MSIxRANGE must NOT be modified when MSIx is ON
+// and NOT ready (MSIxON = 1 and MSIxRDY = 0)
+%% for msi in ["S", "K"]
+bool
+Rcc::enableMultiSpeedInternalClock{{msi}}(MsiFrequency msi_frequency, uint32_t waitCycles)
+{
+	bool retval;
+	uint32_t waitCycles_ = waitCycles;
+	while ((not (retval = (((RCC->CR & RCC_CR_MSI{{msi}}ON) == 0) || ((RCC->CR & RCC_CR_MSI{{msi}}RDY) == RCC_CR_MSI{{msi}}RDY)))) || --waitCycles_)
+		;
+	if (!retval)
+		return false;
+	RCC->ICSCR1 = (RCC->ICSCR1 & ~RCC_ICSCR1_MSI{{msi}}RANGE_Msk) | RCC_ICSCR1_MSIRGSEL | (static_cast<uint32_t>(msi_frequency) << RCC_ICSCR1_MSI{{msi}}RANGE_Pos);
+	RCC->CR |= RCC_CR_MSI{{msi}}ON;
+	waitCycles_ = waitCycles;
+	while (not (retval = (RCC->CR & RCC_CR_MSI{{msi}}RDY)) and --waitCycles)
+		;
+	return retval;
+}
+
+%% endfor
+%% endif
+
 bool
 Rcc::enableExternalClock(uint32_t waitCycles)
 {
@@ -111,12 +124,14 @@ Rcc::enableExternalCrystal(uint32_t waitCycles)
 	return retval;
 }
 
+
+%% set lsi_cr="BDCR" if target.family in ["u5"] else "CSR"
 bool
 Rcc::enableLowSpeedInternalClock(uint32_t waitCycles)
 {
 	bool retval;
-	RCC->CSR |= RCC_CSR_LSION;
-	while (not (retval = (RCC->CSR & RCC_CSR_LSIRDY)) and --waitCycles)
+	RCC->{{lsi_cr}} |= RCC_{{lsi_cr}}_LSION;
+	while (not (retval = (RCC->{{lsi_cr}} & RCC_{{lsi_cr}}_LSIRDY)) and --waitCycles)
 		;
 	return retval;
 }
@@ -170,6 +185,51 @@ Rcc::enablePll{{id}}(PllSource source, const PllFactors& pllFactors, uint32_t wa
 	// enable pll
 	RCC->CR |= RCC_CR_PLL{{id}}ON;
 
+	while (not (tmp = (RCC->CR & RCC_CR_PLL{{id}}RDY)) and --waitCycles)
+		;
+
+	return tmp;
+%% elif target.family in ["u5"]
+	RCC->PLL{{id}}CFGR = 0;
+
+	%% if id == "1"
+	// Voltage scaling is selected through the VOS[1:0] bits in the PWR_VOSR
+	// register. The EPOD (embedded power distribution) booster must be enabled
+	// and ready before increasing the system clock frequency above 55 MHz in
+	// range 1 and range 2.
+	//
+	// Configure the PLL1MBOOST in RCC->PLL1CFGR to generate a booster clock
+	// frequency between 4 and 16 MHz
+	RCC->PLL1CFGR = (RCC->PLL1CFGR & ~RCC_PLL1CFGR_PLL1MBOOST_Msk) | uint32_t(pllFactors.epodPrescaler);
+	%% endif
+
+	// Select clock source
+	RCC->PLL{{id}}CFGR |= (uint32_t(source) & RCC_PLL{{id}}CFGR_PLL{{id}}SRC_Msk);
+
+	// Init pre-divider
+	RCC->PLL{{id}}CFGR |= ((uint32_t(pllFactors.pllM - 1u) << RCC_PLL{{id}}CFGR_PLL{{id}}M_Pos) & RCC_PLL{{id}}CFGR_PLL{{id}}M_Msk);
+
+	// Set PLL fractional value
+	RCC->PLL{{id}}FRACR = pllFactors.pllFrac << RCC_PLL{{id}}FRACR_PLL{{id}}FRACN_Pos;
+
+	// PLL config
+	RCC->PLL{{id}}CFGR |= (uint32_t(pllFactors.range) << RCC_PLL{{id}}CFGR_PLL{{id}}RGE_Pos) |
+		((pllFactors.pllFrac > 0) ? RCC_PLL{{id}}CFGR_PLL{{id}}FRACEN : 0) |
+		RCC_PLL{{id}}CFGR_PLL{{id}}PEN |
+		RCC_PLL{{id}}CFGR_PLL{{id}}QEN |
+		RCC_PLL{{id}}CFGR_PLL{{id}}REN;
+
+	// Set PLL Dividers
+	RCC->PLL{{id}}DIVR =
+			((uint32_t(pllFactors.pllR - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}R_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}R_Msk) |
+			((uint32_t(pllFactors.pllQ - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}Q_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}Q_Msk) |
+			((uint32_t(pllFactors.pllP - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}P_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}P_Msk) |
+			((uint32_t(pllFactors.pllN - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}N_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}N_Msk);
+
+	// enable pll
+	RCC->CR |= RCC_CR_PLL{{id}}ON;
+
+	uint32_t tmp;
 	while (not (tmp = (RCC->CR & RCC_CR_PLL{{id}}RDY)) and --waitCycles)
 		;
 
@@ -427,9 +487,24 @@ Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
 		if (--waitCycles == 0) return false;
 	return true;
 }
-%% endif
+%% elif target.family in ["u5"]
+bool
+Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
+{
+	const auto currentSetting = PWR->VOSR & PWR_VOSR_VOS_Msk;
+	if (voltage == static_cast<VoltageScaling>(currentSetting)) {
+		return true;
+	}
+	const bool sysclkOver55MHz = (voltage == VoltageScaling::Range1) || (voltage == VoltageScaling::Range2);
+	const uint32_t boosten = sysclkOver55MHz ? PWR_VOSR_BOOSTEN : 0;
+	PWR->VOSR = (PWR->VOSR & ~PWR_VOSR_VOS_Msk) | uint32_t(voltage) | boosten;
 
-%% if target.family == "h7"
+	const uint32_t rdy = sysclkOver55MHz ? (PWR_VOSR_BOOSTEN | PWR_VOSR_VOSRDY) : PWR_VOSR_VOSRDY;
+	while (PWR->VOSR & rdy)
+		if (--waitCycles == 0) return false;
+	return true;
+}
+%% elif target.family == "h7"
 bool
 Rcc::setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles)
 {
@@ -501,15 +576,16 @@ Rcc::setHsiPredivider4Enabled(bool divideBy4, uint32_t waitCycles)
 }
 %% endif
 
-// ----------------------------------------------------------------------------
+
+%% set sysclksrcf_cfgr="CFGR1" if target.family in ["u5"] else "CFGR"
 bool
 Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
 {
-	RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | uint32_t(src);
+	RCC->{{sysclksrcf_cfgr}} = (RCC->{{sysclksrcf_cfgr}} & ~RCC_{{sysclksrcf_cfgr}}_SW) | uint32_t(src);
 
 	// Wait till the main PLL is used as system clock source
-	src = SystemClockSource(uint32_t(src) << 2);
-	while ((RCC->CFGR & RCC_CFGR_SWS) != uint32_t(src))
+	src = SystemClockSource(uint32_t(src) << RCC_{{sysclksrcf_cfgr}}_SWS_Pos);
+	while ((RCC->{{sysclksrcf_cfgr}} & RCC_{{sysclksrcf_cfgr}}_SWS) != uint32_t(src))
 		if (not --waitCycles) return false;
 
 	return true;

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -16,7 +16,7 @@
 #ifndef MODM_STM32_RCC_HPP
 #define MODM_STM32_RCC_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include "../device.hpp"
 #include <modm/platform/core/peripherals.hpp>
 #include <modm/platform/gpio/connector.hpp>
@@ -94,8 +94,13 @@ public:
 		/// Multi speed internal clock
 		Msi = RCC_PLLCFGR_PLLSRC_0,
 		MultiSpeedInternalClock = Msi,
+%% elif target.family in ["u5"]
+		None = 0b00,
+		MsiS = 0b01,
+		Hsi16 = 0b10,
+		Hse = 0b11,
 %% endif
-%% if hsi48 and target.family not in ["l4", "l5"]
+%% if hsi48 and target.family not in ["l4", "l5", "u5"]
 		/// High speed internal clock (48 MHz)
 		Hsi48 = RCC_CFGR_PLLSRC_HSI48_PREDIV,
 		InternalClockMHz48 = Hsi48,
@@ -133,6 +138,11 @@ public:
 		Hsi16 = Hsi,
 		Hse = RCC_CFGR_SW_1,
 		Pll = RCC_CFGR_SW_1 | RCC_CFGR_SW_0,
+%% elif target.family in ["u5"]
+		Msi = 0b00,
+		Hsi16 = 0b01,
+		Hse = 0b10,
+		Pll = 0b11,
 %% else
 		Hsi = RCC_CFGR_SW_HSI,
 %% if target.family == "l0"
@@ -182,26 +192,26 @@ public:
 	enum class
 	AhbPrescaler : uint32_t
 	{
-%% if target.family == "l5"
-		Div1   = 0b0000 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div2   = 0b1000 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div4   = 0b1001 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div8   = 0b1010 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div16  = 0b1011 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div64  = 0b1100 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div128 = 0b1101 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div256 = 0b1110 << RCC_{{cfgr1}}_HPRE_Pos,
-		Div512 = 0b1111 << RCC_{{cfgr1}}_HPRE_Pos
+%% if target.family in ["l5", "u5"]
+		Div1   = 0b0000 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div2   = 0b1000 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div4   = 0b1001 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div8   = 0b1010 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div16  = 0b1011 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div64  = 0b1100 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div128 = 0b1101 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div256 = 0b1110 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
+		Div512 = 0b1111 << RCC_{{cfgr_prescaler}}_HPRE_Pos
 %% else
-		Div1   = RCC_{{cfgr1}}_HPRE_DIV1,
-		Div2   = RCC_{{cfgr1}}_HPRE_DIV2,
-		Div4   = RCC_{{cfgr1}}_HPRE_DIV4,
-		Div8   = RCC_{{cfgr1}}_HPRE_DIV8,
-		Div16  = RCC_{{cfgr1}}_HPRE_DIV16,
-		Div64  = RCC_{{cfgr1}}_HPRE_DIV64,
-		Div128 = RCC_{{cfgr1}}_HPRE_DIV128,
-		Div256 = RCC_{{cfgr1}}_HPRE_DIV256,
-		Div512 = RCC_{{cfgr1}}_HPRE_DIV512
+		Div1   = RCC_{{cfgr_prescaler}}_HPRE_DIV1,
+		Div2   = RCC_{{cfgr_prescaler}}_HPRE_DIV2,
+		Div4   = RCC_{{cfgr_prescaler}}_HPRE_DIV4,
+		Div8   = RCC_{{cfgr_prescaler}}_HPRE_DIV8,
+		Div16  = RCC_{{cfgr_prescaler}}_HPRE_DIV16,
+		Div64  = RCC_{{cfgr_prescaler}}_HPRE_DIV64,
+		Div128 = RCC_{{cfgr_prescaler}}_HPRE_DIV128,
+		Div256 = RCC_{{cfgr_prescaler}}_HPRE_DIV256,
+		Div512 = RCC_{{cfgr_prescaler}}_HPRE_DIV512
 %% endif
 	};
 
@@ -219,12 +229,12 @@ public:
 	enum class
 	Apb1Prescaler : uint32_t
 	{
-%% if target.family == "l5"
-		Div1   = 0b000 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
-		Div2   = 0b101 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
-		Div4   = 0b110 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
-		Div8   = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos,
-		Div16  = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE1_Pos
+%% if target.family in ["l5", "u5"]
+		Div1   = 0b000 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE1_Pos,
+		Div2   = 0b100 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE1_Pos,
+		Div4   = 0b101 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE1_Pos,
+		Div8   = 0b110 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE1_Pos,
+		Div16  = 0b111 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE1_Pos
 %% else
 		Div1   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV1,
 		Div2   = RCC_{{cfgr2}}_{{d2}}PPRE1_DIV2,
@@ -237,12 +247,12 @@ public:
 	enum class
 	Apb2Prescaler : uint32_t
 	{
-%% if target.family == "l5"
-		Div1   = 0b000 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
-		Div2   = 0b101 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
-		Div4   = 0b110 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
-		Div8   = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos,
-		Div16  = 0b111 << RCC_{{cfgr2}}_{{d2}}PPRE2_Pos
+%% if target.family in ["l5", "u5"]
+		Div1   = 0b000 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE2_Pos,
+		Div2   = 0b100 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE2_Pos,
+		Div4   = 0b101 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE2_Pos,
+		Div8   = 0b110 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE2_Pos,
+		Div16  = 0b111 << RCC_{{cfgr_prescaler}}_{{d2}}PPRE2_Pos
 %% else
 		Div1   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV1,
 		Div2   = RCC_{{cfgr2}}_{{d2}}PPRE2_DIV2,
@@ -257,11 +267,11 @@ public:
 	enum class
 	Apb3Prescaler : uint32_t
 	{
-		Div1   = RCC_{{cfgr1}}_{{d1}}PPRE_DIV1,
-		Div2   = RCC_{{cfgr1}}_{{d1}}PPRE_DIV2,
-		Div4   = RCC_{{cfgr1}}_{{d1}}PPRE_DIV4,
-		Div8   = RCC_{{cfgr1}}_{{d1}}PPRE_DIV8,
-		Div16  = RCC_{{cfgr1}}_{{d1}}PPRE_DIV16
+		Div1   = RCC_{{cfgr_prescaler}}_{{d1}}PPRE_DIV1,
+		Div2   = RCC_{{cfgr_prescaler}}_{{d1}}PPRE_DIV2,
+		Div4   = RCC_{{cfgr_prescaler}}_{{d1}}PPRE_DIV4,
+		Div8   = RCC_{{cfgr_prescaler}}_{{d1}}PPRE_DIV8,
+		Div16  = RCC_{{cfgr_prescaler}}_{{d1}}PPRE_DIV16
 	};
 
 	enum class
@@ -281,6 +291,23 @@ public:
 		MHz2_4 = 1,
 		MHz4_8 = 2,
 		MHz8_16 = 3,
+	};
+%% elif target.family in ["u5"]
+	enum class
+	Apb3Prescaler : uint32_t
+	{
+		Div1   = 0b000 << RCC_CFGR3_PPRE3_Pos,
+		Div2   = 0b100 << RCC_CFGR3_PPRE3_Pos,
+		Div4   = 0b101 << RCC_CFGR3_PPRE3_Pos,
+		Div8   = 0b110 << RCC_CFGR3_PPRE3_Pos,
+		Div16  = 0b111 << RCC_CFGR3_PPRE3_Pos,
+	};
+
+	enum class
+	PllInputRange : uint8_t
+	{
+		MHz4_8  = 0b00,
+		MHz8_16 = 0b11,
 	};
 %% endif
 
@@ -303,10 +330,10 @@ public:
 		PllSaiP = RCC_DCKCFGR2_CK48MSEL
 	%% endif
 	};
-%% elif target.family in ["g4", "l4", "l5", "u5"]
+%% elif target.family in ["g4", "l4", "l5"]
 	enum class Clock48Source
 	{
-%% set sel48="MSEL" if target.family in ["l5", "u5"] else "SEL"
+%% set sel48="MSEL" if target.family in ["l5"] else "SEL"
 %% if target.family == "l4" and target.name[0] in ["7", "8"]
 		None = 0,
 %% else
@@ -315,6 +342,14 @@ public:
 		PllSai1Q = RCC_{{ccipr1}}_CLK48{{sel48}}_0,
 		PllQ = RCC_{{ccipr1}}_CLK48{{sel48}}_1,
 		Msi = RCC_{{ccipr1}}_CLK48{{sel48}}_1 | RCC_{{ccipr1}}_CLK48{{sel48}}_0
+	};
+%% elif target.family in ["u5"]
+	enum class Clock48Source
+	{
+		Hsi48 = 0b00 << RCC_CCIPR1_ICLKSEL_Pos,
+		Pll2Q = 0b01 << RCC_CCIPR1_ICLKSEL_Pos,
+		Pll1Q = 0b10 << RCC_CCIPR1_ICLKSEL_Pos,
+		Msik  = 0b11 << RCC_CCIPR1_ICLKSEL_Pos,
 	};
 %% endif
 
@@ -359,28 +394,34 @@ public:
 		Csi = RCC_CFGR_MCO2_2,
 		Lsi = RCC_CFGR_MCO2_2 | RCC_CFGR_MCO2_0
 	};
-%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5"]
+%% set cfgr_mco="CFGR1" if target.family in ["u5"] else "CFGR"
 	enum class
 	ClockOutputSource : uint32_t
 	{
-		Disable = 0,
-		SystemClock = (1 << RCC_CFGR_MCOSEL_Pos), // SYSCLK
+		Disable = 0b0000,
+		SystemClock = (0b0001 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // SYSCLK
 	%% if target.family in ["l4", "l5"]
-		MultiSpeedInternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // MSI
+		MultiSpeedInternalClock = (0b0010 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // MSI
+	%% elif target.family in ["u5"]
+		MultiSpeedInternalClockS = (0b0010 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // MSIS
 	%% endif
 	%% if target.family in ["l0", "l1"]
-		InternalClock = (2 << RCC_CFGR_MCOSEL_Pos), // HSI16
-		MultiSpeedInternalClock = (3 << RCC_CFGR_MCOSEL_Pos), // MSI
+		InternalClock = (0b0010 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // HSI16
+		MultiSpeedInternalClock = (0b0011 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // MSI
 	%% else
-		InternalClock = (3 << RCC_CFGR_MCOSEL_Pos), // HSI16
+		InternalClock = (0b0011 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // HSI16
 	%% endif
-		ExternalClock = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
-		ExternalCrystal = (4 << RCC_CFGR_MCOSEL_Pos), // HSE
-		Pll = (5 << RCC_CFGR_MCOSEL_Pos), // Main PLL
-		LowSpeedInternalClock = (6 << RCC_CFGR_MCOSEL_Pos), // LSI
-		LowSpeedExternalClock = (7 << RCC_CFGR_MCOSEL_Pos), // LSE
-	%% if target.family == "l5"
-		Hsi48 = (8 << RCC_CFGR_MCOSEL_Pos), // HSI48
+		ExternalClock = (0b0100 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // HSE
+		ExternalCrystal = ExternalClock, // HSE
+		Pll = (0b0101 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // Main PLL
+		LowSpeedInternalClock = (0b0110 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // LSI
+		LowSpeedExternalClock = (0b0111 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // LSE
+	%% if target.family in ["l5"]
+		Hsi48 = (0b1000 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // HSI48
+	%% elif target.family in ["u5"]
+		Hsi48 = (0b1000 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // HSI48
+		MultiSpeedInternalClockK = (0b1001 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // MSIK
 	%% endif
 	};
 %% else
@@ -405,23 +446,27 @@ public:
 	};
 %% endif
 
-%% if target.family in ["g4", "l5"]
+%% if target.family in ["g4", "l5", "u5"]
 	enum class
 	CanClockSource : uint32_t
 	{
 		Hse = 0,
-		PllQ = RCC_{{ccipr1}}_FDCANSEL_0,
 %% if target.family == "g4"
+		PllQ = RCC_{{ccipr1}}_FDCANSEL_0,
 		Pclk = RCC_{{ccipr1}}_FDCANSEL_1,
 %% elif target.family == "l5"
+		PllQ = RCC_{{ccipr1}}_FDCANSEL_0,
 		PllSai1P = RCC_{{ccipr1}}_FDCANSEL_1,
+%% elif target.family in ["u5"]
+		Pll1Q = 0b01 << RCC_{{ccipr1}}_FDCANSEL_Pos,
+		Pll2P = 0b10 << RCC_{{ccipr1}}_FDCANSEL_Pos,
 %% endif
 	};
 
 	static void
 	setCanClockSource(CanClockSource source)
 	{
-		RCC->{{ccipr1}} = (RCC->{{ccipr1}} & ~RCC_{{ccipr1}}_FDCANSEL) | uint32_t(source);
+		RCC->{{ccipr1}} = (RCC->{{ccipr1}} & ~RCC_{{ccipr1}}_FDCANSEL_Msk) | uint32_t(source);
 	}
 
 	/// FDCAN subsystem prescaler common to all FDCAN instances
@@ -468,7 +513,7 @@ public:
 	enableInternalClockMHz48(uint32_t waitCycles = 2048);
 %% endif
 
-%% if target.family in ["l0", "l1", "l4", "l5"]
+%% if target.family in ["l0", "l1", "l4", "l5", "u5"]
 	enum class
 	MsiFrequency : uint32_t
 	{
@@ -506,11 +551,35 @@ public:
 		MHz24  = 0b1001 << RCC_CR_MSIRANGE_Pos,
 		MHz32  = 0b1010 << RCC_CR_MSIRANGE_Pos,
 		MHz48  = 0b1011 << RCC_CR_MSIRANGE_Pos,
+%% elif target.family in ["u5"]
+		MHz48   = 0b0000,
+		MHz24   = 0b0001,
+		MHz16   = 0b0010,
+		MHz12   = 0b0011,
+		MHz4    = 0b0100,
+		MHz2    = 0b0101,
+		kHz1330 = 0b0110,
+		kHz1000 = 0b0111,
+		kHz3072 = 0b1000,
+		kHz1536 = 0b1001,
+		kHz1024 = 0b1010,
+		kHz768  = 0b1011,
+		kHz400  = 0b1100,
+		kHz200  = 0b1101,
+		kHz133  = 0b1110,
+		kHz100  = 0b1111,
 %% endif
 	};
 
+%% if target.family in ["u5"]
+	static bool
+	enableMultiSpeedInternalClockS(MsiFrequency msi_frequency = MsiFrequency::MHz4, uint32_t waitCycles = 2048);
+	static bool
+	enableMultiSpeedInternalClockK(MsiFrequency msi_frequency = MsiFrequency::MHz4, uint32_t waitCycles = 2048);
+%% else
 	static bool
 	enableMultiSpeedInternalClock(MsiFrequency msi_frequency = MsiFrequency::MHz4, uint32_t waitCycles = 2048);
+%% endif
 %% endif
 
 	static bool
@@ -528,6 +597,22 @@ public:
 	static bool
 	enableLowSpeedExternalCrystal(uint32_t waitCycles = 2048);
 
+%% if target.family in ["u5"]
+	enum class
+	EpodBoosterPrescaler : uint32_t
+	{
+		Div1  = 0b0000 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div2  = 0b0001 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div4  = 0b0010 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div6  = 0b0011 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div8  = 0b0100 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div10 = 0b0101 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div12 = 0b0110 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div14 = 0b0111 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+		Div16 = 0b1000 << RCC_PLL1CFGR_PLL1MBOOST_Pos,
+	};
+%% endif
+
 	struct PllFactors
 	{
 %% if target.family in ["h7"]
@@ -537,6 +622,18 @@ public:
 		uint8_t pllP;
 		uint8_t pllQ;
 		uint8_t pllR;
+		uint16_t pllFrac = 0;
+%% elif target.family in ["u5"]
+		PllInputRange range;
+		uint8_t pllM;
+		uint16_t pllN;
+		uint8_t pllP;
+		uint8_t pllQ;
+		uint8_t pllR;
+		/// Only used with PLL1:
+		/// Configure the PLL1MBOOST in RCC->PLL1CFGR to generate a booster
+		/// clock frequency between 4 and 16 MHz.
+		EpodBoosterPrescaler epodPrescaler = EpodBoosterPrescaler::Div1;
 		uint16_t pllFrac = 0;
 %% elif target.family in ["f2", "f4", "f7", "l4", "l5", "g0", "g4"]
 		uint8_t pllM;
@@ -668,11 +765,17 @@ public:
 		RCC->DCKCFGR2 = (RCC->DCKCFGR2 & ~RCC_DCKCFGR2_CK48MSEL) | uint32_t(source);
 	%% endif
 	}
-%% elif target.family in ["g4", "l4", "l5", "u5"]
+%% elif target.family in ["g4", "l4", "l5"]
 	static inline void
 	setClock48Source(Clock48Source source)
 	{
 		RCC->{{ccipr1}} = (RCC->{{ccipr1}} & ~RCC_{{ccipr1}}_CLK48{{sel48}}_Msk) | uint32_t(source);
+	}
+%% elif target.family in ["u5"]
+	static inline void
+	setClock48Source(Clock48Source source)
+	{
+		RCC->CCIPR1 = (RCC->CCIPR1 & ~RCC_CCIPR1_ICLKSEL_Msk) | uint32_t(source);
 	}
 %% endif
 
@@ -730,26 +833,26 @@ public:
 		RCC->CFGR = tmp | uint32_t(src);
 		return true;
 	}
-%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5"]
 	enum class
 	ClockOutputPrescaler : uint32_t
 	{
 		Div1 = 0,
-		Div2 = (1 << RCC_CFGR_MCOPRE_Pos),
-		Div4 = (2 << RCC_CFGR_MCOPRE_Pos),
-		Div8 = (3 << RCC_CFGR_MCOPRE_Pos),
-		Div16 = (4 << RCC_CFGR_MCOPRE_Pos),
+		Div2 = (1 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
+		Div4 = (2 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
+		Div8 = (3 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
+		Div16 = (4 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 %% if target.family in ["g0"]
-		Div32 = (5 << RCC_CFGR_MCOPRE_Pos),
-		Div64 = (6 << RCC_CFGR_MCOPRE_Pos),
-		Div128 = (7 << RCC_CFGR_MCOPRE_Pos),
+		Div32 = (5 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
+		Div64 = (6 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
+		Div128 = (7 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 %% endif
 	};
 
 	static inline bool
 	enableClockOutput(ClockOutputSource src, ClockOutputPrescaler div = ClockOutputPrescaler::Div1)
 	{
-		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCOPRE)) | uint32_t(src) | uint32_t(div);
+		RCC->{{cfgr_mco}} = (RCC->{{cfgr_mco}} & ~(RCC_{{cfgr_mco}}_MCOPRE)) | uint32_t(src) | uint32_t(div);
 		return true;
 	}
 %% else
@@ -765,7 +868,7 @@ public:
 	static inline bool
 	setAhbPrescaler(AhbPrescaler prescaler)
 	{
-		RCC->{{cfgr1}} = (RCC->{{cfgr1}} & ~RCC_{{cfgr1}}_HPRE) | uint32_t(prescaler);
+		RCC->{{cfgr_prescaler}} = (RCC->{{cfgr_prescaler}} & ~RCC_{{cfgr_prescaler}}_HPRE) | uint32_t(prescaler);
 		return true;
 	}
 
@@ -791,11 +894,12 @@ public:
 		return true;
 	}
 %% endif
+
 %% if target.family == "h7"
 	static inline bool
 	setApb3Prescaler(Apb3Prescaler prescaler)
 	{
-		RCC->{{cfgr1}} = (RCC->{{cfgr1}} & ~RCC_{{cfgr1}}_{{d1}}PPRE) | uint32_t(prescaler);
+		RCC->{{cfgr_prescaler}} = (RCC->{{cfgr_prescaler}} & ~RCC_{{cfgr_prescaler}}_{{d1}}PPRE) | uint32_t(prescaler);
 		return true;
 	}
 	static inline bool
@@ -805,7 +909,14 @@ public:
 		return true;
 	}
 %% endif
-
+%% if target.family in ["u5"]
+	static inline bool
+	setApb3Prescaler(Apb3Prescaler prescaler)
+	{
+		RCC->CFGR3 = (RCC->CFGR3 & ~RCC_CFGR3_PPRE3) | uint32_t(prescaler);
+		return true;
+	}
+%% endif
 
 %% if overdrive
 	static bool
@@ -875,9 +986,18 @@ public:
 		Range1 = PWR_CR1_VOS_0,
 		Range2 = PWR_CR1_VOS_1
 	};
+%% elif target.family == "u5"
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Range4 = 0b00 << PWR_VOSR_VOS_Pos, /// Lowest Power
+		Range3 = 0b01 << PWR_VOSR_VOS_Pos,
+		Range2 = 0b10 << PWR_VOSR_VOS_Pos,
+		Range1 = 0b11 << PWR_VOSR_VOS_Pos, /// Highest frequency
+	};
 %% endif
 
-%% if target.family in ["h7", "l5"] or has_r1mode
+%% if target.family in ["h7", "l5", "u5"] or has_r1mode
 	static bool
 	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 2048);
 %% endif

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -77,6 +77,9 @@ Rcc::setFlashLatency()
 %% elif target["family"] == "l0"
 	// enable flash prefetch and pre-read
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_PRE_READ;
+%% elif target["family"] in ["u5"]
+	// enable flash prefetch
+	acr |= FLASH_ACR_PRFTEN;
 %% elif target["family"] not in ["h7", "l5"]
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTBE;

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -54,6 +54,7 @@ def build(env):
         "h7": (4,  4), # CM7  tested on H743 in ITCM
         "l4": (3,  4), # CM4  tested on L476 in SRAM2
         "l5": (3,  4), # CM33 tested on L552 in RAM
+        "u5": (3,  4), # CM33 tested on U575 in RAM
         "f3": (3,  4), # CM4  tested on F334, F303 in CCM RAM
 
         # Defaults of (4, 4) for these families:

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -35,6 +35,8 @@ __modm_initialize_platform(void)
 	RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
 %% elif target.family == "h7"
 	RCC->APB4ENR |= RCC_APB4ENR_SYSCFGEN;
+%% elif target.family == "u5"
+	RCC->APB3ENR |= RCC_APB3ENR_SYSCFGEN;
 %% else
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
 %% endif
@@ -71,6 +73,14 @@ __modm_initialize_platform(void)
 	// Enable VDDIO2
 	PWR->CR2 |= PWR_CR2_IOSV;
 #endif
+%% elif target.family in ["u5"]
+	RCC->AHB3ENR |= RCC_AHB3ENR_PWREN;
+	// Enable power for VDDIO2 and USB
+	PWR->SVMCR |= PWR_SVMCR_ASV | PWR_SVMCR_IO2SV | PWR_SVMCR_USV;
+
+	// Enable Backup SRAM (BKPSRAM)
+	PWR->DBPR |= PWR_DBPR_DBP;
+	RCC->AHB1ENR |= RCC_AHB1ENR_BKPSRAMEN;
 %% endif
 
 %% if vector_table_location == "ram"

--- a/src/modm/platform/extint/stm32/module.lb
+++ b/src/modm/platform/extint/stm32/module.lb
@@ -47,12 +47,12 @@ def validate(env):
 def build(env):
     target = env[":target"].identifier
 
-    separate_flags = target.family in ["g0", "l5"]
+    separate_flags = target.family in ["g0", "l5", "u5"]
     extended = target.family in ["l4", "l5", "g4", "h7"]
     if separate_flags: extended = target.name in ["b1", "c1"]
 
     exti_reg = "SYSCFG"
-    if target.family in ["g0", "l5"]: exti_reg = "EXTI"
+    if target.family in ["g0", "l5", "u5"]: exti_reg = "EXTI"
     if target.family in ["f1"]: exti_reg = "AFIO"
 
     global extimap

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -26,11 +26,14 @@ modm_gpio_enable(void)
 %% elif target.family in ["f1"]
 %%	set clock_tree = "APB2"
 %%	set prefix = "IOP"
-%% elif target.family in ["l4", "l5", "g4"]
+%% elif target.family in ["l4", "l5", "g4", "u5"]
 %%  set clock_tree = 'AHB2'
 %% elif target.family in ["g0", "l0"]
 %%  set clock_tree = 'IOP'
 %% endif
+
+%% set enr="ENR1" if target.family in ["u5"] else "ENR"
+%% set rstr="RSTR1" if target.family in ["u5"] else "RSTR"
 
 %% if target.family in ["h7"]
 	// Enable I/O compensation cell
@@ -42,20 +45,20 @@ modm_gpio_enable(void)
 %% endif
 
 	// Enable GPIO clock
-	RCC->{{ clock_tree }}ENR  |=
+	RCC->{{ clock_tree }}{{enr}}  |=
 %% for port in options.enable_ports
-		RCC_{{ clock_tree }}ENR_{{ prefix }}{{ port | upper }}EN{% if loop.last %};{% else %} |{% endif %}
+		RCC_{{ clock_tree }}{{enr}}_{{ prefix }}{{ port | upper }}EN{% if loop.last %};{% else %} |{% endif %}
 %% endfor
 
 	// Reset GPIO peripheral
-	RCC->{{ clock_tree }}RSTR |=
+	RCC->{{ clock_tree }}{{rstr}} |=
 %% for port in options.enable_ports
-		RCC_{{ clock_tree }}RSTR_{{ prefix }}{{ port | upper }}RST{% if loop.last %};{% else %} |{% endif %}
+		RCC_{{ clock_tree }}{{rstr}}_{{ prefix }}{{ port | upper }}RST{% if loop.last %};{% else %} |{% endif %}
 %% endfor
 
-	RCC->{{ clock_tree }}RSTR &= ~(
+	RCC->{{ clock_tree }}{{rstr}} &= ~(
 %% for port in options.enable_ports
-		RCC_{{ clock_tree }}RSTR_{{ prefix }}{{ port | upper }}RST{% if loop.last %});{% else %} |{% endif %}
+		RCC_{{ clock_tree }}{{rstr}}_{{ prefix }}{{ port | upper }}RST{% if loop.last %});{% else %} |{% endif %}
 %% endfor
 }
 

--- a/src/modm/platform/uart/cortex/itm.cpp.in
+++ b/src/modm/platform/uart/cortex/itm.cpp.in
@@ -61,7 +61,7 @@ Itm::enable(uint8_t prescaler)
 	ITM->TPR  = 0;
 
 	// Trace Control Register
-%% if target.platform == "stm32" and target.family == "l5"
+%% if target.platform == "stm32" and target.family in ["l5", "u5"]
 	ITM->TCR  = (1 << ITM_TCR_TRACEBUSID_Pos) |
 %% else
 	ITM->TCR  = (1 << ITM_TCR_TraceBusID_Pos) |

--- a/src/modm/platform/uart/stm32/uart_base.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_base.hpp.in
@@ -29,7 +29,7 @@
 #define	USART_BRR_DIV_FRACTION	USART_BRR_DIV_Fraction
 #endif
 %% endif
-%% if tcbgt and target.family not in ["g4", "l5"]
+%% if tcbgt and target.family not in ["g4", "l5", "u5"]
 #define USART_CR1_TXEIE   USART_CR1_TXEIE_TXFNFIE
 #define USART_CR1_RXNEIE  USART_CR1_RXNEIE_RXFNEIE
 #define USART_ISR_RXNE    USART_ISR_RXNE_RXFNE

--- a/test/Makefile
+++ b/test/Makefile
@@ -119,6 +119,12 @@ run-nucleo-l552ze-q:
 	$(call run-test,nucleo-l552ze-q,size)
 
 
+compile-nucleo-u575zi-q:
+	$(call compile-test,nucleo-u575zi-q,size)
+run-nucleo-u575zi-q:
+	$(call run-test,nucleo-u575zi-q,size)
+
+
 compile-al-avreb-can:
 	$(call compile-test,al-avreb-can,size)
 run-al-avreb-can:

--- a/test/config/nucleo-u575zi-q.xml
+++ b/test/config/nucleo-u575zi-q.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:nucleo-u575zi-q</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/nucleo-u575zi-q/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/nucleo-u575zi-q/modm-test</option>
+    <option name="modm:platform:exti:with_handlers">false</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>

--- a/tools/openocd/modm/st_nucleo_u5.cfg
+++ b/tools/openocd/modm/st_nucleo_u5.cfg
@@ -1,0 +1,11 @@
+# This is for STM32U5 Nucleo Dev Boards.
+# http://www.st.com/en/evaluation-tools/stm32-mcu-nucleo.html
+
+source [find interface/stlink-dap.cfg]
+
+transport select dapdirect_swd
+
+source [find target/stm32u5x.cfg]
+
+# use hardware reset
+reset_config srst_only srst_nogate

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -131,10 +131,10 @@ def hal_get_modules():
     mapping["I<sup>2</sup>C"].update({"sercom", "twihs"})
     mapping["USB"].update({"usb", "usbhs"})
     mapping["CAN"].update({"fdcan", "mcan"})
-    mapping["DMA"].update({"dmac", "xdmac"})
+    mapping["DMA"].update({"dmac", "xdmac", "gpdma"})
     mapping["Comparator"].update({"ac", "acc"})
     mapping["Internal Flash"].update({"efc", "nvmctrl"})
-    mapping["External Memory"].update({"sdramc", "smc", "quadspi", "xip_ssi"})
+    mapping["External Memory"].update({"sdramc", "smc", "quadspi", "xip_ssi", "octospi"})
 
     print(); print()
     return (all_targets, mapping)


### PR DESCRIPTION
Add STM32U5 devices

Most work was already done in #800.

- [x] Update device files: modm-io/modm-devices#82
- [x] Port RCC driver
- [x] Adapt other platform drivers: Core, Gpio, Uart
- [x] ~~Adapt ADC platform driver: Untested~~ Disable ADC for now
- [ ] ~~Adapt even more platform drivers~~
- [x] Nucleo-U575ZI-Q BSP
- [x] Add CI jobs
- [x] Add and test Nucleo-U575ZI-Q blink example
  - [x] Test on real hardware
- [x] Unittest runner
  - [x] Test on real hardware
- [x] Unambiguous names for all STM32 unittests (e.g. `compile-nucleo-f411` -> `compile-nucleo-f411re`, ...)
- [x] OpenOCD config

### To be implemented later
- DMA (completely new DMA IP(s))
- SPI (same "new" IP as used in STM32H7)