### PR TITLE
Fixes for stm32-extended I²C driver

### DIFF
--- a/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
@@ -501,7 +501,7 @@ modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint32_t timingRegist
 	Rcc::enable<Peripheral::I2c{{id}}>();
 
 	// Disable the I2C peripheral which causes a software reset
-	I2C{{ id }}->CR1 &= ~I2C_CR1_PE;
+	I2C{{ id }}->CR1 = 0;
 
 	// Configure I2Cx: Frequency range
 	// 39.4.8: Before enabling the peripheral, the I2C master clock must be configured by setting the
@@ -538,9 +538,6 @@ modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint32_t timingRegist
 	// Disable Own Address 2
 	I2C{{ id }}->OAR2 = 0;
 
-	// Configure Generalcall and NoStretch mode
-	I2C{{ id }}->CR1 = (0 | I2C_CR1_NOSTRETCH);
-
 %% if shared_interrupt
 	// Enable Interrupt
 	NVIC_SetPriority(I2C{{ id }}_IRQn, 10);
@@ -556,7 +553,7 @@ modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint32_t timingRegist
 %% endif
 
 	// Enable peripheral
-	I2C{{ id }}->CR1 |= I2C_CR1_PE;
+	I2C{{ id }}->CR1 = I2C_CR1_PE;
 }
 
 void

--- a/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.cpp.in
@@ -396,6 +396,7 @@ MODM_ISR(I2C{{ id }}_EV)
 				transaction->detaching(modm::I2c::DetachCause::ErrorCondition);
 				transaction = nullptr;
 			}
+			callNextTransaction();
 		}
 		else if (nextOperation == modm::I2c::Operation::Stop)
 		{


### PR DESCRIPTION
- [x] Do not set bit `I2C_CR1_NOSTRETCH` which must not be set in master mode
- [x] Start next queued transaction after previous one has failed with NACK
- [x] Test on real hardware

From some L4 reference manual:
![nostretch](https://user-images.githubusercontent.com/25187160/216082215-152df5e5-8453-47b8-8c4f-a27f6d3fba08.png)
