### PR TITLE
[rtt] Fix deduplicated options and use standard identifier

### DIFF
--- a/examples/blue_pill_f103/rtt/main.cpp
+++ b/examples/blue_pill_f103/rtt/main.cpp
@@ -34,7 +34,7 @@ modm::log::Logger modm::log::error(rtt_device);
 ╰─────RTT────── stm32f303vct6
 Info : STLINK V2J16S0 (API v2) VID:PID 0483:3748
 Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000c04
 Info : Listening on port 9090 for rtt connections
 Info

--- a/examples/stm32f3_discovery/rtt/main.cpp
+++ b/examples/stm32f3_discovery/rtt/main.cpp
@@ -33,7 +33,7 @@ modm::log::Logger modm::log::error(rtt_device);
 ╰─────RTT────── stm32f303vct6
 Info : STLINK V2J16S0 (API v2) VID:PID 0483:3748
 Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000c04
 Info : Listening on port 9090 for rtt connections
 Info

--- a/src/modm/platform/uart/rtt/module.lb
+++ b/src/modm/platform/uart/rtt/module.lb
@@ -18,10 +18,10 @@ def prepare(module, options):
     if not options[":target"].has_driver("core:cortex-m*"):
         return False
 
-    module.add_set_option(
+    module.add_list_option(
         NumericOption(name="buffer.tx", description="Transmit buffer sizes",
             minimum=0, maximum=2**16), default=512)
-    module.add_set_option(
+    module.add_list_option(
         NumericOption(name="buffer.rx", description="Receive buffer sizes",
             minimum=0, maximum=2**16), default=0)
 

--- a/src/modm/platform/uart/rtt/module.md
+++ b/src/modm/platform/uart/rtt/module.md
@@ -54,7 +54,7 @@ You can also call this from inside GDB via the `monitor` command:
 
 ```
 (gdb) monitor modm_rtt
-rtt: Searching for control block 'modm.rtt.modm'
+rtt: Searching for control block 'SEGGER RTT'
 rtt: Control block found at 0x20001024
 Listening on port 9090 for rtt connections
 (gdb)
@@ -72,7 +72,7 @@ it can only connect to one stream at a time (disconnect with Ctrl+D).
  $ scons log-rtt
 ╭───OpenOCD───> Real Time Transfer
 ╰─────RTT────── stm32f103rbt
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000008
 Listening on port 9090 for rtt connections
 loop 51
@@ -81,7 +81,7 @@ loop 53
 ^D
 
  $ make log-rtt channel=0
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000008
 Listening on port 9090 for rtt connections
 loop 58

--- a/src/modm/platform/uart/rtt/rtt.cpp.in
+++ b/src/modm/platform/uart/rtt/rtt.cpp.in
@@ -74,10 +74,10 @@ struct RttControlBlock
 } modm_packed;
 
 // Explicitly constructed as constinit to force *only* copying via .data section.
-// This prevents the "modm.rtt.modm" identifier leaking into the stack and being
+// This prevents the identifier leaking into the stack and being
 // found by OpenOCD accidentally instead of the real RTT control block.
 static constinit RttControlBlock rtt_control{
-	"modm.rtt.modm",
+	"SEGGER RTT",
 	{{ buffer_tx | length }},
 	{{ buffer_rx | length }},
 	{

--- a/tools/build_script_generator/make/module.md
+++ b/tools/build_script_generator/make/module.md
@@ -367,7 +367,7 @@ simple telnet client. Disconnect with Ctrl+D.
 
 ```
  $ make log-rtt
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000008
 loop: 57
 loop: 58

--- a/tools/build_script_generator/openocd.cfg.in
+++ b/tools/build_script_generator/openocd.cfg.in
@@ -29,7 +29,7 @@ proc modm_program { SOURCE } {
 
 %% if has_rtt
 proc modm_rtt { {POLLING 1} {CHANNELS {{rtt_channels}}} } {
-	rtt setup 0x{{"%0x" % main_ram.start}} {{main_ram.size}} "modm.rtt.modm"
+	rtt setup 0x{{"%0x" % main_ram.start}} {{main_ram.size}} "SEGGER RTT"
 	rtt start
 	rtt polling_interval $POLLING
 	for {set i 0} {$i < $CHANNELS} {incr i} {

--- a/tools/build_script_generator/scons/module.md
+++ b/tools/build_script_generator/scons/module.md
@@ -438,7 +438,7 @@ simple telnet client. Disconnect with Ctrl+D.
  $ scons log-rtt
 ╭───OpenOCD───> Real Time Transfer
 ╰─────RTT────── stm32f103rbt6
-Info : rtt: Searching for control block 'modm.rtt.modm'
+Info : rtt: Searching for control block 'SEGGER RTT'
 Info : rtt: Control block found at 0x20000008
 loop: 57
 loop: 58

--- a/tools/ide/vscode/launch.json.in
+++ b/tools/ide/vscode/launch.json.in
@@ -24,7 +24,7 @@
                 "enabled": true,
                 "address": "0x{{"%0x" % rtt_ram.start}}",
                 "searchSize": {{ rtt_ram.size }},
-                "searchId": "modm.rtt.modm",
+                "searchId": "SEGGER RTT",
                 "polling_interval": 1,
                 "decoders": [
         %% for id in rtt_channels


### PR DESCRIPTION
The set option would remove duplicate buffer sizes, which causes all sorts of confusing issues.

Using the standard `SEGGER RTT` identifier rather than our own, will make the implement more compatible with other RTT debug implementations.