### PR TITLE
add openocd config for nucleo h723 (single bank flash)

### DIFF
--- a/src/modm/board/nucleo_h723zg/module.lb
+++ b/src/modm/board/nucleo_h723zg/module.lb
@@ -42,4 +42,6 @@ def build(env):
     env.template("../board.cpp.in", "board.cpp")
     env.copy('.')
     env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
-    env.collect(":build:openocd.source", "board/st_nucleo_h743zi.cfg");
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/st_nucleo_h723zg.cfg"), "st_nucleo_h723zg.cfg")
+    env.collect(":build:openocd.source", "modm/board/st_nucleo_h723zg.cfg")

--- a/tools/openocd/modm/st_nucleo_h723zg.cfg
+++ b/tools/openocd/modm/st_nucleo_h723zg.cfg
@@ -1,0 +1,10 @@
+# This is an ST NUCLEO-H723ZG board with single STM32H723ZG chip.
+# http://www.st.com/en/evaluation-tools/nucleo-h723zg.html
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32h7x.cfg]
+
+reset_config srst_only


### PR DESCRIPTION
The STM32H723 only has a single bank flash so the open-ocd config for the Nucleo-H743 (which has dual bank flash) that is shipped with open-ocd can not be used.