### PR TITLE
[platform] [stm32] [timer] Add one pulse mode to advanced timers

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -36,7 +36,8 @@ modm::platform::Timer{{ id }}::disable()
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::setMode(Mode mode, SlaveMode slaveMode,
-		SlaveModeTrigger slaveModeTrigger, MasterMode masterMode
+		SlaveModeTrigger slaveModeTrigger, MasterMode masterMode,
+		bool enableOnePulseMode
 %% if advanced_extended
 		, MasterMode2 masterMode2
 %% endif
@@ -54,7 +55,12 @@ modm::platform::Timer{{ id }}::setMode(Mode mode, SlaveMode slaveMode,
 	}
 
 	// ARR Register is buffered, only Under/Overflow generates update interrupt
-	TIM{{ id }}->CR1 = TIM_CR1_ARPE | TIM_CR1_URS | static_cast<uint32_t>(mode);
+	uint32_t cr1 = TIM_CR1_ARPE | TIM_CR1_URS | static_cast<uint32_t>(mode);
+	if (enableOnePulseMode) {
+		TIM{{ id }}->CR1 = cr1 | TIM_CR1_OPM;
+	} else {
+		TIM{{ id }}->CR1 = cr1;
+	}
 %% if advanced_extended
 	TIM{{ id }}->CR2 = 	static_cast<uint32_t>(masterMode) |
 						static_cast<uint32_t>(masterMode2);
@@ -155,7 +161,7 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
-		OutputCompareMode mode, uint16_t compareValue)
+		OutputCompareMode mode, uint16_t compareValue, PinState out)
 {
 	channel -= 1;	// 1..4 -> 0..3
 
@@ -199,7 +205,7 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 	}
 %% endif
 
-	if (mode != OutputCompareMode::Inactive) {
+	if ((mode != OutputCompareMode::Inactive) and (out == PinState::Enable)) {
 		TIM{{ id }}->CCER |= (TIM_CCER_CC1E) << (channel * 4);
 	}
 }

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -108,7 +108,8 @@ public:
 	setMode(Mode mode,
 			SlaveMode slaveMode = SlaveMode::Disabled,
 			SlaveModeTrigger slaveModeTrigger = SlaveModeTrigger::Internal0,
-			MasterMode masterMode = MasterMode::Reset
+			MasterMode masterMode = MasterMode::Reset,
+			bool enableOnePulseMode = false
 %% if advanced_extended
 			, MasterMode2 masterMode2 = MasterMode2::Reset
 %% endif
@@ -333,7 +334,7 @@ public:
 
 	static void
 	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
-			Value compareValue);
+			Value compareValue, PinState out = PinState::Enable);
 	// TODO: Maybe add some functionality from the configureOutput
 	//       function below...
 


### PR DESCRIPTION
Try to have a similar API between general purpose and advanced timers.

Accordingly to RM008, STM32F103's Advanced-control timers (TIM1 and TIM8) **and** General-purpose timers (TIM2 to TIM5) have one-pulse-mode.

I suggest to merge this first. We then might work on a more generalised codebase? There is some copy-paste between general-purpose and advanced-control timers.

Let's first see if the CI can build all code ...