### PR TITLE
[stm32] Fix compilation of SPI DMA driver with GCC 11+

### DIFF
--- a/src/modm/platform/spi/rp/spi_master.hpp.in
+++ b/src/modm/platform/spi/rp/spi_master.hpp.in
@@ -27,9 +27,11 @@ namespace modm::platform
  */
 class SpiMaster{{ id }} : public modm::SpiMaster
 {
+protected:
 	// Bit0: single transfer state
 	// Bit1: block transfer state
 	static inline uint8_t state{0};
+private:
 	static inline uint8_t count{0};
 	static inline void *context{nullptr};
 	static inline ConfigurationHandler configuration{nullptr};

--- a/src/modm/platform/spi/stm32/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.cpp.in
@@ -16,21 +16,6 @@
 
 #include "spi_master_{{id}}.hpp"
 
-// Bit0: single transfer state
-// Bit1: block transfer state
-uint8_t
-modm::platform::SpiMaster{{ id }}::state(0);
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::count(0);
-
-void *
-modm::platform::SpiMaster{{ id }}::context(nullptr);
-
-modm::Spi::ConfigurationHandler
-modm::platform::SpiMaster{{ id }}::configuration(nullptr);
-// ----------------------------------------------------------------------------
-
 uint8_t
 modm::platform::SpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
 {

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -5,6 +5,7 @@
  * Copyright (c) 2012, Georgi Grinshpun
  * Copyright (c) 2013, Kevin Läufer
  * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -38,10 +39,15 @@ namespace platform
  */
 class SpiMaster{{ id }} : public modm::SpiMaster
 {
-	static uint8_t state;
-	static uint8_t count;
-	static void *context;
-	static ConfigurationHandler configuration;
+protected:
+	// `state` must be protected to allow access from SpiMasterDma subclass
+	// Bit0: single transfer state
+	// Bit1: block transfer state
+	static inline uint8_t state{0};
+private:
+	static inline uint8_t count{0};
+	static inline void* context{nullptr};
+	static inline ConfigurationHandler configuration{nullptr};
 public:
 	using Hal = SpiHal{{ id }};
 


### PR DESCRIPTION
Fix incorrect access specifier in `SpiMaster` that prevents `SpiMasterDma` from compiling with GCC 11.

GCC versions prior to 11 allowed accessing private member variables of template base classes from sub-classes: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58993

cc @hshose 

Fixes #876 