### PR TITLE
ATSAM CAN driver (MCAN peripheral)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">○</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>

--- a/examples/samv71_xplained_ultra/fdcan/main.cpp
+++ b/examples/samv71_xplained_ultra/fdcan/main.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+
+using namespace modm::literals;
+using namespace modm::platform;
+using namespace Board;
+
+// Set the log level
+#undef	MODM_LOG_LEVEL
+#define	MODM_LOG_LEVEL modm::log::INFO
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "CAN Test Program" << modm::endl;
+
+	MODM_LOG_INFO << "Mcan1: Initializing with 125kbps / 1Mbps (FDCAN) for boards CAN transceiver (PC12/PC14)." << modm::endl;
+	// Mcan1 is connted in Board::initialize(); CAN transceiver on the dev board
+	Mcan1::initialize<Board::SystemClock, 125_kbps, 1_pct, 1_Mbps>(12);
+
+	MODM_LOG_INFO << "Mcan1: Setting up Filter to receive every message." << modm::endl;
+	Mcan1::setExtendedFilter(0, Mcan1::FilterConfig::Fifo0,
+			modm::can::ExtendedIdentifier(0),
+			modm::can::ExtendedMask(0));
+	Mcan1::setStandardFilter(0, Mcan1::FilterConfig::Fifo0,
+			modm::can::StandardIdentifier(0),
+			modm::can::StandardMask(0));
+
+	Mcan1::setMode(Mcan1::Mode::TestExternalLoopback);
+
+	Mcan1::setErrorInterruptCallback([](){
+		Board::Led1::set();
+	});
+
+	uint32_t counter{0};
+
+	while (true)
+	{
+		counter++;
+		MODM_LOG_INFO << "loop: " << counter << modm::endl;
+
+		modm::can::Message txMsg{counter, 64};
+		txMsg.setExtended(true);
+		for (size_t i = 0; i < txMsg.capacity; ++i) {
+			txMsg.data[i] = counter;
+		}
+		MODM_LOG_INFO << "Mcan1: Sending message... " << txMsg << modm::endl;
+		Mcan1::sendMessage(txMsg);
+
+		if (Mcan1::isMessageAvailable())
+		{
+			MODM_LOG_INFO << "Mcan1: Message is available... ";
+			modm::can::Message rxMsg;
+			if (Mcan1::getMessage(rxMsg))
+				MODM_LOG_INFO << rxMsg << modm::endl;
+			else
+				MODM_LOG_INFO << " but getting message FAILED" << modm::endl;
+		}
+
+		Led0::toggle();
+		modm::delay(500ms);
+	}
+
+	return 0;
+}

--- a/examples/samv71_xplained_ultra/fdcan/project.xml
+++ b/examples/samv71_xplained_ultra/fdcan/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:samv71-xplained-ultra</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/samv71_xplained_ultra/fdcan</option>
+    <option name="modm:architecture:can:message.buffer">64</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/can_message.hpp.in
+++ b/src/modm/architecture/interface/can_message.hpp.in
@@ -26,22 +26,21 @@ namespace modm::can
 /// @ingroup modm_architecture_can
 struct Message
 {
-	inline Message(uint32_t inIdentifier = 0, uint8_t inLength = 0) :
+	constexpr Message(uint32_t inIdentifier = 0, uint8_t inLength = 0) :
 		identifier(inIdentifier), flags()
 	{
         setLength(inLength);
 	}
 
-	inline Message(uint32_t inIdentifier, uint8_t inLength, const uint64_t &inData, bool extended = false) :
+	constexpr Message(uint32_t inIdentifier, uint8_t inLength, const uint64_t &inData, bool extended = false) :
         Message(inIdentifier, std::min(inLength, uint8_t(8)))
 	{
 		flags.extended = extended;
-		const uint8_t *inDataB = reinterpret_cast<const uint8_t *>(&inData);
 		for (uint8_t ii = 0; ii < length; ++ii)
- 			data[ii] = inDataB[length - ii - 1];
+			data[ii] = inData >> ((7 - ii - (8 - length)) * 8);
 	}
 
-	inline Message(uint32_t inIdentifier, uint8_t inLength, const uint8_t *inData, bool extended = false) :
+	constexpr Message(uint32_t inIdentifier, uint8_t inLength, const uint8_t *inData, bool extended = false) :
 		Message(inIdentifier, inLength)
 	{
 		flags.extended = extended;
@@ -49,67 +48,73 @@ struct Message
  			data[ii] = inData[ii];
 	}
 
-	inline uint32_t
+	constexpr Message(const modm::can::Message& rhs)
+		: identifier{rhs.identifier}, flags{rhs.flags}, dlc{rhs.dlc}, length{rhs.length}
+	{
+		std::copy(std::begin(rhs.data), std::end(rhs.data), std::begin(data));
+	}
+
+	constexpr uint32_t
 	getIdentifier() const
 	{
 		return identifier;
 	}
 
-	inline void
+	constexpr void
 	setIdentifier(uint32_t id)
 	{
 		identifier = id;
 	}
 
-	inline constexpr uint8_t
+	constexpr uint8_t
 	getCapacity() const
 	{
 		return capacity;
 	}
 
-	inline void
+	constexpr void
 	setFlexibleData(bool fd = true)
 	{
 		flags.fd = fd;
 	}
 
-	inline bool
+	constexpr bool
 	isFlexibleData() const
 	{
 		return (flags.fd != 0);
 	}
 
-	inline bool
+	constexpr bool
 	isBitRateSwitching() const
 	{
 		return (flags.brs != 0);
 	}
 
-	inline void
+	constexpr void
 	setExtended(bool extended = true)
 	{
 		flags.extended = (extended) ? 1 : 0;
 	}
 
-	inline bool
+	constexpr bool
 	isExtended() const
 	{
 		return (flags.extended != 0);
 	}
 
-	inline void
+	constexpr void
 	setRemoteTransmitRequest(bool rtr = true)
 	{
 		flags.rtr = (rtr) ? 1 : 0;
 	}
 
-	inline bool
+	constexpr bool
 	isRemoteTransmitRequest() const
 	{
 		return (flags.rtr != 0);
 	}
 
-	inline void
+	constexpr void
 	setDataLengthCode(uint8_t inDlc)
 	{
 		while (dlcConversionTable[inDlc] > capacity) inDlc--;
@@ -119,7 +124,7 @@ struct Message
 		if (dlc > 8) setFlexibleData();
 	}
 
-	inline void
+	constexpr void
 	setLength(uint8_t inLength)
 	{
 		if constexpr (capacity <= 8)
@@ -134,13 +139,13 @@ struct Message
 		}
 	}
 
-	inline uint8_t
+	constexpr uint8_t
 	getLength() const
 	{
 		return length;
 	}
 
-	inline uint8_t
+	constexpr uint8_t
 	getDataLengthCode() const
 	{
 		return dlc;
@@ -153,7 +158,7 @@ public:
 	uint32_t identifier;
 	struct Flags
 	{
-		Flags() :
+		constexpr Flags() :
 			fd(0), brs(0), rtr(0), extended(1)
 		{
 		}
@@ -165,10 +170,10 @@ public:
 	} flags;
 	uint8_t dlc;
 	uint8_t length;
-	uint8_t modm_aligned(4) data[capacity];
+	uint8_t modm_aligned(4) data[capacity]{};
 
 public:
-	inline bool
+	constexpr bool
 	operator == (const modm::can::Message& rhs) const
 	{
 		return ((this->identifier     == rhs.identifier) and
@@ -181,7 +186,7 @@ public:
 				std::equal(data, data + getLength(), rhs.data));
 	}
 
-	inline void
+	constexpr modm::can::Message&
 	operator = (const modm::can::Message& rhs)
 	{
 		this->identifier     = rhs.identifier;
@@ -192,9 +197,10 @@ public:
 		this->flags.rtr      = rhs.flags.rtr;
 		this->flags.extended = rhs.flags.extended;
 		std::copy(std::begin(rhs.data), std::end(rhs.data), std::begin(this->data));
+		return *this;
 	}
 
-	inline bool
+	constexpr bool
 	operator < (const modm::can::Message& rhs) const
 	{
 		return (this->identifier << (this->flags.extended ? 0 : 18))

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -121,12 +121,18 @@ class Can(Module):
         module.description = FileReader("interface/can.md")
 
     def prepare(self, module, options):
+        def validate_dlc(s: int):
+            valid_dlcs = [8, 12, 16, 20, 24, 32, 48, 64]
+            if s not in valid_dlcs:
+                raise ValueError(f"Input must be a valid CAN data length: {', '.join(valid_dlcs)}!")
         module.add_option(
             NumericOption(
                 name="message.buffer",
                 description="",
                 minimum=8, maximum=64,
+                validate=validate_dlc,
                 default=8))
+        module.depends(":debug")
         return True
 
     def build(self, env):

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -65,8 +65,8 @@ struct SystemClock
 	}
 };
 
