### PR TITLE
[ci] Update to GCC12

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -7,9 +7,9 @@ on:
 jobs:
   avr-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-avr:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -33,9 +33,9 @@ jobs:
 
   sam-d0x-d1x-d2x-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -59,9 +59,9 @@ jobs:
 
   sam-x5x-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -85,9 +85,9 @@ jobs:
 
   sam-x7x-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -111,9 +111,9 @@ jobs:
 
   stm32f0-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -137,9 +137,9 @@ jobs:
 
   stm32f1-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -163,9 +163,9 @@ jobs:
 
   stm32f2-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -189,9 +189,9 @@ jobs:
 
   stm32f3-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -215,9 +215,9 @@ jobs:
 
   stm32f4-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -241,9 +241,9 @@ jobs:
 
   stm32f4-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -267,9 +267,9 @@ jobs:
 
   stm32f4-compile-all-3:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -293,9 +293,9 @@ jobs:
 
   stm32f7-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -319,9 +319,9 @@ jobs:
 
   stm32f7-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -345,9 +345,9 @@ jobs:
 
   stm32l0-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -371,9 +371,9 @@ jobs:
 
   stm32l0-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -398,9 +398,9 @@ jobs:
 
   stm32l1-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -424,9 +424,9 @@ jobs:
 
   stm32l4-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -450,9 +450,9 @@ jobs:
 
   stm32l4-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -476,9 +476,9 @@ jobs:
 
   stm32l4-compile-all-3:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -502,9 +502,9 @@ jobs:
 
   stm32l5-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -528,9 +528,9 @@ jobs:
 
   stm32g0-compile-all:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -554,9 +554,9 @@ jobs:
 
   stm32g4-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -580,9 +580,9 @@ jobs:
 
   stm32g4-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -606,9 +606,9 @@ jobs:
 
   stm32h7-compile-all-1:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -632,9 +632,9 @@ jobs:
 
   stm32h7-compile-all-2:
     if: github.event.label.name == 'ci:hal'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -26,7 +26,7 @@ jobs:
           (cd test/all && python3 run_all.py at --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: avr-compile-all
           path: test/all/log
@@ -52,7 +52,7 @@ jobs:
           (cd test/all && python3 run_all.py samd0 samd1 samd2 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sam-compile-all
           path: test/all/log
@@ -78,7 +78,7 @@ jobs:
           (cd test/all && python3 run_all.py samd5 same5 samg5 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sam-compile-all
           path: test/all/log
@@ -104,7 +104,7 @@ jobs:
           (cd test/all && python3 run_all.py same7 sams7 samv7 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sam-compile-all
           path: test/all/log
@@ -130,7 +130,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f0 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f0-compile-all
           path: test/all/log
@@ -156,7 +156,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f1 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f1-compile-all
           path: test/all/log
@@ -182,7 +182,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f2 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f2-compile-all
           path: test/all/log
@@ -208,7 +208,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f3 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f3-compile-all
           path: test/all/log
@@ -234,7 +234,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f4 --quick-remaining --split 3 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f4-compile-all-1
           path: test/all/log
@@ -260,7 +260,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f4 --quick-remaining --split 3 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f4-compile-all-2
           path: test/all/log
@@ -286,7 +286,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f4 --quick-remaining --split 3 --part 2)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f4-compile-all-3
           path: test/all/log
@@ -312,7 +312,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f7 --quick-remaining --split 2 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f7-compile-all-1
           path: test/all/log
@@ -338,7 +338,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32f7 --quick-remaining --split 2 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32f7-compile-all-2
           path: test/all/log
@@ -364,7 +364,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l0 --quick-remaining --split 2 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l0-compile-all-1
           path: test/all/log
@@ -390,7 +390,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l0 --quick-remaining --split 2 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l0-compile-all-2
           path: test/all/log
@@ -417,7 +417,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l1 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l1-compile-all
           path: test/all/log
@@ -443,7 +443,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l4 --quick-remaining --split 3 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l4-compile-all-1
           path: test/all/log
@@ -469,7 +469,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l4 --quick-remaining --split 3 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l4-compile-all-2
           path: test/all/log
@@ -495,7 +495,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l4 --quick-remaining --split 3 --part 2)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l4-compile-all-3
           path: test/all/log
@@ -521,7 +521,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32l5 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32l5-compile-all
           path: test/all/log
@@ -547,7 +547,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32g0 --quick-remaining)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32g0-compile-all
           path: test/all/log
@@ -573,7 +573,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32g4 --quick-remaining --split 2 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32g4-compile-all-1
           path: test/all/log
@@ -599,7 +599,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32g4 --quick-remaining --split 2 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32g4-compile-all-2
           path: test/all/log
@@ -625,7 +625,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32h7 --quick-remaining --split 2 --part 0)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32h7-compile-all-1
           path: test/all/log
