### PR TITLE
[stm32] [timer] [fix] Match template to default method

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -368,10 +368,11 @@ public:
 
 	template<typename Signal>
 	static void
-	configureOutputChannel(OutputCompareMode mode, Value compareValue)
+	configureOutputChannel(OutputCompareMode mode,
+			Value compareValue, PinState out = PinState::Enable)
 	{
 		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
-		configureOutputChannel(channel, mode, compareValue);
+		configureOutputChannel(channel, mode, compareValue, out);
 	}
 
 	/*


### PR DESCRIPTION
I overlooked the parameter with default value in PR #912.
The template shall match the default methods.