### PR TITLE
[lbuild] Use SI units for numeric options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 modm (pronounced like dial-up "modem") is a toolbox for
 building custom C++20 libraries tailored to your embedded device.
 modm generates startup code, HALs and their implementations, communication
-protocols, drivers for external devices, BSPs, etc… in a modular, customizable
+protocols, drivers for external devices, and BSPs in a modular, customizable
 process that you can fine-tune to your needs.
 
 <!--webignore-->
@@ -67,13 +67,15 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 - Lightweight unit testing system (suitable for AVRs).
 - Hundreds of tests to ensure correct functionality.
 - Integration of useful third-party software:
-	- [FreeRTOS][] and [FreeRTOS+TCP][].
-	- [CMSIS][] and [CMSIS-DSP][].
-	- [ETL][].
-	- [TinyUSB][].
-	- [FatFS][].
-	- [ROSserial][].
-	- [CrashCatcher][].
+	- [FreeRTOS][] and [FreeRTOS+TCP][] operating system.
+	- [CMSIS][] and [CMSIS-DSP][] interfaces.
+	- [ETL][]: Embedded Template Library.
+	- [TinyUSB][]: USB Host/Device stack.
+	- [FatFS][]: FAT/exFAT filesystem.
+	- [ROSserial][]: Embedded ROS client.
+	- [CrashCatcher][]: Crash reports for HardFaults.
+	- [printf][]: Small printf implementation.
+	- [Nanopb][]: Embedded Protocol Buffers.
 
 
 ## Microcontrollers
@@ -528,8 +530,8 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 </center>
 
 We are only a small team of developers and are limited in the amount of devices
-we can support and test in hardware. [Open an issue][issues] to ask if your
-specific device is supported out-of-the-box and what you can do if it is not.
+we can support and test in hardware. [Open a discussion][discussions] to ask if
+your specific device is supported out-of-the-box and how you can add it otherwise.
 
 
 ### Boards