-using Led0 = GpioA23;
-using Led1 = GpioC9;
+using Led0 = GpioInverted<GpioA23>;
+using Led1 = GpioInverted<GpioC9>;
 using ButtonSW0 = GpioInverted<GpioA9>;
 
 using Leds = SoftwareGpioPort<Led1, Led0>;
@@ -109,6 +109,7 @@ initialize()
 	Debug::Uart::initialize<SystemClock, 115200>();
 	Debug::Uart::connect<Debug::UartTx::Tx, Debug::UartRx::Rx>();
 
+	Leds::reset();
 	Leds::setOutput();
 	ButtonSW0::setInput(InputType::PullUp);
 

--- a/src/modm/board/samv71_xplained_ultra/module.lb
+++ b/src/modm/board/samv71_xplained_ultra/module.lb
@@ -19,7 +19,13 @@ def prepare(module, options):
     if not options[":target"].partname == "samv71q21b-aab":
         return False
 
-    module.depends(":debug", ":platform:clockgen", ":platform:gpio", ":platform:core", ":platform:usart:1", ":platform:i2c:0") #, ":platform:usb")
+    module.depends(":debug",
+                   ":platform:can:1",
+                   ":platform:clockgen",
+                   ":platform:core",
+                   ":platform:gpio",
+                   ":platform:i2c:0",
+                   ":platform:usart:1")  # , ":platform:usb")
     return True
 
 def build(env):

