### PR TITLE
configureOutputChannel metohds that permits the full configuration of the outputchannel 

### DIFF
--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -161,7 +161,7 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
-		OutputCompareMode mode, uint16_t compareValue, PinState out)
+		OutputCompareMode mode, Value compareValue, PinState out)
 {
 	channel -= 1;	// 1..4 -> 0..3
 
@@ -208,6 +208,19 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 	if ((mode != OutputCompareMode::Inactive) and (out == PinState::Enable)) {
 		TIM{{ id }}->CCER |= (TIM_CCER_CC1E) << (channel * 4);
 	}
+}
+
+void
+modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
+OutputCompareMode mode, Value compareValue, 
+PinState out, OutputComparePolarity polarity,
+PinState out_n, OutputComparePolarity polarity_n,
+OutputComparePreload preload)
+{
+	// disable output
+	TIM{{ id }}->CCER &= ~(0xf << ((channel-1) * 4));
+	setCompareValue(channel, compareValue);
+	configureOutputChannel(channel, mode, out, polarity, out_n, polarity_n, preload);
 }
 
 void

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -389,6 +389,25 @@ public:
 		configureOutputChannel(channel, mode, compareValue, out);
 	}
 
+	static void
+	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
+			Value compareValue, PinState out,
+			OutputComparePolarity polarity, PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable);
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode mode,
+			Value compareValue, PinState out,
+			OutputComparePolarity polarity, PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, compareValue, out, polarity, out_n, polarity_n, preload);
+	}
+
 	/*
 	 * Configure Output Channel without changing the Compare Value
 	 *

--- a/src/modm/platform/timer/stm32/general_purpose.cpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.cpp.in
@@ -197,6 +197,59 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 	}
 }
 
+void
+modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
+OutputCompareMode mode, Value compareValue, 
+PinState out, OutputComparePolarity polarity,
+PinState out_n, OutputComparePolarity polarity_n,
+OutputComparePreload preload)
+{
+	// disable output
+	TIM{{ id }}->CCER &= ~(0xf << ((channel-1) * 4));
+	setCompareValue(channel, compareValue);
+	configureOutputChannel(channel, mode, out, polarity, out_n, polarity_n, preload);
+}
+
+void
+modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
+OutputCompareMode mode,
+PinState out, OutputComparePolarity polarity,
+PinState out_n, OutputComparePolarity polarity_n,
+OutputComparePreload preload)
+{
+	channel -= 1;	// 1..4 -> 0..3
+
+	// disable output
+	TIM{{ id }}->CCER &= ~(0xf << (channel * 4));
+
+	uint32_t flags = static_cast<uint32_t>(mode) | static_cast<uint32_t>(preload);
+
+	if (channel <= 1)
+	{
+		const uint32_t offset = 8 * channel;
+
+		flags <<= offset;
+		flags |= TIM{{ id }}->CCMR1 & ~(0xff << offset);
+
+		TIM{{ id }}->CCMR1 = flags;
+	}
+	else {
+		const uint32_t offset = 8 * (channel - 2);
+
+		flags <<= offset;
+		flags |= TIM{{ id }}->CCMR2 & ~(0xff << offset);
+
+		TIM{{ id }}->CCMR2 = flags;
+	}
+
+	// CCER Flags (Enable/Polarity)
+	flags = (static_cast<uint32_t>(polarity_n) << 2) |
+			(static_cast<uint32_t>(out_n)      << 2) |
+			 static_cast<uint32_t>(polarity) | static_cast<uint32_t>(out);
+
+	TIM{{ id }}->CCER |= flags << (channel * 4);
+}
+
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::enableInterruptVector(bool enable, uint32_t priority)

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -387,6 +387,56 @@ public:
 		configureOutputChannel(channel, mode, compareValue, out, enableComparePreload);
 	}
 
+	static void
+	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
+			Value compareValue, PinState out,
+			OutputComparePolarity polarity, PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable);
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode mode,
+			Value compareValue, PinState out,
+			OutputComparePolarity polarity, PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, compareValue, out, polarity, out_n, polarity_n, preload);
+	}
+
+	/*
+	 * Configure Output Channel without changing the Compare Value
+	 *
+	 * Normally used to REconfigure the Output channel without touching
+	 * the compare value. This can e.g. be useful for commutation of a
+	 * bldc motor.
+	 *
+	 * This function probably won't be used for a one time setup but
+	 * rather for adjusting the output setting periodically.
+	 * Therefore it aims aims to provide the best performance possible
+	 * without sacrificing code readability.
+	 */
+	static void
+	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
+			PinState out, OutputComparePolarity polarity,
+			PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable);
+
+	template<typename Signal>
+	static void
+	configureOutputChannel(OutputCompareMode mode,
+			PinState out, OutputComparePolarity polarity,
+			PinState out_n,
+			OutputComparePolarity polarity_n = OutputComparePolarity::ActiveHigh,
+			OutputComparePreload preload = OutputComparePreload::Disable)
+	{
+		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, out, polarity, out_n, polarity_n, preload);
+	}
+
 	/// Switch to Pwm Mode 2
 	///
 	/// While upcounting channel will be active as long as the time value is


### PR DESCRIPTION
This PR add configureOutputChannel methods that permits the full configuration of the output channel by the user for both the advanced timer and the general purpose timer.