### PR TITLE
[sam] Fix SAMx7x DMA LinkedListTransfer copy construction and assignment

### DIFF
--- a/src/modm/platform/dma/samx7x/transfer.hpp
+++ b/src/modm/platform/dma/samx7x/transfer.hpp
@@ -126,6 +126,9 @@ public:
 
 	constexpr LinkedListTransfer();
 
+	constexpr LinkedListTransfer(const LinkedListTransfer& other);
+	constexpr LinkedListTransfer& operator=(const LinkedListTransfer& other);
+
 	template<std::size_t index, typename... Ds>
 	friend auto descriptor(LinkedListTransfer<Ds...>& transfer);
 

--- a/src/modm/platform/dma/samx7x/transfer_impl.hpp
+++ b/src/modm/platform/dma/samx7x/transfer_impl.hpp
@@ -188,6 +188,22 @@ constexpr LinkedListTransfer<Descriptors...>::LinkedListTransfer()
 	detail::SetupList<0, std::tuple<Descriptors...>>::setup(descriptors_);
 }
 
+template<typename... Descriptors>
+constexpr LinkedListTransfer<Descriptors...>::LinkedListTransfer(const LinkedListTransfer& other)
+	: descriptors_{other.descriptors_}
+{
+	detail::SetupList<0, std::tuple<Descriptors...>>::setAddress(descriptors_);
+}
+
+template<typename... Descriptors>
+constexpr LinkedListTransfer<Descriptors...>&
+LinkedListTransfer<Descriptors...>::operator=(const LinkedListTransfer& other)
+{
+	descriptors_ = other.descriptors_;
+	detail::SetupList<0, std::tuple<Descriptors...>>::setAddress(descriptors_);
+	return *this;
+}
+
 template<std::size_t index, typename... Descriptors>
 auto descriptor(LinkedListTransfer<Descriptors...>& transfer)
 {


### PR DESCRIPTION
The compiler generated default copy operations do not update the internal linked list structure to the new addresses. In the example the compiler could do copy elision so nothing was ever copied. Tested in hardware.