### PR TITLE
SAMx7x SPI driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -30,6 +30,7 @@ struct SystemClock
 	static constexpr uint32_t Frequency = 300_MHz;
 	static constexpr uint32_t Mck = Frequency / 2;  // 150 MHz max.
 	static constexpr uint32_t Usart1 = Mck;
+	static constexpr uint32_t Spi0 = Mck;
 //	static constexpr uint32_t Usb = 48_MHz;
 
 	static bool inline

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -63,6 +63,12 @@ struct Leds
 		Led1::setOutput();
 	}
 
+	static void setOutput(bool state)
+	{
+		Led0::setOutput(state);
+		Led1::setOutput(state);
+	}
+
 	static void write(uint32_t value)
 	{
 		Led0::set(value & 1);

--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017-2018, Niklas Hauser
  * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2023, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -221,8 +222,8 @@ public:
 			setPortReg(PIO_PPDDR_OFFSET); // disable pull down
 			setPortReg(PIO_PUDR_OFFSET); // disable pull up
 		} else if (type == InputType::PullDown) {
-			setPortReg(PIO_PPDER_OFFSET); // Enable pull down
 			setPortReg(PIO_PUDR_OFFSET); // disable pull up
+			setPortReg(PIO_PPDER_OFFSET); // enable pull down
 		} else {
 			setPortReg(PIO_PPDDR_OFFSET); // Disable pull down
 			setPortReg(PIO_PUER_OFFSET); // Enable pull up

--- a/src/modm/platform/spi/sam_x7x/module.lb
+++ b/src/modm/platform/spi/sam_x7x/module.lb
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def get_properties(env):
+    device = env[":target"]
+    properties = {}
+    properties["target"] = device.identifier
+    return properties
+
+class Instance(Module):
+    def __init__(self, driver, instance):
+        self.instance = int(instance)
+        self.driver = driver
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        module.depends(":platform:spi")
+        return True
+
+    def build(self, env):
+        properties = get_properties(env)
+        properties["id"] = self.instance
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/spi"
+
+        env.template("spi_hal.hpp.in", "spi_hal_{}.hpp".format(self.instance))
+        env.template("spi_hal_impl.hpp.in", "spi_hal_{}_impl.hpp".format(self.instance))
+        env.template("spi_master.hpp.in", "spi_master_{}.hpp".format(self.instance))
+        env.template("spi_master.cpp.in", "spi_master_{}.cpp".format(self.instance))
+        # TODO: DMA
+        # if env.has_module(":platform:dma"):
+        #    env.template("spi_master_dma.hpp.in", "spi_master_{}_dma.hpp".format(self.instance))
+        #    env.template("spi_master_dma_impl.hpp.in", "spi_master_{}_dma_impl.hpp".format(self.instance))
+
+
+def init(module):
+    module.name = ":platform:spi"
+    module.description = "Serial Peripheral Interface (SPI)"
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("spi:sam") or device.identifier.family != "e7x/s7x/v7x":
+        return False
+
+    module.depends(
+        ":architecture:register",
+        ":architecture:spi",
+        ":cmsis:device",
+        ":math:algorithm",
+        ":platform:gpio")
+
+    for driver in device.get_all_drivers("spi:sam"):
+        for instance in driver["instance"]:
+            module.add_submodule(Instance(driver, instance))
+
+    return True
+
+def build(env):
+    env.substitutions = get_properties(env)
+    env.outbasepath = "modm/src/modm/platform/spi"
+
+    env.template("spi_base.hpp.in")

--- a/src/modm/platform/spi/sam_x7x/spi_base.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_base.hpp.in
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAMX7X_SPI_BASE_HPP
+#define MODM_SAMX7X_SPI_BASE_HPP
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/architecture/interface/register.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Base class for SPI classes
+ *
+ * Provides common enums that do not depend on the specific SPI instance type.
+ *
+ * @author Christopher Durand
+ * @ingroup	modm_platform_spi
+ */
+class SpiBase
+{
+public:
+	enum class
+	Interrupt : uint32_t
+	{
+		RxRegisterFull   = SPI_IMR_RDRF,
+		TxRegisterEmpty  = SPI_IMR_TDRE,
+		ModeFaultError   = SPI_IMR_MODF,
+		OverrunError     = SPI_IMR_OVRES,
+		NssRising        = SPI_IMR_NSSR,
+		TransferFinished = SPI_IMR_TXEMPTY,
+		UnderrunError    = SPI_IMR_UNDES
+	};
+	MODM_FLAGS32(Interrupt);
+
+	enum class
+	StatusFlag : uint32_t
+	{
+		RxRegisterFull   = SPI_SR_RDRF,
+		TxRegisterEmpty  = SPI_SR_TDRE,
+		ModeFaultError   = SPI_SR_MODF,
+		OverrunError     = SPI_SR_OVRES,
+		NssRising        = SPI_SR_NSSR,
+		TransferFinished = SPI_SR_TXEMPTY,
+		UnderrunError    = SPI_SR_UNDES,
+		// SFERR is defined in the datasheet but not in any device header?
+		// SlaveFrameError  = SPI_SR_SFERR,
+		EnableStatus     = SPI_SR_SPIENS
+	};
+	MODM_FLAGS32(StatusFlag);
+
+	enum class
+	MasterSelection : uint32_t
+	{
+		Slave  = 0,
+		Master = SPI_MR_MSTR,
+
+		Mask = SPI_MR_MSTR_Msk
+	};
+
+	enum class
+	LocalLoopback : uint32_t
+	{
+		Disabled = 0,
+		Enabled  = SPI_MR_LLB,
+
+		Mask = SPI_MR_LLB_Msk
+	};
+
+	enum class
+	DataMode : uint32_t
+	{
+		Mode0 = SPI_CSR_NCPHA,                ///< clock normal,   sample on rising  edge
+		Mode1 = 0,                            ///< clock normal,   sample on falling edge
+		Mode2 = SPI_CSR_CPOL | SPI_CSR_NCPHA, ///< clock inverted, sample on falling edge
+		Mode3 = SPI_CSR_CPOL,                 ///< clock inverted, sample on rising  edge
+
+		Mask = SPI_CSR_CPOL_Msk | SPI_CSR_NCPHA_Msk
+	};
+
+	enum class
+	DataSize : uint32_t
+	{
+		Bit8  = SPI_CSR_BITS_8_BIT,
+		Bit9  = SPI_CSR_BITS_9_BIT,
+		Bit10 = SPI_CSR_BITS_10_BIT,
+		Bit11 = SPI_CSR_BITS_11_BIT,
+		Bit12 = SPI_CSR_BITS_12_BIT,
+		Bit13 = SPI_CSR_BITS_13_BIT,
+		Bit14 = SPI_CSR_BITS_14_BIT,
+		Bit15 = SPI_CSR_BITS_15_BIT,
+		Bit16 = SPI_CSR_BITS_16_BIT,
+
+		Mask = SPI_CSR_BITS_Msk
+	};
+};
+
+} // namespace modm::platform
+
+#endif // MODM_SAMX7X_SPI_BASE_HPP

