### PR TITLE
xPack GNU Arm toolchain

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-avr:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -139,7 +139,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -165,7 +165,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -191,7 +191,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -217,7 +217,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -243,7 +243,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -269,7 +269,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -295,7 +295,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -321,7 +321,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -347,7 +347,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -373,7 +373,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -400,7 +400,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -426,7 +426,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -452,7 +452,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -478,7 +478,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -504,7 +504,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -530,7 +530,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -556,7 +556,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -582,7 +582,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -608,7 +608,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -634,7 +634,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -660,7 +660,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,7 +10,7 @@ jobs:
   build-upload-docs:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-base:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-base:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ jobs:
   unittests-linux-generic:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
 
     steps:
       - name: Check out repository
@@ -122,7 +122,7 @@ jobs:
   stm32-examples:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -186,7 +186,7 @@ jobs:
   stm32f4-examples-1:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -206,7 +206,7 @@ jobs:
   stm32f4-examples-2:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -229,7 +229,7 @@ jobs:
   avr-examples:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-avr:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -275,7 +275,7 @@ jobs:
   hal-compile-quick-1:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -300,7 +300,7 @@ jobs:
   hal-compile-quick-2:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -325,7 +325,7 @@ jobs:
   hal-compile-quick-3:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -350,7 +350,7 @@ jobs:
   hal-compile-quick-4:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-01-08
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -7,7 +7,7 @@ with modm:
 - [Software Construct][scons] or [CMake][].
 - [Library Builder][lbuild].
 - AVR toolchain: [avr-gcc][] and [avrdude][].
-- ARM toolchain: [gcc-arm-toolchain][] and [OpenOCD][] (at least v0.11!).
+- ARM toolchain: [toolchain-arm-xpack][] and [OpenOCD][] (at least v0.11!).
 - Optional: [Doxypress][].
 - Optional: [gdbgui][] for IDE-independent debugging.
 
@@ -35,7 +35,7 @@ Please help us [keep these instructions up-to-date][contribute]!
 For Ubuntu 22.04LTS, these commands install the minimal build system:
 
 ```sh
-sudo apt install python3 python3-pip scons git libncurses5
+sudo apt install python3 python3-pip scons git libncursesw5
 pip3 install modm
 ```
 
@@ -82,21 +82,19 @@ export PATH="/opt/doxypress:$PATH"
 
 #### ARM Cortex-M
 
-Install the [pre-built ARM toolchain][gcc-arm-toolchain]:
+Install the GNU toolchain for `arm-none-eabi` target in version 12 (or higher).
+If your Linux distribution provides up-to-date packages, we recommend using them.
+Otherwise, including Ubuntu 22.04, we recommend using the [*xPack GNU Arm Embedded GCC* binary distribution][toolchain-arm-xpack]:
 
 ```sh
-wget -O- https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz | sudo tar xj -C /opt/
+wget -O- https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v12.2.1-1.2/xpack-arm-none-eabi-gcc-12.2.1-1.2-linux-x64.tar.gz | sudo tar xz -C /opt/
 ```
 
 Add it to your `PATH` variable in `~/.bashrc`:
 
 ```sh
-export PATH="/opt/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin:$PATH"
+export PATH="/opt/xpack-arm-none-eabi-gcc-12.2.1-1.2/bin:$PATH"
 ```
-
-!!! warning "Ubuntus 'gcc-arm-none-eabi' package"
-    The Ubuntu package 'gcc-arm-none-eabi' can [cause issues][armgcc-issues],
-    we recommend using only the pre-built toolchain.
 
 Install the OpenOCD tool:
 