--- a/src/modm/platform/can/sam-mcan/can.hpp
+++ b/src/modm/platform/can/sam-mcan/can.hpp
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2019, 2023, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <optional>
+
+#include <modm/architecture/interface/can.hpp>
+#include <modm/architecture/interface/can_filter.hpp>
+#include <modm/platform/gpio/connector.hpp>
+
+#include "can_bit_timings.hpp"
+
+#include "message_ram.hpp"
+
+namespace modm::platform
+{
+
+using McanErrorCallback = void (*)();
+
+extern McanErrorCallback mcan0ErrorCallback;
+extern McanErrorCallback mcan1ErrorCallback;
+
+/**
+ * @brief		MCAN (CAN with Flexible Data-Rate)
+ *
+ * @author		Raphael Lehmann <raphael@rleh.de>
+ * @author		Christopher Durand <christopher.durand@rwth-aachen.de>
+ * @ingroup		modm_platform_can
+ */
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+class McanDriver : public ::modm::Can
+{
+public:
+	enum class
+	Mode : uint32_t
+	{
+		Normal,
+		Restricted,
+		Monitoring,
+		Sleep,
+		TestExternalLoopback,
+		TestInternalLoopback,
+
+		// for compatibility with bxCAN:
+		ListenOnly = Monitoring, // no acknowledging
+		LoopBack = TestInternalLoopback,
+
+	};
+
+private:
+	static auto*
+	Regs()
+	{
+		if constexpr (id == 0)
+		{
+			return MCAN0;
+		}
+#ifdef MCAN1
+		else if constexpr (id == 1)
+		{
+			return MCAN1;
+		}
+#endif
+		else
+		{
+			return nullptr;
+		}
+	}
+
+	// helper for static_assert
+	template<class T = void>
+	static constexpr bool
+	always_false_v = false;
+
+	using MessageRam = fdcan::MessageRam<id, mrc>;
+	static_assert(MessageRam::StandardFilterCount <= 128, "A maximum of 128 standard filters are allowed.");
+	static_assert(MessageRam::ExtendedFilterCount <= 64, "A maximum of 64 standard filters are allowed.");
+	static_assert(MessageRam::RxFifo0Elements <= 64, "A maximum of 64 Rx Fifo 0 elements are allowed.");
+	static_assert(MessageRam::RxFifo1Elements <= 64, "A maximum of 64 Rx Fifo 1 elements are allowed.");
+	static_assert(MessageRam::RxBufferElements <= 64, "A maximum of 64 dedicated Rx buffers are allowed.");
+	static_assert(MessageRam::TxEventFifoEntries <= 32, "A maximum of 32 Tx Event Fifo elements are allowed.");
+	static_assert(MessageRam::TxFifoElements <= 32, "A maximum of 32 Tx Fifo elements are allowed.");
+	static_assert(MessageRam::Size <= 4352*4, "Max message ram size is 4352 words.");
+
+	static inline std::array<uint32_t, MessageRam::Size/4> modm_aligned(4)
+	messageRamMemory{};
+
+	struct RxMessage
+	{
+		modm::can::Message message;
+		uint8_t filter_id;
+		uint16_t timestamp;
+	};
+
+	static void
+	initializeWithPrescaler(CanBitTimingConfiguration standardTimings,
+							std::optional<CanBitTimingConfiguration> fdDataTimings,
+							uint32_t interruptPriority, Mode startupMode, bool overwriteOnOverrun);
+
+public:
+	// Expose template parameters to be checked by e.g. drivers or application
+	static constexpr size_t RxBufferSize = std::min(MessageRam::RxFifo0Elements, MessageRam::RxFifo1Elements);
+	static constexpr size_t TxBufferSize = MessageRam::TxFifoElements;
+
+	template<class... Pins>
+	static void
+	connect(modm::platform::InputType inputType = modm::platform::InputType::Floating)
+	{
+		using RxPin = GetPin_t<PeripheralPin::Rx, Pins...>;
+		using TxPin = GetPin_t<PeripheralPin::Tx, Pins...>;
+
+		using Peripheral = typename Peripherals::Mcan<id>;
+
+		if constexpr (!std::is_void_v<RxPin>) {
+			RxPin::configure(inputType);
+			using RxConnector = typename RxPin::template Connector<Peripheral, typename Peripheral::template Canrx<id>>;
+			RxConnector::connect();
+		}
+
+		if constexpr (!std::is_void_v<TxPin>) {
+			using TxConnector = typename TxPin::template Connector<Peripheral, typename Peripheral::template Cantx<id>>;
+			TxConnector::connect();
+		}
+	}
+
+	/**
+	 * Enables the clock for the CAN controller and resets all settings
+	 *
+	 * \tparam SystemClock
+	 * 			System clock struct with an MCAN member containing
+	 * 			the clock speed supplied to the peripheral.
+	 * 			\warning	The CAN subsystem prescaler can be configured using
+	 * 						the RCC module and must be taken into account in
+	 * 						the provided clock speed value.
+	 * \tparam bitrate
+	 * 			Nominal CAN bitrate
+	 * \tparam tolerance
+	 * 			Maximum relative deviation between requested and resulting
+	 * 			CAN bitrates. If the tolerance is exceeded a compile-time
+	 * 			assertion will be triggered.
+	 * \tparam fastDataBitrate
+	 * 			CAN bitrate for data in FD frames with bit rate switching
+	 * 			Set to 0 to disable CANFD support.
+	 *
+	 * \param interruptPriority
+	 * 			Not used in this driver: Interrupt vector priority (0=highest to 15=lowest)
+	 * \param startupMode
+	 * 			Mode of operation set after initialization
+	 * 			\see Mcan<id>::Mode
+	 * \param overwriteOnOverrun
+	 * 			Once a receive FIFO is full the next incoming message
+	 * 			will overwrite the previous one if \c true otherwise
+	 * 			the incoming message will be discarded
+	 *
+	 * \warning	Has to called after connect(), but before any
+	 * 			other function from this class!
+	 */
+	template<
+		class SystemClock,
+		bitrate_t bitrate=kbps(125),
+		percent_t tolerance=pct(1),
+		bitrate_t fastDataBitrate=0 // 0: MCAN mode disabled
+	>
+	static inline void
+	initialize(uint32_t interruptPriority, Mode startupMode = Mode::Normal,
+				bool overwriteOnOverrun = true)
+	{
+		using Timings = CanBitTiming<
+			SystemClock::Mcan,
+			bitrate,
+			9, 8, 7, 7
+		>;
+		Timings::template assertBitrateInTolerance<tolerance>();
+
+		std::optional<CanBitTimingConfiguration> fastDataTimings = std::nullopt;
+
+		if constexpr (fastDataBitrate != 0) {
+			using DataTimings = CanBitTiming<
+				SystemClock::Mcan,
+				fastDataBitrate,
+				5, 5, 4, 3
+			>;
+			DataTimings::template assertBitrateInTolerance<tolerance>();
+
+			fastDataTimings = DataTimings::getBitTimings();
+		}
+
+		return initializeWithPrescaler(
+			Timings::getBitTimings(),
+			fastDataTimings,
+			interruptPriority,
+			startupMode,
+			overwriteOnOverrun);
+	}
+
+	/**
+	 * Set the operating mode.
+	 *
+	 * Default after initialization is the normal mode.
+	 */
+	static void
+	setMode(Mode mode);
+
+	static void
+	setAutomaticRetransmission(bool retransmission);
+
+public:
+	// Can interface methods
+	static bool
+	isMessageAvailable();
+
+	static bool
+	getMessage(can::Message& message, uint8_t *filter_id=nullptr, uint16_t *timestamp=nullptr);
+
+	static bool
+	isReadyToSend();
+
+	static bool
+	sendMessage(const can::Message& message);
+
+public:
+	// Can filter configuration
+
+	using FilterConfig = MessageRam::FilterConfig;
+
+	/// Set standard filter with id and mask
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier id_,
+		modm::can::StandardMask mask);
+
+	/// Set standard filter with dual ids
+	/// Matches on any of both specified ids
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier id0,
+		modm::can::StandardIdentifier id1);
+
+	/// Set standard range filter
+	/// Matches the inclusive range between both specified ids
+	/// \param standardIndex Standard filter index 0..27
+	/// \returns true if filter index is valid
+	static bool
+	setStandardRangeFilter(uint8_t standardIndex, FilterConfig config,
+		modm::can::StandardIdentifier first,
+		modm::can::StandardIdentifier last);
+
+	/// Set extended filter with id and mask
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier id_,
+		modm::can::ExtendedMask mask);
+
+	/// Set standard filter with dual ids
+	/// Matches on any of both specified ids
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier id0,
+		modm::can::ExtendedIdentifier id1);
+
+	/// Set standard range filter
+	/// Matches the inclusive range between both specified ids
+	/// \param extendedIndex Extended filter index 0..7
+	/// \returns true if filter index is valid
+	static bool
+	setExtendedRangeFilter(uint8_t extendedIndex, FilterConfig config,
+		modm::can::ExtendedIdentifier first,
+		modm::can::ExtendedIdentifier last);
+
+	/// Disable all standard filters, receive no standard frames
+	static void
+	clearStandardFilters();
+
+	/// Disable all extended filters, receive no extended frames
+	static void
+	clearExtendedFilters();
+
+public:
+	// Extended Functionality
+	/**
+	 * Get Receive Error Counter.
+	 *
+	 * In case of an error during reception, this counter is
+	 * incremented by 1 or by 8 depending on the error condition as
+	 * defined by the CAN standard. After every successful reception
+	 * the counter is decremented by 1 or reset to 120 if its value
+	 * was higher than 128. When the counter value exceeds 127, the
+	 * CAN controller enters the error passive state.
+	 */
+	static inline uint8_t
+	getReceiveErrorCounter()
+	{
+		return ((Regs()->MCAN_ECR >> 8) & 0x7F);
+	}
+
+	/**
+	 * Get Transmit Error Counter.
+	 *
+	 */
+	static inline uint8_t
+	getTransmitErrorCounter()
+	{
+		return (Regs()->MCAN_ECR & 0xFF);
+	}
+
+	static BusState
+	getBusState();
+
+	/**
+	 * Set the error interrupt callback.
+	 *
+	 * It will be called on the following events:
+	 * - The MCAN peripheral enters ERROR_PASSIVE or BUS_OFF state
+	 * - The error counter exceeds the warning limit
+	 *
+	 * To disable the interrupt set the callback to nullptr.
+	 */
+	static void
+	setErrorInterruptCallback(McanErrorCallback callback)
+	{
+		if constexpr (id == 0) {
+			modm::platform::mcan0ErrorCallback = callback;
+		}
+		else {
+			modm::platform::mcan1ErrorCallback = callback;
+		}
+		if(callback) {
+			Regs()->MCAN_IE |=  (MCAN_IE_BOE | MCAN_IE_EPE | MCAN_IE_EWE);
+		} else {
+			Regs()->MCAN_IE &= ~(MCAN_IE_BOE | MCAN_IE_EPE | MCAN_IE_EWE);
+		}
+	}
+
+	static McanErrorCallback
+	getErrorInterruptCallback()
+	{
+		if constexpr (id == 0) {
+			return modm::platform::mcan0ErrorCallback;
+		}
+		else {
+			return modm::platform::mcan1ErrorCallback;
+		}
+	}
+
+	static uint16_t
+	getCurrentTimestamp()
+	{
+		return Regs()->MCAN_TSCV;
+	}
+
+private:
+	static void
+	configureMode(Mode mode);
+
+	static void
+	configureInterrupts(uint32_t interruptPriority);
+
+	struct EnterInitMode
+	{
+		EnterInitMode()
+		{
+			Regs()->MCAN_CCCR |= MCAN_CCCR_INIT;
+			int deadlockPreventer = 10'000; // max ~10ms
+			while (((Regs()->MCAN_CCCR & MCAN_CCCR_INIT) == 0) and (deadlockPreventer-- > 0)) {
+				using namespace std::literals;
+				modm::delay_us(1);
+				// Wait until the initialization mode is entered.
+			}
+			modm_assert(deadlockPreventer > 0, "can.init", "timeout expired");
+			Regs()->MCAN_CCCR |= MCAN_CCCR_CCE;
+		}
+
+		~EnterInitMode()
+		{
+			// Switch to normal operation, automatically clears CCE flag
+			Regs()->MCAN_CCCR &= ~MCAN_CCCR_INIT;
+		}
+
+		EnterInitMode(const EnterInitMode&) = delete;
+		EnterInitMode& operator=(const EnterInitMode&) = delete;
+	};
+
+private:
+	static bool
+	isHardwareTxQueueFull();
+
+	static bool
+	rxFifo0HasMessage();
+
+	static bool
+	rxFifo1HasMessage();
+
+	static void
+	acknowledgeRxFifoRead(uint8_t fifoIndex, uint8_t getIndex);
+
+	static uint8_t
+	retrieveRxFifoGetIndex(uint8_t fifoIndex);
+
+	static uint8_t
+	retrieveTxFifoPutIndex();
+
+	static void
+	readMsg(modm::can::Message& message, uint8_t fifoIndex, uint8_t* filter_id, uint16_t *timestamp);
+
+	static bool
+	sendMsg(const modm::can::Message& message);
+};
+
+}	// namespace modm::platform
+
+#include "can_impl.hpp"

