### PR TITLE
Add SAM software gpio port

### DIFF
--- a/src/modm/board/samd21_xplained_pro/board.hpp
+++ b/src/modm/board/samd21_xplained_pro/board.hpp
@@ -63,26 +63,7 @@ struct SystemClock
 using Led0 = GpioB30;
 using Button = GpioA15;
 
-// No SoftwareGpioPort yet for SAM
-struct Leds
-{
-	static constexpr std::size_t width{1};
-
-	static void setOutput()
-	{
-		Led0::setOutput();
-	}
-
-	static void write(uint32_t value)
-	{
-		Led0::set(value & 1);
-	}
-
-	static void toggle()
-	{
-		Led0::toggle();
-	}
-};
+using Leds = SoftwareGpioPort<Led0>;
 
 struct Debug
 {

--- a/src/modm/board/same54_xplained_pro/board.hpp
+++ b/src/modm/board/same54_xplained_pro/board.hpp
@@ -69,21 +69,7 @@ struct SystemClock
 using Led0 = GpioC18;
 using Button = GpioB31;
 
-// No SoftwareGpioPort yet for SAM
-struct Leds
-{
-	static constexpr std::size_t width{1};
-
-	static void setOutput()
-	{
-		Led0::setOutput();
-	}
-
-	static void write(uint32_t value)
-	{
-		Led0::set(value & 1);
-	}
-};
+using Leds = SoftwareGpioPort<Led0>;
 
 struct Debug
 {

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -53,29 +53,7 @@ using Led0 = GpioA23;
 using Led1 = GpioC9;
 using ButtonSW0 = GpioA9;
 
-// No SoftwareGpioPort yet for SAM
-struct Leds
-{
-	static constexpr std::size_t width{2};
-
-	static void setOutput()
-	{
-		Led0::setOutput();
-		Led1::setOutput();
-	}
-
-	static void setOutput(bool state)
-	{
-		Led0::setOutput(state);
-		Led1::setOutput(state);
-	}
-
-	static void write(uint32_t value)
-	{
-		Led0::set(value & 1);
-		Led1::set(value & 2);
-	}
-};
+using Leds = SoftwareGpioPort<Led1, Led0>;
 
 struct Debug
 {

--- a/src/modm/platform/gpio/sam/module.lb
+++ b/src/modm/platform/gpio/sam/module.lb
@@ -128,5 +128,6 @@ def build(env):
     if len(env["enable_ports"]):
         env.template("enable.cpp.in")
     env.template("pin.hpp.in")
+    env.template("software_port.hpp.in")
     env.copy("unused.hpp")
     env.copy("../common/inverted.hpp", "inverted.hpp")

--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -110,6 +110,25 @@ struct OneOfSignals
 	static constexpr bool value = ((std::is_same_v<typename Signal::signal, Signals>) | ...);
 };
 
+// Detect if a pin is inverted
+// Used to support both pins config and gpio classes being passed to GpioSet.
+// Pin config classes don't define isInverted and are treated as non-inverted.
+template<typename T>
+struct is_inverted
+{
+    static constexpr bool value = false;
+};
+
+template<typename T>
+    requires (T::isInverted == true)
+struct is_inverted<T>
+{
+    static constexpr bool value = true;
+};
+
+template<typename T>
+constexpr bool is_inverted_v = is_inverted<T>::value;
+
 %% if target["family"] in ["g5x", "e7x/s7x/v7x"]
 
 template<class... PinConfigs>
@@ -143,10 +162,22 @@ class GpioSet : protected PinMuxMixin<PinConfigs...>
 protected:
 	using PinMux = PinMuxMixin<PinConfigs...>;
 
-	static constexpr uint32_t
+	static consteval uint32_t
 	mask(PortName port)
 	{
 		return (((PinConfigs::port == port) ? 1u << PinConfigs::pin : 0u) | ...);
+	}
+
+	static consteval uint32_t
+	invertedMask(PortName port)
+	{
+		return (((PinConfigs::port == port) ? (is_inverted_v<PinConfigs> ? 1u : 0u) << PinConfigs::pin : 0u) | ...);
+	}
+
+	static consteval uint32_t
+	nonInvertedMask(PortName port)
+	{
+		return mask(port) & ~invertedMask(port);
 	}
 
 	template<PortName port>
@@ -237,7 +268,14 @@ public:
 	static void
 	set()
 	{
-		setPortReg(PIO_SODR_OFFSET);
+%% for port in ports
+		if constexpr (nonInvertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PIO_SODR_OFFSET) = nonInvertedMask(PortName::{{ port }});
+		}
+		if constexpr (invertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PIO_CODR_OFFSET) = invertedMask(PortName::{{ port }});
+		}
+%% endfor
 	}
 
 	static void
