### PR TITLE
MCP9902/3/4 temperature sensor driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,37 +692,38 @@ you specific needs.
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp23x17">MCP23x17</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp2515">MCP2515</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp7941x">MCP7941x</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp990x">MCP990X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mmc5603">MMC5603</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5611">MS5611</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5611">MS5611</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nokia5110">NOKIA5110</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nrf24">NRF24</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-parallel_tft_display">TFT-DISPLAY</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pat9125el">PAT9125EL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca8574">PCA8574</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9535">PCA9535</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9535">PCA9535</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9548a">PCA9548A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9685">PCA9685</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sh1106">SH1106</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s65">SIEMENS-S65</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s75">SIEMENS-S75</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk6812">SK6812</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk6812">SK6812</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ssd1306">SSD1306</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-st7586s">ST7586S</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stts22h">STTS22H</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stusb4500">STUSB4500</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3472">TCS3472</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tlc594x">TLC594x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp102">TMP102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp12x">TMP12x</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl53l0">VL53L0</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl6180">VL6180</a></td>

--- a/examples/nucleo_f303re/temperature_mcp990x/main.cpp
+++ b/examples/nucleo_f303re/temperature_mcp990x/main.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+#include <modm/driver/temperature/mcp990x.hpp>
+
+using namespace Board;
+using namespace std::literals;
+
+using I2c = I2cMaster2;
+using Sda = GpioA10;
+using Scl = GpioOutputA9;
+
+int main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	I2c::connect<Sda::Sda, Scl::Scl>();
+	I2c::initialize<Board::SystemClock, 400_kHz>();
+
+	MODM_LOG_INFO << "Welcome to MCP9902/3/4 Test" << modm::endl;
+
+	modm::mcp990x::Data data{};
+	// I2C address MCP990xT-1: 0x4c, -2: 0x4d, -A: adjustable, see datasheet
+	modm::Mcp990x<I2c> sensor{data, 0x4d};
+
+	// wait for sensor boot-up time
+	modm::delay(15ms);
+
+	bool success = RF_CALL_BLOCKING(sensor.initialize());
+	if (!success)
+	{
+		MODM_LOG_ERROR << "Initialization failed" << modm::endl;
+	}
+
+	modm::PeriodicTimer timer{500ms};
+	while (true)
+	{
+		if (timer.execute())
+		{
+			if (RF_CALL_BLOCKING(sensor.readInternalTemperature()))
+			{
+				MODM_LOG_INFO.printf("temperature: %3.3f\n °C\n", data.getTemperature());
+			}
+			else
+			{
+				MODM_LOG_INFO << "Reading temperature failed!\n";
+			}
+		}
+	}
+
+	return 0;
+}
+

--- a/examples/nucleo_f303re/temperature_mcp990x/project.xml
+++ b/examples/nucleo_f303re/temperature_mcp990x/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f303re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f303re/temperature_mcp990x</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:i2c:2</module>
+    <module>modm:driver:mcp990x</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f303re/board.hpp
+++ b/src/modm/board/nucleo_f303re/board.hpp
@@ -47,8 +47,10 @@ struct SystemClock
 	static constexpr uint32_t Usart2 = Apb1;
 	static constexpr uint32_t Usart3 = Apb1;
 
-	// I2C1 clock source is HSI per default
-	static constexpr uint32_t I2c1   = 8_MHz;
+	// I2C clock source is HSI by default
+	static constexpr uint32_t I2c1 = 8_MHz;
+	static constexpr uint32_t I2c2 = 8_MHz;
+	static constexpr uint32_t I2c3 = 8_MHz;
 
 	static constexpr uint32_t Apb1Timer = Apb1 * 2;
 	static constexpr uint32_t Apb2Timer = Apb2 * 1;