@@ -651,7 +651,7 @@ jobs:
           (cd test/all && python3 run_all.py stm32h7 --quick-remaining --split 2 --part 1)
       - name: Upload log artifacts
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stm32h7-compile-all-2
           path: test/all/log

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   build-upload-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-base:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-base:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -48,9 +48,9 @@ jobs:
           git push origin master
 
   api-docs-all:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-base:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-base:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,9 +4,9 @@ on: [pull_request]
 
 jobs:
   unittests-linux-generic:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
 
     steps:
       - name: Check out repository
@@ -116,9 +116,9 @@ jobs:
           python3 tools/xpcc_generator/builder/system_layout.py examples/xpcc/xml/communication.xml -o /tmp
 
   stm32-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -176,9 +176,9 @@ jobs:
           (cd examples && ../tools/scripts/examples_compile.py nucleo_h743zi nucleo_h723zg stm32h750vbt6_devebox)
 
   stm32f4-examples-1:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -196,9 +196,9 @@ jobs:
           (cd examples && ../tools/scripts/examples_compile.py stm32f4_discovery stm32f429_discovery stm32f469_discovery)
 
   stm32f4-examples-2:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -219,9 +219,9 @@ jobs:
           (cd examples && ../tools/scripts/examples_compile.py nucleo_f401re nucleo_f411re nucleo_f429zi nucleo_f446re nucleo_f446ze nucleo_f439zi black_pill_f401 black_pill_f411 stm32f407vet6_devebox stm32_f4ve)
 
   avr-examples:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-avr:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -265,9 +265,9 @@ jobs:
           path: test/all/log
 
   hal-compile-quick-1:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -290,9 +290,9 @@ jobs:
           path: test/all/log
 
   hal-compile-quick-2:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -315,9 +315,9 @@ jobs:
           path: test/all/log
 
   hal-compile-quick-3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -340,9 +340,9 @@ jobs:
           path: test/all/log
 
   hal-compile-quick-4:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2022-09-27
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -364,8 +364,10 @@ jobs:
           name: hal-compile-quick-4
           path: test/all/log
 
+  # Niklas: Running on the old container until I can figure out why the doc generator hangs
   build-docs-test:
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     container:
       image: ghcr.io/modm-ext/modm-build-base:2022-09-27
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -259,7 +259,7 @@ jobs:
         run: |
           (cd test/all && python3 run_all.py at --quick)
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hal-compile-quick-avr
           path: test/all/log
@@ -284,7 +284,7 @@ jobs:
         run: |
           (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 0)
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hal-compile-quick-1
           path: test/all/log
@@ -309,7 +309,7 @@ jobs:
         run: |
           (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 1)
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hal-compile-quick-2
           path: test/all/log
@@ -334,7 +334,7 @@ jobs:
         run: |
           (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 2)
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hal-compile-quick-3
           path: test/all/log
@@ -359,7 +359,7 @@ jobs:
         run: |
           (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 3)
       - name: Upload log artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hal-compile-quick-4
           path: test/all/log
@@ -393,7 +393,7 @@ jobs:
           export COLUMNS=120
           python3 tools/scripts/docs_modm_io_generator.py -t -c -j4 -d
       - name: Upload Doxypress Documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-docs-test
           path: modm-api-docs.tar.gz
@@ -408,7 +408,7 @@ jobs:
           ls -l docs/src/reference/module
           (cd docs && mkdocs build)
       - name: Upload Homepage Documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-homepage-test
           path: docs/modm.io

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,22 +8,26 @@ jobs:
 
     steps:
       # update Xcode version to fix linker bug
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '14.1'
+      # - uses: maxim-lobanov/setup-xcode@v1
+      #   with:
+      #     xcode-version: '14.2'
 
       - name: Setup environment - Brew tap
         run: |
           brew tap modm-ext/arm
