### PR TITLE
Fix STM32G4 ADC channels

### DIFF
--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2014, Kevin Läufer
  * Copyright (c) 2014, 2016-2018, Niklas Hauser
  * Copyright (c) 2017, Sascha Schade
+ * Copyright (c) 2022, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -59,7 +60,12 @@ public:
 		BatDiv2   = 17,
 		InternalReference = 18,
 		// TODO: Add internal connections
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["g4"]
+		Opamp1 = 13,
+		Temperature = 16,
+		BatDiv3 = 17,
+		InternalReference = 18,
+%% elif target["family"] in ["l4"]
 		Temperature = 17,
 		BatDiv3     = 18,
 %% elif target["family"] in ["l5"]
@@ -71,25 +77,49 @@ public:
 %% if target["family"] in ["f3"]
 		Opamp2 = 17,
 		InternalReference = 18,
-%% elif target["family"] in ["l4", "l5", "g4"]
+%% elif target["family"] in ["l4", "l5"]
 		Dac1 = 17,
 		Dac2 = 18,
+%% elif target["family"] in ["g4"]
+		Opamp2 = 16,
+		Opamp3 = 18,
 %% endif
 %% elif id == 3
 %% if target["family"] in ["f3"]
 		Vss    =  4,	// ADC3_IN4 not bonded and connected to VSS
 		Opamp3 = 17,
 		InternalReference = 18,
-%% elif target["family"] in ["l4", "g4"]
+%% elif target["family"] in ["l4"]
 		Dac1 = 14,
 		Dac2 = 15,
 		Vss  = 16,
 		Temperature = 17,
 		BatDiv3 = 18,
+%% elif target["family"] in ["g4"]
+		Opamp3 = 13,
+%% if target["name"] in ["91", "a1"]
+		Opamp6 = 17,
+%% else
+		BatDiv3 = 17,
+%% endif
+		InternalReference = 18,
 %% endif
 %% elif id == 4
-		Opamp3 = 17,
+%% if target["family"] in ["f3"]
+		Opamp4 = 17,
 		InternalReference = 18,
+%% elif target["family"] in ["g4"]
+		Opamp6 = 17,
+		InternalReference = 18,
+%% endif
+%% elif id == 5
+%% if target["family"] in ["g4"]
+		Opamp5 = 3,
+		Temperature = 4,
+		Opamp4 = 5,
+		BatDiv3 = 17,
+		InternalReference = 18,
+%% endif
 %% endif
 	};
 

--- a/src/modm/platform/adc/stm32f3/module.lb
+++ b/src/modm/platform/adc/stm32f3/module.lb
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2016-2018, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2022, Christopher Durand
 #
 # This file is part of the modm project.
 #
@@ -41,7 +42,12 @@ class Instance(Module):
                 channels = range(1,17)
             elif target["family"] == "g4":
                 # ADC1 is connected to 14 external channels + 4 internal channels
-                channels = range(1,15)
+                # Channel 13: Opamp1
+                # Channel 16: Temperature
+                # Channel 17: VBat/3
+                # Channel 18: VRefint
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,14,15]
+                assert(len(channels) == 14)
             else:
                 # 11-14 reserved
                 channels = [1,2,3,4,5,6,7,8,9,10,15,16,17,18]
@@ -51,7 +57,10 @@ class Instance(Module):
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,17,18]
             elif target["family"] == "g4":
                 # ADC2 is connected to 16 external channels + 2 internal channels
-                channels = range(1,17)
+                # Channel 16: Opamp2
+                # Channel 18: Opamp3
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17]
+                assert(len(channels) == 16)
             elif target["family"] == "l5":
                 # ADC1 is connected to 16 external channels + 2 internal channels
                 channels = range(1,17)
@@ -63,21 +72,34 @@ class Instance(Module):
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
             elif target["family"] == "g4":
                 # ADC3 is connected to 15 external channels + 3 internal channels
-                channels = range(1,16)
+                # Channel 13: Opamp3
+                # Channel 17: VBat/3
+                # Channel 18: VRefint
+                channels = [1,2,3,4,5,6,7,8,9,10,11,12,14,15,16]
+                assert(len(channels) == 15)
             else:
                 # ADC3 is connected to 12 external channels + 4 internal channels
                 channels = [1,2,3,4,6,7,8,9,10,11,12,13]
         elif instance_id == 4:
             if target["family"] == "g4":
                 # ADC4 is connected to 16 external channels + 2 internal channels
+                # Channel 17: Opamp6
+                # Channel 18: VRefint
                 channels = range(1,17)
+                assert(len(channels) == 16)
             else:
                 # 14-16 reserved
                 channels = [1,2,3,4,5,6,7,8,9,10,11,12,13,17,18]
         elif instance_id == 5:
             if target["family"] == "g4":
                 # ADC5 is connected to 13 external channels + 5 internal channels
-                channels = range(1,14)
+                # Channel 3: Opamp5
+                # Channel 4: Temperature
+                # Channel 5: Opamp4
+                # Channel 17: VBat/3
+                # Channel 18: VRefint
+                channels = [1,2,6,7,8,9,10,11,12,13,14,15,16]
+                assert(len(channels) == 13)
             else:
                 raise NotImplementedError
         properties["channels"] = sorted(channels)


### PR DESCRIPTION
Fix STM32G4 ADC channel mappings. The data was extracted from semi-structured data inside the ST HAL headers ([here](https://github.com/modm-ext/stm32-cube-hal-drivers/blob/main/stm32g4xx/Inc/stm32g4xx_hal_adc_ex.h#L705) and [here](https://github.com/modm-ext/stm32-cube-hal-drivers/blob/main/stm32g4xx/Inc/stm32g4xx_ll_adc.h#L795)) in a semi-manual way using some regex-replace.

The changes to the external channel definitions match what is in #324, although the data has been derived independently. The generated ADC headers match the G4 reference manual which was not used as a source for the initial changes. With all these cross-checks I am confident the data is correct.

There was one inconsistency with regard to ADC3 channel 17. The section in the header claims G4x3 and G4x4 devices would have Opamp6 mapped to channel 17 instead of `VBat/3`, but I went with what CubeMX and the reference manual say.

Fixes #802 and https://github.com/modm-io/modm-devices/issues/93.