--- a/src/modm/driver/temperature/mcp990x.hpp
+++ b/src/modm/driver/temperature/mcp990x.hpp
@@ -1,0 +1,174 @@
+/*
+* Copyright (c) 2022, Christopher Durand
+*
+* This file is part of the modm project.
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_MCP990X_HPP
+#define MODM_MCP990X_HPP
+
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/i2c_device.hpp>
+#include <array>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_mcp990x
+struct mcp990x
+{
+protected:
+	/// @cond
+	enum class
+	Register : uint8_t
+	{
+		IntTempHigh		= 0x00,
+		Ext1TempHigh	= 0x01,
+		Config			= 0x03,
+		Ext1TempLow		= 0x10,
+		Ext2TempHigh	= 0x23,
+		Ext2TempLow		= 0x24,
+		Ext1Ideality	= 0x27,
+		Ext2Ideality	= 0x28,
+		IntTempLow		= 0x29,
+		Ext3TempHigh	= 0x2a,
+		Ext3TempLow		= 0x2b,
+		Ext3Ideality	= 0x31,
+		ProductId		= 0xfd
+	};
+
+	enum class
+	Config : uint8_t
+	{
+		MaskAlert = Bit7,
+		Standby = Bit6,
+		AlertMode = Bit5,
+		DisableErrorCorrectionExternalDiode1 = Bit4,
+		DisableErrorCorrectionExternalDiode2 = Bit3,
+		ExtendedRange = Bit2,
+		DisableDynamicAveraging = Bit1,
+		DisableAntiParallelDiodeMode = Bit0
+	};
+	MODM_FLAGS8(Config);
+	/// @endcond
+public:
+	enum class ExternalDiode : uint8_t
+	{
+		Diode1 = 0,
+		Diode2 = 1,
+		Diode3 = 2
+	};
+
+	struct modm_packed
+	Data
+	{
+		static constexpr auto ExtendedOffset{64}; // °C
+		uint8_t data[2];
+
+		/// @return temperature in 0.125 °C steps
+		constexpr int16_t
+		getTemperatureFractional()
+		{
+			return ((data[1] << 3) | (data[0] >> 5)) - (ExtendedOffset * 8);
+		}
+
+		/// @return temperature integral part in °C
+		constexpr int8_t
+		getTemperatureInteger()
+		{
+			return data[1] - ExtendedOffset;
+		}
+
+		/// @return temperature as float in °C
+		constexpr float
+		getTemperature()
+		{
+			return getTemperatureFractional() / 8.f;
+		}
+	};
+};
+
+/**
+ * Simple driver for MCP9902/3/4 I2C temperature sensor.
+ *
+ * @ingroup modm_driver_mcp990x
+ *
+ * @author Christopher Durand
+ */
+template <class I2cMaster>
+class Mcp990x : public mcp990x, public I2cDevice<I2cMaster, 3>
+{
+public:
+	/// \param address I2C address, MCP990xT-1: 0x4c, -2: 0x4d, -A: adjustable, see datasheet
+	Mcp990x(Data& data, uint8_t address = 0x4d);
+
+	/// Initialize sensor
+	modm::ResumableResult<bool>
+	initialize();
+
+	/// Detect sensor
+	modm::ResumableResult<bool>
+	ping();
+
+	/// Read internal temperature sensor
+	/// \pre sensor is succesfully initialized
+	modm::ResumableResult<bool>
+	readInternalTemperature();
+
+	/// Read external diode temperature sensor
+	/// \pre sensor is succesfully initialized
+	modm::ResumableResult<bool>
+	readExternalDiodeTemperature(ExternalDiode diode);
+
+	/// Set external diode ideality factor
+	/// See datasheet for values
+	modm::ResumableResult<bool>
+	setExternalDiodeIdealityFactor(ExternalDiode diode, uint8_t idealitySetting);
+
+	inline Data&
+	getData()
+	{ return data_; }
+
+private:
+	// MCP9902: 0x20, MCP9903: 0x21, MCP9904: 0x25
+	static constexpr uint8_t DeviceIds[3]{0x20, 0x21, 0x25};
+
+	static constexpr Register ExtHighReg[3] {
+		Register::Ext1TempHigh,
+		Register::Ext2TempHigh,
+		Register::Ext3TempHigh
+	};
+	static constexpr Register ExtLowReg[3] {
+		Register::Ext1TempLow,
+		Register::Ext2TempLow,
+		Register::Ext3TempLow
+	};
+	static constexpr Register ExtIdealityReg[3] {
+		Register::Ext1Ideality,
+		Register::Ext2Ideality,
+		Register::Ext3Ideality
+	};
+
+	modm::ResumableResult<bool>
+	write(Register reg, uint8_t config);
+
+	modm::ResumableResult<bool>
+	read(Register reg, uint8_t& value);
+
+	modm::ResumableResult<bool>
+	readTemperature(Register highReg, Register lowReg);
+
+	Data& data_;
+	std::array<uint8_t, 2> buffer_;
+};
+
+}	// namespace modm
+
+#include "mcp990x_impl.hpp"
+
+#endif // MODM_MCP990X_HPP

