### PR TITLE
fix modm:platform:itm

### DIFF
--- a/src/modm/platform/uart/cortex/itm.cpp.in
+++ b/src/modm/platform/uart/cortex/itm.cpp.in
@@ -97,7 +97,7 @@ Itm::write(uint8_t data)
 	update();
 	return txBuffer.push(data);
 %% else
-	return write_itm(data);
+	return write_itm(data << 24);
 %% endif
 }
 


### PR DESCRIPTION
Itm not work if buffer.tx option is not set.
Itm::write_itm assumes data is stored in highest byte.