### PR TITLE
Add SAMx7x PWM driver

### DIFF
--- a/examples/samv71_xplained_ultra/pwm/main.cpp
+++ b/examples/samv71_xplained_ultra/pwm/main.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+// Complementary output on PWM0 Channel2 High / Low outputs
+using OutH2 = GpioC19;
+using OutL2 = GpioD26;
+
+int main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "PWM Test" << modm::endl;
+
+	Pwm0::connect<OutH2::PwmH2, OutL2::PwmL2>();
+
+	Pwm0::initialize();
+	// Period 1500 => MCLK / 1500 = 100 kHz
+	Pwm0::setPeriod(Pwm0::Channel::Ch2, 1500);
+	// 500/1500 = 33.3% duty-cycle
+	Pwm0::setDutyCycle(Pwm0::Channel::Ch2, 500);
+
+	constexpr auto mode = Pwm0::ChannelMode()
+		.setClock(Pwm0::ChannelClock::Mck)
+		.setDeadTimeGeneration(Pwm0::DeadTimeGeneration::Enabled);
+
+	Pwm0::setChannelMode(Pwm0::Channel::Ch2, mode);
+
+	// Set 50 ticks dead-time for both high and low output
+	const auto deadTimeL = 50; // ticks
+	const auto deadTimeH = 50; // ticks
+	Pwm0::setDeadTime(Pwm0::Channel::Ch2, deadTimeL, deadTimeH);
+
+	// Set all outputs to low in override mode
+	Pwm0::configureOutputOverrideValues(Pwm0::Outputs_t{});
+
+	Pwm0::enableChannelOutput(Pwm0::Channels::Ch2);
+
+	while (true)
+	{
+		Led0::toggle();
+		Led1::toggle();
+		modm::delay(500ms);
+
+		// Activate override mode to force outputs to low when button is pressed
+		const auto outputs = Pwm0::Outputs::Ch2PwmH | Pwm0::Outputs::Ch2PwmL;
+		if (ButtonSW0::read())
+			Pwm0::setOutputOverride(outputs, false);
+		else
+			Pwm0::clearOutputOverride(outputs, false);
+
+	}
+
+	return 0;
+}

--- a/examples/samv71_xplained_ultra/pwm/project.xml
+++ b/examples/samv71_xplained_ultra/pwm/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:samv71-xplained-ultra</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/samv71_xplained_ultra/pwm</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:pwm:*</module>
+  </modules>
+</library>

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -51,7 +51,7 @@ struct SystemClock
 
 using Led0 = GpioA23;
 using Led1 = GpioC9;
-using ButtonSW0 = GpioA9;
+using ButtonSW0 = GpioInverted<GpioA9>;
 
 using Leds = SoftwareGpioPort<Led1, Led0>;
 

--- a/src/modm/platform/gpio/sam/pin.hpp.in
+++ b/src/modm/platform/gpio/sam/pin.hpp.in
@@ -61,6 +61,19 @@ enum class PeripheralPin
 	I2sdi,
 	I2sdo,
 	I2smck,
+	PwmH0,
+	PwmH1,
+	PwmH2,
+	PwmH3,
+	PwmL0,
+	PwmL1,
+	PwmL2,
+	PwmL3,
+	PwmFi0,
+	PwmFi1,
+	PwmFi2,
+	PwmExtrg0,
+	PwmExtrg1
 };
 
 template<typename... Tuples>
@@ -550,7 +563,19 @@ public:
 	using I2sdi = As<PeripheralPin::I2sdi>;
 	using I2sdo = As<PeripheralPin::I2sdo>;
 	using I2smck = As<PeripheralPin::I2smck>;
-
+	using PwmH0 = As<PeripheralPin::PwmH0>;
+	using PwmH1 = As<PeripheralPin::PwmH1>;
+	using PwmH2 = As<PeripheralPin::PwmH2>;
+	using PwmH3 = As<PeripheralPin::PwmH3>;
+	using PwmL0 = As<PeripheralPin::PwmL0>;
+	using PwmL1 = As<PeripheralPin::PwmL1>;
+	using PwmL2 = As<PeripheralPin::PwmL2>;
+	using PwmL3 = As<PeripheralPin::PwmL3>;
+	using PwmFi0 = As<PeripheralPin::PwmFi0>;
+	using PwmFi1 = As<PeripheralPin::PwmFi1>;
+	using PwmFi2 = As<PeripheralPin::PwmFi2>;
+	using PwmExtrg0 = As<PeripheralPin::PwmExtrg0>;
+	using PwmExtrg1 = As<PeripheralPin::PwmExtrg1>;
 
 	inline static bool
 	read()

