### PR TITLE
[stm32] [dma] [irq] Always inline IRQ handler to reduce IRQ latency

### DIFF
--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -307,7 +307,7 @@ public:
 		 * Reads the IRQ status and checks for error or transfer complete. In case
 		 * of error the DMA channel will be disabled.
 		 */
-		static void
+		modm_always_inline static void
 		interruptHandler()
 		{
 %% if dmaType in ["stm32-channel-request", "stm32-channel", "stm32-mux"]

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -339,10 +339,12 @@ public:
 				if (transferError)
 					transferError();
 			}
-			if ((isr & HT_Flag) and halfTransferComplete)
+			if (halfTransferComplete and (isr & HT_Flag)) {
 				halfTransferComplete();
-			if ((isr & TC_Flag) and transferComplete)
+			}
+			if (transferComplete and (isr & TC_Flag)) {
 				transferComplete();
+			}
 
 			ControlHal::clearInterruptFlags(InterruptFlags::Global, ChannelID);
 		}


### PR DESCRIPTION
As mentioned by @chris-durand in #963

Shaves off 80ns on (slightly overclocked) STM32F107 ...