-          brew tap modm-ext/avr
+          brew tap osx-cross/avr
 
       - name: Setup environment - Brew install
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1 # saves time
           brew update
-          brew install doxygen boost gcc avr-gcc@10 arm-gcc-bin cmake || true
-          brew link --force avr-gcc@10
+          brew install doxygen boost gcc avr-gcc@12 arm-gcc-bin@12 cmake || true
+          brew link --force avr-gcc@12
           # brew upgrade boost gcc git || true
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
 
       - name: Setup environment - Python pip
         run: |
@@ -39,25 +43,27 @@ jobs:
           python --version  || true
           python3 --version || true
           python3 -c "import os; print(os.cpu_count())"
-          which scons
-          scons --version
           which g++
           g++ --version
+          which avr-g++
+          avr-g++ --version
           which arm-none-eabi-g++
           arm-none-eabi-g++ --version
           which lbuild
           lbuild --version
-          which avr-g++
-          avr-g++ --version
+          which scons
+          scons --version
 
       - name: Check out repository
+        if: always()
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
 
       - name: Update lbuild
+        if: always()
         run: |
-          pip3 install --upgrade --upgrade-strategy=eager modm
+          pip3 install --upgrade --user --upgrade-strategy=eager modm
 
       - name: Hosted Unittests
         if: always()

--- a/.github/workflows/windows_armcortexm.yml
+++ b/.github/workflows/windows_armcortexm.yml
@@ -15,9 +15,9 @@ jobs:
         run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install Python packages
         run: |
@@ -27,16 +27,15 @@ jobs:
         shell: powershell
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -OutFile gcc-arm-none-eabi-win32.zip https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-win32.zip
+          Invoke-WebRequest -OutFile gcc-arm-none-eabi-win64.zip https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip
 
       - name: Install ARM Toolchain
         shell: powershell
         run: |