--- a/src/modm/platform/pwm/sam_x7x/module.lb
+++ b/src/modm/platform/pwm/sam_x7x/module.lb
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021, Jeff McBride
+# Copyright (c) 2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+props = {}
+class Instance(Module):
+    def __init__(self, driver, instance):
+        self.driver = driver
+        self.instance = int(instance)
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        global props
+        props["id"] = self.instance
+
+        env.substitutions = props
+        env.outbasepath = "modm/src/modm/platform/pwm"
+        env.template("pwm.hpp.in", "pwm_{}.hpp".format(self.instance))
+        env.template("pwm_impl.hpp.in", "pwm_{}_impl.hpp".format(self.instance))
+
+def init(module):
+    module.name = ":platform:pwm"
+    module.description = "PWM Generator"
+
+def prepare(module, options):
+    device = options[":target"]
+    family = device.identifier.family
+    if not device.has_driver("pwm:sam*") or family != "e7x/s7x/v7x":
+        return False
+
+    module.depends(
+        ":cmsis:device",
+        ":platform:clock",
+        ":platform:gpio")
+
+    timers = device.get_all_drivers("pwm:sam*")
+    for driver in timers:
+        for instance in driver["instance"]:
+            instance = int(instance)
+            module.add_submodule(Instance(driver, instance))
+
+    global props
+    device = options[":target"]
+    props["target"] = device.identifier
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/platform/pwm"
+    env.substitutions = props
+    env.template("pwm_base.hpp.in", "pwm_base.hpp")
+    env.template("pwm_base_impl.hpp.in", "pwm_base_impl.hpp")

