### PR TITLE
create method to enable and disable scan mode

### DIFF
--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -370,6 +370,18 @@ public:
 	static inline void
 	acknowledgeInterruptFlags(const InterruptFlag_t flags);
 
+	/**
+	 * Enables scan mode
+	 */
+	static inline void
+	enableScanMode();
+
+	/**
+	 * Disables scan mode
+	 */
+	static inline void
+	disableScanMode();
+
 private:
 	/**
 	 * Select the frequency of the clock to the ADC. The clock is common

--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -252,3 +252,15 @@ modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t fla
 {
 	ADC{{ per }}->SR = ~flags.value;
 }
+
+void
+modm::platform::Adc{{ id }}::enableScanMode()
+{
+	ADC{{ per }}->CR1 |= (1 << ADC_CR1_SCAN);
+}
+
+void
+modm::platform::Adc{{ id }}::disableScanMode()
+{
+	ADC{{ per }}->CR1 &= ~(1 << ADC_CR1_SCAN);
+}


### PR DESCRIPTION
This Pull request create enable and disable methods for STM32's adc. Currently there is support for adding multiple channels on the adc but not for enabling scan mode. 
https://github.com/modm-io/modm/discussions/973