### PR TITLE
[sam] Fix SAMx7x b-variant USART defines

### DIFF
--- a/src/modm/platform/uart/sam/uart_base.hpp.in
+++ b/src/modm/platform/uart/sam/uart_base.hpp.in
@@ -25,12 +25,12 @@ public:
 	{
 %% if type == "usart"
 %% if target.family == "e7x/s7x/v7x" and target.variant == "b"
-		Disabled  = US_MR_USART_PAR_NO_Val,
-		Even      = US_MR_USART_PAR_EVEN_Val,
-		Odd       = US_MR_USART_PAR_ODD_Val,
-		Space	  = US_MR_USART_PAR_SPACE_Val,
-		Mark      = US_MR_USART_PAR_MARK_Val,
-		MultiDrop = US_MR_USART_PAR_MULTIDROP_Val
+		Disabled  = US_MR_USART_PAR_NO,
+		Even      = US_MR_USART_PAR_EVEN,
+		Odd       = US_MR_USART_PAR_ODD,
+		Space	  = US_MR_USART_PAR_SPACE,
+		Mark      = US_MR_USART_PAR_MARK,
+		MultiDrop = US_MR_USART_PAR_MULTIDROP
 %% else
 		Disabled  = US_MR_PAR_NO,
 		Even      = US_MR_PAR_EVEN,


### PR DESCRIPTION
The `UsartBase::Parity` enum constants have to use the shifted bit constants from the device header, not `_Val`. This led to the wrong bits in the `MR` register being configured. The error showed up now with V71 devices because another bug regarding device identifiers was previously fixed that caused the a deprecated `a`-variant defines to be selected on V71 `b`-variant devices.

This has been tested in hardware with V71 Xplained-Pro board blink example.