@@ -752,7 +754,7 @@ See [CONTRIBUTING.md][contrib] for our contribution guidelines.
 <!--authors-->
 The modm project is maintained by
 Niklas Hauser ([\@salkinium](https://github.com/salkinium)),
-Raphael Lehmann ([\@rleh](https://github.com/rleh)) and
+Raphael Lehmann ([\@rleh](https://github.com/rleh)), and
 Christopher Durand ([\@chris-durand](https://github.com/chris-durand)) with significant contributions from
 Sascha Schade ([\@strongly-typed](https://github.com/strongly-typed)),
 Fabian Greif ([\@dergraaf](https://github.com/dergraaf)),
@@ -762,7 +764,7 @@ Daniel Krebs ([\@daniel-k](https://github.com/daniel-k)),
 Georgi Grinshpun ([\@georgi-g](https://github.com/georgi-g)),
 David Hebbeker ([\@dhebbeker](https://github.com/dhebbeker)),
 Thorsten Lajewski ([\@TheTh0r](https://github.com/TheTh0r)),
-Mike Wolfram ([\@mikewolfram](https://github.com/mikewolfram))
+Mike Wolfram ([\@mikewolfram](https://github.com/mikewolfram)),
 and [many more contributors][contributors].
 <!--/authors-->
 
@@ -830,4 +832,6 @@ and [many more contributors][contributors].
 [FatFS]:           http://elm-chan.org/fsw/ff/00index_e.html
 [ROSserial]:       https://wiki.ros.org/rosserial
 [CrashCatcher]:    https://github.com/adamgreen/CrashCatcher
+[printf]:          https://github.com/eyalroz/printf
+[Nanopb]:          https://github.com/nanopb/nanopb
 <!--/links-->

--- a/docs/src/guide/discover.md
+++ b/docs/src/guide/discover.md
@@ -67,13 +67,13 @@ Parser(lbuild)
     ├── Module(modm:platform)   Platform HAL
     │   ├── Module(modm:platform:cortex-m)   ARM Cortex-M Core
     │   │   ├── Option(float-abi) = hard in [hard, soft, softfp]   Floating point ABI
-    │   │   ├── Option(main_stack_size) = 3*1024 (3072) in [256 .. 3*1024 .. 65536]
+    │   │   ├── Option(main_stack_size) = 3Ki (3072) in [256 .. 3Ki .. 64Ki]
     │   │   ├── Option(vector_table_location) = rom in [ram, rom]   Vector table location
    ... ...
     │   ├── Module(modm:platform:uart)   Universal Asynchronous Receiver Transmitter (UART)
     │   │   ├── Module(modm:platform:uart:1)   Instance 1
-    │   │   │   ├── Option(buffer.rx) = 0 in [0 ... 65534]
-    │   │   │   ╰── Option(buffer.tx) = 0 in [0 ... 65534]
+    │   │   │   ├── Option(buffer.rx) = 0 in [0 ... 64Ki-2]
+    │   │   │   ╰── Option(buffer.tx) = 0 in [0 ... 64Ki-2]
 ```
 
 Since there are no more REQUIRED options, you can now discover all module and

--- a/docs/src/how-modm-works.md
+++ b/docs/src/how-modm-works.md
@@ -338,12 +338,12 @@ sensible default size for its purpose.
 ```
  $ lbuild discover-module-options
 ...
-modm:platform:cortex-m:main_stack_size = 3040  [256 ... 65536]
+modm:platform:cortex-m:main_stack_size = 3Ki  [256 .. 3Ki .. 64Ki]
 
   Minimum size of the application main stack
 ...
-modm:platform:uart:1:buffer.rx = 16  [1 ... 65534]
-modm:platform:uart:1:buffer.tx = 250  [1 ... 65534]
+modm:platform:uart:1:buffer.rx = 16  [0 ... 64Ki-2]
+modm:platform:uart:1:buffer.tx = 250  [0 ... 64Ki-2]
 ```
 
 We transparently show you how much static memory your application is using,
@@ -360,10 +360,10 @@ Program:    8144B (0.8% used)
 (.fastcode + .fastdata + .hardware_init + .reset + .rodata + .table.copy.intern +
  .table.section_heap + .table.zero.intern + .text)
 
-Data:       3464B (1.7% used) = 424B static (0.2%) + 3040B stack (1.5%)
+Data:       3496B (1.8% used) = 424B static (0.2%) + 3072B stack (1.6%)
 (.bss + .fastdata + .stack)
 
-Heap:     197240B (98.3% available)
+Heap:     197240B (98.2% available)
 (.heap0 + .heap1 + .heap2 + .heap5)
 ```
 <!-- (⚡️ automate size generation from example output) -->

--- a/examples/avr/1-wire/ds18b20/project.xml
+++ b/examples/avr/1-wire/ds18b20/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/1-wire/ds18b20</option>
   </options>
   <modules>

--- a/examples/avr/adc/basic/project.xml
+++ b/examples/avr/adc/basic/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/adc/basic</option>
   </options>
   <modules>

--- a/examples/avr/adc/oversample/project.xml
+++ b/examples/avr/adc/oversample/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/adc/oversample</option>
   </options>
   <modules>

--- a/examples/avr/app_can2usb/project.xml
+++ b/examples/avr/app_can2usb/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">at90can128-16au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
     <option name="modm:build:build.path">../../../build/avr/app_can2usb</option>
   </options>
   <modules>

--- a/examples/avr/block_device_mirror/project.xml
+++ b/examples/avr/block_device_mirror/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../build/avr/block_device_mirror</option>
     <option name="modm:io:with_printf">True</option>
   </options>

--- a/examples/avr/can/mcp2515/project.xml
+++ b/examples/avr/can/mcp2515/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/can/mcp2515</option>
     <option name="modm:io:with_printf">True</option>
   </options>

--- a/examples/avr/can/mcp2515_uart/project.xml
+++ b/examples/avr/can/mcp2515_uart/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/can/mcp2515_uart</option>
     <option name="modm:io:with_printf">True</option>
   </options>

--- a/examples/avr/display/dogm128/benchmark/project.xml
+++ b/examples/avr/display/dogm128/benchmark/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/benchmark</option>
     <option name="modm:build:image.source">images</option>
   </options>

--- a/examples/avr/display/dogm128/caged_ball/project.xml
+++ b/examples/avr/display/dogm128/caged_ball/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/caged_ball</option>
   </options>
   <modules>

--- a/examples/avr/display/dogm128/draw/project.xml
+++ b/examples/avr/display/dogm128/draw/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/draw</option>
   </options>
   <modules>

--- a/examples/avr/display/dogm128/image/project.xml
+++ b/examples/avr/display/dogm128/image/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/image</option>
     <option name="modm:build:image.source">images</option>
   </options>

--- a/examples/avr/display/dogm128/text/project.xml
+++ b/examples/avr/display/dogm128/text/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/text</option>
   </options>
   <modules>

--- a/examples/avr/display/dogm128/touch/project.xml
+++ b/examples/avr/display/dogm128/touch/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../../build/avr/display/dogm128/touch</option>
   </options>
   <modules>

--- a/examples/avr/display/dogm132/project.xml
+++ b/examples/avr/display/dogm132/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/display/dogm132</option>
   </options>
   <modules>

--- a/examples/avr/display/dogm163/project.xml
+++ b/examples/avr/display/dogm163/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
     <option name="modm:build:build.path">../../../../build/avr/display/dogm163</option>
   </options>
   <modules>

--- a/examples/avr/display/hd44780/project.xml
+++ b/examples/avr/display/hd44780/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/display/hd44780</option>
   </options>
   <modules>

--- a/examples/avr/display/siemens_s65/project.xml
+++ b/examples/avr/display/siemens_s65/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
     <option name="modm:build:build.path">../../../../build/avr/display/siemens_s65</option>
   </options>
   <modules>

--- a/examples/avr/flash/project.xml
+++ b/examples/avr/flash/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega328p-au</option>
-    <option name="modm:platform:core:f_cpu">1000000</option>
+    <option name="modm:platform:core:f_cpu">1M</option>
     <option name="modm:build:build.path">../../../build/avr/flash</option>
   </options>
   <modules>

--- a/examples/avr/gpio/blinking/project.xml
+++ b/examples/avr/gpio/blinking/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega328p-au</option>
-    <option name="modm:platform:core:f_cpu">1000000</option>
+    <option name="modm:platform:core:f_cpu">1M</option>
     <option name="modm:build:build.path">../../../../build/avr/gpio/blinking</option>
   </options>
   <modules>

--- a/examples/avr/gpio/button_group/project.xml
+++ b/examples/avr/gpio/button_group/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/gpio/button_group</option>
   </options>
   <modules>

--- a/examples/avr/logger/project.xml
+++ b/examples/avr/logger/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../build/avr/logger</option>
   </options>
   <modules>

--- a/examples/avr/protothread/project.xml
+++ b/examples/avr/protothread/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../build/avr/protothread</option>
   </options>
   <modules>

--- a/examples/avr/sab/master/project.xml
+++ b/examples/avr/sab/master/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/sab/master</option>
   </options>
   <modules>

--- a/examples/avr/sab/slave/project.xml
+++ b/examples/avr/sab/slave/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/sab/slave</option>
   </options>
   <modules>

--- a/examples/avr/timeout/project.xml
+++ b/examples/avr/timeout/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../build/avr/timeout</option>
   </options>
   <modules>

--- a/examples/avr/uart/basic/project.xml
+++ b/examples/avr/uart/basic/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644pa-au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/uart/basic</option>
   </options>
   <modules>

--- a/examples/avr/uart/extended/project.xml
+++ b/examples/avr/uart/extended/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/uart/extended</option>
   </options>
   <modules>

--- a/examples/avr/xpcc/receiver/project.xml
+++ b/examples/avr/xpcc/receiver/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/xpcc/receiver</option>
     <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
     <option name="modm::xpcc:generator:container">receiver</option>

--- a/examples/avr/xpcc/sender/project.xml
+++ b/examples/avr/xpcc/sender/project.xml
@@ -1,7 +1,7 @@
 <library>
   <options>
     <option name="modm:target">atmega644-20au</option>
-    <option name="modm:platform:core:f_cpu">14745600</option>
+    <option name="modm:platform:core:f_cpu">14.7456M</option>
     <option name="modm:build:build.path">../../../../build/avr/xpcc/sender</option>
     <option name="modm::xpcc:generator:source">../../../xpcc/xml/communication.xml</option>
     <option name="modm::xpcc:generator:container">sender</option>

--- a/examples/generic/i2c_multiplex/project.xml
+++ b/examples/generic/i2c_multiplex/project.xml
@@ -4,8 +4,8 @@
   <options>
     <option name=":target">stm32f303k8t6</option>
     <!-- <option name=":target">stm32f103c8t6</option> -->
-    <option name=":platform:uart:2:buffer.tx">2048</option>
-    <option name=":platform:uart:2:buffer.rx">2048</option>
+    <option name=":platform:uart:2:buffer.tx">2Ki</option>
+    <option name=":platform:uart:2:buffer.rx">2Ki</option>
     <option name=":build:build.path">../../../build/generic/i2c_multiplex</option>
   </options>
   <modules>

--- a/examples/stm32f0_discovery/logger/project.xml
+++ b/examples/stm32f0_discovery/logger/project.xml
@@ -2,7 +2,7 @@
   <extends>modm:disco-f051r8</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f0_discovery/logger</option>
-    <option name="modm:platform:uart:1:buffer.tx">1024</option>
+    <option name="modm:platform:uart:1:buffer.tx">1Ki</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f4_discovery/can/project.xml
+++ b/examples/stm32f4_discovery/can/project.xml
@@ -2,7 +2,7 @@
   <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/can</option>
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f4_discovery/can2/project.xml
+++ b/examples/stm32f4_discovery/can2/project.xml
@@ -2,7 +2,7 @@
   <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/can2</option>
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:debug</module>

--- a/examples/stm32f4_discovery/pressure_ams5915/project.xml
+++ b/examples/stm32f4_discovery/pressure_ams5915/project.xml
@@ -2,7 +2,7 @@
   <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/pressure_ams5915</option>
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:driver:ams5915</module>

--- a/examples/stm32f4_discovery/temperature_ltc2984/project.xml
+++ b/examples/stm32f4_discovery/temperature_ltc2984/project.xml
@@ -2,7 +2,7 @@
   <extends>modm:disco-f407vg</extends>
   <options>
     <option name="modm:build:build.path">../../../build/stm32f4_discovery/temperature_ltc2984</option>
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:driver:ltc2984</module>

--- a/ext/tlsf/module.lb
+++ b/ext/tlsf/module.lb
@@ -52,9 +52,9 @@ def prepare(module, options):
         NumericOption(
             name="minimum_pool_size",
             description="Minimum pool size in byte",
-            minimum=2**12,
-            maximum=2**29,
-            default=max_ram_size(options[":target"])))
+            minimum="4Ki",
+            maximum="512Mi",
+            default="{}Ki".format(int(max_ram_size(options[":target"])/1024))))
 
     return True
 

--- a/repo.lb
+++ b/repo.lb
@@ -24,7 +24,7 @@ from os.path import normpath
 
 # Check for miminum required lbuild version
 import lbuild
-min_lbuild_version = "1.21.5"
+min_lbuild_version = "1.21.6"
 if StrictVersion(getattr(lbuild, "__version__", "0.1.0")) < StrictVersion(min_lbuild_version):
     print("modm requires at least lbuild v{}, please upgrade!\n"
           "    pip3 install -U lbuild".format(min_lbuild_version))

--- a/src/modm/board/al_avreb_can/board.xml
+++ b/src/modm/board/al_avreb_can/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">at90can128-16au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
   </options>
   <modules>
     <module>modm:board:al-avreb-can</module>

--- a/src/modm/board/arduino_nano/board.xml
+++ b/src/modm/board/arduino_nano/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">atmega328p-au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
   </options>
   <modules>
     <module>modm:board:arduino-nano</module>

--- a/src/modm/board/arduino_uno/board.xml
+++ b/src/modm/board/arduino_uno/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">atmega328p-au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
   </options>
   <modules>
     <module>modm:board:arduino-uno</module>

--- a/src/modm/board/disco_f469ni/board.xml
+++ b/src/modm/board/disco_f469ni/board.xml
@@ -7,9 +7,9 @@
 
   <options>
     <option name="modm:target">stm32f469nih6</option>
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
     <option name="modm:platform:heap:allocator">tlsf</option>
-    <option name="modm:tlsf:minimum_pool_size">2**24</option>
+    <option name="modm:tlsf:minimum_pool_size">16Mi</option>
   </options>
   <modules>
     <module>modm:board:disco-f469ni</module>

--- a/src/modm/board/disco_f746ng/board.xml
+++ b/src/modm/board/disco_f746ng/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f746ngh6</option>
 
-    <option name="modm:platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:disco-f746ng</module>

--- a/src/modm/board/disco_f769ni/board.xml
+++ b/src/modm/board/disco_f769ni/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f769nih6</option>
 
-    <option name="modm:platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:disco-f769ni</module>

--- a/src/modm/board/disco_l152rc/board.xml
+++ b/src/modm/board/disco_l152rc/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l152rct6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:disco-l152rc</module>

--- a/src/modm/board/feather_rp2040/board.xml
+++ b/src/modm/board/feather_rp2040/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">rp2040</option>
     <option name="modm:platform:core:boot2">generic_03h</option>
-    <option name="modm:platform:core:boot2_size">8*1024*1024</option>
+    <option name="modm:platform:core:boot2_size">8Mi</option>
   </options>
   <modules>
     <module>modm:board:feather-rp2040</module>

--- a/src/modm/board/mega_2560_pro/board.xml
+++ b/src/modm/board/mega_2560_pro/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">atmega2560-16au</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
   </options>
   <modules>
     <module>modm:board:mega-2560-pro</module>

--- a/src/modm/board/nucleo_f031k6/board.xml
+++ b/src/modm/board/nucleo_f031k6/board.xml
@@ -9,7 +9,7 @@
     <option name="modm:target">stm32f031k6t6</option>
 
     <option name="modm:platform:uart:1:buffer.tx">256</option>
-    <option name="modm:platform:cortex-m:main_stack_size">1024</option>
+    <option name="modm:platform:cortex-m:main_stack_size">1Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f031k6</module>

--- a/src/modm/board/nucleo_f042k6/board.xml
+++ b/src/modm/board/nucleo_f042k6/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f042k6t6</option>
     <option name="modm:platform:uart:2:buffer.tx">256</option>
-    <option name="modm:platform:cortex-m:main_stack_size">1024</option>
+    <option name="modm:platform:cortex-m:main_stack_size">1Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f042k6</module>

--- a/src/modm/board/nucleo_f103rb/board.xml
+++ b/src/modm/board/nucleo_f103rb/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f103rbt6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f103rb</module>

--- a/src/modm/board/nucleo_f303k8/board.xml
+++ b/src/modm/board/nucleo_f303k8/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f303k8t6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f303k8</module>

--- a/src/modm/board/nucleo_f303re/board.xml
+++ b/src/modm/board/nucleo_f303re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f303ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f303re</module>

--- a/src/modm/board/nucleo_f334r8/board.xml
+++ b/src/modm/board/nucleo_f334r8/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f334r8t6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f334r8</module>

--- a/src/modm/board/nucleo_f401re/board.xml
+++ b/src/modm/board/nucleo_f401re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f401ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f401re</module>

--- a/src/modm/board/nucleo_f411re/board.xml
+++ b/src/modm/board/nucleo_f411re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f411ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f411re</module>

--- a/src/modm/board/nucleo_f429zi/board.xml
+++ b/src/modm/board/nucleo_f429zi/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f429zit6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f429zi</module>

--- a/src/modm/board/nucleo_f439zi/board.xml
+++ b/src/modm/board/nucleo_f439zi/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f439zit6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f439zi</module>

--- a/src/modm/board/nucleo_f446re/board.xml
+++ b/src/modm/board/nucleo_f446re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f446ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f446re</module>

--- a/src/modm/board/nucleo_f446ze/board.xml
+++ b/src/modm/board/nucleo_f446ze/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f446zet6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f446ze</module>

--- a/src/modm/board/nucleo_f746zg/board.xml
+++ b/src/modm/board/nucleo_f746zg/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f746zgt6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f746zg</module>

--- a/src/modm/board/nucleo_f767zi/board.xml
+++ b/src/modm/board/nucleo_f767zi/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f767zit6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-f767zi</module>

--- a/src/modm/board/nucleo_g071rb/board.xml
+++ b/src/modm/board/nucleo_g071rb/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">stm32g071rbt6</option>
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-g071rb</module>

--- a/src/modm/board/nucleo_g431kb/board.xml
+++ b/src/modm/board/nucleo_g431kb/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32g431kbt6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-g431kb</module>

--- a/src/modm/board/nucleo_g431rb/board.xml
+++ b/src/modm/board/nucleo_g431rb/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32g431rbt6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-g431rb</module>

--- a/src/modm/board/nucleo_g474re/board.xml
+++ b/src/modm/board/nucleo_g474re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32g474ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-g474re</module>

--- a/src/modm/board/nucleo_h723zg/board.xml
+++ b/src/modm/board/nucleo_h723zg/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32h723zgt6</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-h723zg</module>

--- a/src/modm/board/nucleo_h743zi/board.xml
+++ b/src/modm/board/nucleo_h743zi/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32h743zit6/revY</option>
 
-    <option name="modm:platform:uart:3:buffer.tx">2048</option>
+    <option name="modm:platform:uart:3:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-h743zi</module>

--- a/src/modm/board/nucleo_l031k6/board.xml
+++ b/src/modm/board/nucleo_l031k6/board.xml
@@ -9,7 +9,7 @@
     <option name="modm:target">stm32l031k6t6</option>
 
     <option name="modm:platform:uart:2:buffer.tx">256</option>
-    <option name="modm:platform:cortex-m:main_stack_size">1024</option>
+    <option name="modm:platform:cortex-m:main_stack_size">1Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l031k6</module>

--- a/src/modm/board/nucleo_l053r8/board.xml
+++ b/src/modm/board/nucleo_l053r8/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l053r8t6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l053r8</module>

--- a/src/modm/board/nucleo_l152re/board.xml
+++ b/src/modm/board/nucleo_l152re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l152ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l152re</module>

--- a/src/modm/board/nucleo_l432kc/board.xml
+++ b/src/modm/board/nucleo_l432kc/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l432kcu6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l432kc</module>

--- a/src/modm/board/nucleo_l452re/board.xml
+++ b/src/modm/board/nucleo_l452re/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l452ret6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l452re</module>

--- a/src/modm/board/nucleo_l476rg/board.xml
+++ b/src/modm/board/nucleo_l476rg/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32l476rgt6</option>
 
-    <option name="modm:platform:uart:2:buffer.tx">2048</option>
+    <option name="modm:platform:uart:2:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:nucleo-l476rg</module>

--- a/src/modm/board/nucleo_l496zg-p/board.xml
+++ b/src/modm/board/nucleo_l496zg-p/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">stm32l496zgt6p</option>
-    <option name="modm:platform:uart:lpuart1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:lpuart1:buffer.tx">2Ki</option>
   </options>
 
   <modules>

--- a/src/modm/board/nucleo_l552ze-q/board.xml
+++ b/src/modm/board/nucleo_l552ze-q/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">stm32l552zet6q</option>
-    <option name="modm:platform:uart:lpuart1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:lpuart1:buffer.tx">2Ki</option>
   </options>
 
   <modules>

--- a/src/modm/board/olimexino_stm32/board.xml
+++ b/src/modm/board/olimexino_stm32/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">stm32f103rbt6</option>
 
-    <option name="modm:platform:uart:1:buffer.tx">2048</option>
+    <option name="modm:platform:uart:1:buffer.tx">2Ki</option>
   </options>
   <modules>
     <module>modm:board:olimexino-stm32</module>

--- a/src/modm/board/rp_pico/board.xml
+++ b/src/modm/board/rp_pico/board.xml
@@ -8,6 +8,7 @@
   <options>
     <option name="modm:target">rp2040</option>
     <option name="modm:platform:core:boot2">w25q080</option>
+    <option name="modm:platform:core:boot2_size">2Mi</option>
   </options>
   <modules>
     <module>modm:board:rp-pico</module>

--- a/src/modm/board/srxe/board.xml
+++ b/src/modm/board/srxe/board.xml
@@ -7,7 +7,7 @@
 
   <options>
     <option name="modm:target">atmega128rfa1-zu</option>
-    <option name="modm:platform:core:f_cpu">16000000</option>
+    <option name="modm:platform:core:f_cpu">16M</option>
   </options>
   <modules>
     <module>modm:board:srxe</module>

--- a/src/modm/board/thingplus_rp2040/board.xml
+++ b/src/modm/board/thingplus_rp2040/board.xml
@@ -8,7 +8,7 @@
   <options>
     <option name="modm:target">rp2040</option>
     <option name="modm:platform:core:boot2">w25q080</option>
-    <option name="modm:platform:core:boot2_size">16*1024*1024</option>
+    <option name="modm:platform:core:boot2_size">16Mi</option>
   </options>
   <modules>
     <module>modm:board:thingplus-rp2040</module>

--- a/src/modm/platform/can/stm32-fdcan/module.lb
+++ b/src/modm/platform/can/stm32-fdcan/module.lb
@@ -17,13 +17,13 @@ def load_options(module):
         NumericOption(
             name="buffer.tx",
             description="",
-            minimum=1, maximum=2 ** 16 - 2,
+            minimum=1, maximum="64Ki-2",
             default=32))
     module.add_option(
         NumericOption(
             name="buffer.rx",
             description="",
-            minimum=1, maximum=2 ** 16 - 2,
+            minimum=1, maximum="64Ki-2",
             default=32))
 
 class Instance(Module):

--- a/src/modm/platform/can/stm32/module.lb
+++ b/src/modm/platform/can/stm32/module.lb
@@ -20,13 +20,13 @@ def load_options(module):
         NumericOption(
             name="buffer.tx",
             description="",
-            minimum=1, maximum=2 ** 16 - 2,
+            minimum=1, maximum="64Ki-2",
             default=32))
     module.add_option(
         NumericOption(
             name="buffer.rx",
             description="",
-            minimum=1, maximum=2 ** 16 - 2,
+            minimum=1, maximum="64Ki-2",
             default=32))
 
 

--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -24,7 +24,7 @@ def prepare(module, options):
             name="f_cpu",
             description="CPU clock frequency",
             minimum=1,
-            maximum=32000000))
+            maximum="32M"))
 
     module.depends(":architecture:interrupt", ":stdc++")
     return True

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -194,8 +194,8 @@ def prepare(module, options):
             name="main_stack_size",
             description=FileReader("option/main_stack_size.md"),
             minimum=2 ** 8,
-            maximum=2 ** 16,
-            default="3*1024"))
+            maximum="64Ki",
+            default="3Ki"))
 
     if "f" in options[":target"].get_driver("core")["type"]:
         module.add_option(

--- a/src/modm/platform/core/rp/module.lb
+++ b/src/modm/platform/core/rp/module.lb
@@ -34,8 +34,8 @@ def prepare(module, options):
             name="boot2_size",
             description="Specify the size of external QSPI FLASH chip",
             minimum=0,
-            maximum=2 ** 24,
-            default=2 ** 21))
+            maximum="16Mi",
+            default="2Mi"))
     return True
 
 

--- a/src/modm/platform/heap/avr/module.lb
+++ b/src/modm/platform/heap/avr/module.lb
@@ -33,8 +33,8 @@ def prepare(module, options):
             name="ram_length",
             description="",
             minimum=64,
-            maximum=32768,
-            default=1024))
+            maximum="32Ki",
+            default="1Ki"))
 
     return True
 

--- a/src/modm/platform/i2c/stm32-extended/module.lb
+++ b/src/modm/platform/i2c/stm32-extended/module.lb
@@ -25,7 +25,7 @@ class Instance(Module):
                 name="buffer.transaction",
                 description="",
                 minimum=1,
-                maximum=2 ** 16 - 2,
+                maximum="64Ki-2",
                 default=8))
 
         return True

--- a/src/modm/platform/i2c/stm32/module.lb
+++ b/src/modm/platform/i2c/stm32/module.lb
@@ -26,7 +26,7 @@ class Instance(Module):
                 name="buffer.transaction",
                 description="",
                 minimum=1,
-                maximum=2 ** 16 - 2,
+                maximum="64Ki-2",
                 default=8))
 
         return True

