### PR TITLE
fix scan mode for STM32F3

### DIFF
--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -370,18 +370,6 @@ public:
 	static inline void
 	acknowledgeInterruptFlags(const InterruptFlag_t flags);
 
-	/**
-	 * Enables scan mode
-	 */
-	static inline void
-	enableScanMode();
-
-	/**
-	 * Disables scan mode
-	 */
-	static inline void
-	disableScanMode();
-
 private:
 	/**
 	 * Select the frequency of the clock to the ADC. The clock is common

--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -127,6 +127,11 @@ modm::platform::Adc{{ id }}::addChannel(const Channel channel,
 	}
 	// update channel count
 	ADC{{ per }}->SQR1 = (ADC{{ per }}->SQR1 & ~ADC_SQR1_L) | (channel_count << 20);
+%% if target["family"] not in ["f3"]
+	// set hardware scan mode
+	ADC{{ per }}->CR1 |= ADC_CR1_SCAN;
+
+%%endif
 
 	setSampleTime(channel, sampleTime);
 	return true;
@@ -251,16 +256,4 @@ void
 modm::platform::Adc{{ id }}::acknowledgeInterruptFlags(const InterruptFlag_t flags)
 {
 	ADC{{ per }}->SR = ~flags.value;
-}
-
-void
-modm::platform::Adc{{ id }}::enableScanMode()
-{
-	ADC{{ per }}->CR1 |= (1 << ADC_CR1_SCAN);
-}
-
-void
-modm::platform::Adc{{ id }}::disableScanMode()
-{
-	ADC{{ per }}->CR1 &= ~(1 << ADC_CR1_SCAN);
 }


### PR DESCRIPTION
This PR removes enableScanMode and disableScanMode methods and incorporate them into addChannel.

 - [STM32F3](https://www.st.com/resource/en/reference_manual/rm0316-stm32f303xbcde-stm32f303x68-stm32f328x8-stm32f358xc-stm32f398xe-advanced-armbased-mcus-stmicroelectronics.pdf) family doesn't have a hardware Scan mode. Its scan mode is computed via ADCx->SQR1 L bits only. Methods enableScanMode and disableScanMode make little sense then, since the addChannle method already handles it.
