### PR TITLE
[ui] Fix uninitialized frame buffer memory in MonochromeGraphicDisplay

### DIFF
--- a/src/modm/ui/display/monochrome_graphic_display.hpp
+++ b/src/modm/ui/display/monochrome_graphic_display.hpp
@@ -76,7 +76,7 @@ public:
 	clear() final;
 
 protected:
-	uint8_t buffer[BufferHeight][BufferWidth];
+	uint8_t buffer[BufferHeight][BufferWidth]{};
 };
 }  // namespace modm
 


### PR DESCRIPTION
Before:
![display1](https://user-images.githubusercontent.com/25187160/203679395-739472d4-0f9c-425e-bbff-50e079cd03f5.jpg)

After:
![display2](https://user-images.githubusercontent.com/25187160/203679406-9ff1c975-5282-452c-a92b-aaf5aeb1dd3f.jpg)