--- a/src/modm/platform/spi/sam_x7x/spi_hal.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_hal.hpp.in
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAMX7X_SPI_HAL{{ id }}_HPP
+#define MODM_SAMX7X_SPI_HAL{{ id }}_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include "spi_base.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * Serial peripheral interface (SPI{{ id }})
+ *
+ * Low-level SPI peripheral register access API
+ *
+ * @author		Christopher Durand
+ * @ingroup		modm_platform_spi modm_platform_spi_{{id}}
+ */
+class SpiHal{{ id }} : public SpiBase
+{
+public:
+	/// Enable the clock, reset and enable the peripheral
+	static void
+	enable();
+
+	/// Disable the peripheral clock
+	static void
+	disable();
+
+	/**
+	 * Enable and initialize SPI in master mode
+	 *
+	 * \param prescaler clock divider (1..255), value 0 is not allowed
+	 * \todo Support for slave mode and hardware-managed chip select
+	 */
+	static void
+	initialize(uint8_t prescaler,
+				DataMode dataMode = DataMode::Mode0,
+				DataSize dataSize = DataSize::Bit8);
+
+	static void
+	setDataMode(DataMode dataMode);
+
+	static void
+	setDataSize(DataSize dataSize);
+
+	static void
+	setMasterSelection(MasterSelection masterSelection);
+
+	static void
+	setLoopbackMode(LocalLoopback loopback);
+
+	/**
+	 * Write up to 8 bits to the data register
+	 *
+	 * \pre Transmit data register must be empty
+	 */
+	static void
+	write(std::byte data);
+
+	/**
+	 * Write up to 16 bits to the data register
+	 *
+	 * \pre Transmit data register must be empty
+	 */
+	static void
+	write(uint16_t data);
+
+	/**
+	 * Read byte value from the receive data register
+	 *
+	 * \pre the receive data register must contain a valid value
+	 */
+	static void
+	read(std::byte& data);
+
+	/**
+	 * Read 16-bit value from the receive data register
+	 *
+	 * \pre the receive data register must contain a valid value
+	 */
+	static void
+	read(uint16_t& data);
+
+	static void
+	enableInterruptVector(bool enable, uint32_t priority);
+
+	static void
+	enableInterrupt(Interrupt_t interrupt);
+
+	static void
+	disableInterrupt(Interrupt_t interrupt);
+
+	/// Read status flags
+	/// Clears all flags except rx data full, tx data empty and spi enable
+	static StatusFlag_t
+	readStatusFlags();
+
+private:
+	// workaround for vendor macros using "Spi*" which is erroneously resolved to "modm::Spi*"
+	static auto
+	regs() { return reinterpret_cast<::Spi*>(SPI{{ id }}); }
+};
+
+} // namespace modm::platform
+
+#include "spi_hal_{{ id }}_impl.hpp"
+
+#endif // MODM_SAMX7X_SPI_HAL{{ id }}_HPP

