### PR TITLE
Ads7828 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,92 +637,93 @@ you specific needs.
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-adis16470">ADIS16470</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-adns9800">ADNS9800</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ads101x">ADS101X</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-ads7843">ADS7843</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ads7828">ADS7828</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ads7843">ADS7843</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ads816x">ADS816x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ams5915">AMS5915</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-apa102">APA102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-block-device-spi-flash">SPI Flash</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bme280">BME280</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-bmp085">BMP085</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-bmp085">BMP085</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bno055">BNO055</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-cat24aa">CAT24AA</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-drv832x_spi">DRV832X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1302">DS1302</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1631">DS1631</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-ds18b20">DS18B20</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ds18b20">DS18B20</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ea_dog">EA-DOG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input">Encoder Input</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input-bitbang">Encoder Input BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_output-bitbang">Encoder Output BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ft245">FT245</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-ft6x06">FT6x06</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ft6x06">FT6x06</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-gpio_sampler">Gpio Sampler</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hclax">HCLAx</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hd44780">HD44780</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc58x">HMC58x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc6343">HMC6343</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-hx711">HX711</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-hx711">HX711</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-i2c-eeprom">I2C-EEPROM</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ili9341">ILI9341</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-is31fl3733">IS31FL3733</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-itg3200">ITG3200</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-l3gd20">L3GD20</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lan8720a">LAN8720A</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lan8720a">LAN8720A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lawicel">LAWICEL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis302dl">LIS302DL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3dsh">LIS3DSH</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3mdl">LIS3MDL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lm75">LM75</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lp503x">LP503x</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lp503x">LP503x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm303a">LSM303A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6ds33">LSM6DS33</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ltc2984">LTC2984</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max31855">MAX31855</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max6966">MAX6966</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-max7219">MAX7219</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-max7219">MAX7219</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp23x17">MCP23x17</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp2515">MCP2515</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp7941x">MCP7941x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mmc5603">MMC5603</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5611">MS5611</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-nokia5110">NOKIA5110</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-nokia5110">NOKIA5110</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nrf24">NRF24</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-parallel_tft_display">TFT-DISPLAY</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pat9125el">PAT9125EL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca8574">PCA8574</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9535">PCA9535</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9548a">PCA9548A</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9548a">PCA9548A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9685">PCA9685</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sh1106">SH1106</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s65">SIEMENS-S65</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s75">SIEMENS-S75</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sk6812">SK6812</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ssd1306">SSD1306</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-st7586s">ST7586S</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stts22h">STTS22H</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stusb4500">STUSB4500</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3472">TCS3472</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tlc594x">TLC594x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp102">TMP102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp12x">TMP12x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl53l0">VL53L0</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl6180">VL6180</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ws2812">WS2812</a></td>

--- a/examples/nucleo_g474re/ads7828/main.cpp
+++ b/examples/nucleo_g474re/ads7828/main.cpp
@@ -1,0 +1,192 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2022, Jonas Kazem  Andersen
+ * Copyright (c) 2022, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+#include <modm/driver/adc/ads7828.hpp>
+
+using Scl = modm::platform::GpioC6;
+using Sda = modm::platform::GpioC7;
+using I2cMaster = modm::platform::I2cMaster4;
+
+using namespace Board;
+
+class AdcThread : public modm::pt::Protothread
+{
+
+public:
+    AdcThread() : adc(data, 0x48)
+    {
+    }
+
+    inline bool
+    run()
+    {
+        PT_BEGIN();
+
+        while (PT_CALL(adc.ping()) == false)
+        {
+            MODM_LOG_ERROR << "Could not ping Ads7828" << modm::endl;
+
+            timeout.restart(std::chrono::milliseconds(1000));
+            PT_WAIT_UNTIL(timeout.isExpired());
+        }
+
+        while (true)
+        {
+            MODM_LOG_INFO << "-------------------------------" << modm::endl << modm::endl;
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch0 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch1));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch1 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch2));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch2 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch3));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch3 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch4));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch4 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch5));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch5 measuremnt is  \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch6));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch6 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch7));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch7 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            MODM_LOG_INFO << "----Diff Inputs-------------" << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0Ch1));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch0 - Ch1 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch2Ch3));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch2 - Ch3 is\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch4Ch5));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch4 - Ch5 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch6Ch7));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch6 - Ch7 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch1Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch1 - Ch0 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch3Ch2));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch3 - Ch2 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch5Ch4));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch5 - Ch4 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch7Ch6));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Ch7 - Ch6 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            MODM_LOG_INFO << "---Toggling Power Down and Internal Ref----" << modm::endl;
+
+            PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOffAdcConverterOff));
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Default: \t\t\t\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOnAdcConverterOff));
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Internal ref on:  \t\t\t %.4f", data.getVoltage(2.5f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOffAdcConverterOn));
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("No power down \t\t\t\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO << modm::endl;
+
+            PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOnAdcConverterOn));
+            PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
+            PT_CALL(adc.readConversionResult());
+            MODM_LOG_INFO.printf("Internal ref on, no power down: \t %.4f", data.getVoltage(2.5f));
+            MODM_LOG_INFO << modm::endl;
+
+            MODM_LOG_INFO << "-------------------------------" << modm::endl << modm::endl;
+
+            timeout.restart(std::chrono::milliseconds(1000));
+            PT_WAIT_UNTIL(timeout.isExpired());
+        }
+        PT_END();
+    }
+
+private:
+    modm::ads7828::Data data;
+    modm::Ads7828<I2cMaster> adc;
+
+    modm::ShortTimeout timeout;
+} adcThread;
+
+int
+main()
+{
+    Board::initialize();
+
+    I2cMaster::connect<Scl::Scl, Sda::Sda>(I2cMaster::PullUps::Internal);
+    I2cMaster::initialize<Board::SystemClock, 100_kHz>();
+
+
+    MODM_LOG_INFO << "==========Ads7828 Test==========" << modm::endl;
+    MODM_LOG_DEBUG << "Debug logging here" << modm::endl;
+    MODM_LOG_INFO << "Info logging here" << modm::endl;
+    MODM_LOG_WARNING << "Warning logging here" << modm::endl;
+    MODM_LOG_ERROR << "Error logging here" << modm::endl;
+    MODM_LOG_INFO << "===============================" << modm::endl;
+
+    while (true)
+    {
+        adcThread.run();
+    }
+    return 0;
+}