--- a/src/modm/platform/pwm/sam_x7x/pwm.hpp.in
+++ b/src/modm/platform/pwm/sam_x7x/pwm.hpp.in
@@ -1,0 +1,178 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAM_PWM{{ id }}_HPP
+#define MODM_SAM_PWM{{ id }}_HPP
+
+#include <modm/platform/clock/clockgen.hpp>
+#include <modm/platform/pwm/pwm_base.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Four channel complementary PWM generator.
+ *
+ * \todo External trigger inputs, fault inputs and DMA are not supported.
+ *
+ * \author Christopher Durand
+ * \ingroup		modm_platform_i2c modm_platform_i2c_{{id}}
+ */
+
+class Pwm{{ id }} : public PwmBase
+{
+public:
+	/// Connect GPIO pin to peripheral
+	template<typename... Pins>
+	static void
+	connect();
+
+	/// Initialize peripheral
+	/// Must be called prior to using any other function except connect()
+	static void
+	initialize();
+
+	/// Setup ClockA or ClockB divided tinmer clocks
+	/// \param clock clock to configure
+	/// \param preDiv 2^N pre-divider
+	/// \param div 1..255 clock divider, set to 0 to disable clock
+	static void
+	configureDividedClock(DividedClock clock, PreDivider preDiv, uint8_t div);
+
+	/** Configure channel mode settings
+	 *
+	 * \warning Disable channel output before changing the configuration.
+	 *
+	 * Example usage:
+	 * \code
+	 * constexpr auto mode = Pwm{{id}}::ChannelMode()
+	 *   .setClock(Pwm{{id}}::ChannelClock::Mck)
+	 *   .setDeadTimeGeneration(Pwm{{id}}::DeadTimeGeneration::Enabled);
+	 *
+	 * Pwm{{id}}::setChannelMode(Pwm{{id}}::Channel::Ch1, mode);
+	 * \endcode
+	 */
+	static void
+	setChannelMode(Channel channel, ChannelMode mode);
+
+	/// Get current channel mode configuration
+	static ChannelMode
+	channelMode(Channel channel);
+
+	/// Set counter period (1 .. (2^16 - 1))
+	static void
+	setPeriod(Channel channel, uint16_t period);
+
+	/// Update counter period at the start of the next cycle
+	/// \warning Cannot be used for the initial configuration, no update will occur.
+	static void
+	setPeriodUpdate(Channel channel, uint16_t period);
+
+	/// Read the current counter period.
+	static uint16_t
+	period(Channel channel);
+
+	/// Set channel duty cycle (0 .. period)
+	static void
+	setDutyCycle(Channel channel, uint16_t dutyCycle);
+
+	/// Update channel duty-cycle at the start of the next cycle
+	/// \warning Cannot be used for the initial configuration, no update will occur.
+	static void
+	setDutyCycleUpdate(Channel channel, uint16_t dutyCycle);
+
+	/// Read the current duty cycle
+	static uint16_t
+	dutyCycle(Channel channel);
+
+	/// Read the current timer counter value
+	static uint16_t
+	counter(Channel channel);
+
+	/// Enable channel output
+	static void
+	enableChannelOutput(Channels_t channels);
+
+	/// Disable channel output
+	static void
+	disableChannelOutput(Channels_t channels);
+
+	/// Read currently enabled channels
+	static Channels_t
+	isChannelOutputEnabled();
+
+	/// Configure dead-time duration.
+	/// Dead-time must be enabled in the channel mode register or this setting has no effect.
+	/// \param pwmL Low output dead-time in timer ticks
+	/// \param pwmH High output dead-time in timer ticks
+	static void
+	setDeadTime(Channel channel, uint16_t pwmL, uint16_t pwmH);
+
+	/// Configure output state in override mode
+	/// \param outputHigh If the respective output flag is set the output is high, else low.
+	static void
+	configureOutputOverrideValues(Outputs_t outputHigh);
+
+	/// Enable output override mode
+	/// \param outputs Enable override for all set outputs
+	/// \param immediateUpdate Update at next cycle if false, else immediately.
+	static void
+	setOutputOverride(Outputs_t outputs, bool immediateUpdate = true);
+
+	/// Disable output override mode
+	/// \param outputs Disable override for all set outputs
+	/// \param immediateUpdate Update at next cycle if false, else immediately.
+	static void
+	clearOutputOverride(Outputs_t outputs, bool immediateUpdate = true);
+
+	/// Enable interrupt flags
+	static void
+	enableInterrupt(Interrupt_t interrupt);
+
+	/// Disable interrupt flags
+	static void
+	disableInterrupt(Interrupt_t interrupt);
+
+	/// Get enabled interrupt flags
+	static Interrupt_t
+	isInterruptEnabled();
+
+	static void
+	enableInterruptVector(uint32_t priority);
+
+	static void
+	disableInterruptVector();
+
+	/// Read interrupt flags. All flags are automatically cleared on read.
+	static Interrupt_t
+	readInterruptFlags();
+
+	/// Convert channel flags to the corresponding event interrupt flags
+	static constexpr Interrupt_t
+	eventInterruptFlags(Channels_t channels);
+
+	/// Configure channels in synchronized mode (see datasheet).
+	/// Only update method 1 (UPDM = 0) is supported for now.
+	static void
+	configureSynchronousChannels(Channels_t syncChannels);
+
+	/// Update synchronous channels period, duty cycle and dead-time at next period
+	static void
+	updateSynchronousChannels();
+};
+
+} // namespace modm::platform
+
+#include "pwm_{{ id }}_impl.hpp"
+
+#endif // MODM_SAM_PWM{{ id }}_HPP
+