--- a/src/modm/platform/spi/sam_x7x/spi_hal_impl.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_hal_impl.hpp.in
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAMX7X_SPI_HAL{{ id }}_HPP
+#	error 	"Don't include this file directly, use 'spi_hal{{ id }}.hpp' instead!"
+#endif
+
+#include <modm/platform/clock/clockgen.hpp>
+
+namespace modm::platform
+{
+
+inline void SpiHal{{ id }}::enable()
+{
+	ClockGen::enable<ClockPeripheral::Spi{{ id }}>();
+	regs()->SPI_CR = SPI_CR_SWRST; // reset
+}
+
+inline void SpiHal{{ id }}::disable()
+{
+	if (ClockGen::isEnabled<ClockPeripheral::Spi{{ id }}>()) {
+		regs()->SPI_CR = SPI_CR_SPIDIS; // disable
+	}
+	ClockGen::disable<ClockPeripheral::Spi{{ id }}>();
+}
+
+inline void SpiHal{{ id }}::initialize(uint8_t prescaler, DataMode dataMode,
+									   DataSize dataSize)
+{
+	enable();
+	 // master mode, no mode error detection (multi-master not supported yet)
+	regs()->SPI_MR = SPI_MR_MODFDIS | uint32_t(MasterSelection::Master);
+
+	// set prescaler
+	auto& reg = regs()->SPI_CSR[0];
+	reg = (reg & ~SPI_CSR_SCBR_Msk) | (prescaler << SPI_CSR_SCBR_Pos);
+
+	setDataMode(dataMode);
+	setDataSize(dataSize);
+
+	regs()->SPI_CR = SPI_CR_SPIEN; // enable
+}
+
+inline void SpiHal{{ id }}::setDataMode(DataMode dataMode)
+{
+	auto& reg = regs()->SPI_CSR[0];
+	reg = (reg & ~static_cast<uint32_t>(DataMode::Mask))
+		| static_cast<uint32_t>(dataMode);
+}
+
+inline void SpiHal{{ id }}::setDataSize(DataSize dataSize)
+{
+	auto& reg = regs()->SPI_CSR[0];
+	reg = (reg & ~static_cast<uint32_t>(DataSize::Mask))
+		| static_cast<uint32_t>(dataSize);
+}
+
+inline void SpiHal{{ id }}::setMasterSelection(MasterSelection masterSelection)
+{
+	auto& reg = regs()->SPI_MR;
+	reg = (reg & ~static_cast<uint32_t>(MasterSelection::Mask))
+		| static_cast<uint32_t>(masterSelection);
+}
+
+inline void SpiHal{{ id }}::setLoopbackMode(LocalLoopback loopback)
+{
+	auto& reg = regs()->SPI_MR;
+	reg = (reg & ~static_cast<uint32_t>(LocalLoopback::Mask))
+		| static_cast<uint32_t>(loopback);
+}
+
+inline void SpiHal{{ id }}::write(std::byte data)
+{
+	*(reinterpret_cast<__IO std::byte*>(&regs()->SPI_TDR)) = data;
+}
+
+inline void SpiHal{{ id }}::write(uint16_t data)
+{
+	[[gnu::may_alias]] auto* ptr = reinterpret_cast<__IO uint16_t*>(&regs()->SPI_TDR);
+	*ptr = data;
+}
+
+inline void SpiHal{{ id }}::read(std::byte& data)
+{
+	data = *(reinterpret_cast<const __IO std::byte*>(&regs()->SPI_RDR));
+}
+
+inline void SpiHal{{ id }}::read(uint16_t& data)
+{
+	[[gnu::may_alias]] auto* ptr = reinterpret_cast<const __IO uint16_t*>(&regs()->SPI_RDR);
+	data = *ptr;
+}
+
+inline void SpiHal{{ id }}::enableInterruptVector(bool enable, uint32_t priority)
+{
+	if (enable) {
+		NVIC_SetPriority(SPI{{ id }}_IRQn, priority);
+		NVIC_EnableIRQ(SPI{{ id }}_IRQn);
+	}
+	else {
+		NVIC_DisableIRQ(SPI{{ id }}_IRQn);
+	}
+}
+
+inline void SpiHal{{ id }}::enableInterrupt(Interrupt_t interrupt)
+{
+	regs()->SPI_IER = interrupt.value;
+}
+
+inline void SpiHal{{ id }}::disableInterrupt(Interrupt_t interrupt)
+{
+	regs()->SPI_IDR = interrupt.value;
+}
+
+inline auto SpiHal{{ id }}::readStatusFlags()
+	-> StatusFlag_t
+{
+	return StatusFlag_t(regs()->SPI_SR);
+}
+
+} // namespace modm::platform

