### PR TITLE
[board] Add Can1 and Can2 to Board::SystemClock

### DIFF
--- a/src/modm/board/nucleo_f446re/board.hpp
+++ b/src/modm/board/nucleo_f446re/board.hpp
@@ -52,6 +52,9 @@ struct SystemClock
 	static constexpr uint32_t Uart5  = Apb1;
 	static constexpr uint32_t Usart6 = Apb2;
 
+	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can2   = Apb1;
+
 	static constexpr uint32_t I2c1   = Apb1;
 	static constexpr uint32_t I2c2   = Apb1;
 	static constexpr uint32_t I2c3   = Apb1;

--- a/src/modm/board/nucleo_f446ze/board.hpp
+++ b/src/modm/board/nucleo_f446ze/board.hpp
@@ -51,6 +51,9 @@ struct SystemClock
 	static constexpr uint32_t Uart5  = Apb1;
 	static constexpr uint32_t Usart6 = Apb2;
 
+	static constexpr uint32_t Can1   = Apb1;
+	static constexpr uint32_t Can2   = Apb1;
+
 	static constexpr uint32_t I2c1   = Apb1;
 	static constexpr uint32_t I2c2   = Apb1;
 	static constexpr uint32_t I2c3   = Apb1;


### PR DESCRIPTION
Is there a specific reason I do not know why this was left out?

There might be other board examples where the Can is accidentally left out.