### PR TITLE
Fix STM32H7 RCC clock output

### DIFF
--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -318,7 +318,7 @@ public:
 	};
 %% endif
 
-%% if target.family in ["f2", "f4", "f7", "h7"]
+%% if target.family in ["f2", "f4", "f7"]
 	enum class
 	ClockOutput1Source : uint32_t
 	{
@@ -338,6 +338,27 @@ public:
 		Pll = RCC_CFGR_MCO2_1 | RCC_CFGR_MCO2_0,
 	};
 	%% endif
+%% elif target.family in ["h7"]
+	enum class
+	ClockOutput1Source : uint32_t
+	{
+		Hsi = 0,
+		Lse = RCC_CFGR_MCO1_0,
+		Hse = RCC_CFGR_MCO1_1,
+		Pll1Q = RCC_CFGR_MCO1_1 | RCC_CFGR_MCO1_0,
+		Hsi48 = RCC_CFGR_MCO1_2
+	};
+
+	enum class
+	ClockOutput2Source : uint32_t
+	{
+		SystemClock = 0,
+		Pll2P = RCC_CFGR_MCO2_0,
+		Hse = RCC_CFGR_MCO2_1,
+		Pll = RCC_CFGR_MCO2_1 | RCC_CFGR_MCO2_0,
+		Csi = RCC_CFGR_MCO2_2,
+		Lsi = RCC_CFGR_MCO2_2 | RCC_CFGR_MCO2_0
+	};
 %% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
 	enum class
 	ClockOutputSource : uint32_t
@@ -654,7 +675,7 @@ public:
 	}
 %% endif
 
-%% if target.family in ["f2", "f4", "f7", "h7"]
+%% if target.family in ["f2", "f4", "f7"]
 	static inline bool
 	enableClockOutput1(ClockOutput1Source src, uint8_t div)
 	{
@@ -674,7 +695,24 @@ public:
 		return true;
 	}
 	%% endif
+%% elif target.family in ["h7"]
+	static inline bool
+	enableClockOutput1(ClockOutput1Source src, uint8_t div)
+	{
+		uint32_t tmp = RCC->CFGR & ~(RCC_CFGR_MCO1 | RCC_CFGR_MCO1PRE);
+		if (div > 1) tmp |= (div << 18);
+		RCC->CFGR = tmp | uint32_t(src);
+		return true;
+	}
 
+	static inline bool
+	enableClockOutput2(ClockOutput2Source src, uint8_t div)
+	{
+		uint32_t tmp = RCC->CFGR & ~(RCC_CFGR_MCO2 | RCC_CFGR_MCO2PRE);
+		if (div > 1) tmp |= (div << 25);
+		RCC->CFGR = tmp | uint32_t(src);
+		return true;
+	}
 %% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4"]
 	enum class
 	ClockOutputPrescaler : uint32_t

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2012, 2017, Fabian Greif
  * Copyright (c) 2012, 2014-2017, Niklas Hauser
  * Copyright (c) 2013-2014, Kevin Läufer
- * Copyright (c) 2018, 2021, Christopher Durand
+ * Copyright (c) 2018, 2021-2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include "../device.hpp"
 #include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/connector.hpp>
 #include <modm/architecture/interface/delay.hpp>
 
 namespace modm::platform
@@ -842,6 +843,14 @@ public:
 	template< uint32_t Core_Hz >
 	static void
 	updateCoreFrequency();
+
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Rcc, Signals...>;
+		Connector::connect();
+	}
 
 public:
 	template< Peripheral peripheral >


### PR DESCRIPTION
Fix STM32H7 RCC clock output and add `connect()` method for alternate function configuration of clock outputs to RCC driver. Tested in hardware on a STM32H755ZI-Q Nucleo.

I haven't yet added an example because support for STM32H7 dual-core is still work in progress. It will go into #844.

Fixes #852 