--- a/src/modm/platform/uart/cortex/module.lb
+++ b/src/modm/platform/uart/cortex/module.lb
@@ -27,7 +27,7 @@ def prepare(module, options):
 
     module.add_option(
         NumericOption(name="buffer.tx", description=descr_buffer_tx,
-            minimum=0, maximum=2**16 - 2, default=0))
+            minimum=0, maximum="64Ki-2", default=0))
 
     return True
 

--- a/src/modm/platform/uart/lpc/module.lb
+++ b/src/modm/platform/uart/lpc/module.lb
@@ -35,13 +35,13 @@ class Instance(Module):
             NumericOption(
                 name="buffer.tx",
                 description="",
-                minimum=1, maximum=2 ** 16 - 2,
+                minimum=1, maximum="64Ki-2",
                 default=250))
         module.add_option(
             NumericOption(
                 name="buffer.rx",
                 description="",
-                minimum=1, maximum=2 ** 16 - 2,
+                minimum=1, maximum="64Ki-2",
                 default=16))
 
         return True

--- a/src/modm/platform/uart/rp/module.lb
+++ b/src/modm/platform/uart/rp/module.lb
@@ -24,13 +24,13 @@ class Instance(Module):
             NumericOption(
                 name="buffer.tx",
                 description="",
-                minimum=32, maximum=2 ** 16 - 2,
+                minimum=32, maximum="64Ki-2",
                 default=32))
         module.add_option(
             NumericOption(
                 name="buffer.rx",
                 description="",
-                minimum=32, maximum=2 ** 16 - 2,
+                minimum=32, maximum="64Ki-2",
                 default=32))
 
         return True

