### PR TITLE
[docs] Member function documentation

### DIFF
--- a/src/modm/driver/storage/at24mac402.hpp
+++ b/src/modm/driver/storage/at24mac402.hpp
@@ -56,7 +56,6 @@ public:
 	modm::ResumableResult<bool>
 	readUniqueId(std::span<uint8_t, 16> data);
 
-	// start documentation inherited
 	modm::ResumableResult<bool>
 	ping();
 
@@ -79,7 +78,6 @@ public:
 	template<typename T>
 	modm::ResumableResult<bool>
 	read(uint32_t address, T& data);
-	// end documentation inherited
 private:
 	uint8_t address_{};
 };

--- a/src/modm/platform/adc/stm32/adc.hpp.in
+++ b/src/modm/platform/adc/stm32/adc.hpp.in
@@ -322,7 +322,6 @@ public:
 
 	static inline void
 	setRightAdjustResult();
-	// stop documentation inherited
 
 %% if target["family"] == "f1"
 	/**

--- a/src/modm/platform/gpio/hosted/unused.hpp.in
+++ b/src/modm/platform/gpio/hosted/unused.hpp.in
@@ -59,7 +59,6 @@ public:
 
 public:
 	// GpioOutput
-	// start documentation inherited
 	static void setOutput() {}
 	static void setOutput(bool) {}
 	static void set() {}
@@ -67,18 +66,13 @@ public:
 	static void reset() {}
 	static void toggle() {}
 	static bool isSet() { return false; }
-	// stop documentation inherited
 
 	// GpioInput
-	// start documentation inherited
 	static void setInput() {}
 	static bool read() { return false; }
-	// end documentation inherited
 
 	// GpioIO
-	// start documentation inherited
 	static Direction getDirection() { return Direction::Special; }
-	// end documentation inherited
 };
 
 } // namespace modm::platform

--- a/src/modm/platform/gpio/rpi/unused.hpp
+++ b/src/modm/platform/gpio/rpi/unused.hpp
@@ -64,7 +64,6 @@ public:
 
 public:
 	// GpioOutput
-	// start documentation inherited
 	static void setOutput() {}
 	static void setOutput(bool) {}
 	static void set() {}
@@ -72,18 +71,13 @@ public:
 	static void reset() {}
 	static void toggle() {}
 	static bool isSet() { return false; }
-	// stop documentation inherited
 
 	// GpioInput
-	// start documentation inherited
 	static void setInput() {}
 	static bool read() { return false; }
-	// end documentation inherited
 
 	// GpioIO
-	// start documentation inherited
 	static Direction getDirection() { return Direction::Special; }
-	// end documentation inherited
 };
 
 } // namespace platform

--- a/src/modm/platform/gpio/sam/unused.hpp
+++ b/src/modm/platform/gpio/sam/unused.hpp
@@ -35,7 +35,6 @@ public:
 	static constexpr uint32_t mask = 0;
 
 	// GpioOutput
-	// start documentation inherited
 	static void setOutput() {}
 	static void setOutput(bool) {}
 	static void set() {}
@@ -43,18 +42,13 @@ public:
 	static void reset() {}
 	static void toggle() {}
 	static bool isSet() { return false; }
-	// stop documentation inherited
 
 	// GpioInput
-	// start documentation inherited
 	static void setInput() {}
 	static bool read() { return false; }
-	// end documentation inherited
 
 	// GpioIO
-	// start documentation inherited
 	static Direction getDirection() { return Direction::Special; }
-	// end documentation inherited
 	static void lock() {}
 	static void disconnect() {}
 };

--- a/src/modm/platform/gpio/xmega/gpio.hpp.in
+++ b/src/modm/platform/gpio/xmega/gpio.hpp.in
@@ -201,7 +201,6 @@ public:
 	}
 		%% if type in ["", "Output"]
 	// GpioOutput
-	// start documentation inherited
 	static void setOutput() {
 		PORT{{port}}_DIRSET = mask;
 	}
@@ -222,7 +221,6 @@ public:
 	static void toggle() {
 		PORT{{port}}_OUTTGL = mask;
 	}
-	// end documentation inherited
 	static void setOutput(Configuration config,
 										Inverted invert = Inverted::No) {
 		configure(config, invert);
@@ -237,7 +235,6 @@ public:
 		%% endif
 		%% if type in ["", "Input"]
 	// GpioInput
-	// start documentation inherited
 	static void
 	setInput() {
 		 PORT{{port}}_DIRCLR = mask;
@@ -246,7 +243,6 @@ public:
 		(void) {{pin}};
 		return (PORT{{port}}_IN & mask);
 	}
-	// end documentation inherited
 	static void setInput(Configuration config,
 										Inverted invert = Inverted::No) {
 		setInput();

--- a/src/modm/platform/i2c/at90_tiny_mega/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/at90_tiny_mega/i2c_master.hpp.in
@@ -112,7 +112,6 @@ public:
 		initialize(twbr, prescaler);
 	};
 
-	// start documentation inherited
 	static bool
 	start(I2cTransaction *transaction, ConfigurationHandler handler = nullptr);
 
@@ -121,7 +120,6 @@ public:
 
 	static void
 	reset();
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/i2c/bitbang/bitbang_i2c_master.hpp.in
+++ b/src/modm/platform/i2c/bitbang/bitbang_i2c_master.hpp.in
@@ -50,7 +50,6 @@ class BitBangI2cMaster : public modm::I2cMaster
 %% endif
 
 public:
-	// start documentation inherited
 	template< class... Signals >
 	static void
 	connect(PullUps pullups = PullUps::External, ResetDevices reset = ResetDevices::Standard);
@@ -70,7 +69,6 @@ public:
 
 	static inline void
 	reset();
-	// end documentation inherited
 
 private:
 	// error handling

--- a/src/modm/platform/i2c/rp/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/rp/i2c_master.hpp.in
@@ -70,7 +70,6 @@ public:
 	static uint32_t
 	setBaudrate();
 
-	// start documentation inherited
 	static bool
 	start(I2cTransaction *transaction, ConfigurationHandler handler = nullptr);
 
@@ -79,7 +78,6 @@ public:
 
 	static void
 	reset();
-	// end documentation inherited
 
 	template <typename Wait>
 	static Error transfer(uint8_t addr,const uint8_t* write,size_t writeLen,

--- a/src/modm/platform/i2c/sam_x7x/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/sam_x7x/i2c_master.hpp.in
@@ -156,7 +156,6 @@ public:
 		initializeWithClockConfig(registerValue.value());
 	}
 
-	// start documentation inherited
 	static bool
 	start(I2cTransaction* transaction, ConfigurationHandler handler = nullptr);
 
@@ -165,7 +164,6 @@ public:
 
 	static void
 	reset();
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/i2c/stm32-extended/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32-extended/i2c_master.hpp.in
@@ -105,7 +105,6 @@ public:
 		initializeWithPrescaler(timingRegisterValue.value());
 	}
 
-	// start documentation inherited
 	static bool
 	start(I2cTransaction *transaction, ConfigurationHandler handler = nullptr);
 
@@ -114,7 +113,6 @@ public:
 
 	static void
 	reset();
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/i2c/stm32/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.hpp.in
@@ -99,7 +99,6 @@ public:
 		initializeWithPrescaler(freq, trise, prescaler);
 	}
 
-	// start documentation inherited
 	static bool
 	start(I2cTransaction *transaction, ConfigurationHandler handler = nullptr);
 
@@ -108,7 +107,6 @@ public:
 
 	static void
 	reset();
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/i2c/xmega/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/xmega/i2c_master.hpp.in
@@ -63,7 +63,6 @@ public:
 		initializeWithBaud(baud);
 	}
 
-	// start documentation inherited
 	static bool
 	start(modm::I2cDelegate *delegate);
 
@@ -75,7 +74,6 @@ public:
 
 	static void
 	reset(DetachCause cause=DetachCause::SoftwareReset);
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
@@ -67,7 +67,6 @@ public:
 	};
 
 public:
-	// start documentation inherited
 	template< class... Signals >
 	static void
 	connect()
@@ -155,7 +154,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 
 protected:
 	static void

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
@@ -70,7 +70,6 @@ public:
 	};
 
 public:
-	// start documentation inherited
 	template< class... Signals >
 	static void
 	connect()
@@ -171,7 +170,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 
 protected:
 	static void

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
@@ -44,7 +44,6 @@ template< typename Sck,
 class BitBangSpiMaster : public ::modm::SpiMaster
 {
 public:
-	// start documentation inherited
 	template< class... Signals >
 	static void
 	connect();
@@ -80,7 +79,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 
 private:
 	static void

--- a/src/modm/platform/spi/rp/spi_master.hpp.in
+++ b/src/modm/platform/spi/rp/spi_master.hpp.in
@@ -137,7 +137,6 @@ public:
 		return result_baudrate;
 	}
 
-	// start documentation inherited
 	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=5_pct >
 	static void
 	initialize()
@@ -198,7 +197,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 
 protected:
 	/** Perform transmit-only transaction

--- a/src/modm/platform/spi/sam/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam/spi_master.hpp.in
@@ -86,7 +86,6 @@ public:
 		}
 	}
 
-	// start documentation inherited
 	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=5_pct >
 	static void
 	initialize() {
@@ -143,7 +142,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 
 	/** Enable local loopback mode, to internally connect MOSI to MISO */
 	static void