@@ -252,7 +290,14 @@ public:
 	static void
 	reset()
 	{
-		setPortReg(PIO_CODR_OFFSET);
+%% for port in ports
+		if constexpr (nonInvertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PIO_CODR_OFFSET) = nonInvertedMask(PortName::{{ port }});
+		}
+		if constexpr (invertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PIO_SODR_OFFSET) = invertedMask(PortName::{{ port }});
+		}
+%% endfor
 	}
 
 	static void
@@ -316,10 +361,22 @@ class GpioSet : protected PinCfgMixin<PinConfigs...>
 protected:
 	using PinCfg = PinCfgMixin<PinConfigs...>;
 
-	static constexpr uint32_t
+	static consteval uint32_t
 	mask(PortName port)
 	{
 		return (((PinConfigs::port == port) ? 1u << PinConfigs::pin : 0u) | ...);
+	}
+
+	static consteval uint32_t
+	invertedMask(PortName port)
+	{
+		return (((PinConfigs::port == port) ? (is_inverted_v<PinConfigs> ? 1u : 0u) << PinConfigs::pin : 0u) | ...);
+	}
+
+	static consteval uint32_t
+	nonInvertedMask(PortName port)
+	{
+		return mask(port) & ~invertedMask(port);
 	}
 
 	template<PortName port>
@@ -396,7 +453,14 @@ public:
 	static void
 	set()
 	{
-		setPortReg(PORT_OUTSET_OFFSET);
+%% for port in ports
+		if constexpr (nonInvertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PORT_OUTSET_OFFSET) = nonInvertedMask(PortName::{{ port }});
+		}
+		if constexpr (invertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PORT_OUTCLR_OFFSET) = invertedMask(PortName::{{ port }});
+		}
+%% endfor
 	}
 
 	static void
@@ -411,7 +475,14 @@ public:
 	static void
 	reset()
 	{
-		setPortReg(PORT_OUTCLR_OFFSET);
+%% for port in ports
+		if constexpr (nonInvertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PORT_OUTCLR_OFFSET) = nonInvertedMask(PortName::{{ port }});
+		}
+		if constexpr (invertedMask(PortName::{{ port }})) {
+			*getPortReg<PortName::{{ port }}>(PORT_OUTSET_OFFSET) = invertedMask(PortName::{{ port }});
+		}
+%% endfor
 	}
 
 	static void

--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -446,6 +446,9 @@ public:
 	using Data = PinConfig;
 	static constexpr bool isInverted = false;
 
+	static constexpr auto pin = PinConfig::pin;
+	static constexpr auto port = PinConfig::port;
+
 	template<PeripheralPin peripheral_pin_v>
 	struct As;
 