--- a/src/modm/driver/temperature/mcp990x.lb
+++ b/src/modm/driver/temperature/mcp990x.lb
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:mcp990x"
+    module.description = """
+Minimal driver for MCP9902/3/4 temperature sensor.
+Only I2c is supported. SMBUS alert functions and power saving modes are not implemented.
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:i2c.device",
+        ":architecture:register")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/temperature"
+    env.copy("mcp990x.hpp")
+    env.copy("mcp990x_impl.hpp")

--- a/src/modm/driver/temperature/mcp990x_impl.hpp
+++ b/src/modm/driver/temperature/mcp990x_impl.hpp
@@ -1,0 +1,109 @@
+/*
+* Copyright (c) 2021, Christopher Durand
+*
+* This file is part of the modm project.
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_MCP990X_HPP
+#error "Don't include this file directly, use 'mcp990x.hpp' instead!"
+#endif
+
+namespace modm
+{
+
+template < typename I2cMaster >
+Mcp990x<I2cMaster>::Mcp990x(Data &data, uint8_t address) :
+	I2cDevice<I2cMaster, 3>{address}, data_{data}
+{
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::write(Register reg, uint8_t value)
+{
+	RF_BEGIN();
+
+	buffer_[0] = static_cast<uint8_t>(reg);
+	buffer_[1] = value;
+
+	this->transaction.configureWrite(&buffer_[0], 2);
+
+	RF_END_RETURN_CALL(this->runTransaction());
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::read(Register reg, uint8_t& value)
+{
+	RF_BEGIN();
+
+	buffer_[0] = static_cast<uint8_t>(reg);
+	this->transaction.configureWriteRead(&buffer_[0], 1, &value, 1);
+
+	RF_END_RETURN_CALL(this->runTransaction());
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::initialize()
+{
+	RF_BEGIN();
+	if (!RF_CALL(this->ping())) {
+		RF_RETURN(false);
+	}
+	RF_END_RETURN_CALL(write(Register::Config, uint8_t(Config::ExtendedRange)));
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::ping()
+{
+	RF_BEGIN();
+	// It's ok here to use buffer_[1] as temporary storage
+	// since read() only uses buffer_[0]
+	if (!RF_CALL(read(Register::ProductId, buffer_[1]))) {
+		RF_RETURN(false);
+	}
+	RF_END_RETURN(buffer_[1] == DeviceIds[0] || buffer_[1] == DeviceIds[1] || buffer_[1] == DeviceIds[2]);
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::readInternalTemperature()
+{
+	return readTemperature(Register::IntTempHigh, Register::IntTempLow);
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::readExternalDiodeTemperature(ExternalDiode diode)
+{
+	const auto index = static_cast<uint8_t>(diode);
+	return readTemperature(ExtHighReg[index], ExtLowReg[index]);
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::setExternalDiodeIdealityFactor(ExternalDiode diode, uint8_t idealitySetting)
+{
+	const auto index = static_cast<uint8_t>(diode);
+	return write(ExtIdealityReg[index], idealitySetting & 0b0011'1111);
+}
+
+template<class I2cMaster>
+ResumableResult<bool>
+Mcp990x<I2cMaster>::readTemperature(Register highReg, Register lowReg)
+{
+	RF_BEGIN();
+	if (!RF_CALL(read(highReg, data_.data[1]))) {
+		RF_RETURN(false);
+	}
+	RF_END_RETURN_CALL(read(lowReg, data_.data[0]));
+}
+
+} // namespace modm


### PR DESCRIPTION
Simplistic driver for MCP9902/3/4 temperature sensor. Tested in hardware on a custom board with an STM32F302C8. ~~The example is not tested yet.~~