### PR TITLE
fix: remove default value in setFlashLatency implementation template …

### DIFF
--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -49,7 +49,7 @@ Rcc::computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV)
 	return {latency, max_freq};
 }
 
-template< uint32_t Core_Hz, uint16_t Core_mV = 3300 >
+template< uint32_t Core_Hz, uint16_t Core_mV>
 uint32_t
 Rcc::setFlashLatency()
 {


### PR DESCRIPTION
Default value in template param Core_mV is both in declaration and implementation, doesn't work :)