--- a/examples/nucleo_g474re/ads7828/project.xml
+++ b/examples/nucleo_g474re/ads7828/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/ads7828</option>
+  </options>
+  <modules>
+    <module>modm:driver:ads7828</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c:4</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:timer</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/driver/adc/ads7828.hpp
+++ b/src/modm/driver/adc/ads7828.hpp
@@ -1,0 +1,164 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/*
+ * Copyright (c) 2022, Jónas Holm Wentzlau
+ * Copyright (c) 2022, Jonas Kazem Andersen
+ * Copyright (c) 2022, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_ADS7828_HPP
+#define MODM_ADS7828_HPP
+
+#include <modm/architecture/interface/i2c_device.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_ads7828
+struct ads7828
+{
+protected:
+    enum class
+    CommandByte : uint8_t
+    {
+        SD = Bit7,
+        C2 = Bit6,
+        C1 = Bit5,
+        C0 = Bit4,
+        PD1 = Bit3,
+        PD0 = Bit2,
+    };
+    MODM_FLAGS8(CommandByte);
+
+public:
+    enum class
+    InputChannel : uint8_t
+    {
+        // Differential Inputs
+        Ch0Ch1 = 0u,
+        Ch2Ch3 = int(CommandByte::C0),
+        Ch4Ch5 = int(CommandByte::C1),
+        Ch6Ch7 = int(CommandByte::C1) | int(CommandByte::C0),
+        Ch1Ch0 = int(CommandByte::C2),
+        Ch3Ch2 = int(CommandByte::C2) | int(CommandByte::C0),
+        Ch5Ch4 = int(CommandByte::C2) | int(CommandByte::C1),
+        Ch7Ch6 = int(CommandByte::C2) | int(CommandByte::C1) | int(CommandByte::C0),
+
+        // Single-Ended Inputs
+        Ch0 = int(CommandByte::SD),
+        Ch1 = int(CommandByte::SD) | int(CommandByte::C2),
+        Ch2 = int(CommandByte::SD) | int(CommandByte::C0),
+        Ch3 = int(CommandByte::SD) | int(CommandByte::C2) | int(CommandByte::C0),
+        Ch4 = int(CommandByte::SD) | int(CommandByte::C1),
+        Ch5 = int(CommandByte::SD) | int(CommandByte::C2) | int(CommandByte::C1),
+        Ch6 = int(CommandByte::SD) | int(CommandByte::C1) | int(CommandByte::C0),
+        Ch7 = int(CommandByte::SD) | int(CommandByte::C2) | int(CommandByte::C1) | int(CommandByte::C0),
+    };
+    typedef Configuration<CommandByte_t, InputChannel, Bit7 | Bit6 | Bit5 | Bit4> InputChannel_t;
+
+    enum class
+    PowerDown : uint8_t
+    {
+        InternalReferenceOffAdcConverterOff = 0u,
+        InternalReferenceOnAdcConverterOff  = int(CommandByte::PD1),
+        InternalReferenceOffAdcConverterOn  = int(CommandByte::PD0),
+        InternalReferenceOnAdcConverterOn   = int(CommandByte::PD1) | int(CommandByte::PD0),
+    };
+    typedef Configuration<CommandByte_t, PowerDown, Bit3 | Bit2> PowerDown_t;
+
+    struct modm_packed
+    Data
+    {
+        template <class I2cMaster>
+        friend class Ads7828;
+
+        constexpr uint16_t
+        getValue() const
+        {
+            return static_cast<uint16_t>((data[0] << 8) | data[1]);
+        }
+
+        constexpr float
+        getVoltage(float vref) const
+        {
+            return vref * getValue() / 4096;
+        }
+
+    protected:
+        uint8_t data[2];
+    };
+};
+
+/**
+ * @tparam	I2cMaster	I2cMaster interface
+ *
+ * @author	Jonas Holm Wentzlau
+ * @author	Jonas Kazem Andersen
+ * @author  Rasmus Kleist Hørlyck Sørensen
+ * @ingroup modm_driver_ads101x
+ */
+template <typename I2cMaster>
+class Ads7828 : public ads7828, public modm::I2cDevice<I2cMaster, 1>
+{
+public:
+    /**
+     * @brief Construct a new Ads7828 object
+     *
+     * @param data
+     * @param address
+     *      The adress is the i2c adress
+     */
+    Ads7828(Data &data, uint8_t address = 0b1001000);
+
+    /**
+     * @brief Measures the voltage in a single channel
+     *
+     * @param channel
+     *      Channelx where x is the channel to be read
+     * @param settings
+     *      The ads7828 has an internal reference which can be on or off, and the adc itself can be on or off.
+     *		INTERNAL_REFERENCE_mode_ADC_mode, where mode is either ON or OFF. Does not have to be the same
+        */
+    modm::ResumableResult<bool>
+    startMeasurement(InputChannel input);
+
+    /**
+     * @brief Sets the power down selection
+     *
+     * @param powerDownSelection
+     *      PD1 = 1 to have internal reference ON
+     *      PD0 = 1 to have A/D converter ON
+     */
+    modm::ResumableResult<bool>
+    setPowerDownSelection(PowerDown powerDownSelection);
+
+    /**
+     * @brief Reads the latest measurement result
+     **/
+    modm::ResumableResult<bool>
+    readConversionResult();
+
+    inline Data &
+    getData()
+    {
+        return data;
+    }
+
+private:
+    Data &data;
+
+    CommandByte_t commandByte;
+};
+
+} // modm namespace
+
+#include "ads7828_impl.hpp"
+
+#endif // MODM_ADS7828_HPP

