### PR TITLE
Use STM32 Timer channel signal in methods

### DIFF
--- a/examples/blue_pill_f103/servo_pwm/main.cpp
+++ b/examples/blue_pill_f103/servo_pwm/main.cpp
@@ -50,7 +50,7 @@ int main()
 	Timer4::setPrescaler(22);
 	Timer4::setOverflow(overflow);
 
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, 0);
 
 	Timer4::applyAndReset();
 
@@ -64,11 +64,11 @@ int main()
 	MODM_LOG_INFO << "1.0 ms pulse width for 1 s" << modm::endl;
 
 	LedGreen::set();
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, minPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, minPwm);
 	modm::delay(2s);
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, maxPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, maxPwm);
 	modm::delay(2s);
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, minPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, minPwm);
 	LedGreen::reset();
 	modm::delay(1s);
 
@@ -76,7 +76,7 @@ int main()
 	MODM_LOG_INFO << modm::endl;
 
 	MODM_LOG_INFO << "Pulse width set to 1.5 ms" << modm::endl;
-	Timer4::setCompareValue(2, targetPwm);
+	Timer4::setCompareValue<GpioB7::Ch2>(targetPwm);
 
 	while (true)
 	{

--- a/examples/nucleo_g474re/servo_pwm/main.cpp
+++ b/examples/nucleo_g474re/servo_pwm/main.cpp
@@ -37,7 +37,7 @@ main()
 	Timer4::setPrescaler(52);
 	Timer4::setOverflow(overflow);
 
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, 0);
 
 	Timer4::applyAndReset();
 
@@ -49,11 +49,11 @@ main()
 	MODM_LOG_INFO << "2.0 ms pulse width for 2 s" << modm::endl;
 	MODM_LOG_INFO << "1.0 ms pulse width for 1 s" << modm::endl;
 	LedD13::set();
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, minPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, minPwm);
 	modm::delay(2000ms);
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, maxPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, maxPwm);
 	modm::delay(2000ms);
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, minPwm);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, minPwm);
 	LedD13::reset();
 	modm::delay(1000ms);
 
@@ -65,11 +65,11 @@ main()
 		modm::delay(100ms);
 
 		if (!Button::read()) {
-			Timer4::setCompareValue(2, targetPwm);
+			Timer4::setCompareValue<GpioB7::Ch2>(targetPwm);
 			MODM_LOG_INFO << "^";
 		}
 		else {
-			Timer4::setCompareValue(2, minPwm);
+			Timer4::setCompareValue<GpioB7::Ch2>(minPwm);
 			MODM_LOG_INFO << "-";
 		}
 	}

--- a/examples/nucleo_g474re/timer_input_capture/main.cpp
+++ b/examples/nucleo_g474re/timer_input_capture/main.cpp
@@ -22,14 +22,12 @@
 using namespace Board;
 
 // Input Capture Timer Configuration
-constexpr uint8_t 	input_capture_channel 		= 2;
 constexpr uint16_t 	input_capture_overflow 		= 0xFFFF;
 constexpr float 	input_capture_freq_hz 		= 3000.00;	// Hz
 constexpr uint16_t 	input_capture_prescaler 	= SystemClock::Frequency / input_capture_freq_hz;
 constexpr float 	input_capture_ms_per_tick 	= ( 1.0 / input_capture_freq_hz ) * 1000.0;
 
 // PWM Generator Timer Configuration
-constexpr uint8_t 	pwm_gen_channel 		= 2u;
 constexpr uint16_t 	pwm_gen_overflow 		= 0xFFFF;
 constexpr float 	pwm_gen_frequency_hz 	= 50.00; 	// Hz
 constexpr float 	pwm_gen_pulse_width_ms 	= 1.5f;		// Milliseconds
@@ -67,7 +65,7 @@ MODM_ISR(TIM20_CC)
 	LedD13::toggle();	// Visual Feedback of the interruption being triggered
 
 	old_input_timer_value = latest_input_timer_value;
-	latest_input_timer_value = Timer20::getCompareValue(input_capture_channel);
+	latest_input_timer_value = Timer20::getCompareValue<GpioC2::Ch2>();
 	temp_ticks_between_interrups = (latest_input_timer_value-old_input_timer_value);
 
 	// Ingore negative values (overflow of counter register)
@@ -98,7 +96,7 @@ void generatePwm()
 	Timer4::setMode(Timer4::Mode::UpCounter);
 	Timer4::setPrescaler(pwm_gen_prescaler);
 	Timer4::setOverflow(pwm_gen_overflow);
