### PR TITLE
[ci] Fix MacOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: macos-13
 
     steps:
-      # update Xcode version to fix linker bug
-      # - uses: maxim-lobanov/setup-xcode@v1
-      #   with:
-      #     xcode-version: '14.2'
 
       - name: Setup environment - Brew tap
         run: |
@@ -21,7 +17,8 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1 # saves time
           brew update
-          brew install doxygen boost gcc avr-gcc@12 arm-gcc-bin@12 cmake || true
+          brew unlink gcc
+          brew install doxygen boost gcc@12 avr-gcc@12 arm-gcc-bin@12 cmake || true
           brew link --force avr-gcc@12
           # brew upgrade boost gcc git || true
 
@@ -59,11 +56,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-
-      - name: Update lbuild
-        if: always()
-        run: |
-          pip3 install --upgrade --user --upgrade-strategy=eager modm
 
       - name: Hosted Unittests
         if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   macos_testing:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       # update Xcode version to fix linker bug


### PR DESCRIPTION
- [x] Fix bug with GCC by using `gcc@12` ~~(Apple thinks it's a good idea to link `g++` to their Clang/LLVM binary. Clang 14 seems to have some issues.)~~
- [x] Update to MacOS 13 (Ventura)