--- a/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
@@ -72,7 +72,6 @@ public:
 		}
 	}
 
-	// start documentation inherited
 	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static void
 	initialize()
@@ -119,7 +118,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t* tx, uint8_t* rx, std::size_t length);
-	// end documentation inherited
 };
 
 } // namespace modm::platform

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -89,7 +89,6 @@ public:
 		Connector::connect();
 	}
 
-	// start documentation inherited
 	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
 	static void
 	initialize()
@@ -154,7 +153,6 @@ public:
 
 	static modm::ResumableResult<void>
 	transfer(const uint8_t *tx, uint8_t *rx, std::size_t length);
-	// end documentation inherited
 };
 
 } // namespace platform

--- a/src/modm/platform/uart/at90_tiny_mega/uart.hpp.in
+++ b/src/modm/platform/uart/at90_tiny_mega/uart.hpp.in
@@ -61,7 +61,6 @@ public:
 		Connector::connect();
 	}
 
-	// start documentation inherited
 	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(2) >
 	static inline void
 	initialize()
@@ -108,7 +107,6 @@ public:
 
 	static std::size_t
 	discardTransmitBuffer();
-	// end documentation inherited
 
 	// MARK: error
 	/**

--- a/src/modm/platform/uart/xmega/uart.hpp.in
+++ b/src/modm/platform/uart/xmega/uart.hpp.in
@@ -77,7 +77,6 @@ public:
 		initializeWithFractionalBaudrate(bsel, bscale);
 	}
 
-	// start documentation inherited
 	// MARK: write blocking
 	static void
 	writeBlocking(uint8_t data);
@@ -111,7 +110,6 @@ public:
 
 	static std::size_t
 	discardTransmitBuffer();
-	// end documentation inherited
 
 	// MARK: error
 	/**

--- a/tools/doc_generator/doxypress.json.in
+++ b/tools/doc_generator/doxypress.json.in
@@ -48,7 +48,7 @@
         "inherit-docs": true,
         "inline-grouped-classes": false,
         "inline-info": true,
-        "inline-inherited-member": false,
+        "inline-inherited-member": true,
         "inline-simple-struct": false,
         "internal-docs": false,
         "javadoc-auto-brief": false,


### PR DESCRIPTION
- Remove useless `// documentation inherited` comments
- Enable doxypress `inline-inherited-member` option, the effect can best be seen in the screenshots below:

<details>
<summary>Screenshots</summary>

Before:
![image](https://user-images.githubusercontent.com/2820734/230479125-524d5f95-9b24-4153-bd61-606a72a86339.png)

After:
![image](https://user-images.githubusercontent.com/2820734/230479427-dc0a2d53-323f-40b1-9bc7-c1b4996b2ade.png)

</details>

What do you think about the change?