### PR TITLE
Add TSVREFE bit if temperature or internal reference channels is added

### DIFF
--- a/src/modm/platform/adc/stm32/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32/adc_impl.hpp.in
@@ -97,6 +97,12 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel,
 	ADC{{ per }}->SQR3 = uint32_t(channel) & 0x1f;
 
 	setSampleTime(channel, sampleTime);
+%% if temperature_available
+	if(channel == Channel::TemperatureSensor || channel == Channel::InternalReference)
+	{
+		enableTemperatureRefVMeasurement();
+	}
+%%endif
 	return true;
 }
 
@@ -129,6 +135,12 @@ modm::platform::Adc{{ id }}::addChannel(const Channel channel,
 	ADC{{ per }}->SQR1 = (ADC{{ per }}->SQR1 & ~ADC_SQR1_L) | (channel_count << 20);
 
 	setSampleTime(channel, sampleTime);
+%% if temperature_available
+	if(channel == Channel::TemperatureSensor || channel == Channel::InternalReference)
+	{
+		enableTemperatureRefVMeasurement();
+	}
+%%endif
 	return true;
 }
 


### PR DESCRIPTION
This PR enables TSVREFE bit automatically if either the internal temperature or internal voltage reference are added. 