### PR TITLE
[xpcc] Separate the rx handling part of the update fct of the dispatcher

### DIFF
--- a/src/modm/communication/xpcc/dispatcher.cpp
+++ b/src/modm/communication/xpcc/dispatcher.cpp
@@ -35,6 +35,20 @@ xpcc::Dispatcher::update()
 	//Check if a new packet was received by the backend
 	while (this->backend->isPacketAvailable())
 	{
+		this->updateOnceRx();
+		this->backend->dropPacket();
+	}
+
+	// check if there are packets to send
+	this->handleWaitingMessages();
+}
+
+void
+xpcc::Dispatcher::updateOnceRx()
+{
+	//Check if a new packet was received by the backend
+	if (this->backend->isPacketAvailable())
+	{
 		const Header& header = this->backend->getPacketHeader();
 		const modm::SmartPointer& payload = this->backend->getPacketPayload();
 
@@ -46,17 +60,12 @@ xpcc::Dispatcher::update()
 		{
 			const bool is_response = this->handlePacket(header, payload);
 			if (!header.isAcknowledge && header.destination != 0)
-            {
-            	if (is_response or postman->isComponentAvailable(header.destination))
-                    this->sendAcknowledge(header);
-            }
+			{
+				if (is_response or postman->isComponentAvailable(header.destination))
+					this->sendAcknowledge(header);
+			}
 		}
-
-		this->backend->dropPacket();
 	}
-
-	// check if there are packets to send
-	this->handleWaitingMessages();
 }
 
 void

--- a/src/modm/communication/xpcc/dispatcher.hpp.in
+++ b/src/modm/communication/xpcc/dispatcher.hpp.in
@@ -48,6 +48,9 @@ namespace xpcc
 		void
 		update();
 
+		void
+		updateOnceRx();
+
 	private:
 		/// Does not handle requests which are not acknowledge.
 		bool


### PR DESCRIPTION
Call that separated function instead
and have it available as a public function as well.

Then it is possible to use the XPCC dispatcher and postman,
and combine e.g. the zeromq gateway example with that.