### PR TITLE
[stm32] Uart: Add transmission complete flag

### DIFF
--- a/src/modm/platform/uart/stm32/uart_hal.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal.hpp.in
@@ -118,6 +118,10 @@ public:
 	static inline bool
 	isTransmitRegisterEmpty();
 
+	/// Returns true if the transmission of a frame containing data is complete
+	static inline bool
+	isTransmissionComplete();
+
 	static inline void
 	enableInterruptVector(bool enable, uint32_t priority);
 

--- a/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/stm32/uart_hal_impl.hpp.in
@@ -210,6 +210,16 @@ bool
 %% endif
 }
 
+bool
+{{ hal }}::isTransmissionComplete()
+{
+%% if extended_driver
+	return {{ peripheral }}->ISR & USART_ISR_TC;
+%% else
+	return {{ peripheral }}->SR & USART_SR_TC;
+%% endif
+}
+
 void
 {{ hal }}::enableInterruptVector(bool enable, uint32_t priority)
 {


### PR DESCRIPTION
Just a quick expose the TC flag in the API.

TXE goes high when the shift register started pouring the bytes to the line and a new byte can be written to the data register.
The TC flag goes high after the stop bit is send. Required for manually enabling and disabling line drivers.