--- a/src/modm/platform/can/sam-mcan/can_impl.hpp
+++ b/src/modm/platform/can/sam-mcan/can_impl.hpp
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2019, 2023, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/architecture/interface/assert.hpp>
+#include <modm/platform/clock/clockgen.hpp>
+
+#include "can.hpp"
+
+namespace modm::platform {
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::isHardwareTxQueueFull()
+{
+	return ((Regs()->MCAN_TXFQS & MCAN_TXFQS_TFQF) != 0);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::rxFifo0HasMessage()
+{
+	return ((Regs()->MCAN_RXF0S & MCAN_RXF0S_F0FL_Msk) > 0);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::rxFifo1HasMessage()
+{
+	return ((Regs()->MCAN_RXF1S & MCAN_RXF1S_F1FL_Msk) > 0);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::acknowledgeRxFifoRead(uint8_t fifoIndex, uint8_t getIndex)
+{
+	if (fifoIndex == 0) {
+		Regs()->MCAN_RXF0A = getIndex;
+	}
+	else {
+		Regs()->MCAN_RXF1A = getIndex;
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+uint8_t
+McanDriver<id, mrc>::retrieveRxFifoGetIndex(uint8_t fifoIndex)
+{
+	if (fifoIndex == 0) {
+		return ((Regs()->MCAN_RXF0S & MCAN_RXF0S_F0GI_Msk) >> MCAN_RXF0S_F0GI_Pos);
+	} else {
+		return ((Regs()->MCAN_RXF1S & MCAN_RXF1S_F1GI_Msk) >> MCAN_RXF1S_F1GI_Pos);
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+uint8_t
+McanDriver<id, mrc>::retrieveTxFifoPutIndex()
+{
+	return ((Regs()->MCAN_TXFQS & MCAN_TXFQS_TFQPI_Msk) >> MCAN_TXFQS_TFQPI_Pos);
+}
+
+// Internal function to receive a message from an RX Fifo.
+// Called by RX interrupt or by getMessage()
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::readMsg(modm::can::Message& message, uint8_t fifoIndex, uint8_t* filter_id, uint16_t *timestamp)
+{
+	using CommonHeader = MessageRam::CommonFifoHeader;
+	using RxFifoAddress = MessageRam::RxFifoAddress;
+
+	// retrieve index of next frame in RX fifo
+	const uint8_t getIndex = retrieveRxFifoGetIndex(fifoIndex);
+	const RxFifoAddress address = {fifoIndex, getIndex};
+
+	const auto [commonHeader, rxHeader] = MessageRam::readRxHeaders(address);
+
+	message.setExtended(bool(commonHeader & CommonHeader::ExtendedId));
+	message.setRemoteTransmitRequest(bool(commonHeader & CommonHeader::RemoteFrame));
+	const auto canid = MessageRam::CanId_t::get(commonHeader);
+	if(message.isExtended()) {
+		message.setIdentifier(canid);
+	} else {
+		message.setIdentifier(canid >> 18);
+	}
+
+	if (filter_id != nullptr) {
+		*filter_id = MessageRam::FilterIndex_t::get(rxHeader);
+	}
+
+	if (timestamp != nullptr) {
+		*timestamp = MessageRam::Timestamp_t::get(rxHeader);
+	}
+
+	const uint8_t dlcValue = MessageRam::RxDlc_t::get(rxHeader);
+	message.setDataLengthCode(dlcValue);
+
+	// required for optimization in MessageRam::readData()
+	static_assert((std::size(decltype(message.data){}) % 4) == 0);
+
+	MessageRam::readData(address, {&message.data[0], message.getLength()});
+	acknowledgeRxFifoRead(fifoIndex, getIndex);
+}
+
+// Internal function to send a CAN message.
+// called by sendMessage and by TX Interrupt.
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::sendMsg(const modm::can::Message& message)
+{
+	if (!McanDriver<id, mrc>::isReadyToSend()) {
+		return false;
+	}
+
+	const uint8_t putIndex = retrieveTxFifoPutIndex();
+	const auto commonHeader = MessageRam::headerFromMessage(message);
+	const auto txHeader = MessageRam::txHeaderFromMessage(message);
+	MessageRam::writeTxHeaders(putIndex, commonHeader, txHeader);
+
+	// required for optimization in MessageRam::readData()
+	static_assert((std::size(decltype(message.data){}) % 4) == 0);
+
+	MessageRam::writeData(putIndex, {&message.data[0], message.getLength()});
+
+	// Make sure data is written to RAM before transfer is started.
+	// Otherwise messages are corrupted.
+	__DMB();
+
+	// Activate the corresponding transmission request
+	Regs()->MCAN_TXBAR = (1u << putIndex);
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::initializeWithPrescaler(
+		CanBitTimingConfiguration standardTimings,
+		std::optional<CanBitTimingConfiguration> fdDataTimings,
+		uint32_t interruptPriority, Mode startupMode,
+		bool overwriteOnOverrun)
+{
+	if constexpr (id == 0) {
+		ClockGen::enable<ClockPeripheral::Can0>();
+	}
+#ifdef MCAN1
+	else if constexpr (id == 1) {
+		ClockGen::enable<ClockPeripheral::Can1>();
+	}
+#endif
+
+	EnterInitMode init;
+
+	MessageRam::setRamBase(uintptr_t(&messageRamMemory[0]));
+
+	// Configure message ram upper 16 bits
+	if constexpr (id == 0) {
+		MATRIX->CCFG_CAN0 = (MATRIX->CCFG_CAN0 & ~CCFG_CAN0_CAN0DMABA_Msk) |
+							CCFG_CAN0_CAN0DMABA((MessageRam::getRamBase() >> 16));
+	}
+#ifdef MCAN1
+	else if constexpr (id == 1) {
+		MATRIX->CCFG_SYSIO = (MATRIX->CCFG_SYSIO & ~CCFG_SYSIO_CAN1DMABA_Msk) |
+							 CCFG_SYSIO_CAN1DMABA((MessageRam::getRamBase() >> 16));
+	}
+#endif
+
+	// Configure nominal bitrate
+	Regs()->MCAN_NBTP =
+		((standardTimings.sjw - 1) << MCAN_NBTP_NSJW_Pos) |
+		((standardTimings.bs2 - 1) << MCAN_NBTP_NTSEG2_Pos) |
+		((standardTimings.bs1 - 1) << MCAN_NBTP_NTSEG1_Pos) |
+		((standardTimings.prescaler - 1) << MCAN_NBTP_NBRP_Pos);
+
+	if(fdDataTimings) {
+		// Configure FD mode fast data bitrate
+		const auto& timings = *fdDataTimings;
+		Regs()->MCAN_DBTP =
+			((timings.sjw - 1) << MCAN_DBTP_DSJW_Pos) |
+			((timings.bs2 - 1) << MCAN_DBTP_DTSEG2_Pos) |
+			((timings.bs1 - 1) << MCAN_DBTP_DTSEG1_Pos) |
+			((timings.prescaler - 1) << MCAN_DBTP_DBRP_Pos)/* |
+			MCAN_DBTP_TDC*/; // enable "Transceiver Delay Compensation"
+	}
+
+	// Timestamp: FDCAN internal counter with prescaler=1
+	// In CAN FD mode the internal timestamp counter TCP does not provide a constant time
+	// base due to the different CAN bit times between arbitration phase and data phase.
+	Regs()->MCAN_TSCC = (1 << MCAN_TSCC_TSS_Pos);
+
+	// Fifo configuration
+	Regs()->MCAN_RXF0C = (overwriteOnOverrun ? MCAN_RXF0C_F0OM : 0) |
+						 MCAN_RXF0C_F0S(MessageRam::RxFifo0Elements) |
+						 MCAN_RXF0C_F0SA(MessageRam::RxFifo0() >> 2);
+	Regs()->MCAN_RXF1C = (overwriteOnOverrun ? MCAN_RXF1C_F1OM : 0) |
+						 MCAN_RXF1C_F1S(MessageRam::RxFifo1Elements) |
+						 MCAN_RXF1C_F1SA(MessageRam::RxFifo1() >> 2);
+
+	// Buffer / FIFO Element Size Configuration
+
+	Regs()->MCAN_RXESC = 0;
+
+	if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 8 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_8_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 12 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_12_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 16 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_16_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 20 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_20_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 24 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_24_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 32 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_32_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 48 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_48_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo0ElementSize - 2*4) == 64 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F0DS_64_BYTE;
+	}
+	else {
+		static_assert(always_false_v<>, "Invalid MessageRam::RxFifo0ElementSize value");
+	}
+
+	if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 8 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_8_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 12 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_12_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 16 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_16_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 20 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_20_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 24 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_24_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 32 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_32_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 48 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_48_BYTE;
+	}
+	else if constexpr ((MessageRam::RxFifo1ElementSize - 2*4) == 64 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_F1DS_64_BYTE;
+	}
+	else {
+		static_assert(always_false_v<>, "Invalid MessageRam::RxFifo1ElementSize value");
+	}
+
+	if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 8 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_8_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 12 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_12_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 16 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_16_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 20 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_20_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 24 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_24_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 32 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_32_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 48 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_48_BYTE;
+	}
+	else if constexpr ((MessageRam::RxBufferElementSize - 2*4) == 64 ) {
+		Regs()->MCAN_RXESC |= MCAN_RXESC_RBDS_64_BYTE;
+	}
+	else {
+		static_assert(always_false_v<>, "Invalid MessageRam::RxBufferElementSize value");
+	}
+
+	if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 8 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_8_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 12 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_12_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 16 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_16_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 20 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_20_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 24 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_24_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 32 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_32_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 48 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_48_BYTE;
+	}
+	else if constexpr ((MessageRam::TxFifoElementSize - 2*4) == 64 ) {
+		Regs()->MCAN_TXESC = MCAN_TXESC_TBDS_64_BYTE;
+	}
+	else {
+		static_assert(always_false_v<>, "Invalid MessageRam::TxFifoElementSize value");
+	}
+
+	// Configure dedicated Rx buffer address
+	Regs()->MCAN_RXBC = MCAN_RXBC_RBSA(MessageRam::RxBuffer() >> 2);
+
+	// Filter configuration
+	Regs()->MCAN_SIDFC = MCAN_SIDFC_LSS(MessageRam::StandardFilterCount) |
+						 MCAN_SIDFC_FLSSA(MessageRam::FilterListStandard() >> 2);
+	Regs()->MCAN_XIDFC = MCAN_XIDFC_LSE(MessageRam::ExtendedFilterCount) |
+						 MCAN_XIDFC_FLESA(MessageRam::FilterListExtended() >> 2);
+
+	// reject non-matching frames, allow remote frames
+	Regs()->MCAN_GFC = MCAN_GFC_ANFE(0b11) | MCAN_GFC_ANFS(0b11);
+
+	// Tx buffer: queue mode, no dedicated transmit buffers
+	Regs()->MCAN_TXBC = MCAN_TXBC_TFQM | MCAN_TXBC_TFQS(MessageRam::TxFifoElements) |
+						MCAN_TXBC_NDTB(0) | MCAN_TXBC_TBSA(MessageRam::TxFifo() >> 2);
+
+	Regs()->MCAN_TXEFC = MCAN_TXEFC_EFS(MessageRam::TxEventFifoEntries) |
+						 MCAN_TXEFC_EFSA(MessageRam::TxEventFifo() >> 2);
+
+	// Enable bit rate switching and CANFD frame format
+	if(fdDataTimings) {
+		Regs()->MCAN_CCCR |= MCAN_CCCR_BRSE | MCAN_CCCR_FDOE;
+	} else {
+		Regs()->MCAN_CCCR &= ~(MCAN_CCCR_BRSE | MCAN_CCCR_FDOE);
+	}
+
+	configureInterrupts(interruptPriority);
+
+	configureMode(startupMode);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::setMode(Mode mode)
+{
+	EnterInitMode init;
+	configureMode(mode);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::configureMode(Mode mode)
+{
+	// Reset all mode register bits
+	Regs()->MCAN_TEST = 0;
+	Regs()->MCAN_CCCR &= ~(MCAN_CCCR_ASM | MCAN_CCCR_MON | MCAN_CCCR_CSR | MCAN_CCCR_TEST);
+
+	// set mode
+	switch(mode) {
+		case Mode::Normal:
+			break;
+		case Mode::Restricted:
+			Regs()->MCAN_CCCR |= MCAN_CCCR_ASM;
+			break;
+		case Mode::Monitoring:
+			Regs()->MCAN_CCCR |= MCAN_CCCR_MON;
+			break;
+		case Mode::Sleep:
+			Regs()->MCAN_CCCR |= MCAN_CCCR_CSR;
+			break;
+		case Mode::TestExternalLoopback:
+			Regs()->MCAN_CCCR |= MCAN_CCCR_TEST;
+			Regs()->MCAN_TEST = MCAN_TEST_LBCK;
+			break;
+		case Mode::TestInternalLoopback:
+			Regs()->MCAN_CCCR |= MCAN_CCCR_TEST | MCAN_CCCR_MON;
+			Regs()->MCAN_TEST = MCAN_TEST_LBCK;
+			break;
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::setAutomaticRetransmission(bool retransmission)
+{
+	if (retransmission) {
+		// Enable retransmission
+		Regs()->MCAN_CCCR &= ~MCAN_CCCR_DAR;
+	} else {
+		// Disable retransmission
+		Regs()->MCAN_CCCR |= MCAN_CCCR_DAR;
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::isMessageAvailable()
+{
+	return rxFifo0HasMessage() || rxFifo1HasMessage();
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::getMessage(can::Message& message, uint8_t *filter_id, uint16_t *timestamp)
+{
+	if (rxFifo0HasMessage()) {
+		readMsg(message, 0, filter_id, timestamp);
+		return true;
+	} else if (rxFifo1HasMessage()) {
+		readMsg(message, 1, filter_id, timestamp);
+		return true;
+	}
+	return false;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::isReadyToSend()
+{
+	return !isHardwareTxQueueFull();
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::sendMessage(const can::Message& message)
+{
+	return sendMsg(message);
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+McanDriver<id, mrc>::BusState
+McanDriver<id, mrc>::getBusState()
+{
+	if (Regs()->MCAN_PSR & MCAN_PSR_BO) {
+		return BusState::Off;
+	}
+	else if (Regs()->MCAN_PSR & MCAN_PSR_EP) {
+		return BusState::ErrorPassive;
+	}
+	else if (Regs()->MCAN_PSR & MCAN_PSR_EW) {
+		return BusState::ErrorWarning;
+	}
+	else {
+		return BusState::Connected;
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setStandardFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier id_,
+	modm::can::StandardMask mask)
+{
+	if (standardIndex >= MessageRam::StandardFilterCount) {
+		return false;
+	}
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Classic,
+		config, uint16_t(id_), uint16_t(mask));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setStandardFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier id0,
+	modm::can::StandardIdentifier id1)
+{
+	if (standardIndex >= MessageRam::StandardFilterCount) {
+		return false;
+	}
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Dual,
+		config, uint16_t(id0), uint16_t(id1));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setStandardRangeFilter(
+	uint8_t standardIndex, FilterConfig config,
+	modm::can::StandardIdentifier first,
+	modm::can::StandardIdentifier last)
+{
+	if (standardIndex >= MessageRam::StandardFilterCount) {
+		return false;
+	}
+
+	MessageRam::setStandardFilter(standardIndex,
+		MessageRam::FilterType::Range,
+		config, uint16_t(first), uint16_t(last));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setExtendedFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier id_,
+	modm::can::ExtendedMask mask)
+{
+	if (extendedIndex >= MessageRam::ExtendedFilterCount) {
+		return false;
+	}
+
+	MessageRam::setExtendedFilterDisabled(extendedIndex);
+
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Classic, uint32_t(mask));
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(id_));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setExtendedFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier id0,
+	modm::can::ExtendedIdentifier id1)
+{
+	if (extendedIndex >= MessageRam::ExtendedFilterCount) {
+		return false;
+	}
+
+	MessageRam::setExtendedFilterDisabled(extendedIndex);
+
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Dual, uint32_t(id1));
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(id0));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+bool
+McanDriver<id, mrc>::setExtendedRangeFilter(
+	uint8_t extendedIndex, FilterConfig config,
+	modm::can::ExtendedIdentifier first,
+	modm::can::ExtendedIdentifier last)
+{
+	if (extendedIndex >= MessageRam::ExtendedFilterCount) {
+		return false;
+	}
+
+	MessageRam::setExtendedFilterDisabled(extendedIndex);
+
+	MessageRam::setExtendedFilter1(extendedIndex,
+		MessageRam::FilterType::Range, uint32_t(last));
+	MessageRam::setExtendedFilter0(extendedIndex,
+		config, uint32_t(first));
+
+	return true;
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::clearStandardFilters()
+{
+	for (unsigned i = 0; i < MessageRam::StandardFilterCount; ++i) {
+		MessageRam::setStandardFilterDisabled(i);
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::clearExtendedFilters()
+{
+	for (unsigned i = 0; i < MessageRam::ExtendedFilterCount; ++i) {
+		MessageRam::setExtendedFilterDisabled(i);
+	}
+}
+
+template<uint8_t id, fdcan::MessageRamConfig mrc>
+void
+McanDriver<id, mrc>::configureInterrupts(uint32_t interruptPriority)
+{
+	if constexpr (id == 0) {
+		NVIC_SetPriority(MCAN0_INT0_IRQn, interruptPriority);
+		NVIC_EnableIRQ(MCAN0_INT0_IRQn);
+	}
+#ifdef MCAN1
+	else if constexpr (id == 1) {
+		NVIC_SetPriority(MCAN1_INT0_IRQn, interruptPriority);
+		NVIC_EnableIRQ(MCAN1_INT0_IRQn);
+	}
+#endif
+}
+
+}

--- a/src/modm/platform/can/sam-mcan/can_instance.hpp.in
+++ b/src/modm/platform/can/sam-mcan/can_instance.hpp.in
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "can.hpp"
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_can_{{ id }}
+/// @brief Mcan{{ id }} instance with configurable message RAM
+template<fdcan::MessageRamConfig mrc = fdcan::defaultMessageRamConfig>
+using Mcan{{ id }}Custom = modm::platform::McanDriver<{{ id }}, mrc>;
+
+
+/// @ingroup modm_platform_can_{{ id }}
+/// @brief Mcan{{ id }} instance with default message RAM config. For more
+/// filters, larger buffers or other options see `Mcan{{ id }}Custom`
+using Mcan{{ id }} = modm::platform::McanDriver<{{ id }}, fdcan::defaultMessageRamConfig>;
+
+}

--- a/src/modm/platform/can/sam-mcan/can_interrupt.cpp.in
+++ b/src/modm/platform/can/sam-mcan/can_interrupt.cpp.in
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "can_{{ id }}.hpp"
+
+namespace modm::platform
+{
+
+McanErrorCallback mcan{{ id }}ErrorCallback{nullptr};
+
+// line 0 used as TX and error interrupt
+// generated on finished frame transmission and error state
+MODM_ISR(MCAN{{ id }}_INT0)
+{
+	if (mcan{{ id }}ErrorCallback) {
+		const bool hasErrorInterrupt = (MCAN{{ id }}->MCAN_IR & (MCAN_IR_BO | MCAN_IR_EW | MCAN_IR_EP));
+		if (hasErrorInterrupt) {
+			mcan{{ id }}ErrorCallback();
+		}
+	}
+	MCAN{{ id }}->MCAN_IR = MCAN_IR_BO | MCAN_IR_EW | MCAN_IR_EP;
+}
+
+}

--- a/src/modm/platform/can/sam-mcan/message_ram.hpp
+++ b/src/modm/platform/can/sam-mcan/message_ram.hpp
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2019, 2023, Raphael Lehmann
+ * Copyright (c) 2021, Christopher Durand
+ * Copyright (c) 2022, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <concepts>
+#include <span>
+
+#include <modm/math/utils/bit_constants.hpp>
+#include <modm/architecture/interface/register.hpp>
+
+/// @cond
+
+namespace modm::platform::fdcan
+{
+
+
+struct MessageRamConfig
+{
+	uint32_t filterCountStandard;
+	uint32_t filterCountExtended;
+	uint32_t rxFifo0Elements;
+	uint32_t rxFifo0ElementSize;
+	uint32_t rxFifo1Elements;
+	uint32_t rxFifo1ElementSize;
+	uint32_t rxBufferElements;
+	uint32_t rxBufferElementSize;
+	uint32_t txEventFifoEntries;
+	uint32_t txFifoElements;
+	uint32_t txFifoElementSize;
+};
+
+constexpr MessageRamConfig defaultMessageRamConfig
+{
+	.filterCountStandard 	= 8,
+	.filterCountExtended	= 8,
+	.rxFifo0Elements		= 32,
+	.rxFifo0ElementSize		= 2*4 + modm::can::Message::capacity,
+	.rxFifo1Elements		= 32,
+	.rxFifo1ElementSize		= 2*4 + modm::can::Message::capacity,
+	.rxBufferElements		= 0,
+	.rxBufferElementSize	= 2*4 + modm::can::Message::capacity,
+	.txEventFifoEntries		= 0,
+	.txFifoElements			= 32,
+	.txFifoElementSize		= 2*4 + modm::can::Message::capacity,
+};
+
+/// Internal class to manage FDCAN message ram
+/// \tparam InstanceIndex index of FDCAN instance (starts at 0)
+/// \tparam Config configuration of the Tx/Rx/Filter/... buffer sizes
+template<uint8_t InstanceIndex, MessageRamConfig config = defaultMessageRamConfig>
+class MessageRam
+{
+public:
+	/// Header common to RX and TX elements
+	enum class CommonFifoHeader : uint32_t
+	{
+		ErrorIndicator 	= Bit31,
+		ExtendedId		= Bit30,
+		RemoteFrame 	= Bit29,
+		// bits 28-0: can id
+	};
+	MODM_FLAGS32(CommonFifoHeader);
+	using CanId_t = Value<CommonFifoHeader_t, 29>;
+
+	/// TX element specific header
+	enum class TxFifoHeader : uint32_t
+	{
+		// bit 31-24: message marker
+		StoreEvents		= Bit23,
+		// bit 22: reserved
+		FdFrame 		= Bit21,
+		BitRateSwitching	= Bit20,
+		// bit 19-16: dlc
+		// bit 15-0: reserved
+	};
+	MODM_FLAGS32(TxFifoHeader);
+	using TxDlc_t = Value<TxFifoHeader_t, 4, 16>;
+
+	/// RX element specific header
+	enum class RxFifoHeader : uint32_t
+	{
+		NonMatchingFrame	= Bit31,
+		// bit 30-24: filter index
+		StoreEvents		= Bit23,
+		// bit 22: reserved
+		FdFrame 		= Bit21,
+		BitRateSwitching	= Bit20,
+		// bit 19-16: dlc
+		// bit 15-0: timestamp
+	};
+	MODM_FLAGS32(RxFifoHeader);
+	using FilterIndex_t = Value<RxFifoHeader_t, 7, 24>;
+	using RxDlc_t = Value<RxFifoHeader_t, 4, 16>;
+	using Timestamp_t = Value<RxFifoHeader_t, 16>;
+
+	enum class FilterType : uint32_t
+	{
+		Range = 0,
+		Dual = (1u << 30),
+		Classic = (1u << 31)
+	};
+
+	enum class FilterConfig : uint32_t
+	{
+		/// skip filter
+		Disabled 	= 0b000u << 27,
+		/// store in RX fifo 0 if filter matches
+		Fifo0		= 0b001u << 27,
+		/// store in RX fifo 1 if filter matches
+		Fifo1		= 0b010u << 27,
+		/// reject if filter matches
+		Reject		= 0b011u << 27
+	};
+public:
+	static constexpr uint32_t StandardFilterCount 	= config.filterCountStandard;
+	static constexpr uint32_t StandardFilterSize	= 1*4;
+	static constexpr uint32_t ExtendedFilterCount	= config.filterCountExtended;
+	static constexpr uint32_t ExtendedFilterSize	= 2*4;
+	static constexpr uint32_t RxFifo0Elements		= config.rxFifo0Elements;
+	static constexpr uint32_t RxFifo0ElementSize	= config.rxFifo0ElementSize;
+	static constexpr uint32_t RxFifo1Elements		= config.rxFifo1Elements;
+	static constexpr uint32_t RxFifo1ElementSize	= config.rxFifo1ElementSize;
+	static constexpr uint32_t RxBufferElements		= config.rxBufferElements;
+	static constexpr uint32_t RxBufferElementSize	= config.rxBufferElementSize;
+	static constexpr uint32_t TxEventFifoEntries	= config.txEventFifoEntries;
+	static constexpr uint32_t TxEventFifoEntrySize	= 2*4;
+	static constexpr uint32_t TxFifoElements		= config.txFifoElements;
+	static constexpr uint32_t TxFifoElementSize		= config.txFifoElementSize;
+
+	/// Total message ram size in bytes
+	static constexpr uint32_t Size =
+		(StandardFilterCount * StandardFilterSize) +
+		(ExtendedFilterCount * ExtendedFilterSize) +
+		(RxFifo0Elements * RxFifo0ElementSize) +
+		(RxFifo1Elements * RxFifo1ElementSize) +
+		(RxBufferElements * RxBufferElementSize) +
+		(TxEventFifoEntries * TxEventFifoEntrySize) +
+		(TxFifoElements * TxFifoElementSize);
+
+	// InstanceIndex is not really used (anymore), but needed to have a unique MessageRam<> type for
+	// each CAN peripheral
+	static inline uintptr_t RamBase;
+	static void setRamBase(uintptr_t address) { RamBase = address; }
+	static uintptr_t getRamBase() { return RamBase; }
+
+	static constexpr uintptr_t FilterListStandardOffset = 0;
+	static constexpr uintptr_t FilterListExtendedOffset = FilterListStandardOffset + (StandardFilterCount * StandardFilterSize);
+	static constexpr uintptr_t RxFifo0Offset = FilterListExtendedOffset + (ExtendedFilterCount * ExtendedFilterSize);
+	static constexpr uintptr_t RxFifo1Offset = RxFifo0Offset + (RxFifo0Elements * RxFifo0ElementSize);
+	static constexpr uintptr_t RxBufferOffset = RxFifo1Offset + (RxFifo1Elements * RxFifo1ElementSize);
+	static constexpr uintptr_t TxEventFifoOffset = RxBufferOffset + (RxBufferElements * RxBufferElementSize);
+	static constexpr uintptr_t TxFifoOffset = TxEventFifoOffset + (TxEventFifoEntries * TxEventFifoEntrySize);
+
+
+	static uintptr_t FilterListStandard() { return getRamBase() + FilterListStandardOffset; }
+	static uintptr_t FilterListExtended() { return getRamBase() + FilterListExtendedOffset; }
+	static uintptr_t RxFifo0() { return getRamBase() + RxFifo0Offset; }
+	static uintptr_t RxFifo1() { return getRamBase() + RxFifo1Offset; }
+	static uintptr_t RxBuffer() { return getRamBase() + RxBufferOffset; }
+	static uintptr_t TxEventFifo() { return getRamBase() + TxEventFifoOffset; }
+	static uintptr_t TxFifo() { return getRamBase() + TxFifoOffset; }
+
+	/// Address of element in RX FIFO
+	struct RxFifoAddress
+	{
+		uint8_t fifoIndex;
+		uint8_t getIndex;
+
+		/// \returns pointer to RX fifo element
+		uint32_t*
+		ptr() const
+		{
+			if (fifoIndex == 0)
+				return reinterpret_cast<uint32_t*>(RxFifo0() +
+												   (getIndex * RxFifo0ElementSize));
+			else
+				return reinterpret_cast<uint32_t*>(RxFifo1() +
+												   (getIndex * RxFifo1ElementSize));
+		}
+	};
+
+	/// \returns pointer to element in TX queue
+	static uint32_t*
+	txFifoElement(uint8_t putIndex)
+	{
+		return reinterpret_cast<uint32_t*>(getRamBase() + TxFifoOffset +
+										   (putIndex * TxFifoElementSize));
+	}
+
+	/// \returns pointer to standard filter element
+	static uint32_t*
+	standardFilter(uint8_t index)
+	{
+		const auto address = getRamBase() + FilterListStandardOffset + (index * StandardFilterSize);
+		return reinterpret_cast<uint32_t*>(address);
+	}
+
+	/// \returns pointer to extended filter element
+	static uint32_t*
+	extendedFilter(uint8_t index)
+	{
+		const auto address = getRamBase() + FilterListExtendedOffset + (index * ExtendedFilterSize);
+		return reinterpret_cast<uint32_t*>(address);
+	}
+public:
+	/// Write TX element headers to TX queue
+	static void
+	writeTxHeaders(uint8_t putIndex, CommonFifoHeader_t common, TxFifoHeader_t tx)
+	{
+		uint32_t* messageRam = txFifoElement(putIndex);
+		*messageRam++ = common.value;
+		*messageRam = tx.value;
+	}
+
+	/// Read RX element headers from RX fifo
+	static std::tuple<CommonFifoHeader, RxFifoHeader>
+	readRxHeaders(RxFifoAddress address)
+	{
+		const uint32_t* messageRam = address.ptr();
+		const auto commonHeader = CommonFifoHeader{*messageRam++};
+		const auto rxHeader = RxFifoHeader{*messageRam};
+		return {commonHeader, rxHeader};
+	}
+
+	/// Read message data from RX fifo
+	static void
+	readData(RxFifoAddress address, std::span<uint8_t> outData)
+	{
+		const auto size = std::min(outData.size(), 64u);
+
+		// + 2: skip 2x32 bit headers
+		const uint32_t* messageRam = address.ptr() + 2;
+		// message data must be read in 32bit accesses, memcpy on message ram does not work
+		for (auto i = 0u; i < size; i += 4) {
+			const uint32_t receivedData = *messageRam++;
+
+			// copy in 32 bit words, memcpy is optimized to single store instruction
+			// CAN message buffer must fit full multiples of 4 bytes
+			std::memcpy(&outData[i], &receivedData, 4);
+		}
+	}
+
+	/// Write message data to TX queue
+	static void
+	writeData(uint_fast8_t putIndex, std::span<const uint8_t> inData)
+	{
+		const auto size = std::min(inData.size(), 64u);
+
+		// + 2: skip 2x32 bit headers
+		uint32_t* messageRam = txFifoElement(putIndex) + 2;
+		// message data must be written in 32bit accesses, memcpy to message ram does not work
+		for (auto i = 0u; i < size; i += 4) {
+			uint32_t outputData{};
+			// copy in 32 bit words, memcpy is optimized to single store instruction
+			// CAN message buffer must fit full multiples of 4 bytes
+			std::memcpy(&outputData, &inData[i], 4);
+			*messageRam++ = outputData;
+		}
+	}
+
+	/// Construct common fifo header from CanMessage
+	static CommonFifoHeader_t
+	headerFromMessage(const modm::can::Message& message)
+	{
+		CommonFifoHeader_t header = (message.isExtended() ? CommonFifoHeader::ExtendedId : CommonFifoHeader(0))
+			| (message.isRemoteTransmitRequest() ? CommonFifoHeader::RemoteFrame : CommonFifoHeader(0));
+
+		const auto canId = message.isExtended() ? message.getIdentifier() : (message.getIdentifier() << 18);
+		CanId_t::set(header, canId);
+
+		return header;
+	}
+
+	/// Construct Tx Header from CanMessage
+	static TxFifoHeader_t
+	txHeaderFromMessage(const modm::can::Message& message)
+	{
+		TxFifoHeader_t header = (message.isFlexibleData() ? TxFifoHeader::FdFrame : TxFifoHeader(0))
+			| (message.isBitRateSwitching() ? TxFifoHeader::BitRateSwitching : TxFifoHeader(0));
+
+		const uint8_t dlc = message.getDataLengthCode();
+		MessageRam::TxDlc_t::set(header, dlc);
+
+		return header;
+	}
+
+	static void
+	setStandardFilter(uint8_t index, FilterType type, FilterConfig filterConfig, uint16_t id1, uint16_t id2)
+	{
+		constexpr auto idMask = (1u << 11) - 1;
+		*standardFilter(index) = uint32_t(type) | uint32_t(filterConfig) |
+			(id2 & idMask) | ((id1 & idMask) << 16);
+	}
+
+	static void
+	setExtendedFilter0(uint8_t index, FilterConfig filterConfig, uint32_t id)
+	{
+		constexpr auto idMask = (1u << 29) - 1;
+		*extendedFilter(index) = (uint32_t(filterConfig) << 2) | (id & idMask);
+	}
+
+	static void
+	setExtendedFilter1(uint8_t index, FilterType type, uint32_t id)
+	{
+		constexpr auto idMask = (1u << 29) - 1;
+		*(extendedFilter(index) + 1) = uint32_t(type) | (id & idMask);
+	}
+
+	static void
+	setStandardFilterDisabled(uint8_t index)
+	{
+		*standardFilter(index) = 0;
+	}
+
+	static void
+	setExtendedFilterDisabled(uint8_t index)
+	{
+		*extendedFilter(index) = 0;
+	}
+
+};
+
+}	// namespace modm::platform::fdcan
+
+/// @endcond

--- a/src/modm/platform/can/sam-mcan/module.lb
+++ b/src/modm/platform/can/sam-mcan/module.lb
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Christopher Durand
+# Copyright (c) 2022-2023, Raphael Lehmann
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+class Instance(Module):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        device = env[":target"]
+        driver = device.get_driver("mcan")
+
+        properties = {}
+        properties["target"] = target = device.identifier
+        properties["driver"] = driver
+        properties["id"] = self.instance
+        properties["reg"] = 'MCAN{}'.format(self.instance)
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/can"
+
+        env.template("can_instance.hpp.in", "can_{}.hpp".format(self.instance))
+        env.template("can_interrupt.cpp.in", "can_interrupt_{}.cpp".format(self.instance))
+
+
+def init(module):
+    module.name = ":platform:can"
+    module.description = "Controller Area Network with Flexible Data-Rate (MCAN)"
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("mcan:sam*"):
+        return False
+    if device.identifier.variant == 'a':
+        return False
+
+    module.depends(
+        ":architecture:assert",
+        ":architecture:can",
+        ":architecture:clock",
+        ":cmsis:device",
+        ":platform:can.common",
+        ":platform:gpio")
+
+    driver = device.get_driver("mcan")
+
+    # Ignore duplicate instances, because modm-devices data is buggy
+    instances = list(dict.fromkeys(listify(driver["instance"])))
+
+    for instance in instances:
+        module.add_submodule(Instance(int(instance)))
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/platform/can"
+    env.copy("can.hpp")
+    env.copy("can_impl.hpp")
+    env.copy("message_ram.hpp")

--- a/src/modm/platform/clock/sam_pmc/clockgen.cpp.in
+++ b/src/modm/platform/clock/sam_pmc/clockgen.cpp.in
@@ -11,6 +11,7 @@
 // ----------------------------------------------------------------------------
 
 #include "clockgen.hpp"
+#include <algorithm>
 #include <cmath>
 
 // CMSIS Core compliance
@@ -132,6 +133,33 @@ ClockGen::pllBFrequency()
 	uint32_t freq = SlowClkFreqHz * mul;
 	if(PMC->PMC_MCKR & PMC_MCKR_PLLBDIV2) freq /= 2;
 	return freq;
+}
+%% endif
+
+%% if target.family == "e7x/s7x/v7x"
+void
+ClockGen::enablePck(Pck clock)
+{
+	PMC->PMC_SCER = 1u << (PMC_SCER_PCK0_Pos + static_cast<uint8_t>(clock));
+
+	int_fast16_t deadlockPreventer = 10'000;  // max ~10ms
+	const uint8_t pckrdyPos = PMC_SR_PCKRDY0_Pos + static_cast<uint8_t>(clock);
+	while (((PMC->PMC_SR & (1 << pckrdyPos)) == 0) and (deadlockPreventer-- > 0))
+		modm::delay(std::chrono::microseconds{1});
+	modm_assert(deadlockPreventer > 0, "clockgen.pck.enable", "timeout expired");
+}
+
+void
+ClockGen::disablePck(Pck clock)
+{
+	PMC->PMC_SCDR = 1u << (PMC_SCDR_PCK0_Pos + static_cast<uint8_t>(clock));
+}
+
+void
+ClockGen::configurePck(Pck clock, PckSource source, uint16_t divider)
+{
+	PMC->PMC_PCK[uint8_t(clock)] = PMC_PCK_CSS(uint8_t(source)) |
+		PMC_PCK_PRES(std::clamp<uint16_t>(divider, 1, 256) - 1);
 }
 %% endif
 

--- a/src/modm/platform/clock/sam_pmc/clockgen.hpp.in
+++ b/src/modm/platform/clock/sam_pmc/clockgen.hpp.in
@@ -228,6 +228,32 @@ UtmiRefClk : uint32_t
 %% endif
 
 static constexpr uint32_t SlowClkFreqHz = 32'768;
+
+%% if target.family == "e7x/s7x/v7x"
+/// Programmable clocks
+enum class Pck
+{
+	Pck0 = 0,
+	Pck1 = 1,
+	Pck2 = 2,
+	Pck3 = 3,
+	Pck4 = 4,
+	Pck5 = 5,
+	Pck6 = 6,
+	Pck7 = 7
+};
+
+/// Programmable clock sources
+enum class PckSource
+{
+	SlowClock = PMC_PCK_CSS_SLOW_CLK,
+	MainClock = PMC_PCK_CSS_MAIN_CLK,
+	PllA = PMC_PCK_CSS_PLLA_CLK,
+	UPll = PMC_PCK_CSS_UPLL_CLK,
+	Mck = PMC_PCK_CSS_MCK
+};
+%% endif
+
 /// @}
 
 /**
@@ -295,6 +321,20 @@ public:
 	template<UtmiRefClk refclk>
 	static void
 	enableUPll(uint32_t wait_cycles = 50);
+
+	static void
+	enablePck(Pck clock);
+
+	static void
+	disablePck(Pck clock);
+
+	/**
+	 * Configure programmable clock.
+	 * @warning The clock must be disabled when changing configuration.
+	 * @param divider clock divider (1-256)
+	 */
+	static void
+	configurePck(Pck clock, PckSource source, uint16_t divider);
 %% endif
 
 	template <MasterClkSource src, MasterClkPrescaler pres,

--- a/src/modm/platform/clock/sam_pmc/clockgen_impl.hpp.in
+++ b/src/modm/platform/clock/sam_pmc/clockgen_impl.hpp.in
@@ -169,7 +169,7 @@ template<UtmiRefClk refclk>
 void
 ClockGen::enableUPll(uint32_t wait_cycles)
 {
-	REG_UTMI_CKTRIM = refclk;
+	UTMI->UTMI_CKTRIM = static_cast<uint32_t>(refclk);
 	PMC->CKGR_UCKR =
 		CKGR_UCKR_UPLLCOUNT(wait_cycles) |
 		CKGR_UCKR_UPLLEN;

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -24,7 +24,7 @@ env["COMPILERPREFIX"] = "arm-none-eabi-"
 %% endif
 %% if family == "darwin"
 # Using homebrew gcc on macOS instead of clang
-env["COMPILERSUFFIX"] = env.Detect(["gcc-13", "gcc-12", "gcc-11", "gcc-10"])[3:]
+env["COMPILERSUFFIX"] = env.Detect(["gcc-12", "gcc-11", "gcc-10"])[3:]
 %% endif
 %% endif
 


### PR DESCRIPTION
- [x] Porting of ST's FDCAN periphal driver (based on the same 3rd party intellectual property)
- [x] Use of existing the `message_ram.hpp` implementation
- [x] Add CAN pinout to SAMV71-XPLAINED board module (there is a CAN transceiver on the dev board!)
- [x] Adapt `connect<...>()`
- [x] Update HAL matrix
- [x] Long frame and fast frame support
- [x] Remove software-buffers and make hardware-buffers directly accessible and configurable.
- [x] Test on real hardware