### PR TITLE
[stm32] Only configure BDTR register for timers with complementary PWM

### DIFF
--- a/examples/blue_pill_f103/servo_pwm/main.cpp
+++ b/examples/blue_pill_f103/servo_pwm/main.cpp
@@ -55,7 +55,6 @@ int main()
 	Timer4::applyAndReset();
 
 	Timer4::start();
-	Timer4::enableOutput();
 
 	MODM_LOG_INFO << modm::endl;
 	MODM_LOG_INFO << "Teaching sequence for electronic speed controllers:" << modm::endl;

--- a/examples/nucleo_g474re/servo_pwm/main.cpp
+++ b/examples/nucleo_g474re/servo_pwm/main.cpp
@@ -42,7 +42,6 @@ main()
 	Timer4::applyAndReset();
 
 	Timer4::start();
-	Timer4::enableOutput();
 
 	MODM_LOG_INFO << "Teaching sequence for electronic speed controllers:" << modm::endl;
 	MODM_LOG_INFO << "1.0 ms pulse width for 2 s" << modm::endl;

--- a/examples/nucleo_g474re/timer_input_capture/main.cpp
+++ b/examples/nucleo_g474re/timer_input_capture/main.cpp
@@ -99,7 +99,6 @@ void generatePwm()
 	Timer4::configureOutputChannel<GpioB7::Ch2>(Timer4::OutputCompareMode::Pwm, pwm_pulse_width_in_ticks);
 	Timer4::applyAndReset();
 	Timer4::start();
-	Timer4::enableOutput();
 }
 
 /**

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -254,7 +254,7 @@ public:
 	}
 
 
-%% if target.family not in ["l0", "l1"]
+%% if target.family not in ["l0", "l1"] and id in [15, 16, 17]
 	static inline void
 	enableOutput()
 	{


### PR DESCRIPTION
Only provide the timer HAL functions to configure the BDTR register if it is present in hardware. Previously the functions were generated for all general purpose timers although only instances 15, 16, 17 and the advanced control timers support it.

@ser-plu