### PR TITLE
fixed filter moving average for floating type

### DIFF
--- a/src/modm/math/filter/moving_average.hpp
+++ b/src/modm/math/filter/moving_average.hpp
@@ -82,7 +82,7 @@ public:
 	{
 		if constexpr(std::floating_point<T>) {
 			buffer[index] = input;
-			sum = std::accumulate(std::begin(buffer), std::end(buffer), 0);
+			sum = std::accumulate(std::begin(buffer), std::end(buffer), T{0});
 		} else {
 			sum -= buffer[index];
 			sum += input;


### PR DESCRIPTION
std::accumulate<T>(first, last, init) deduces type T based on init argument. Therefore, for floating types, you need to pass the type float.