### PR TITLE
[clock] Fix multicore us clock reading on RP2040

### DIFF
--- a/examples/rp_pico/mcblink/main.cpp
+++ b/examples/rp_pico/mcblink/main.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/debug/logger.hpp>
+#include <modm/processing.hpp>
+#include <mutex>
+
+// Create an IODeviceWrapper around the Uart Peripheral we want to use
+modm::IODeviceWrapper<Uart0, modm::IOBuffer::BlockIfFull> loggerDevice;
+modm::log::Logger modm::log::info(loggerDevice);
+modm::log::Logger modm::log::error(loggerDevice);
+
+multicore::Mutex log_mutex;
+uint32_t counter{};
+
+void
+core1_main()
+{
+	modm::PrecisePeriodicTimer tmr(0.100990s);
+	uint32_t us_counter{};
+
+	while (true)
+	{
+		const uint32_t us = modm::PreciseClock::now().time_since_epoch().count();
+		if (us < us_counter)
+		{
+			std::lock_guard<multicore::Mutex> g(log_mutex);
+			MODM_LOG_ERROR << us << " < " << us_counter << modm::endl;
+		}
+		us_counter = us;
+
+		if (tmr.execute())
+		{
+			Board::LedGreen::set();
+			std::lock_guard<multicore::Mutex> g(log_mutex);
+			MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::LedGreen::setOutput();
+	// initialize Uart0 for MODM_LOG_*
+	Uart0::connect<GpioOutput0::Tx>();
+	Uart0::initialize<Board::SystemClock, 115200_Bd>();
+
+	multicore::Core1::run(core1_main);
+
+	modm::PrecisePeriodicTimer tmr(0.1002284s);
+	uint32_t us_counter{};
+
+	while (true)
+	{
+		{
+			const uint32_t us = modm::PreciseClock::now().time_since_epoch().count();
+			if (us < us_counter)
+			{
+				std::lock_guard<multicore::Mutex> g(log_mutex);
+				MODM_LOG_ERROR << us << " < " << us_counter << modm::endl;
+			}
+			us_counter = us;
+		}
+
+		if (tmr.execute())
+		{
+			Board::LedGreen::reset();
+			std::lock_guard<multicore::Mutex> g(log_mutex);
+			MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+		}
+	}
+
+	return 0;
+}

--- a/examples/rp_pico/mcblink/project.xml
+++ b/examples/rp_pico/mcblink/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:rp-pico</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/rp_pico/mcblink</option>
+  </options>
+  <modules>
+    <module>modm:debug</module>
+    <module>modm:processing:timer</module>
+    <module>modm:platform:multicore</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/clock/systick/module.lb
+++ b/src/modm/platform/clock/systick/module.lb
@@ -63,8 +63,13 @@ def build(env):
     env.substitutions = {
         "systick_frequency": env.get(":freertos:frequency", freq),
         "has_freertos": env.has_module(":freertos"),
+        "multicore": False,
         "ref_clk": div
     }
+    if env.has_module(":platform:multicore"):
+        cores = int(env[":target"].identifier.cores)
+        env.substitutions["cores"] = cores
+        env.substitutions["multicore"] = True
     env.outbasepath = "modm/src/modm/platform/clock"
     env.template("systick_timer.hpp.in")
     env.template("systick_timer.cpp.in")

--- a/src/modm/platform/clock/systick/systick_timer.cpp.in
+++ b/src/modm/platform/clock/systick/systick_timer.cpp.in
@@ -13,14 +13,21 @@
 
 #include <modm/architecture/interface/atomic_lock.hpp>
 #include <modm/platform/device.hpp>
+%% if multicore
+#include <modm/platform/core/multicore.hpp>
+%% endif
 
 #include "systick_timer.hpp"
 
 static constexpr auto systick_step({{ 1000 // systick_frequency }});
-static volatile uint32_t milli_time{0};
-static volatile uint32_t micro_time{0};
-static volatile uint8_t interrupt{false};
-
+static volatile uint32_t milli_time{};
+static volatile uint32_t micro_time{};
+%% if multicore
+static volatile bool interrupts[{{cores}}]{};
+%% else
+static volatile bool interrupt{};
+%% endif
+%#
 extern "C" void
 %% if has_freertos
 vApplicationTickHook()
@@ -30,7 +37,13 @@ SysTick_Handler(void)
 {
 	milli_time += systick_step;
 	micro_time += systick_step * 1'000ul;
+%% if multicore
+%% for core in range(cores)
+	interrupts[{{core}}] = true;
+%% endfor
+%% else
 	interrupt = true;
+%% endif
 }
 
 // pick the lowest possible priority for the SysTick interrupt
@@ -69,8 +82,11 @@ modm::chrono::milli_clock::now() noexcept
 %% if systick_frequency == 1000
 	return time_point{duration{milli_time}};
 %% else
-	uint32_t val;
-	uint32_t ms;
+	uint32_t val, ms;
+%% if multicore
+	volatile bool &interrupt = interrupts[modm::platform::multicore::Core::cpuId()];
+%% endif
+%#
 	do	// We cannot use an atomic lock here, the counter still overflows even
 	{	// if the interrupt hasn't happened yet.
 		interrupt = false;
@@ -90,8 +106,11 @@ modm::chrono::milli_clock::now() noexcept
 modm::chrono::micro_clock::time_point modm_weak
 modm::chrono::micro_clock::now() noexcept
 {
-	uint32_t val;
-	uint32_t us;
+	uint32_t val, us;
+%% if multicore
+	volatile bool &interrupt = interrupts[modm::platform::multicore::Core::cpuId()];
+%% endif
+%#
 	do	// We cannot use an atomic lock here, the counter still overflows even
 	{	// if the interrupt hasn't happened yet.
 		interrupt = false;


### PR DESCRIPTION
When using the microsecond clock from both Core0 and Core1, the interrupt semaphore was accessed by both, which broke the overflow detection and caused jitters of up to 1ms.
This gives each core its own flag.

- [x] Implement fix
- [x] Test fix
- ~Add 64-bit timer as alternative~ too much effort, cannot be bothered
- [x] Add examples

Fixes #907. cc @cocasema 