--- a/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2009, Martin Rosekeit
+ * Copyright (c) 2009-2012, Fabian Greif
+ * Copyright (c) 2010, Georgi Grinshpun
+ * Copyright (c) 2012-2017, Niklas Hauser
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "spi_master_{{id}}.hpp"
+
+uint8_t
+modm::platform::SpiMaster{{ id }}::acquire(void* ctx, ConfigurationHandler handler)
+{
+	if (context == nullptr)
+	{
+		context = ctx;
+		count = 1;
+		// if handler is not nullptr and is different from previous configuration
+		if (handler and configuration != handler) {
+			configuration = handler;
+			configuration();
+		}
+		return 1;
+	}
+
+	if (ctx == context)
+		return ++count;
+
+	return 0;
+}
+
+uint8_t
+modm::platform::SpiMaster{{ id }}::release(void* ctx)
+{
+	if (ctx == context)
+	{
+		if (--count == 0)
+			context = nullptr;
+	}
+	return count;
+}
+// ----------------------------------------------------------------------------
+
+modm::ResumableResult<uint8_t>
+modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
+{
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (LSB of state):
+	//   1. waiting to start, and
+	//   2. waiting to finish.
+
+	const auto status = SpiHal{{ id }}::readStatusFlags();
+
+	// LSB != Bit0 ?
+	if (!(state & Bit0))
+	{
+		// wait for previous transfer to finish
+		if (!(status & StatusFlag::TxRegisterEmpty))
+			return {modm::rf::Running};
+
+		// start transfer by copying data into register
+		SpiHal{{ id }}::write(std::byte{data});
+
+		// set LSB = Bit0
+		state |= Bit0;
+	}
+
+	if (!(status & StatusFlag::RxRegisterFull))
+		return {modm::rf::Running};
+
+	std::byte value;
+	SpiHal{{ id }}::read(value);
+
+	// transfer finished
+	state &= ~Bit0;
+	return {modm::rf::Stop, uint8_t(value)};
+}
+
+modm::ResumableResult<void>
+modm::platform::SpiMaster{{ id }}::transfer(
+		const uint8_t* tx, uint8_t* rx, std::size_t length)
+{
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (Bit1 of state):
+	//   1. initialize index, and
+	//   2. wait for 1-byte transfer to finish.
+
+	// we need to globally remember which byte we are currently transferring
+	static std::size_t index = 0;
+
+	// we are only interested in Bit1
+	switch(state & Bit1)
+	{
+		case 0:
+			// we will only visit this state once
+			state |= Bit1;
+
+			// initialize index and check range
+			index = 0;
+			while (index < length)
+			{
+		default:
+		{
+				// if tx == 0, we use a dummy byte 0x00
+				// else we copy it from the array
+				// call the resumable function
+				modm::ResumableResult<uint8_t> result = transfer(tx ? tx[index] : 0);
+
+				// if the resumable function is still running, so are we
+				if (result.getState() > modm::rf::NestingError)
+					return {modm::rf::Running};
+
+				// if rx != 0, we copy the result into the array
+				if (rx) rx[index] = result.getResult();
+		}
+				index++;
+			}
+
+			// clear the state
+			state &= ~Bit1;
+			return {modm::rf::Stop};
+	}
+}

