### PR TITLE
Fix MacOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: macos-12
 
     steps:
+      # update Xcode version to fix linker bug
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.1'
+
       - name: Setup environment - Brew tap
         run: |
           brew tap modm-ext/arm


### PR DESCRIPTION
Compilation of MacOS hosted examples fails due to a [toolchain bug in Xcode 14.0](https://stackoverflow.com/questions/73714336/xcode-update-to-version-2395-ld-compile-problem-occurs-computedatomcount-m). Update Xcode to 14.1 to fix the issue.

The linker crashes with:
```
ld: Assertion failed: (_file->_atomsArrayCount == computedAtomCount &&
 "more atoms allocated than expected"), function parse,
 file macho_relocatable_file.cpp, line 2061.ld: Assertion failed: (_file->_atomsArrayCount == computedAtomCount && "more atoms allocated than expected"), function parse, file macho_relocatable_file.cpp, line 2061.
```
