### PR TITLE
[build] Remove GCC10 vs GCC12 compile flags differences

### DIFF
--- a/src/modm/platform/core/avr/module.lb
+++ b/src/modm/platform/core/avr/module.lb
@@ -36,6 +36,7 @@ def build(env):
     env.outbasepath = "modm/link"
     env.copy("linkerscript.ld")
     env.collect(":build:linkflags", "-L{project_source_dir}",
+                "-Wl,--no-warn-rwx-segment",
                 "-T{}".format(env.relcwdoutpath("modm/link/linkerscript.ld")))
 
     env.substitutions = {
@@ -78,5 +79,6 @@ def build(env):
         mmcu = mmcu[:-2] + mmcu[-2:].replace(suffix, "")
     env.collect(":build:archflags","-mmcu={}".format(mmcu))
     env.collect(":build:cppdefines", "F_CPU={}".format(env["f_cpu"]))
+    env.collect(":build:ccflags", "--param=min-pagesize=0")
 
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -346,7 +346,8 @@ def build(env):
     if env.has_module(":architecture:unaligned"):
         env.template("unaligned_impl.hpp.in")
 
-    env.collect(":build:linkflags", "-Wl,--no-wchar-size-warning", "-L{project_source_dir}")
+    env.collect(":build:linkflags", "-Wl,--no-wchar-size-warning",
+                "-Wl,--no-warn-rwx-segment", "-L{project_source_dir}")
     # Linkerscript
     linkerscript = env["linkerscript.override"]
     env.collect(":build:linkflags", "-T{}".format(env.relcwdoutpath(

--- a/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
+++ b/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
@@ -120,13 +120,6 @@ set({{ name | upper }}{{ "_" ~ (profile | upper) if profile | length else "" }}
 {{ generate_flags("ccwarn") }}
 {{ generate_flags("cxxwarn") }}
 
-if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 12)
-  list(APPEND LINKFLAGS -Wl,--no-warn-rwx-segment)
-%% if core.startswith("avr")
-  list(APPEND CCFLAGS --param=min-pagesize=0)
-%% endif
-endif()
-
   target_compile_definitions(${target_options} INTERFACE
     ${CPPDEFINES}
     $<$<CONFIG:MinSizeRel>:${CPPDEFINES_RELEASE}>

--- a/tools/build_script_generator/make/resources/Makefile.in
+++ b/tools/build_script_generator/make/resources/Makefile.in
@@ -146,19 +146,19 @@ ui?=tui
 .PHONY: debug
 debug: build
 	@$(PYTHON3) -m modm_tools.gdb $(MODM_GDB_COMMANDS) \
-	  		$(MODM_GDB_COMMANDS_OPENOCD) --elf $(ELF_FILE) --ui=$(ui) \
+			$(MODM_GDB_COMMANDS_OPENOCD) --elf $(ELF_FILE) --ui=$(ui) \
 			openocd $(addprefix -f ,$(MODM_OPENOCD_CONFIGFILES))
 
 .PHONY: debug-bmp
 debug-bmp: build
 	@$(PYTHON3) -m modm_tools.gdb $(MODM_GDB_COMMANDS) \
-	  		$(MODM_GDB_COMMANDS_BMP) --elf $(ELF_FILE) --ui=$(ui) \
+			$(MODM_GDB_COMMANDS_BMP) --elf $(ELF_FILE) --ui=$(ui) \
 			bmp -p $(port)
 
 .PHONY: debug-jlink
 debug-jlink: build
 	@$(PYTHON3) -m modm_tools.gdb $(MODM_GDB_COMMANDS) \
-	  		$(MODM_GDB_COMMANDS_JLINK) --elf $(ELF_FILE) --ui=$(ui) \
+			$(MODM_GDB_COMMANDS_JLINK) --elf $(ELF_FILE) --ui=$(ui) \
 			jlink -device $(MODM_JLINK_DEVICE)
 
 coredump?=coredump.txt

--- a/tools/build_script_generator/make/resources/compiler.mk.in
+++ b/tools/build_script_generator/make/resources/compiler.mk.in
@@ -19,9 +19,9 @@ else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		C_SUFFIX := -12
-        # Using homebrew include and lib paths on macOS
-        CPPDEFINES += -I/usr/local/include
-        LIBPATH += -L/usr/local/lib
+		# Using homebrew include and lib paths on macOS
+		CPPDEFINES += -I/usr/local/include
+		LIBPATH += -L/usr/local/lib
 	endif
 %% endif
 endif
@@ -31,15 +31,15 @@ CXX := $(C_PREFIX)g++$(C_SUFFIX)
 ASM := $(CC)
 
 ifeq ($(C_SUFFIX),)
-    AS := $(C_PREFIX)as
+	AS := $(C_PREFIX)as
 	AR := $(C_PREFIX)ar
-    NM := $(C_PREFIX)nm
+	NM := $(C_PREFIX)nm
 	RANLIB := $(C_PREFIX)ranlib
 else
-    AS := $(CXX)
-    AR := $(C_PREFIX)gcc-ar$(C_SUFFIX)
-    NM := $(C_PREFIX)gcc-nm$(C_SUFFIX)
-    RANLIB := $(C_PREFIX)gcc-ranlib$(C_SUFFIX)
+	AS := $(CXX)
+	AR := $(C_PREFIX)gcc-ar$(C_SUFFIX)
+	NM := $(C_PREFIX)gcc-nm$(C_SUFFIX)
+	RANLIB := $(C_PREFIX)gcc-ranlib$(C_SUFFIX)
 endif
 
 OBJCOPY := $(C_PREFIX)objcopy

--- a/tools/build_script_generator/make/resources/repo.mk.in
+++ b/tools/build_script_generator/make/resources/repo.mk.in
@@ -43,15 +43,6 @@ CCFLAGS += $(ARCHFLAGS)
 ASFLAGS += $(ARCHFLAGS)
 LINKFLAGS += $(ARCHFLAGS)
 
-%% if platform != "hosted"
-# This flag is neccessary for GCC12, but fails for earlier GCCs
-ifeq "$(shell expr `echo $(COMPILER_VERSION) | cut -f1 -d.` \>= 12)" "1"
- 	LINKFLAGS += "-Wl,--no-warn-rwx-segment"
-%% if core.startswith("avr")
-	CCFLAGS += "--param=min-pagesize=0"
-%% endif
-endif
-%% endif
 %% endif
 
 %% if include_paths | length

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -82,14 +82,6 @@ env.Append(CCFLAGS="$ARCHFLAGS")
 env.Append(ASFLAGS="$ARCHFLAGS")
 env.Append(LINKFLAGS="$ARCHFLAGS")
 
-%% if platform != "hosted"
-if env.CompilerVersion() >= 120000:
-	env.Append(LINKFLAGS="-Wl,--no-warn-rwx-segment")
-%% if core.startswith("avr")
-	env.Append(CCFLAGS="--param=min-pagesize=0")
-%% endif
-%% endif
-
 %% if family != "darwin"
 # Search all linked static libraries multiple times
 env["_LIBFLAGS"] = "-Wl,--start-group " + env["_LIBFLAGS"] + " -Wl,--end-group"


### PR DESCRIPTION
There was a time we were supporting GCC10, GCC11, and GCC12, unfortunately they required slightly different compile and link flags, which had to be detected at runtime.

Since we're now GCC12 only, we can remove these hacks.