--- a/src/modm/platform/uart/rtt/module.lb
+++ b/src/modm/platform/uart/rtt/module.lb
@@ -20,10 +20,10 @@ def prepare(module, options):
 
     module.add_list_option(
         NumericOption(name="buffer.tx", description="Transmit buffer sizes",
-            minimum=0, maximum=2**16), default=512)
+            minimum=0, maximum="64Ki"), default=512)
     module.add_list_option(
         NumericOption(name="buffer.rx", description="Receive buffer sizes",
-            minimum=0, maximum=2**16), default=0)
+            minimum=0, maximum="64Ki"), default=0)
 
     module.depends(":architecture:uart")
     return True

--- a/src/modm/platform/uart/samg/module.lb
+++ b/src/modm/platform/uart/samg/module.lb
@@ -28,13 +28,13 @@ class Instance(Module):
             NumericOption(
                 name="buffer.tx",
                 description="Size of transmit buffer",
-                minimum=1, maximum=2 ** 16 - 2,
+                minimum=1, maximum="64Ki-2",
                 default=64))
         module.add_option(
             NumericOption(
                 name="buffer.rx",
                 description="Size of receive buffer",
-                minimum=1, maximum=2 ** 16 - 2,
+                minimum=1, maximum="64Ki-2",
                 default=64))
 
         return True

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -33,13 +33,13 @@ class Instance(Module):
             NumericOption(
                 name="buffer.tx",
                 description="",
-                minimum=0, maximum=2 ** 16 - 2,
+                minimum=0, maximum="64Ki-2",
                 default=0))
         module.add_option(
             NumericOption(
                 name="buffer.rx",
                 description="",
-                minimum=0, maximum=2 ** 16 - 2,
+                minimum=0, maximum="64Ki-2",
                 default=0))
 
         return True

--- a/test/all/avr.xml
+++ b/test/all/avr.xml
@@ -7,7 +7,7 @@
   </repositories>
 
   <options>
-    <option name="modm:platform:core:f_cpu">8000000</option>
+    <option name="modm:platform:core:f_cpu">8M</option>
     <option name="modm:build:scons:cache_dir">$cache</option>
   </options>
   <modules>


### PR DESCRIPTION
https://github.com/modm-io/lbuild/pull/78/ added support for SI units in NumericOptions, so I'm adding them here to make the options more readable. cc @cocasema

Also polished the Readme a little, it was missing printf and Nanopb modules.