@@ -104,10 +102,10 @@ Install the OpenOCD tool:
 sudo apt install openocd
 ```
 
-!!! warning "OpenOCD < v0.11"
-    Make sure to get at least OpenOCD release v0.11, since v0.10 is too old for
-    some targets (STM32G0, STM32G4, STM32F7). You can manually install an
-    up-to-date version of OpenOCD by [following the instructions here][openocd-install].
+!!! warning "OpenOCD < v0.12"
+    Make sure to get at least OpenOCD release v0.12, since v0.10 is too old for
+    some targets (STM32L5, STM32U5). You can manually install an up-to-date
+    version of OpenOCD by [following the instructions here][openocd-install].
 
 
 #### Microchip AVR
@@ -253,7 +251,7 @@ files in the next steps.
 
 #### ARM Cortex-M
 
-Install the [pre-built ARM toolchain via the 64-bit installer][gcc-arm-toolchain]
+Install the [pre-built ARM toolchain via the 64-bit installer][toolchain-arm-xpack]
 and make sure you select **Add path to environment variable** at the end!
 Open a new command prompt to test the compiler:
 
@@ -390,7 +388,7 @@ picocom --baud 115200 --imap lfcrlf --echo /dev/ttyACM0
 [contribute]: https://github.com/modm-io/modm/blob/develop/CONTRIBUTING.md
 [newissue]: https://github.com/modm-io/modm/issues/new
 [examples]: https://github.com/modm-io/modm/tree/develop/examples
-[gcc-arm-toolchain]: https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm
+[toolchain-arm-xpack]: https://xpack.github.io/dev-tools/arm-none-eabi-gcc/
 [openocd]: http://openocd.org
 [openocd-source]: https://github.com/ntfreak/openocd
 [avr-gcc]: https://www.nongnu.org/avr-libc
@@ -407,7 +405,6 @@ picocom --baud 115200 --imap lfcrlf --echo /dev/ttyACM0
 [pywin]: https://docs.python.org/3/using/windows.html
 [7_zip]: https://www.7-zip.org
 [modm-avr-gcc]: https://github.com/modm-io/avr-gcc
-[armgcc-issues]: https://github.com/modm-io/modm/issues/468
 [openocd-install]: https://github.com/rleh/openocd-build
 [udev-rules-openocd]: https://github.com/openocd-org/openocd/blob/master/contrib/60-openocd.rules#L84-L99
 [usbipd]: https://github.com/dorssel/usbipd-win

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -7,7 +7,7 @@ with modm:
 - [Software Construct][scons] or [CMake][].
 - [Library Builder][lbuild].
 - AVR toolchain: [avr-gcc][] and [avrdude][].
-- ARM toolchain: [toolchain-arm-xpack][] and [OpenOCD][] (at least v0.11!).
+- ARM toolchain: [toolchain-arm-xpack][] and [OpenOCD][] (at least v0.12!).
 - Optional: [Doxypress][].
 - Optional: [gdbgui][] for IDE-independent debugging.
 
@@ -103,7 +103,7 @@ sudo apt install openocd
 ```
 
 !!! warning "OpenOCD < v0.12"
-    Make sure to get at least OpenOCD release v0.12, since v0.10 is too old for
+    Make sure to get at least OpenOCD release v0.12, since v0.11 is too old for
     some targets (STM32L5, STM32U5). You can manually install an up-to-date
     version of OpenOCD by [following the instructions here][openocd-install].
 
@@ -261,8 +261,7 @@ arm-none-eabi-gcc --version
 
 Install the  and then download the latest [pre-built OpenOCD tool][openocd_binaries]:
 
-1. unpack the `.tar.gz` file using the context menu `7-Zip > Extract Here`.
-2. unpack the `.tar` file using `7-Zip > Extract to "openocd-v0.11.0-..."`
+Unpack the `.7z` file using `7-Zip > Extract to "OpenOCD-20230202..."`.
 
 Then rename and move the extracted folder to `C:\Program Files (x86)\openocd`.
 Open PowerShell to add the `\bin` folder to the `Path`:

--- a/tools/modm_tools/info.py
+++ b/tools/modm_tools/info.py
@@ -218,11 +218,7 @@ def build_info(directory=None, cxx_compiler=None):
         if directory is not None and cxx_compiler is not None:
             c = subprocess.check_output([cxx_compiler, "--version"], cwd=directory)
             c = c.decode(locale.getpreferredencoding()).split("\n", 1)[0]
-
-            m = re.match(r"(?P<name>[a-z0-9\-\+]+) +.*? +(?P<version>\d+\.\d+\.\d+)", c)
-            if m: comp = "{0} {1}".format(m.group("name"), m.group("version"))
-            else: comp = c
-            info["MODM_BUILD_COMPILER"] = comp.strip()
+            info["MODM_BUILD_COMPILER"] = c.strip()
     except:
         pass
 


### PR DESCRIPTION
- [x] [docs] Installation guide: Use xPack GNU Arm toolchain instead Arm precompiled
  - [x] Linux
  - [ ] macOS
  - [x] Windows
- [x] [ci] Update docker images to `:2023-03-12` version
- [x] Add xPack formula to [modm-ext/homebrew-modm](https://github.com/modm-ext/homebrew-modm): modm-ext/homebrew-modm/pull/1
- [x] Diff the disassembly of a few interesting example
- [x] Test new compiler in hardware
  - [x] Tested by @rleh with STM32U575 and STM32F429
- [x] Don't strip extra compiler version info from [`MODM_BUILD_COMPILER`](https://modm.io/reference/module/modm-build/#build-information)

Fixes #971