-          Add-Type -Assembly "System.IO.Compression.Filesystem"
-          [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-arm-none-eabi-win32.zip", "C:\")
-          dir C:\gcc-arm-none-eabi-10.3-2021.10
-          echo "C:\gcc-arm-none-eabi-10.3-2021.10\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          rm gcc-arm-none-eabi-win32.zip
+          Expand-Archive -Path gcc-arm-none-eabi-win64.zip -DestinationPath C:\ -Force
+          dir C:\arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi
+          echo "C:\arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm gcc-arm-none-eabi-win64.zip
 
       - name: Show lbuild and arm-none-eabi-gcc Version Information
         run: |

--- a/.github/workflows/windows_hosted.yml
+++ b/.github/workflows/windows_hosted.yml
@@ -15,9 +15,9 @@ jobs:
         run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install Python packages
         run: |
@@ -26,7 +26,7 @@ jobs:
       - name: Download GCC for Windows
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -OutFile winlibs-gcc.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/10.3.0-12.0.0-9.0.0-r2/winlibs-x86_64-posix-seh-gcc-10.3.0-mingw-w64-9.0.0-r2.zip
+          Invoke-WebRequest -OutFile winlibs-gcc.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-15.0.6-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-12.2.0-mingw-w64msvcrt-10.0.0-r3.zip
 
       - name: Unpack GCC for Windows
         shell: powershell

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -15,8 +15,8 @@ Note that the modm examples use the SCons build system by default, however,
 you are not *required* to use it. See [the reference manual](../../reference/build-systems)
 for additional build system documentation.
 
-!!! info "Use GCC 10 or newer"
-    modm uses C++20, so you need *at least* GCC 10.
+!!! info "Use GCC 12 or newer"
+    modm uses C++20, so you need *at least* GCC 10. However, we recommend using GCC12.
 
 !!! warning "Beware of AVRs"
     We **strongly discourage** using AVRs for new designs, due to a significant
@@ -32,7 +32,7 @@ Please help us [keep these instructions up-to-date][contribute]!
 
 ## Linux
 
-For Ubuntu 20.04LTS, these commands install the minimal build system:
+For Ubuntu 22.04LTS, these commands install the minimal build system:
 
 ```sh
 sudo apt install python3 python3-pip scons git libncurses5
@@ -70,7 +70,7 @@ We use [Doxypress][doxypress_binaries] to generate the API documentation:
 
 ```sh
 sudo mkdir /opt/doxypress
-wget -O- https://github.com/copperspice/doxypress/releases/download/dp-1.4.2/doxypress-1.4.2-ubuntu20.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
+wget -O- https://github.com/copperspice/doxypress/releases/download/dp-1.5.0/doxypress-1.5.0-ubuntu22.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
 ```
 
 Add the directory to your `PATH` variable in `~/.bashrc`:
@@ -85,18 +85,18 @@ export PATH="/opt/doxypress:$PATH"
 Install the [pre-built ARM toolchain][gcc-arm-toolchain]:
 
 ```sh
-wget -O- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | sudo tar xj -C /opt/
+wget -O- https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz | sudo tar xj -C /opt/
 ```
 
 Add it to your `PATH` variable in `~/.bashrc`:
 
 ```sh
-export PATH="/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH"
+export PATH="/opt/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin:$PATH"
 ```
 
 !!! warning "Ubuntus 'gcc-arm-none-eabi' package"
-    The Ubuntu package 'gcc-arm-none-eabi' causes [issues at the moment][armgcc-issues]
-    and ships only version 9.3.
+    The Ubuntu package 'gcc-arm-none-eabi' can [cause issues][armgcc-issues],
+    we recommend using only the pre-built toolchain.
 
 Install the OpenOCD tool:
 
@@ -115,7 +115,7 @@ sudo apt install openocd
 Download and extract the [pre-built AVR toolchain][modm-avr-gcc]:
 
 ```sh
-wget -O- https://github.com/modm-io/avr-gcc/releases/download/v11.2.0/modm-avr-gcc.tar.bz2 | sudo tar xj -C /opt
+wget -O- https://github.com/modm-io/avr-gcc/releases/download/v12.2.0/modm-avr-gcc.tar.bz2 | sudo tar xj -C /opt
 ```
 
 !!! warning "AVR toolchain install directory"
@@ -174,7 +174,7 @@ Install the [pre-built ARM toolchain](https://github.com/osx-cross/homebrew-arm)
 
 ```sh
 brew tap osx-cross/arm
-brew install arm-gcc-bin
+brew install arm-gcc-bin@12
 brew install openocd --HEAD
 ```
 
@@ -191,8 +191,8 @@ Install the [AVR toolchain from source](https://github.com/osx-cross/homebrew-av
 
 ```sh
 brew tap osx-cross/avr
-brew install avr-gcc@10
-brew link --force avr-gcc@10
+brew install avr-gcc@12
+brew link --force avr-gcc@12
 ```
 
 
@@ -253,7 +253,7 @@ files in the next steps.
 
 #### ARM Cortex-M
 
-Install the [pre-built ARM toolchain via the 32-bit installer][gcc-arm-toolchain]
+Install the [pre-built ARM toolchain via the 64-bit installer][gcc-arm-toolchain]
 and make sure you select **Add path to environment variable** at the end!
 Open a new command prompt to test the compiler:
 
@@ -282,7 +282,7 @@ openocd --version
 #### Microchip AVR
 
 Download the [pre-built AVR toolchain][winavr] and unpack the `.zip` file using
-the context menu `7-Zip > Extract to "avr-gcc-10.1.0-..."`
+the context menu `7-Zip > Extract to "avr-gcc-12.1.0-..."`
 Then rename and move the extracted folder to `C:\Program Files\avr-gcc`.
 Open PowerShell to add the `\bin` folder to the `Path`:
 

--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -36,7 +36,7 @@ main()
 	while (true)
 	{
 		Adc1::startConversion();
-		while(!Adc1::isConversionFinished)
+		while(!Adc1::isConversionFinished())
 			;
 		int adcValue = Adc1::getValue();
 		MODM_LOG_INFO << "adcValue=" << adcValue;

--- a/examples/nucleo_l552ze-q/adc_basic/main.cpp
+++ b/examples/nucleo_l552ze-q/adc_basic/main.cpp
@@ -38,7 +38,7 @@ main()
 	while (true)
 	{
 		Adc1::startConversion();
-		while(!Adc1::isConversionFinished)
+		while(!Adc1::isConversionFinished())
 			;
 		const auto adcValue = Adc1::getValue();
 		MODM_LOG_INFO << "adcValue=" << adcValue;

--- a/examples/stm32f3_discovery/adc/simple/main.cpp
+++ b/examples/stm32f3_discovery/adc/simple/main.cpp
@@ -44,7 +44,7 @@ main()
 	{
 		Adc4::startConversion();
 		// wait for conversion to finish
-		while(!Adc4::isConversionFinished);
+		while(!Adc4::isConversionFinished());
 		// print result
 		int adcValue = Adc4::getValue();
 		MODM_LOG_INFO << "adcValue=" << adcValue;

--- a/ext/gcc/cxxabi.cpp.in
+++ b/ext/gcc/cxxabi.cpp.in
@@ -17,6 +17,7 @@
 extern "C"
 {
 
+void *__dso_handle = &__dso_handle;
 void __cxa_pure_virtual()
 { modm_assert(0, "virt.pure", "A pure virtual function was called!"); }
 void __cxa_deleted_virtual()

--- a/src/modm/container/deque.hpp
+++ b/src/modm/container/deque.hpp
@@ -185,6 +185,8 @@ namespace modm
 		removeFront();
 
 	public:
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		/**
 		 * \brief	Bidirectional const iterator
 		 *
@@ -214,6 +216,7 @@ namespace modm
 
 			Size count;
 		};
+		#pragma GCC diagnostic pop
 
 		const_iterator
 		begin() const;

--- a/src/modm/container/doubly_linked_list.hpp
+++ b/src/modm/container/doubly_linked_list.hpp
@@ -99,6 +99,8 @@ namespace modm
 		Node *back;
 
 	public:
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		/**
 		 * \brief	Forward iterator
 		 *
@@ -167,6 +169,7 @@ namespace modm
 
 			const Node* node;
 		};
+		#pragma GCC diagnostic pop
 
 		/**
 		 * Returns a read/write iterator that points to the first element in      the

--- a/src/modm/container/dynamic_array.hpp
+++ b/src/modm/container/dynamic_array.hpp
@@ -256,6 +256,8 @@ namespace modm
 		}
 
 	public:
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		/**
 		 * \brief	Forward iterator
 		 */
@@ -324,6 +326,7 @@ namespace modm
 			const DynamicArray *parent;
 			SizeType index;
 		};
+		#pragma GCC diagnostic pop
 
 		/**
 		 * Returns a read/write iterator that points to the first element in the

--- a/src/modm/container/linked_list.hpp
+++ b/src/modm/container/linked_list.hpp
@@ -114,6 +114,8 @@ namespace modm
 		Node *back;
 
 	public:
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		/**
 		 * \brief	Forward iterator
 		 */
@@ -178,6 +180,7 @@ namespace modm
 			// a difference
 			Node* node;
 		};
+		#pragma GCC diagnostic pop
 
 		/**
 		 * Returns a read/write iterator that points to the first element in      the

--- a/src/modm/platform/can/common/can_bit_timings.hpp
+++ b/src/modm/platform/can/common/can_bit_timings.hpp
@@ -19,6 +19,7 @@
 #include <modm/math/units.hpp>
 #include <modm/math/utils/misc.hpp>
 #include <cmath>
+#include <optional>
 
 namespace modm
 {

--- a/src/modm/platform/can/stm32-fdcan/message_ram.hpp
+++ b/src/modm/platform/can/stm32-fdcan/message_ram.hpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <concepts>
 #include <span>
+#include <tuple>
 
 #include <modm/math/utils/bit_constants.hpp>
 #include <modm/architecture/interface/register.hpp>

--- a/src/modm/platform/clock/sam/gclk.hpp.in
+++ b/src/modm/platform/clock/sam/gclk.hpp.in
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <utility>
 #include "../device.hpp"
 #include <modm/architecture/interface/delay.hpp>
 #include <modm/platform/gpio/config.hpp>

--- a/src/modm/platform/clock/sam/gclk_impl.hpp.in
+++ b/src/modm/platform/clock/sam/gclk_impl.hpp.in
@@ -57,7 +57,7 @@ GenericClockController::updateCoreFrequency()
 	delay_ns_per_loop = computeDelayNsPerLoop(Core_Hz);
 }
 
-template< uint32_t Core_Hz, uint16_t Vdd_mV=3300 >
+template< uint32_t Core_Hz, uint16_t Vdd_mV >
 uint32_t
 GenericClockController::setFlashLatency()
 {
@@ -223,7 +223,7 @@ GenericClockController::connect(ClockGenerator clockGen)
 }
 %% endif
 
-template<frequency_t frequency, XoscStartupTime startupTime = XoscStartupTime::Start_15625us>
+template<frequency_t frequency, XoscStartupTime startupTime>
 bool
 %% if target.family == "d5x/e5x"
 GenericClockController::enableExternalCrystal(Xosc clock, uint32_t waitCycles)

--- a/src/modm/platform/core/avr/interrupts.hpp.in
+++ b/src/modm/platform/core/avr/interrupts.hpp.in
@@ -26,14 +26,14 @@ namespace platform
 /// @{
 
 /// enables global interrupts
-static void
+static inline void
 enableInterrupts()
 {
 	sei();
 }
 
 /// disables global interrupts
-static void
+static inline void
 disableInterrupts()
 {
 	cli();

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -251,6 +251,9 @@ MAIN_STACK_SIZE = {{ options[":platform:cortex-m:main_stack_size"] }};
 		*(.ARM.extab* .gnu.linkonce.armextab.*)
 		KEEP(*(.eh_frame*))
 	} >{{memory}}
+
+	/* required by libc __libc_fini_array, but never called */
+	_fini = .;
 	%% else
 	%#
 	/* C++ exception unwind tables are discarded */

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include <array>
 #include "../device.hpp"
 #include "dma_hal.hpp"
 

--- a/src/modm/platform/uart/hosted/serial_port.hpp
+++ b/src/modm/platform/uart/hosted/serial_port.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <queue>
+#include <utility>
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>

--- a/test/Makefile
+++ b/test/Makefile
@@ -174,6 +174,11 @@ compile-mega-2560-pro_B:
 	$(call compile-test,mega-2560-pro_B,size)
 run-mega-2560-pro_B:
 	$(call run-test,mega-2560-pro_B,size)
+compile-mega-2560-pro_C:
+	$(call compile-test,mega-2560-pro_C,size)
+run-mega-2560-pro_C:
+	$(call run-test,mega-2560-pro_C,size)
+
 
 compile-samv71-xplained-ultra:
 	$(call compile-test,samv71-xplained-ultra,size)

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -20,8 +20,9 @@ import lbuild
 import random
 import tempfile
 import argparse
+import platform
 import subprocess
-import multiprocessing
+import multiprocessing as mp
 from pathlib import Path
 from collections import defaultdict
 
@@ -287,7 +288,7 @@ if __name__ == "__main__":
 
     print("Using {} parallel jobs for {} devices".format(args.jobs, len(devices)))
     try:
-        with multiprocessing.Pool(args.jobs) as pool:
+        with mp.get_context("spawn").Pool(args.jobs) as pool:
             test_runs = pool.map(build_device,
                             [TestRun(x, cache_dir, cache_limit) for x in devices])
 

--- a/test/config/mega-2560-pro_A.xml
+++ b/test/config/mega-2560-pro_A.xml
@@ -13,15 +13,16 @@
   <modules>
     <module>modm-test:test:architecture</module>
     <module>modm-test:test:communication:sab</module>
-    <module>modm-test:test:communication:xpcc</module>
     <module>modm-test:test:container</module>
     <module>modm-test:test:driver</module>
     <module>modm-test:test:stdc++</module>
     <module>modm-test:test:io</module>
 
-    <!-- <module>modm-test:test:platform:**</module>
+    <!-- <module>modm-test:test:math</module>
+
+    <module>modm-test:test:communication:xpcc</module>
+    <module>modm-test:test:platform:**</module>
     <module>modm-test:test:processing</module>
-    <module>modm-test:test:ui</module>
-    <module>modm-test:test:math</module> -->
+    <module>modm-test:test:ui</module> -->
   </modules>
 </library>

--- a/test/config/mega-2560-pro_C.xml
+++ b/test/config/mega-2560-pro_C.xml
@@ -2,8 +2,8 @@
 <library>
   <extends>modm:mega-2560-pro</extends>
   <options>
-    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro_B/</option>
-    <option name="modm:build:unittest.source">../../build/generated-unittest/mega-2560-pro_B/modm-test</option>
+    <option name="modm:build:build.path">../../build/generated-unittest/mega-2560-pro_C/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/mega-2560-pro_C/modm-test</option>
     <option name="modm:build:info.git">Disabled</option>
     <option name="modm:io:with_float">True</option>
     <option name="modm:io:with_long_long">True</option>
@@ -16,13 +16,13 @@
     <module>modm-test:test:container</module>
     <module>modm-test:test:driver</module>
     <module>modm-test:test:stdc++</module>
-    <module>modm-test:test:io</module> -->
+    <module>modm-test:test:io</module>
 
-    <module>modm-test:test:math</module>
+    <module>modm-test:test:math</module> -->
 
-    <!-- <module>modm-test:test:communication:xpcc</module>
+    <module>modm-test:test:communication:xpcc</module>
     <module>modm-test:test:platform:**</module>
     <module>modm-test:test:processing</module>
-    <module>modm-test:test:ui</module> -->
+    <module>modm-test:test:ui</module>
   </modules>
 </library>

--- a/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
+++ b/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
@@ -120,6 +120,13 @@ set({{ name | upper }}{{ "_" ~ (profile | upper) if profile | length else "" }}
 {{ generate_flags("ccwarn") }}
 {{ generate_flags("cxxwarn") }}
 
+if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 12)
+  list(APPEND LINKFLAGS -Wl,--no-warn-rwx-segment)
+%% if core.startswith("avr")
+  list(APPEND CCFLAGS --param=min-pagesize=0)
+%% endif
+endif()
+
   target_compile_definitions(${target_options} INTERFACE
     ${CPPDEFINES}
     $<$<CONFIG:MinSizeRel>:${CPPDEFINES_RELEASE}>

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -290,6 +290,11 @@ def common_compiler_flags(compiler, target):
         flags["linkflags"] += [
             "-Wl,-Map,{target_base}.map,--cref"
         ]
+    # We still want to support GCC10 and GCC11, but this flag is GCC12 only
+    # if target.identifier["platform"] not in ["hosted"]:
+    #     flags["linkflags"] += [
+    #         "-Wl,--no-warn-rwx-segment",
+    #     ]
     # C Preprocessor defines
     flags["cppdefines"] = []
     if target.identifier["family"] == "windows":

--- a/tools/build_script_generator/make/resources/compiler.mk.in
+++ b/tools/build_script_generator/make/resources/compiler.mk.in
@@ -50,4 +50,5 @@ DEBUGGER := $(C_PREFIX)gdb
 CPPFILT := $(C_PREFIX)c++filt
 
 GCC_BASE := $(dir $(realpath $(dir $(realpath $(shell which $(CC))))))
+COMPILER_VERSION = $(shell $(CC) -dumpversion)
 

--- a/tools/build_script_generator/make/resources/repo.mk.in
+++ b/tools/build_script_generator/make/resources/repo.mk.in
@@ -42,6 +42,16 @@ endif
 CCFLAGS += $(ARCHFLAGS)
 ASFLAGS += $(ARCHFLAGS)
 LINKFLAGS += $(ARCHFLAGS)
+
+%% if platform != "hosted"
+# This flag is neccessary for GCC12, but fails for earlier GCCs
+ifeq "$(shell expr `echo $(COMPILER_VERSION) | cut -f1 -d.` \>= 12)" "1"
+ 	LINKFLAGS += "-Wl,--no-warn-rwx-segment"
+%% if core.startswith("avr")
+	CCFLAGS += "--param=min-pagesize=0"
+%% endif
+endif
+%% endif
 %% endif
 
 %% if include_paths | length

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -24,7 +24,7 @@ env["COMPILERPREFIX"] = "arm-none-eabi-"
 %% endif
 %% if family == "darwin"
 # Using homebrew gcc on macOS instead of clang
-env["COMPILERSUFFIX"] = env.Detect(["gcc-12", "gcc-11", "gcc-10"])[3:]
+env["COMPILERSUFFIX"] = env.Detect(["gcc-13", "gcc-12", "gcc-11", "gcc-10"])[3:]
 %% endif
 %% endif
 
@@ -81,6 +81,14 @@ if profile == "{{ profile }}":
 env.Append(CCFLAGS="$ARCHFLAGS")
 env.Append(ASFLAGS="$ARCHFLAGS")
 env.Append(LINKFLAGS="$ARCHFLAGS")
+
+%% if platform != "hosted"
+if env.CompilerVersion() >= 120000:
+	env.Append(LINKFLAGS="-Wl,--no-warn-rwx-segment")
+%% if core.startswith("avr")
+	env.Append(CCFLAGS="--param=min-pagesize=0")
+%% endif
+%% endif
 
 %% if family != "darwin"
 # Search all linked static libraries multiple times

--- a/tools/build_script_generator/scons/site_tools/utils.py
+++ b/tools/build_script_generator/scons/site_tools/utils.py
@@ -15,6 +15,7 @@
 import os
 import os.path
 
+from modm_tools import utils
 from SCons.Script import *
 
 def _listify(obj):
@@ -74,6 +75,10 @@ def phony_target(env, **kw):
         env.AlwaysBuild(env.Alias(target, [], action))
 
 
+def compiler_version(env):
+    return utils.compiler_version(env.subst(env["CC"]))
+
+
 def artifact_firmware(env, source):
     firmware = ARGUMENTS.get("firmware", None)
     if firmware:
@@ -95,6 +100,8 @@ def generate(env, **kw):
     env.AddMethod(phony_target, 'Phony')
 
     env.AddMethod(listify, 'Listify')
+
+    env.AddMethod(compiler_version, 'CompilerVersion')
 
     env.AddMethod(artifact_firmware, 'ChooseFirmware')
 

--- a/tools/modm_tools/utils.py
+++ b/tools/modm_tools/utils.py
@@ -11,8 +11,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
+import re
 import glob
 import platform
+import subprocess
+
 
 def _listify(obj):
     if obj is None:
@@ -50,3 +53,20 @@ def guess_serial_port(port_hint=None):
         ports = glob.glob('/dev/tty[A-Za-z]*')
     return next(iter(ports), None)
 
+
+def compiler_version(gcc):
+    """
+    :returns: the compiler version as a single integer with two decimals per
+              sub-version. v10.1.2 -> 100102
+    """
+    output = subprocess.run(gcc + " -dumpversion", shell=True, capture_output=True, text=True)
+    version = re.match(r"^(\d+)\.(\d+)\.(\d+)", output.stdout)
+    if version:
+        compiler_version = (int(version.group(1)) * 10000 +
+                            int(version.group(2)) * 100 +
+                            int(version.group(3)))
+    else:
+        # Compiler version could not be detected
+        compiler_version = 0
+
+    return compiler_version

--- a/tools/scripts/docs_modm_io_generator.py
+++ b/tools/scripts/docs_modm_io_generator.py
@@ -12,17 +12,17 @@
 
 import os
 import sys
+import json
 import shutil
 import zipfile
 import tempfile
 import argparse
 import datetime
-import multiprocessing
-import os, sys
+import platform
+import multiprocessing as mp
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 from collections import defaultdict
-import json
 
 def repopath(path):
     return Path(__file__).absolute().parents[2] / path
@@ -136,7 +136,7 @@ def main():
         print("Starting to generate documentation...")
         template_overview(output_dir, device_list, board_list, template_path)
         print("... for {} devices, estimated memory footprint is {} MB".format(len(device_list) + len(board_list), (len(device_list)*70)+2000))
-        with multiprocessing.Pool(args.jobs) as pool:
+        with mp.get_context("spawn").Pool(args.jobs) as pool:
             # We can only pass one argument to pool.map
             devices = ["{}|{}|{}||{}".format(modm_path, tempdir, dev, args.deduplicate) for dev in device_list]
             devices += ["{}|{}|{}|{}|{}".format(modm_path, tempdir, dev, brd, args.deduplicate) for (brd, dev) in board_list]


### PR DESCRIPTION
Updating modm to GCC12 to keep up with the times.

- [x] Merge osx-cross/avr-gcc@12 on macOS PR
- [x] Merge docker-modm-build PR
- [x] Update Install instructions
- [x] Update Build System Documentation
- [x] avrlibstdc++ needs to have its floating point math forwarding functions removed to prevent loops
- [x] Fix additional compile flags for GCC12 are unknown to earlier compilers
  - [x] Tested backward compatibility with GCC10
  - [x] Tested new flags on GCC12
- [x] Tested in Hardware
- [x] Fix Python >3.8 multiprocessing issue with `examples_compile.py` and test all script
- [ ] Fix Python  >3.8 multiprocessing and filesystem issue with docs generator
   - hangs the system, unclear why, so it's not fixed, instead using the previous container image where it still works
