### PR TITLE
[math] added initializer_list initialization to matrix

### DIFF
--- a/src/modm/math/matrix.hpp
+++ b/src/modm/math/matrix.hpp
@@ -19,6 +19,7 @@
 #include <stdint.h>
 
 #include <modm/io/iostream.hpp>
+#include <modm/math/matrix.hpp>
 
 namespace modm
 {
@@ -60,7 +61,7 @@ namespace modm
 		 * Creates a Matrix with uninitialized elements. Use zeroMatrix() to
 		 * create a matrix with all elements set to zero.
 		 */
-		Matrix();
+		Matrix() = default;
 
 		/**
 		 * \brief	Create a matrix from an array
@@ -77,6 +78,17 @@ namespace modm
 		 * \endcode
 		 */
 		Matrix(const T *data);
+
+		/**
+		 * \brief	Create a matrix from an initializer list
+		 *
+		 * Example:
+		 * \code
+		 * modm::Matrix<int16_t, 3, 2> a{1,2,3,4,5,6};
+		 * \endcode
+		 */
+		template<typename... U>
+		explicit constexpr Matrix(U... data) requires (std::is_convertible_v<U, T> && ...);
 
 		/**
 		 * \brief	Get a zero matrix

--- a/src/modm/math/matrix_impl.hpp
+++ b/src/modm/math/matrix_impl.hpp
@@ -17,17 +17,20 @@
 
 // ----------------------------------------------------------------------------
 template<typename T, uint8_t ROWS, uint8_t COLUMNS>
-modm::Matrix<T, ROWS, COLUMNS>::Matrix()
-{
-}
-
-// ----------------------------------------------------------------------------
-template<typename T, uint8_t ROWS, uint8_t COLUMNS>
 modm::Matrix<T, ROWS, COLUMNS>::Matrix(const T *data)
 {
 	for (uint_fast8_t i = 0; i < getNumberOfElements(); ++i) {
 		element[i] = data[i];
 	}
+}
+
+template<typename T, uint8_t ROWS, uint8_t COLUMNS>
+template<typename... U>
+constexpr modm::Matrix<T, ROWS, COLUMNS>::Matrix(U... data)
+	requires (std::is_convertible_v<U, T> && ...)
+	: element{T(data)...}
+{
+	static_assert(sizeof...(data) == ROWS * COLUMNS, "Invalid element count");
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Added constructor with initializer list to `modm::math::Matrix` class.

The huge diff is from the clang-format script... Not sure if you want to have this?