### PR TITLE
[sam] Fix compiler warnings for GpioUnused in SoftwareGpioPort

### DIFF
--- a/src/modm/platform/gpio/sam/unused.hpp
+++ b/src/modm/platform/gpio/sam/unused.hpp
@@ -31,7 +31,7 @@ public:
 	using Type = GpioUnused;
 	static constexpr bool isInverted = false;
 	static constexpr PortName port = PortName(-1);
-	static constexpr uint8_t pin = uint8_t(-1);
+	static constexpr uint8_t pin = 0;
 	static constexpr uint32_t mask = 0;
 
 	// GpioOutput


### PR DESCRIPTION
Having a `GpioUnused` in a `SoftwareGpioPort` emits a lot of nuissance warnings. The current pin id for `GpioUnused` is set to the random invalid value `0xff`. The gpio code contains shift expressions like `1u << pin`. For unused pins the result is never evaluated but the compiler complains about arithmetic overflow:

```
modm/src/modm/platform/gpio/pin.hpp:190:44: warning: left shift count >= width of type [-Wshift-count-overflow]
  190 |   return (((PinConfigs::port == port) ? 1u << PinConfigs::pin : 0u) | ...);
```

Changing the pin id to `0` avoids special handling in a lot of places to avoid warnings. Since the unused pin has an invalid port set the pin value is never used anyway.