--- a/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2009-2011, Fabian Greif
+ * Copyright (c) 2010, Martin Rosekeit
+ * Copyright (c) 2011-2017, Niklas Hauser
+ * Copyright (c) 2012, Georgi Grinshpun
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAMX7X_SPI_MASTER{{ id }}_HPP
+#define MODM_SAMX7X_SPI_MASTER{{ id }}_HPP
+
+#include <modm/architecture/interface/spi_master.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/math/algorithm/prescaler.hpp>
+#include "spi_hal_{{ id }}.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * Serial peripheral interface (SPI{{ id }}).
+ *
+ * Simple unbuffered implementation.
+ *
+ * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
+ */
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiBase
+{
+private:
+	// Bit0: single transfer state
+	// Bit1: block transfer state
+	static inline uint8_t state{0};
+	static inline uint8_t count{0};
+	static inline void* context{nullptr};
+	static inline ConfigurationHandler configuration{nullptr};
+public:
+	using DataMode = SpiBase::DataMode;
+	using Hal = SpiHal{{ id }};
+
+	template<class... Pins>
+	static void
+	connect()
+	{
+		using SckPin = GetPin_t<PeripheralPin::Spck, Pins...>;
+		using MosiPin = GetPin_t<PeripheralPin::Mosi, Pins...>;
+		using MisoPin = GetPin_t<PeripheralPin::Miso, Pins...>;
+
+		using Peripheral = Peripherals::Spi<{{ id | int }}>;
+
+		if constexpr (!std::is_void_v<SckPin>) {
+			using SckConnector = typename SckPin::template Connector<Peripheral, Peripheral::Spck>;
+			SckConnector::connect();
+		}
+
+		if constexpr (!std::is_void_v<MosiPin>) {
+			using MosiConnector = typename MosiPin::template Connector<Peripheral, Peripheral::Mosi>;
+			MosiConnector::connect();
+		}
+
+		if constexpr (!std::is_void_v<MisoPin>) {
+			using MisoConnector = typename MisoPin::template Connector<Peripheral, Peripheral::Miso>;
+			MisoConnector::connect();
+		}
+	}
+
+	// start documentation inherited
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
+	static void
+	initialize()
+	{
+		constexpr auto result = modm::Prescaler::from_range(SystemClock::Spi{{ id }}, baudrate, 1, 255);
+		assertBaudrateInTolerance<result.frequency, baudrate, tolerance>();
+
+		SpiHal{{ id }}::initialize(result.prescaler);
+		state = 0;
+	}
+
+	static void
+	setDataMode(DataMode mode)
+	{
+		SpiHal{{ id }}::setDataMode(mode);
+	}
+
+	static void
+	setDataSize(DataSize size)
+	{
+		SpiHal{{ id }}::setDataSize(size);
+	}
+
+	static uint8_t
+	acquire(void* ctx, ConfigurationHandler handler = nullptr);
+
+	static uint8_t
+	release(void* ctx);
+
+	static uint8_t
+	transferBlocking(uint8_t data)
+	{
+		return RF_CALL_BLOCKING(transfer(data));
+	}
+
+	static void
+	transferBlocking(const uint8_t* tx, uint8_t* rx, std::size_t length)
+	{
+		RF_CALL_BLOCKING(transfer(tx, rx, length));
+	}
+
+	static modm::ResumableResult<uint8_t>
+	transfer(uint8_t data);
+
+	static modm::ResumableResult<void>
+	transfer(const uint8_t* tx, uint8_t* rx, std::size_t length);
+	// end documentation inherited
+};
+
+} // namespace modm::platform
+
+#endif // MODM_SAMX7X_SPI_MASTER{{ id }}_HPP