-	Timer4::configureOutputChannel(pwm_gen_channel, Timer4::OutputCompareMode::Pwm, pwm_pulse_width_in_ticks);
+	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, pwm_pulse_width_in_ticks);
 	Timer4::applyAndReset();
 	Timer4::start();
 	Timer4::enableOutput();
@@ -115,7 +113,7 @@ void inputTimerConfig()
 	Timer20::setMode(Timer20::Mode::UpCounter);
 	Timer20::setPrescaler(input_capture_prescaler);
 	Timer20::setOverflow(input_capture_overflow);
-	Timer20::configureInputChannel(input_capture_channel, Timer20::InputCaptureMapping::InputOwn,
+	Timer20::configureInputChannel<GpioC2::Ch2>(Timer20::InputCaptureMapping::InputOwn,
 									interrupt_prescaler, Timer20::InputCapturePolarity::Rising, 0, false);
 	Timer20::enableInterruptVector(Timer20::Interrupt::CaptureCompare2, true, interrupt_priority);
 	Timer20::enableInterrupt(Timer20::Interrupt::CaptureCompare2);
@@ -170,7 +168,7 @@ int main()
 		{
 			float period_of_signal_ms = getPeriodOfSignalInMs();
 			MODM_LOG_INFO << "Current Timer Value: " << Timer20::getValue() << modm::endl;
-			MODM_LOG_INFO << "Capture Compare Value: " << Timer20::getCompareValue(2) << modm::endl;
+			MODM_LOG_INFO << "Capture Compare Value: " << Timer20::getCompareValue<GpioC2::Ch2>() << modm::endl;
 			MODM_LOG_INFO << "Ticks between interrupts: " << ticks_between_interrupts << modm::endl;
 			MODM_LOG_INFO.printf("Period of the signal in ms: %.2f\n", (double) period_of_signal_ms);
 			MODM_LOG_INFO << "-----------------------------" << modm::endl ;

--- a/examples/nucleo_l432kc/pwm/main.cpp
+++ b/examples/nucleo_l432kc/pwm/main.cpp
@@ -39,10 +39,10 @@ main()
 	Timer1::setOverflow(65535);
 
 
-	Timer1::configureOutputChannel(1, Timer1::OutputCompareMode::Pwm, 32767);
-	Timer1::configureOutputChannel(2, Timer1::OutputCompareMode::Pwm, 32767);
-	Timer1::configureOutputChannel(3, Timer1::OutputCompareMode::Pwm, 32767);
-	Timer1::configureOutputChannel(4, Timer1::OutputCompareMode::Pwm, 32767);
+	Timer1::configureOutputChannel<GpioOutputA8::Ch1>(Timer1::OutputCompareMode::Pwm, 32767);
+	Timer1::configureOutputChannel<GpioOutputA9::Ch2>(Timer1::OutputCompareMode::Pwm, 32767);
+	Timer1::configureOutputChannel<GpioOutputA10::Ch3>(Timer1::OutputCompareMode::Pwm, 32767);
+	Timer1::configureOutputChannel<GpioOutputA11::Ch4>(Timer1::OutputCompareMode::Pwm, 32767);
 
 	Timer1::applyAndReset();
 

--- a/examples/nucleo_l432kc/pwm_advanced/main.cpp
+++ b/examples/nucleo_l432kc/pwm_advanced/main.cpp
@@ -59,7 +59,7 @@ main()
 				TriggerOut::set();
 
 				MODM_LOG_INFO << "Mode: PWM" << modm::endl;
-				Timer1::configureOutputChannel(1,
+				Timer1::configureOutputChannel<GpioOutputA8::Ch1>(
 						Timer1::OutputCompareMode::Pwm,
 						Timer1::PinState::Enable,
 						Timer1::OutputComparePolarity::ActiveHigh,
@@ -70,7 +70,7 @@ main()
 				break;
 			case 1:
 				MODM_LOG_INFO << "Mode: HiZ" << modm::endl;
-				Timer1::configureOutputChannel(1,
+				Timer1::configureOutputChannel<GpioOutputA8::Ch1>(
 						Timer1::OutputCompareMode::ForceActive,
 						Timer1::PinState::Enable,
 						Timer1::OutputComparePolarity::ActiveLow,
@@ -81,7 +81,7 @@ main()
 				break;
 			case 2:
 				MODM_LOG_INFO << "Mode: High" << modm::endl;
-				Timer1::configureOutputChannel(1,
+				Timer1::configureOutputChannel<GpioOutputA8::Ch1>(
 						Timer1::OutputCompareMode::ForceActive,
 						Timer1::PinState::Enable,
 						Timer1::OutputComparePolarity::ActiveHigh,
@@ -92,7 +92,7 @@ main()
 				break;
 			case 3:
 				MODM_LOG_INFO << "Mode: Low" << modm::endl;
-				Timer1::configureOutputChannel(1,
+				Timer1::configureOutputChannel<GpioOutputA8::Ch1>(
 						Timer1::OutputCompareMode::ForceActive,
 						Timer1::PinState::Enable,
 						Timer1::OutputComparePolarity::ActiveLow,
@@ -102,7 +102,7 @@ main()
 						);
 				break;
 		}
-		Timer1::setCompareValue(1, compareValue);
+		Timer1::setCompareValue<GpioOutputA8::Ch1>(compareValue);
 		Timer1::applyAndReset();
 
 		// Go to next state after 250 ms

--- a/examples/stm32f3_discovery/timer/basic/main.cpp
+++ b/examples/stm32f3_discovery/timer/basic/main.cpp
@@ -29,8 +29,8 @@ main()
 	Timer1::start();
 
 	Timer1::connect<Board::LedNorth::Ch1, Board::LedNorthWest::Ch1n>();
-	Timer1::setCompareValue(1, 0);
-	Timer1::configureOutputChannel(1,
+	Timer1::setCompareValue<Board::LedNorth::Ch1>(0);
+	Timer1::configureOutputChannel<Board::LedNorth::Ch1>(
 			static_cast<uint32_t>(Timer1::OutputCompareMode::Pwm) | 0b0101);
 	Timer1::setDeadTime(7);
 
@@ -38,7 +38,7 @@ main()
 
 	uint8_t i = 0;
 	while (true){
-		Timer1::setCompareValue(1, ++i);
+		Timer1::setCompareValue<Board::LedNorth::Ch1>(++i);
 		modm::delay(10ms);
 	}
 

--- a/examples/stm32f4_discovery/timer/main.cpp
+++ b/examples/stm32f4_discovery/timer/main.cpp
@@ -18,22 +18,22 @@
 // create the leds with these lambda callbacks
 modm::ui::Led orange([](uint8_t brightness)
 {
-	Timer4::setCompareValue(2, modm::ui::table22_16_256[brightness]);
+	Timer4::setCompareValue<Board::LedOrange::Ch2>(modm::ui::table22_16_256[brightness]);
 });
 
 modm::ui::Led red([](uint8_t brightness)
 {
-	Timer4::setCompareValue(3, modm::ui::table22_16_256[brightness]);
+	Timer4::setCompareValue<Board::LedRed::Ch3>(modm::ui::table22_16_256[brightness]);
 });
 
 modm::ui::Led green([](uint8_t brightness)
 {
-	Timer4::setCompareValue(1, modm::ui::table22_16_256[brightness]);
+	Timer4::setCompareValue<Board::LedGreen::Ch1>(modm::ui::table22_16_256[brightness]);
 });
 
 modm::ui::Led blue([](uint8_t brightness)
 {
-	Timer4::setCompareValue(4, modm::ui::table22_16_256[brightness]);
+	Timer4::setCompareValue<Board::LedBlue::Ch4>(modm::ui::table22_16_256[brightness]);
 });
 // ----------------------------------------------------------------------------
 
@@ -93,10 +93,10 @@ main()
 	Timer4::setPrescaler(1);
 	Timer4::setOverflow(65535);
 	// configure the output channels
-	Timer4::configureOutputChannel(1, Timer4::OutputCompareMode::Pwm, 0);
-	Timer4::configureOutputChannel(2, Timer4::OutputCompareMode::Pwm, 0);
-	Timer4::configureOutputChannel(3, Timer4::OutputCompareMode::Pwm, 0);
-	Timer4::configureOutputChannel(4, Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<Board::LedGreen::Ch1>(Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<Board::LedOrange::Ch2>(Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<Board::LedRed::Ch3>(Timer4::OutputCompareMode::Pwm, 0);
+	Timer4::configureOutputChannel<Board::LedBlue::Ch4>(Timer4::OutputCompareMode::Pwm, 0);
 	Timer4::applyAndReset();
 	// start the timer
 	Timer4::start();

--- a/src/modm/driver/encoder/encoder_input.hpp
+++ b/src/modm/driver/encoder/encoder_input.hpp
@@ -46,8 +46,8 @@ public:
 		Timer::setPrescaler(PRESCALER);
 
 		if(filter) {
-			Timer::configureInputChannel(1, filter);
-			Timer::configureInputChannel(2, filter);
+			Timer::template configureInputChannel<typename SignalA::Ch1>(filter);
+			Timer::template configureInputChannel<typename SignalB::Ch2>(filter);
 		}
 
 		Timer::applyAndReset();

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2009, 2011-2012, Georgi Grinshpun
  * Copyright (c) 2010, Martin Rosekeit
  * Copyright (c) 2011, 2013-2017, Niklas Hauser
- * Copyright (c) 2013, 2015, Sascha Schade
+ * Copyright (c) 2013, 2015, 2022, Sascha Schade
  * Copyright (c) 2013, 2016, Kevin Läufer
  *
  * This file is part of the modm project.
@@ -270,6 +270,14 @@ public:
 		TIM{{ id }}->CR2 = flags;
 	}
 
+	template<typename Signal>
+	static void
+	setOutputIdleState(OutputIdleState idle, OutputIdleState idle_n = OutputIdleState::Reset)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		setOutputIdleState(channel, idle, idle_n);
+	}
+
 	/*
 	 * Set Dead Time Value
 	 *
@@ -326,17 +334,45 @@ public:
 	static void
 	configureInputChannel(uint32_t channel, uint8_t filter);
 
+	template<typename Signal>
+	static void
+	configureInputChannel(uint8_t filter)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureInputChannel(channel, filter);
+	}
+
 	static void
 	configureInputChannel(uint32_t channel, InputCaptureMapping input,
 			InputCapturePrescaler prescaler,
 			InputCapturePolarity polarity, uint8_t filter,
 			bool xor_ch1_3=false);
 
+	template<typename Signal>
+	static void
+	configureInputChannel(InputCaptureMapping input,
+			InputCapturePrescaler prescaler,
+			InputCapturePolarity polarity, uint8_t filter,
+			bool xor_ch1_3=false)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureInputChannel(channel, input, prescaler, polarity, filter, xor_ch1_3);
+	}
+
+
 	static void
 	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
 			Value compareValue, PinState out = PinState::Enable);
 	// TODO: Maybe add some functionality from the configureOutput
 	//       function below...
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode mode, Value compareValue)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, compareValue);
+	}
 
 	/*
 	 * Configure Output Channel without changing the Compare Value
@@ -356,6 +392,18 @@ public:
 			PinState out_n,
 			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
 			OutputComparePreload preload = OutputComparePreload::Disable);
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode mode,
+			PinState out, OutputComparePolarity polarity,
+			PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, out, polarity, out_n, polarity_n, preload);
+	}
 
 	/*
 	 * Configure Output Channel width Mode/OutputPort uint
@@ -380,6 +428,14 @@ public:
 	static void
 	configureOutputChannel(uint32_t channel, uint32_t modeOutputPorts);
 
+	template<typename Signal>
+	static void
+	configureOutputChannel(uint32_t modeOutputPorts)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, modeOutputPorts);
+	}
+
 	static inline void
 	setCompareValue(uint32_t channel, Value value)
 	{
@@ -396,10 +452,26 @@ public:
 %% endif
 	}
 
+	template<typename Signal>
+	static void
+	setCompareValue(Value value)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		setCompareValue(channel, value);
+	}
+
 	static inline Value
 	getCompareValue(uint32_t channel)
 	{
 		return *(&TIM{{ id }}->CCR1 + (channel - 1));
+	}
+
+	template<typename Signal>
+	static inline Value
+	getCompareValue()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		return getCompareValue(channel);
 	}
 
 public:

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -4,7 +4,8 @@
  * Copyright (c) 2010, Martin Rosekeit
  * Copyright (c) 2011, 2013-2017, Niklas Hauser
  * Copyright (c) 2013-2014, 2016, Kevin Läufer
- * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2014, 2022, Sascha Schade
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -332,16 +333,45 @@ public:
 	static void
 	configureInputChannel(uint32_t channel, uint8_t filter);
 
+	template<typename Signal>
+	static void
+	configureInputChannel(uint8_t filter)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureInputChannel(channel, filter);
+	}
+
 	static void
 	configureInputChannel(uint32_t channel, InputCaptureMapping input,
 			InputCapturePrescaler prescaler,
 			InputCapturePolarity polarity, uint8_t filter,
 			bool xor_ch1_3=false);
 
+	template<typename Signal>
+	static void
+	configureInputChannel(InputCaptureMapping input,
+			InputCapturePrescaler prescaler,
+			InputCapturePolarity polarity, uint8_t filter,
+			bool xor_ch1_3=false)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureInputChannel(channel, input, prescaler, polarity, filter, xor_ch1_3);
+	}
+
 	static void
 	configureOutputChannel(uint32_t channel, OutputCompareMode_t mode,
 			Value compareValue, PinState out = PinState::Enable,
 			bool enableComparePreload = true);
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode_t mode,
+			Value compareValue, PinState out = PinState::Enable,
+			bool enableComparePreload = true)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, compareValue, out, enableComparePreload);
+	}
 
 	/// Switch to Pwm Mode 2
 	///
@@ -373,6 +403,14 @@ public:
 				TIM{{ id }}->CCMR2 = flags;
 			}
 		}
+	}
+
+	template<typename Signal>
+	static void
+	setInvertedPwm()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		setInvertedPwm(channel);
 	}
 
 	/// Switch to Pwm Mode 1
@@ -407,6 +445,14 @@ public:
 		}
 	}
 
+	template<typename Signal>
+	static void
+	setNormalPwm()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		setNormalPwm(channel);
+	}
+
 	/// Switch to Inactive Mode
 	///
 	/// The channel output will be forced to the inactive level.
@@ -436,6 +482,14 @@ public:
 				TIM{{ id }}->CCMR2 = flags;
 			}
 		}
+	}
+
+	template<typename Signal>
+	static void
+	forceInactive()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		forceInactive(channel);
 	}
 
 	/// Switch to Active Mode
@@ -469,6 +523,14 @@ public:
 		}
 	}
 
+	template<typename Signal>
+	static void
+	forceActive()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		forceActive(channel);
+	}
+
 	%% if (id !=6 and id != 7)
 	/// Returns if the capture/compare channel of the timer is configured as input.
 	///
@@ -494,10 +556,20 @@ public:
 	%% endif
 
 	%% endif
+
 	static inline void
 	setCompareValue(uint32_t channel, Value value)
 	{
 		*(&TIM{{ id }}->CCR1 + (channel - 1)) = value;
+	}
+
+
+	template<typename Signal>
+	static void
+	setCompareValue(Value value)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{id}}, Signal>();
+		setCompareValue(channel, value);
 	}
 
 	static inline Value
@@ -506,6 +578,13 @@ public:
 		return *(&TIM{{ id }}->CCR1 + (channel - 1));
 	}
 
+	template<typename Signal>
+	static inline Value
+	getCompareValue()
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		return getCompareValue(channel);
+	}
 public:
 	static void
 	enableInterruptVector(bool enable, uint32_t priority);

--- a/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2013, Kevin Läufer
  * Copyright (c) 2014, Fabian Greif
  * Copyright (c) 2014-2017, Niklas Hauser
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -15,6 +16,8 @@
 #define MODM_STM32_TIMER_GP_BASE_HPP
 
 #include "basic_base.hpp"
+#include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/data.hpp>
 
 namespace modm
 {
@@ -265,6 +268,28 @@ public:
 	 */
 	static uint16_t
 	getCompareValue(uint32_t channel);
+
+protected:
+	template<Peripheral p, typename Signal>
+	static consteval int
+	signalToChannel()
+	{
+		modm::platform::detail::SignalConnection<Signal, p>{};
+		if constexpr (Signal::Signal == Gpio::Signal::Ch1) {
+			return 1;
+		} else if constexpr (Signal::Signal == Gpio::Signal::Ch2) {
+			return 2;
+		} else if constexpr (Signal::Signal == Gpio::Signal::Ch3) {
+			return 3;
+%% if target.family != "l0" or target.pin != "d"
+		} else if constexpr (Signal::Signal == Gpio::Signal::Ch4) {
+			return 4;
+%% endif
+		} else {
+			// assert is always false, static_assert(false) would not compile
+			static_assert(!sizeof(Signal), "Invalid timer channel");
+		}
+	}
 };
 
 } // namespace platform

--- a/src/modm/platform/timer/stm32/module.lb
+++ b/src/modm/platform/timer/stm32/module.lb
@@ -110,8 +110,8 @@ def prepare(module, options):
     props["target"] = target = device.identifier
     props["types"] = set()
     # extended advanced control timer with 6 channels and trigger out 2
-    props["advanced_extended"] = target.family not in ["f0", "f1", "f2", "f4", "l0", "l1"] or \
-            target.family == "f3" and target.name not in ["73", "78"]
+    props["advanced_extended"] = (target.family not in ["f0", "f1", "f2", "f3", "f4", "l0", "l1"]) or \
+            ((target.family == "f3") and (target.name not in ["73", "78"]))
 
     props["timer_vectors"] = tim_vectors = defaultdict(list)
     vectors = [v["name"] for v in device.get_driver("core")["vector"] if "TIM" in v["name"]]


### PR DESCRIPTION
Adding on @chris-durand example in #908

The `advanced_extended` property still looks a bit rough to me. That information should come from modm-devices ... I had to disable some device families to get all tests run. I would leave it as it is and add better props later.