### PR TITLE
[driver] use std::has_single_bit to assert power of 2

### DIFF
--- a/src/modm/driver/encoder/bitbang_encoder_input.hpp
+++ b/src/modm/driver/encoder/bitbang_encoder_input.hpp
@@ -35,7 +35,7 @@ template<typename SignalA, typename SignalB, uint8_t PRESCALER = 4,
 		 std::signed_integral DeltaType = int8_t>
 class BitBangEncoderInput
 {
-	static_assert(std::popcount(PRESCALER) == 1,
+	static_assert(std::has_single_bit(PRESCALER),
 				  "PRESCALER must be an integer to basis 2 and not 0: 1, 2, 4, 8, 16, ...");
 	static_assert(PRESCALER <= std::numeric_limits<DeltaType>::max(),
 				  "DeltaType is to small for PRESCALER.");

--- a/src/modm/driver/encoder/encoder_input.hpp
+++ b/src/modm/driver/encoder/encoder_input.hpp
@@ -22,10 +22,11 @@ namespace modm
  * @tparam SignalA		First modm::platform::Gpio pin that connects to Timer::Ch1
  * @tparam SignalB		Second modm::platform::Gpio pin that connects to Timer::Ch2
  * @tparam PRESCALER	How many encoder pulses to count as one
- * @tparam DeltaType	Fast encoders may require int16_t
+ * @tparam DeltaType	For very fast or high resolution encoder, int32_t may be required
  */
 template<class Timer, typename SignalA, typename SignalB, uint16_t PRESCALER = 4,
 	std::signed_integral DeltaType = int16_t>
+requires (std::numeric_limits<DeltaType>::max() < std::pow(2, 31))
 class EncoderInput
 {
 public:


### PR DESCRIPTION
Have discovered `std::has_single_bit` and cause it's exactly, whats required in `modm::BitBangEncoderInput` it must have been fixed for reference reasons.