--- a/test/Makefile
+++ b/test/Makefile
@@ -174,3 +174,8 @@ compile-mega-2560-pro_B:
 	$(call compile-test,mega-2560-pro_B,size)
 run-mega-2560-pro_B:
 	$(call run-test,mega-2560-pro_B,size)
+
+compile-samv71-xplained-ultra:
+	$(call compile-test,samv71-xplained-ultra,size)
+run-samv71-xplained-ultra:
+	$(call run-test,samv71-xplained-ultra,size)

--- a/test/config/samv71-xplained-ultra.xml
+++ b/test/config/samv71-xplained-ultra.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <extends>modm:samv71-xplained-ultra</extends>
+  <options>
+    <option name="modm:build:build.path">../../build/generated-unittest/samv71-xplained-ultra/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/samv71-xplained-ultra/modm-test</option>
+  </options>
+  <modules>
+    <module>modm:platform:heap</module>
+    <module>modm-test:test:**</module>
+  </modules>
+</library>

--- a/test/modm/driver/adc/ad7280a_test.cpp
+++ b/test/modm/driver/adc/ad7280a_test.cpp
@@ -25,7 +25,7 @@
 
 modm_test::SpiDevice device;
 
-class Spi
+class DummySpi
 {
 public:
 	static uint8_t
@@ -55,7 +55,7 @@ struct Cs
 	}
 };
 
-typedef modm::Ad7280a<Spi, Cs, modm::platform::GpioUnused, 1> Ad7280a;
+typedef modm::Ad7280a<DummySpi, Cs, modm::platform::GpioUnused, 1> Ad7280a;
 
 // ----------------------------------------------------------------------------
 void

