### PR TITLE
Ref. #926 Preserves .hardware_init functions from being optimised out

### DIFF
--- a/src/modm/architecture/utils.hpp
+++ b/src/modm/architecture/utils.hpp
@@ -137,6 +137,7 @@
 
 	#define modm_always_inline		inline __attribute__((always_inline))
 	#define modm_noinline			__attribute__((noinline))
+	#define modm_used				__attribute__((used))
 	#define modm_unused				__attribute__((unused))
 	#define modm_aligned(n)			__attribute__((aligned(n)))
 	#define modm_packed				__attribute__((packed))

--- a/src/modm/platform/core/cortex/hardware_init.hpp
+++ b/src/modm/platform/core/cortex/hardware_init.hpp
@@ -19,24 +19,24 @@
 /// @hideinitializer
 #define MODM_HARDWARE_INIT(function) \
 	modm_section(".hardware_init") \
-	void* const MODM_CONCAT(__modm_hardware_init_ptr_, function) = (void*)&function
+	void* const MODM_CONCAT(__modm_hardware_init_ptr_, function) modm_used = (void*)&function
 
 /// Call `function` during boot process with a unique name.
 /// @hideinitializer
 #define MODM_HARDWARE_INIT_NAME(name, function) \
 	modm_section(".hardware_init") \
-	void* const MODM_CONCAT(__modm_hardware_init_ptr_, name) = (void*)&function
+	void* const MODM_CONCAT(__modm_hardware_init_ptr_, name) modm_used = (void*)&function
 
 /// Call `function` during boot process in a global order.
 /// @hideinitializer
 #define MODM_HARDWARE_INIT_ORDER(function, order) \
 	modm_section(".hardware_init.order_" MODM_STRINGIFY(order)) \
-	void* const MODM_CONCAT(__modm_hardware_init_ptr_, function) = (void*)&function
+	void* const MODM_CONCAT(__modm_hardware_init_ptr_, function) modm_used = (void*)&function
 
 /// Call `function` during boot process in a global order with a unique name.
 /// @hideinitializer
 #define MODM_HARDWARE_INIT_NAME_ORDER(name, function, order) \
 	modm_section(".hardware_init.order_" MODM_STRINGIFY(order)) \
-	void* const MODM_CONCAT(__modm_hardware_init_ptr_, name) = (void*)&function
+	void* const MODM_CONCAT(__modm_hardware_init_ptr_, name) modm_used = (void*)&function
 
 /// @}


### PR DESCRIPTION
resolves #926 