--- a/src/modm/driver/adc/ads7828.lb
+++ b/src/modm/driver/adc/ads7828.lb
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022, Jonas Kazem Andersen
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:ads7828"
+    module.description = """\
+# ADS7828 ADC
+The ADS7828 is a single-supply, low-power, 12-bit data acquisition device
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:i2c.device",
+        ":processing:resumable")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/adc"
+    env.copy("ads7828.hpp")
+    env.copy("ads7828_impl.hpp")

--- a/src/modm/driver/adc/ads7828_impl.hpp
+++ b/src/modm/driver/adc/ads7828_impl.hpp
@@ -1,0 +1,63 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/*
+ * Copyright (c) 2022, Jónas Holm Wentzlau
+ * Copyright (c) 2022, Jonas Kazem Andersen
+ * Copyright (c) 2022, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_ADS7828_HPP
+#error "Don't include this file directly, use 'ads7828.hpp' instead!"
+#endif
+
+namespace modm
+{
+
+template <typename I2cMaster>
+Ads7828<I2cMaster>::Ads7828(Data &data, uint8_t address) : data(data), modm::I2cDevice<I2cMaster, 1>(address)
+{
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename I2cMaster>
+modm::ResumableResult<bool>
+Ads7828<I2cMaster>::startMeasurement(InputChannel channel)
+{
+    RF_BEGIN();
+    InputChannel_t::set(commandByte, channel);
+    this->transaction.configureWrite(&commandByte.value, 1);
+    RF_END_RETURN_CALL(this->runTransaction());
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename I2cMaster>
+modm::ResumableResult<bool>
+Ads7828<I2cMaster>::setPowerDownSelection(PowerDown powerDownSelection)
+{
+    RF_BEGIN();
+    PowerDown_t::set(commandByte, powerDownSelection);
+    this->transaction.configureWrite(&commandByte.value, 1);
+    RF_END_RETURN_CALL(this->runTransaction());
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename I2cMaster>
+modm::ResumableResult<bool>
+Ads7828<I2cMaster>::readConversionResult()
+{
+    RF_BEGIN();
+    this->transaction.configureRead(data.data, 2);
+    RF_END_RETURN_CALL(this->runTransaction());
+}
+
+} // modm namespace


### PR DESCRIPTION
Ads7828 driver implementation with example for the NucleoG474. The example uses the same pins as on our custom board on which the driver has been tested.