### PR TITLE
C++23 and C23

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!--/webignore-->
 
 modm (pronounced like dial-up "modem") is a toolbox for
-building custom C++20 libraries tailored to your embedded device.
+building custom C++23 libraries tailored to your embedded device.
 modm generates startup code, HALs and their implementations, communication
 protocols, drivers for external devices, and BSPs in a modular, customizable
 process that you can fine-tune to your needs.
@@ -49,7 +49,7 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Features
 
-- Efficient and fast object-oriented C++20 API.
+- Efficient and fast object-oriented C++23 API.
 - Support for thousands of AVR and ARM Cortex-M microcontrollers from Microchip, STMicroelectronics and Raspberry Pi.
 - Build system agnostic: Choose SCons, CMake, Makefile or use your own.
 - Modular, data-driven, target-specific HAL generation using the lbuild code generator.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: 'modm barebone embedded library'
-site_description: 'A modular C++20 library generator for barebone embedded programming'
+site_description: 'A modular C++23 library generator for barebone embedded programming'
 site_author: 'Niklas Hauser'
 site_url: 'http://modm.io'
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -16,7 +16,7 @@ you are not *required* to use it. See [the reference manual](../../reference/bui
 for additional build system documentation.
 
 !!! info "Use GCC 12 or newer"
-    modm uses C++20, so you need *at least* GCC 10. However, we recommend using GCC12.
+    modm uses C++23, so you need *at least* GCC 12.
 
 !!! warning "Beware of AVRs"
     We **strongly discourage** using AVRs for new designs, due to a significant
@@ -70,7 +70,7 @@ We use [Doxypress][doxypress_binaries] to generate the API documentation:
 
 ```sh
 sudo mkdir /opt/doxypress
-wget -O- https://github.com/copperspice/doxypress/releases/download/dp-1.5.0/doxypress-1.5.0-ubuntu22.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
+wget -O- https://github.com/copperspice/doxypress/releases/download/dp-1.5.1/doxypress-1.5.1-ubuntu22.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
 ```
 
 Add the directory to your `PATH` variable in `~/.bashrc`:

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -263,7 +263,7 @@ def common_compiler_flags(compiler, target):
         "-Wredundant-decls",
         "-Wstrict-prototypes",
         "-Wbad-function-cast",
-        "-std=gnu11",
+        "-std=gnu2x",
         # "-pedantic",
     ]
     # flags only for C++
@@ -273,7 +273,7 @@ def common_compiler_flags(compiler, target):
         # "-Wnon-virtual-dtor",
         # "-Wold-style-cast",
         "-fstrict-enums",
-        "-std=c++20",
+        "-std=c++23",
         "-Wno-volatile",  # volatile is deprecated in C++20 but lots of our external code uses it...
         # "-pedantic",
     ]

--- a/tools/build_script_generator/module.md
+++ b/tools/build_script_generator/module.md
@@ -41,11 +41,11 @@ For *debug builds*:
 
 #### Only C
 
-- `-std=gnu11`: use C11 with GNU extensions (for `asm volatile`).
+- `-std=gnu2x`: use C23 with GNU extensions (for `asm volatile`).
 
 #### Only C++
 
-- `-std=c++20`: use C++20
+- `-std=c++23`: use C++23
 
 For exception and RTTI flags, see `modm:stdc++` module.
 

--- a/tools/doc_generator/doxypress.json.in
+++ b/tools/doc_generator/doxypress.json.in
@@ -1,7 +1,7 @@
 {
     "clang": {
         "clang-compilation-path": "",
-        "clang-dialect": "-std=c++20",
+        "clang-dialect": "-std=c++23",
         "clang-flags": [
             ""
         ],

--- a/tools/ide/vscode/c_cpp_properties.json.in
+++ b/tools/ide/vscode/c_cpp_properties.json.in
@@ -19,8 +19,8 @@
                 "{{ flag }}"{% if not loop.last%},{% endif %}
     %% endfor
             ],
-            "cStandard": "c17",
-            "cppStandard": "c++20",
+            "cStandard": "gnu23",
+            "cppStandard": "c++23",
             "intelliSenseMode": "gcc-arm"
         }{% if not loop.last%},{% endif %}
 %% endfor


### PR DESCRIPTION
Do we plan to enable C++23 (and C23) for modm in the (near) future?
This would give access to nice new [lanuage and library features](https://en.cppreference.com/w/cpp/compiler_support) even already with GCC12.

- [x] Testing
- [x] Remove GCC10 vs GCC12 build system flags hack