--- a/test/modm/platform/spi/samx7x/module.lb
+++ b/test/modm/platform/spi/samx7x/module.lb
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def init(module):
+    module.name = ":test:platform:spi"
+    module.description = "Tests for SAMx7x SPI"
+
+def prepare(module, options):
+    target = options[":target"]
+
+    identifier = target.identifier
+    if identifier.platform != "sam" or identifier.family != "e7x/s7x/v7x":
+        return False
+
+    module.depends(":platform:spi:0")
+    return True
+
+def build(env):
+    if not env.has_module(":board:samv71-xplained-ultra"):
+        env.log.warn("The SPI test uses hardcoded GPIO pins."
+                     "Please make sure the pins are safe to use on other hardware.")
+        return
+
+    env.outbasepath = "modm-test/src/modm-test/platform/spi_test"
+    env.copy("spi_test.hpp")
+    env.copy("spi_test.cpp")

--- a/test/modm/platform/spi/samx7x/spi_test.cpp
+++ b/test/modm/platform/spi/samx7x/spi_test.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "spi_test.hpp"
+
+#include <modm/platform.hpp>
+#include <modm/board.hpp>
+
+using namespace modm::platform;
+
+using Spck = GpioD22;
+using Mosi = GpioD21;
+using Miso = GpioD20;
+
+void
+SpiTest::setUp()
+{
+	SpiMaster0::connect<Spck::Spck, Mosi::Mosi, Miso::Miso>();
+	SpiMaster0::initialize<Board::SystemClock, 1_Mbps, 1_pct>();
+}
+
+void
+SpiTest::testTransferLoopback()
+{
+	SpiHal0::setLoopbackMode(SpiHal0::LocalLoopback::Enabled);
+
+	uint8_t value = SpiMaster0::transferBlocking(0xAB);
+	TEST_ASSERT_EQUALS(value, 0xAB);
+
+	value = RF_CALL_BLOCKING(SpiMaster0::transfer(0x12));
+	TEST_ASSERT_EQUALS(value, 0x12);
+
+	constexpr std::array<uint8_t, 7> tx{0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56};
+	std::array<uint8_t, 7> rx{};
+	SpiMaster0::transferBlocking(tx.data(), rx.data(), 7);
+	TEST_ASSERT_TRUE(rx == tx);
+
+	rx.fill(0);
+	RF_CALL_BLOCKING(SpiMaster0::transfer(tx.data(), rx.data(), 7));
+	TEST_ASSERT_TRUE(rx == tx);
+
+	SpiHal0::setLoopbackMode(SpiHal0::LocalLoopback::Disabled);
+}
+
+void
+SpiTest::testReceivePin()
+{
+	Miso::configure(Miso::InputType::PullUp);
+	modm::delay_us(1);
+	uint8_t value = SpiMaster0::transferBlocking(0xAB);
+	TEST_ASSERT_EQUALS(value, 0xFF);
+
+	Miso::configure(Miso::InputType::PullDown);
+	modm::delay_us(1);
+	value = SpiMaster0::transferBlocking(0xAB);
+	TEST_ASSERT_EQUALS(value, 0x00);
+
+	Miso::configure(Miso::InputType::Floating);
+}

--- a/test/modm/platform/spi/samx7x/spi_test.hpp
+++ b/test/modm/platform/spi/samx7x/spi_test.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_platform_spi
+class SpiTest : public unittest::TestSuite
+{
+public:
+	void
+	setUp() override;
+
+	void
+	testTransferLoopback();
+
+	void
+	testReceivePin();
+};


### PR DESCRIPTION
- [x] Add SAMx7x SPI driver
- [x] Add SAMV71 SPI hardware unit test
- [x] Fix input type configuration for SAMx7x / SAMG5x when changing pin from pull-up to pull-down mode
- [x] Test in hardware with SAMV70N19 and MCP3008 SPI ADC.

The basic functionality of the driver has been verified with the hardware unit test. Also, the output waveforms look like SPI and have the right frequency.