--- a/src/modm/platform/gpio/sam/software_port.hpp.in
+++ b/src/modm/platform/gpio/sam/software_port.hpp.in
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, Niklas Hauser
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "pin.hpp"
+#include <type_traits>
+
+namespace modm::platform
+{
+
+/**
+ * Create an up to 32-bit port from arbitrary pins.
+ *
+ * This class optimizes the data type for the `read()` and `write()` methods.
+ * Supplying up to 8 Gpios will use `uint8_t`, up to 16 Gpios `uint16_t` and
+ * up to 32 Gpios `uint32_t`.
+ *
+ * @note Since the bit order is explicitly given by the order of template arguments,
+ *       this class only supports `DataOrder::Normal`.
+ *       If you need reverse bit order, reverse the order of `Gpios`!
+ *
+ * @tparam Gpios	Up to 32 GpioIO classes, ordered MSB to LSB
+ *
+ * @author	Christopher Durand
+ * @author	Niklas Hauser
+ * @ingroup	modm_platform_gpio
+ */
+template<class... Gpios>
+class SoftwareGpioPort : public ::modm::GpioPort, public GpioSet<Gpios...>
+{
+	using Set = GpioSet<Gpios...>;
+public:
+	static constexpr auto width = sizeof...(Gpios);
+	static_assert(width <= 32, "Only a maximum of 32 pins are supported by this port!");
+	using PortType = std::conditional_t< (width > 8),
+					 std::conditional_t< (width > 16),
+										 uint32_t,
+										 uint16_t >,
+										 uint8_t >;
+	static constexpr DataOrder getDataOrder()
+	{ return ::modm::GpioPort::DataOrder::Normal; }
+
+protected:
+%% for port in ports
+	static constexpr int8_t shift_masks_{{port}}[] = {
+		int8_t(Gpios::port == PortName::{{port}} ? Gpios::pin : -1)...
+	};
+	static_assert(std::size(shift_masks_{{port}}) == width);
+	static constexpr int8_t shift_mask_{{port}}(uint8_t pos) { return shift_masks_{{port}}[width - 1 - pos]; };
+%% endfor
+	using Set::mask;
+	using Set::invertedMask;
+
+public:
+	static PortType isSet()
+	{
+		PortType r{0};
+%% for port in ports
+		if constexpr (mask(PortName::{{port}})) {
+	%% if target["family"] in ["g5x", "e7x/s7x/v7x"]
+			const uint32_t p = Set::template readPortReg<PortName::{{port}}>(PIO_ODSR_OFFSET) ^ invertedMask(PortName::{{port}});
+	%% else
+			const uint32_t p = Set::template readPortReg<PortName::{{port}}>(PORT_OUT_OFFSET) ^ invertedMask(PortName::{{port}});
+	%% endif
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) if constexpr (constexpr auto pos = shift_mask_{{port}}({{pos}}); pos >= 0) r |= ((p >> pos) & 1) << {{pos}};
+	%% endfor
+		}
+%% endfor
+		return r;
+	}
+
+	static void write(PortType data)
+	{
+%% for port in ports
+		if constexpr (mask(PortName::{{port}})) {
+			uint32_t set{0};
+			uint32_t reset{0};
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) {
+				if constexpr (constexpr auto shift = shift_mask_{{port}}({{pos}}); shift >= 0) {
+					if (bool(data & (1ul << {{pos}})) != bool(invertedMask(PortName::{{port}}) & (1 << shift)))
+						set |= (1ul << shift);
+					else
+						reset |= (1ul << shift);
+				}
+			}
+	%% endfor
+	%% if target["family"] in ["g5x", "e7x/s7x/v7x"]
+			*(Set::template getPortReg<PortName::{{port}}>(PIO_SODR_OFFSET)) = set;
+			*(Set::template getPortReg<PortName::{{port}}>(PIO_CODR_OFFSET)) = reset;
+	%% else
+			*(Set::template getPortReg<PortName::{{port}}>(PORT_OUTSET_OFFSET)) = set;
+			*(Set::template getPortReg<PortName::{{port}}>(PORT_OUTCLR_OFFSET)) = reset;
+	%% endif
+		}
+%% endfor
+	}
+
+	static PortType read()
+	{
+		PortType r{0};
+%% for port in ports
+		if constexpr (mask(PortName::{{port}})) {
+	%% if target["family"] in ["g5x", "e7x/s7x/v7x"]
+			const uint32_t p = (Set::template readPortReg<PortName::{{port}}>(PIO_PDSR_OFFSET) & mask(PortName::{{port}})) ^ invertedMask(PortName::{{port}});
+	%% else
+			const uint32_t p = (Set::template readPortReg<PortName::{{port}}>(PORT_IN_OFFSET) & mask(PortName::{{port}})) ^ invertedMask(PortName::{{port}});
+	%% endif
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) if constexpr (constexpr auto pos = shift_mask_{{port}}({{pos}}); pos >= 0) r |= ((p >> pos) & 1) << {{pos}};
+	%% endfor
+		}
+%% endfor
+		return r;
+	}
+};
+
+} // namespace modm::platform

--- a/test/modm/platform/software_gpio_port/gpio_port_test.hpp
+++ b/test/modm/platform/software_gpio_port/gpio_port_test.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_platform_gpio_port
+class GpioPortTest : public unittest::TestSuite
+{
+public:
+	virtual void
+	setUp() override;
+
+	void
+	testPortRead();
+
+	void
+	testPortWrite();
+
+	void
+	testPortInverted();
+};