--- a/src/modm/platform/pwm/sam_x7x/pwm_base.hpp.in
+++ b/src/modm/platform/pwm/sam_x7x/pwm_base.hpp.in
@@ -1,0 +1,298 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAM_PWM_BASE_HPP
+#define MODM_SAM_PWM_BASE_HPP
+
+#include <cstdint>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/platform/gpio/pin.hpp>
+
+namespace modm::platform
+{
+
+class PwmBase
+{
+public:
+	enum class Channel : uint8_t
+	{
+		Ch0 = 0,
+		Ch1 = 1,
+		Ch2 = 2,
+		Ch3 = 3
+	};
+
+	enum class Channels : uint8_t
+	{
+		Ch0 = Bit0,
+		Ch1 = Bit1,
+		Ch2 = Bit2,
+		Ch3 = Bit3
+	};
+	MODM_FLAGS8(Channels);
+
+	enum class PreDivider : uint8_t
+	{
+		Div1 = 0,
+		Div2 = 1,
+		Div4 = 2,
+		Div8 = 3,
+		Div16 = 4,
+		Div32 = 5,
+		Div64 = 6,
+		Div128 = 7,
+		Div256 = 8,
+		Div512 = 9,
+		Div1024 = 10
+	};
+
+	enum class DividedClock : uint8_t
+	{
+		ClockA = 0,
+		ClockB = 1
+	};
+
+	enum class Outputs : uint32_t
+	{
+		Ch0PwmH = Bit0,
+		Ch1PwmH = Bit1,
+		Ch2PwmH = Bit2,
+		Ch3PwmH = Bit3,
+		Ch0PwmL = Bit16,
+		Ch1PwmL = Bit17,
+		Ch2PwmL = Bit18,
+		Ch3PwmL = Bit19,
+
+		Mask = PWM_OS_Msk
+	};
+	MODM_FLAGS32(Outputs);
+
+	enum class Interrupt : uint32_t
+	{
+		Ch0Event = Bit0,
+		Ch1Event = Bit1,
+		Ch2Event = Bit2,
+		Ch3Event = Bit3,
+		Ch0Fault = Bit16,
+		Ch1Fault = Bit17,
+		Ch2Fault = Bit18,
+		Ch3Fault = Bit19
+	};
+	MODM_FLAGS32(Interrupt);
+
+	enum class ChannelClock
+	{
+		Mck = PWM_CMR_CPRE_MCK,
+		MckDiv2 = PWM_CMR_CPRE_MCK_DIV_2,
+		MckDiv4 = PWM_CMR_CPRE_MCK_DIV_4,
+		MckDiv8 = PWM_CMR_CPRE_MCK_DIV_8,
+		MckDiv16 = PWM_CMR_CPRE_MCK_DIV_16,
+		MckDiv32 = PWM_CMR_CPRE_MCK_DIV_32,
+		MckDiv64 = PWM_CMR_CPRE_MCK_DIV_64,
+		MckDiv128 = PWM_CMR_CPRE_MCK_DIV_128,
+		MckDiv256 = PWM_CMR_CPRE_MCK_DIV_256,
+		MckDiv512 = PWM_CMR_CPRE_MCK_DIV_512,
+		MckDiv1024 = PWM_CMR_CPRE_MCK_DIV_1024,
+		ClockA = PWM_CMR_CPRE_CLKA,
+		ClockB = PWM_CMR_CPRE_CLKB,
+
+		Mask = PWM_CMR_CPRE_Msk
+	};
+
+	enum class ChannelAlignment
+	{
+		LeftAligned = 0,
+		CenterAligned = PWM_CMR_CALG,
+
+		Mask = CenterAligned
+	};
+
+	enum class ComparatorPolarity
+	{
+		StartLow = 0,
+		StartHigh = PWM_CMR_CPOL,
+
+		Mask = StartHigh
+	};
+
+	/// Configuration for center-aligned mode counter event and update
+	/// If EnableEvent is set a counter event will also be triggered at half-period.
+	/// If EnableUpdate is set a register update will also be triggered at half-period.
+	/// Unused in left-aligned mode.
+	enum class HalfPeriodMode : uint32_t
+	{
+		EnableEvent = PWM_CMR_CES,
+		EnableUpdate = PWM_CMR_UPDS,
+
+		Mask = PWM_CMR_CES | PWM_CMR_UPDS
+	};
+	MODM_FLAGS32(HalfPeriodMode);
+
+	/// Set if the comparator output polarity is inverted in disabled state.
+	/// If normal is set the output corresponds to the setting of the comparator
+	/// polarity (CPOL bit). If inverted is selected it is inverted respective to that.
+	enum class DisabledPolarity
+	{
+		Normal = 0,
+		Inverted = PWM_CMR_DPOLI,
+
+		Mask = Inverted
+	};
+
+	/// Set source of trigger output to Timer / Counter peripheral
+	enum class TcTriggerSource
+	{
+		Comparator = 0,
+		CounterEvent = PWM_CMR_TCTS,
+
+		Mask = CounterEvent
+	};
+
+	enum class DeadTimeGeneration
+	{
+		Disabled = 0,
+		Enabled = PWM_CMR_DTE,
+
+		Mask = Enabled
+	};
+
+	/// Invert output polarity (after dead-time generator, no effect on override mode)
+	enum class OutputPolarity
+	{
+		PwmHInverted = PWM_CMR_DTHI,
+		PwmLInverted = PWM_CMR_DTLI,
+
+		Mask = (PWM_CMR_DTHI | PWM_CMR_DTLI)
+	};
+
+	enum class PushPullMode
+	{
+		Disabled = 0,
+		Enabled = PWM_CMR_PPM,
+
+		Mask = Enabled
+	};
+
+	/**
+	 * Channel mode config
+	 *
+	 * Example usage:
+	 * \code
+	 * constexpr auto mode = Pwm{{id}}::ChannelMode()
+	 *   .setClock(Pwm{{id}}::ChannelClock::Mck)
+	 *   .setDeadTimeGeneration(Pwm{{id}}::DeadTimeGeneration::Enabled);
+	 *
+	 * Pwm{{id}}::setChannelMode(Pwm{{id}}::Channel::Ch1, mode);
+	 * \endcode
+	 */
+	struct ChannelMode
+	{
+		/// Set channel clock source
+		constexpr ChannelMode
+		setClock(ChannelClock clock);
+
+		/// Read channel clock source
+		constexpr ChannelClock
+		clock() const;
+
+		/// Set channel alignment (left / center-aligned)
+		constexpr ChannelMode
+		setAlignment(ChannelAlignment alignment);
+
+		/// Read channel alignment (left / center-aligned)
+		constexpr ChannelAlignment
+		alignment() const;
+
+		/// Set channel comparator polarity
+		constexpr ChannelMode
+		setComparatorPolarity(ComparatorPolarity polarity);
+
+		/// Read channel comparator polarity
+		constexpr ComparatorPolarity
+		comparatorPolarity() const;
+
+		/// Configure center-aligned mode counter event and update at half-cycle
+		/// Unused in left-aligned mode.
+		constexpr ChannelMode
+		setHalfPeriodMode(HalfPeriodMode mode);
+
+		/// Read center-aligned mode counter event and update at half-cycle
+		constexpr HalfPeriodMode
+		halfPeriodMode() const;
+
+		// Invert channel polarity in disabled state
+		constexpr ChannelMode
+		setDisabledPolarity(DisabledPolarity polarity);
+
+		constexpr DisabledPolarity
+		disabledPolarity() const;
+
+		// Configure trigger output source to Timer / Counter peripheral
+		constexpr ChannelMode
+		setTcTriggerSource(TcTriggerSource source);
+
+		constexpr TcTriggerSource
+		tcTriggerSource() const;
+
+		/// Enable or disable dead-time generatiom
+		constexpr ChannelMode
+		setDeadTimeGeneration(DeadTimeGeneration deadTime);
+
+		constexpr DeadTimeGeneration
+		deadTimeGeneration() const;
+
+		/// Set inverted output polarity (after dead-time generator, no effect on override mode)
+		constexpr ChannelMode
+		setOutputPolarity(OutputPolarity polarity);
+
+		constexpr OutputPolarity
+		outputPolarity() const;
+
+		/// Set push-pull mode
+		/// Special mode for transformer-based power converters to avoid core DC saturation.
+		constexpr ChannelMode
+		setPushPullMode(PushPullMode mode);
+
+		constexpr PushPullMode
+		pushPullMode() const;
+
+		/// raw PWM_CMRx register value
+		uint32_t value{};
+	};
+};
+
+} // namespace modm::platform
+
+/// \cond
+namespace modm::platform::pwm
+{
+
+template <typename Peripheral, PeripheralPin pinType, typename Signal, typename... Pins>
+struct Connect
+{
+	static void connect()
+	{
+		using Pin = GetPin_t<pinType, Pins...>;
+
+		if constexpr (!std::is_void_v<Pin>) {
+			using PinConnector = typename Pin::template Connector<Peripheral, Signal>;
+			PinConnector::connect();
+		}
+	}
+}; // namespace modm::platform::pwm
+
+}
+/// \endcond
+
+#include "pwm_base_impl.hpp"
+
+#endif // MODM_SAM_PWM_BASE_HPP

