### PR TITLE
[board] Update information about board revisions of F469NI Disco.Kits

### DIFF
--- a/src/modm/board/disco_f469ni/module.lb
+++ b/src/modm/board/disco_f469ni/module.lb
@@ -14,7 +14,7 @@
 def init(module):
     module.name = ":board:disco-f469ni"
     module.description = FileReader("module.md")
-    # Revisions = [b-03, b-01]
+    # Revisions = [b-03, b-02, b-01]
 
 def prepare(module, options):
     if not options[":target"].partname.startswith("stm32f469nih"):

--- a/src/modm/board/disco_f469ni/module.md
+++ b/src/modm/board/disco_f469ni/module.md
@@ -30,7 +30,7 @@ Call `Board::initializeTouchscreen()` to setup the peripherals.
 
 ## Hardware Revisions
 
-The revision B-03 has a different touch sensor address from B-01, which is
+The revision B-03 has a different touch sensor address from B-01 and B-02, which is
 provided as `Board::ft6::TouchAddress`:
 
 ```cpp


### PR DESCRIPTION
Board Rev-2 has the same touchscreen address as Rev-1.

But let me double-check that today/tomorrow :relaxed: 