--- a/test/modm/platform/software_gpio_port/gpio_port_test_samv71.cpp
+++ b/test/modm/platform/software_gpio_port/gpio_port_test_samv71.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "gpio_port_test.hpp"
+
+#include <modm/platform.hpp>
+
+using namespace modm::platform;
+
+using Port = SoftwareGpioPort<
+	GpioA23,
+	GpioC9,
+	GpioD20,
+	GpioD21
+>;
+
+using Port2 = SoftwareGpioPort<
+	GpioA23,
+	GpioInverted<GpioC9>,
+	GpioInverted<GpioD20>,
+	GpioD21
+>;
+
+void
+GpioPortTest::setUp()
+{
+	Port::setOutput(false);
+}
+
+void
+GpioPortTest::testPortRead()
+{
+	Port::setOutput(false);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0000);
+
+	GpioA23::set();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b1000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b1000);
+
+	GpioD20::set();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b1010);
+	TEST_ASSERT_EQUALS(Port::read(), 0b1010);
+
+	GpioA23::reset();
+	GpioD20::reset();
+	GpioC9::set();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0100);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0100);
+
+	GpioD21::set();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0101);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0101);
+
+	Port::reset();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0000);
+}
+
+void
+GpioPortTest::testPortWrite()
+{
+	Port::write(0b1001);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b1001);
+	TEST_ASSERT_EQUALS(Port::read(), 0b1001);
+
+	Port::write(0b0110);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0110);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0110);
+
+	Port::write(0b0010);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0010);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0010);
+
+	Port::write(0b0000);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0000);
+
+	Port::set();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b1111);
+	TEST_ASSERT_EQUALS(Port::read(), 0b1111);
+
+	Port::reset();
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0000);
+}
+
+void
+GpioPortTest::testPortInverted()
+{
+	// inverted read
+	Port::write(0b1111);
+	TEST_ASSERT_EQUALS(Port2::isSet(), 0b1001);
+	TEST_ASSERT_EQUALS(Port2::read(), 0b1001);
+
+	Port::write(0b1101);
+	TEST_ASSERT_EQUALS(Port2::isSet(), 0b1011);
+	TEST_ASSERT_EQUALS(Port2::read(), 0b1011);
+
+	Port::write(0b1001);
+	TEST_ASSERT_EQUALS(Port2::isSet(), 0b1111);
+	TEST_ASSERT_EQUALS(Port2::read(), 0b1111);
+
+	Port::write(0b0000);
+	TEST_ASSERT_EQUALS(Port2::isSet(), 0b0110);
+	TEST_ASSERT_EQUALS(Port2::read(), 0b0110);
+
+	// inverted write
+	Port2::write(0b0000);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0110);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0110);
+
+	Port2::write(0b0100);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0010);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0010);
+
+	Port2::write(0b0110);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b0000);
+	TEST_ASSERT_EQUALS(Port::read(), 0b0000);
+
+	Port2::write(0b1111);
+	TEST_ASSERT_EQUALS(Port::isSet(), 0b1001);
+	TEST_ASSERT_EQUALS(Port::read(), 0b1001);
+}

--- a/test/modm/platform/software_gpio_port/module.lb
+++ b/test/modm/platform/software_gpio_port/module.lb
@@ -1,0 +1,21 @@
+def init(module):
+    module.name = ":test:platform:software_gpio_port"
+    module.description = "Tests for Software GPIO port"
+
+def prepare(module, options):
+    if not options[":target"].partname == "samv71q21b-aab":
+        return False
+
+    module.depends(":platform:gpio")
+    return True
+
+def build(env):
+    if not env.has_module(":board:samv71-xplained-ultra"):
+        env.log.warn("GPIO port test has been hardcoded to the SAMV71 Xplained board"
+                     "When porting make sure this test does not damage your board!")
+        return
+
+    #env.substitutions = properties
+    env.outbasepath = "modm-test/src/modm-test/platform/software_gpio_port"
+    env.copy("gpio_port_test.hpp")
+    env.copy("gpio_port_test_samv71.cpp")


### PR DESCRIPTION
SAM GPIO improvements:
- [x] Add `SoftwareGpioPort` implementation
- [x] Allow construction of GpioSet from Gpios, not only config classes 
- [x] Add support for inverted pins in GpioSet
- [x] Working hardware unit test for `SoftwareGpioPort`