--- a/src/modm/platform/pwm/sam_x7x/pwm_base_impl.hpp.in
+++ b/src/modm/platform/pwm/sam_x7x/pwm_base_impl.hpp.in
@@ -1,0 +1,137 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAM_PWM_BASE_HPP
+#error "Don't include this file directly, use 'pwm_base.hpp' instead!"
+#endif
+
+namespace modm::platform
+{
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setClock(ChannelClock clock)
+{
+	value = (value & ~uint32_t(ChannelClock::Mask)) | uint32_t(clock);
+	return *this;
+}
+
+constexpr PwmBase::ChannelClock
+PwmBase::ChannelMode::clock() const
+{
+	return ChannelClock(value & uint32_t(ChannelClock::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setAlignment(ChannelAlignment alignment)
+{
+	value = (value & ~uint32_t(ChannelAlignment::Mask)) | uint32_t(alignment);
+	return *this;
+}
+
+constexpr PwmBase::ChannelAlignment
+PwmBase::ChannelMode::alignment() const
+{
+	return ChannelAlignment(value & uint32_t(ChannelAlignment::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setComparatorPolarity(ComparatorPolarity polarity)
+{
+	value = (value & ~uint32_t(ComparatorPolarity::Mask)) | uint32_t(polarity);
+	return *this;
+}
+
+constexpr PwmBase::ComparatorPolarity
+PwmBase::ChannelMode::comparatorPolarity() const
+{
+	return ComparatorPolarity(value & uint32_t(ComparatorPolarity::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setHalfPeriodMode(HalfPeriodMode mode)
+{
+	value = (value & ~uint32_t(HalfPeriodMode::Mask)) | uint32_t(mode);
+	return *this;
+}
+
+constexpr PwmBase::HalfPeriodMode
+PwmBase::ChannelMode::halfPeriodMode() const
+{
+	return HalfPeriodMode(value & uint32_t(HalfPeriodMode::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setDisabledPolarity(DisabledPolarity polarity)
+{
+	value = (value & ~uint32_t(DisabledPolarity::Mask)) | uint32_t(polarity);
+	return *this;
+}
+
+constexpr PwmBase::DisabledPolarity
+PwmBase::ChannelMode::disabledPolarity() const
+{
+	return DisabledPolarity(value & uint32_t(DisabledPolarity::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setTcTriggerSource(TcTriggerSource source)
+{
+	value = (value & ~uint32_t(TcTriggerSource::Mask)) | uint32_t(source);
+	return *this;
+}
+
+constexpr PwmBase::TcTriggerSource
+PwmBase::ChannelMode::tcTriggerSource() const
+{
+	return TcTriggerSource(value & uint32_t(TcTriggerSource::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setDeadTimeGeneration(DeadTimeGeneration deadTime)
+{
+	value = (value & ~uint32_t(TcTriggerSource::Mask)) | uint32_t(deadTime);
+	return *this;
+}
+
+constexpr PwmBase::DeadTimeGeneration
+PwmBase::ChannelMode::deadTimeGeneration() const
+{
+	return DeadTimeGeneration(value & uint32_t(DeadTimeGeneration::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setOutputPolarity(OutputPolarity polarity)
+{
+	value = (value & ~uint32_t(OutputPolarity::Mask)) | uint32_t(polarity);
+	return *this;
+}
+
+constexpr PwmBase::OutputPolarity
+PwmBase::ChannelMode::outputPolarity() const
+{
+	return OutputPolarity(value & uint32_t(OutputPolarity::Mask));
+}
+
+constexpr PwmBase::ChannelMode
+PwmBase::ChannelMode::setPushPullMode(PushPullMode mode)
+{
+	value = (value & ~uint32_t(PushPullMode::Mask)) | uint32_t(mode);
+	return *this;
+}
+
+constexpr PwmBase::PushPullMode
+PwmBase::ChannelMode::pushPullMode() const
+{
+	return PushPullMode(value & uint32_t(PushPullMode::Mask));
+}
+
+} // namespace modm::platform

--- a/src/modm/platform/pwm/sam_x7x/pwm_impl.hpp.in
+++ b/src/modm/platform/pwm/sam_x7x/pwm_impl.hpp.in
@@ -1,0 +1,231 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_SAM_PWM{{ id }}_HPP
+#error "Don't include this file directly, use 'pwm_{{ id }}.hpp' instead!"
+#endif
+
+namespace modm::platform
+{
+
+template<typename... Pins>
+inline void
+Pwm{{ id }}::connect()
+{
+	using P = Peripherals::Pwm<{{ id | int }}>;
+
+	pwm::Connect<P, PeripheralPin::PwmH0, P::Pwmh<0>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmH1, P::Pwmh<1>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmH2, P::Pwmh<2>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmH3, P::Pwmh<3>, Pins...>::connect();
+
+	pwm::Connect<P, PeripheralPin::PwmL0, P::Pwml<0>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmL1, P::Pwml<1>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmL2, P::Pwml<2>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmL3, P::Pwml<3>, Pins...>::connect();
+
+	pwm::Connect<P, PeripheralPin::PwmFi0, P::Pwmfi<0>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmFi1, P::Pwmfi<1>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmFi2, P::Pwmfi<2>, Pins...>::connect();
+
+	pwm::Connect<P, PeripheralPin::PwmExtrg0, P::Pwmextrg<0>, Pins...>::connect();
+	pwm::Connect<P, PeripheralPin::PwmExtrg1, P::Pwmextrg<1>, Pins...>::connect();
+}
+
+inline void
+Pwm{{ id }}::initialize()
+{
+	ClockGen::enable<ClockPeripheral::Pwm{{ id }}>();
+}
+
+inline void
+Pwm{{ id }}::configureDividedClock(DividedClock clock, PreDivider preDiv, uint8_t div)
+{
+	if (clock == DividedClock::ClockA) {
+		PWM{{ id }}->PWM_CLK = (PWM{{ id }}->PWM_CLK & ~(PWM_CLK_DIVA_Msk | PWM_CLK_PREA_Msk))
+			| (div << PWM_CLK_DIVA_Pos) | PWM_CLK_PREA(uint32_t(preDiv));
+	} else { // ClockB
+		PWM{{ id }}->PWM_CLK = (PWM{{ id }}->PWM_CLK & ~(PWM_CLK_DIVB_Msk | PWM_CLK_PREB_Msk))
+			| (div << PWM_CLK_DIVB_Pos) | PWM_CLK_PREB(uint32_t(preDiv));
+	}
+}
+
+inline void
+Pwm{{ id }}::setChannelMode(Channel channel, ChannelMode mode)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_CMR = (mode.value & PWM_CMR_Msk);
+}
+
+inline Pwm{{ id }}::ChannelMode
+Pwm{{ id }}::channelMode(Channel channel)
+{
+	const auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	return ChannelMode{ch.PWM_CMR};
+}
+
+inline void
+Pwm{{ id }}::setPeriod(Channel channel, uint16_t period)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_CPRD = period;
+}
+
+inline void
+Pwm{{ id }}::setPeriodUpdate(Channel channel, uint16_t period)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_CPRDUPD = period;
+}
+
+inline uint16_t
+Pwm{{ id }}::period(Channel channel)
+{
+	const auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	return ch.PWM_CPRD;
+}
+
+inline void
+Pwm{{ id }}::setDutyCycle(Channel channel, uint16_t dutyCycle)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_CDTY = dutyCycle;
+}
+
+inline void
+Pwm{{ id }}::setDutyCycleUpdate(Channel channel, uint16_t dutyCycle)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_CDTYUPD = dutyCycle;
+}
+
+inline uint16_t
+Pwm{{ id }}::dutyCycle(Channel channel)
+{
+	const auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	return ch.PWM_CDTY;
+}
+
+inline uint16_t
+Pwm{{ id }}::counter(Channel channel)
+{
+	const auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	return ch.PWM_CCNT;
+}
+
+inline void
+Pwm{{ id }}::enableChannelOutput(Channels_t channels)
+{
+	PWM{{ id }}->PWM_ENA = channels.value;
+}
+
+inline void
+Pwm{{ id }}::disableChannelOutput(Channels_t channels)
+{
+	PWM{{ id }}->PWM_DIS = channels.value;
+}
+
+inline Pwm{{ id }}::Channels_t
+Pwm{{ id }}::isChannelOutputEnabled()
+{
+	return Channels_t(PWM{{ id }}->PWM_SR);
+}
+
+inline void
+Pwm{{ id }}::setDeadTime(Channel channel, uint16_t pwmL, uint16_t pwmH)
+{
+	auto& ch = PWM{{ id }}->PwmChNum[uint8_t(channel) & 0b11];
+	ch.PWM_DT = (uint32_t(pwmL) << 16) | pwmH;
+}
+
+inline void
+Pwm{{ id }}::configureOutputOverrideValues(Outputs_t outputs)
+{
+	PWM{{ id }}->PWM_OOV = outputs.value;
+}
+
+inline void
+Pwm{{ id }}::setOutputOverride(Outputs_t outputs, bool immediateUpdate)
+{
+	if (immediateUpdate) {
+		PWM{{ id }}->PWM_OSS = outputs.value;
+	} else {
+		PWM{{ id }}->PWM_OSSUPD = outputs.value;
+	}
+}
+
+inline void
+Pwm{{ id }}::clearOutputOverride(Outputs_t outputs, bool immediateUpdate)
+{
+	if (immediateUpdate) {
+		PWM{{ id }}->PWM_OSC = outputs.value;
+	} else {
+		PWM{{ id }}->PWM_OSCUPD = outputs.value;
+	}
+}
+
+inline void
+Pwm{{ id }}::enableInterrupt(Interrupt_t interrupt)
+{
+	PWM{{ id }}->PWM_IER1 = interrupt.value;
+}
+
+inline void
+Pwm{{ id }}::disableInterrupt(Interrupt_t interrupt)
+{
+	PWM{{ id }}->PWM_IDR1 = interrupt.value;
+}
+
+inline Pwm{{ id }}::Interrupt_t
+Pwm{{ id }}::isInterruptEnabled()
+{
+	return Interrupt_t(PWM{{ id }}->PWM_IMR1);
+}
+
+inline void
+Pwm{{ id }}::enableInterruptVector(uint32_t priority)
+{
+	NVIC_SetPriority(PWM{{ id }}_IRQn, priority);
+	NVIC_EnableIRQ(PWM{{ id }}_IRQn);
+}
+
+inline void
+Pwm{{ id }}::disableInterruptVector()
+{
+	NVIC_DisableIRQ(PWM{{ id }}_IRQn);
+}
+
+inline Pwm{{ id }}::Interrupt_t
+Pwm{{ id }}::readInterruptFlags()
+{
+	return Interrupt_t(PWM{{ id }}->PWM_ISR1);
+}
+
+constexpr Pwm{{ id }}::Interrupt_t
+Pwm{{ id }}::eventInterruptFlags(Channels_t channels)
+{
+	return Interrupt_t(channels.value);
+}
+
+inline void
+Pwm{{ id }}::configureSynchronousChannels(Channels_t syncChannels)
+{
+	PWM{{ id }}->PWM_SCM = (PWM{{ id }}->PWM_SCM & ~0b1111ul) | syncChannels.value;
+}
+
+inline void
+Pwm{{ id }}::updateSynchronousChannels()
+{
+	PWM{{ id }}->PWM_SCUC = PWM_SCUC_UPDULOCK;
+}
+
+} // namespace modm::platform

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -76,7 +76,7 @@ def hal_get_modules():
 
         modules = set()
         # We only care about some modm:platform:* modules here
-        not_interested = {"bitbang", "common", "heap", "core", "fault", "cortex-m", "uart.spi", "itm", "rtt"}
+        not_interested = {"bitbang", "common", "heap", "core", "fault", "cortex-m", "uart.spi", "itm", "rtt", "pwm"}
         imodules = (m  for (repo, mfile) in mfiles  for m in lbuild.module.load_module_from_file(repo, mfile)
                     if m.available and m.fullname.startswith("modm:platform:") and
                     all(p not in m.fullname for p in not_interested) and


### PR DESCRIPTION
Add driver for SAMx7x PWM generator. This peripheral is independent of the Timer / Counter which can also generate PWM. It features 4 complementary output channels and advanced features like dead-time generation.

This driver does not yet implement support for external trigger inputs, fault inputs or DMA.

- [x] Add driver
  - [x] Add Doxygen docs to code
- [x] Example
- [x] Test

The driver is working. ~~Documentation is still missing.~~

![photo_2023-02-06_18-23-10](https://user-images.githubusercontent.com/25187160/217041027-67290e1b-8112-4a17-a484-36d4ef7b3d07.jpg)
