### PR TITLE
Include XPCCs generated paths for VSCode C++ `includePath`

### DIFF
--- a/tools/ide/vscode/module.lb
+++ b/tools/ide/vscode/module.lb
@@ -13,6 +13,7 @@
 
 import subprocess
 import platform
+import os
 
 def init(module):
     module.name = ":ide:vscode"
@@ -66,13 +67,18 @@ def post_build(env):
         for p in ["release", "debug"]
     }
 
+    include_path = env.collector_values("::path.include")
+    if env.has_module("::xpcc:generator"):
+        os.makedirs( env["::xpcc:generator:path"], exist_ok=True )
+        include_path.append( env.relcwdoutpath( env["::xpcc:generator:path"] ) )
+
     env.substitutions = {
         "configs": configs,
         "partname": env[":target"].partname.upper(),
         "with_freertos": env.has_module(":freertos"),
         "platform": core,
         "profiles": profiles,
-        "include_paths": env.collector_values("::path.include"),
+        "include_paths": include_path,
         "compiler_path": compiler_path,
         # FIXME: RTT block is searched for too early.
         # See https://github.com/Marus/cortex-debug/wiki/SEGGER-RTT-support#known-issues


### PR DESCRIPTION
This extends the `"includePath"` list in `.vscode/c_cpp_properties.json`
when using the `::communication:xpcc:generator` in combination with this `::ide:vscode`
by e.g. this entry: `"${workspaceFolder}/generated/xpcc/"`.

Points open for discussion:
* How to get rid of that message, because it does not matter(?):
  `[WARNING] lbuild.node: Module 'modm:ide:vscode' accessing 'modm:communication:xpcc:generator:path' without depending on 'modm:communication:xpcc:generator'!`
* The `os.makedirs` is kind of a workaround to create that empty directory structure here.
  But if the workspace is opened in VS Code with that directory missing, it does not get over it.
  With the directory existing but files not (later created with `scons`) it gets along with that later.
* This itself is also kind of a workaround since this is generated with `scons` and there added to the `includePath` for the actual build
* Reduced number of XPCC example does not make it easy to test.
  * and btw. with the avr example it seems to reveal that there are some includes not properly..?
    The `platform/gpio/port.hpp` has an include for `math/utils/bit_operation.hpp` which is not generated/copied by LBuild
