### PR TITLE
[stm32] fix stm32 timer complementary channel

### DIFF
--- a/examples/nucleo_g431rb/timer/main.cpp
+++ b/examples/nucleo_g431rb/timer/main.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG << "debug" << modm::endl;
+	MODM_LOG_INFO << "info" << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR << "error" << modm::endl;
+
+	using Timer = Timer1;
+	// using Pin  	= D7;
+	using PinN = D11;
+
+	Timer::enable();
+	Timer::setMode(Timer::Mode::UpCounter);
+	// Timer clock: APB2 timer clock (170MHz)
+	Timer::setPrescaler(10);
+	// Prescaler: 1 -> Timer counter frequency: 170MHz
+	static constexpr auto maxPwm = 4250;
+	Timer::setOverflow(4250);
+	// Pwm frequency: 170MHz / 4250 / 10 = 4kHz
+
+	Timer::configureOutputChannel<PinN::Ch1n>(Timer::OutputCompareMode::Pwm, 0);
+
+	// Alternative way to configure this:
+	// Timer::configureOutputChannel(1, Timer::OutputCompareMode::Pwm, 0,Timer::PinState::Enable,
+	// Timer::ComplementaryChannel::ChN);
+
+	// Alternative way to configure this:
+	// Timer::configureOutputChannel(1,
+	// 	Timer::OutputCompareMode::Pwm,
+	// 	Timer::PinState::Disable, // disable Ch1 output
+	// 	Timer::OutputComparePolarity::ActiveHigh, // this doesn't matter
+	// 	Timer::PinState::Enable, // enable Ch1n output
+	// 	Timer::OutputComparePolarity::ActiveHigh, // OutputComparePolarity for Ch1n
+	// 	Timer::OutputComparePreload::Disable
+	// 	);
+
+	Timer::applyAndReset();
+	Timer::setCompareValue(1, 0);
+	Timer::applyAndReset();
+	Timer::pause();
+	Timer::enableOutput();
+	Timer::connect<PinN::Ch1n>();  // it works to just connect the Ch1n
+	Timer::start();
+	Timer::setCompareValue(1, maxPwm / 2);
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delay(100ms);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g431rb/timer/project.xml
+++ b/examples/nucleo_g431rb/timer/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-g431rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g431rb/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:timer:1</module>
+  </modules>
+</library>

--- a/src/modm/platform/timer/stm32/advanced.cpp.in
+++ b/src/modm/platform/timer/stm32/advanced.cpp.in
@@ -161,7 +161,7 @@ modm::platform::Timer{{ id }}::configureInputChannel(uint32_t channel,
 // ----------------------------------------------------------------------------
 void
 modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
-		OutputCompareMode mode, uint16_t compareValue, PinState out)
+		OutputCompareMode mode, uint16_t compareValue, PinState out, ComplementaryChannel cc )
 {
 	channel -= 1;	// 1..4 -> 0..3
 
@@ -206,7 +206,12 @@ modm::platform::Timer{{ id }}::configureOutputChannel(uint32_t channel,
 %% endif
 
 	if ((mode != OutputCompareMode::Inactive) and (out == PinState::Enable)) {
-		TIM{{ id }}->CCER |= (TIM_CCER_CC1E) << (channel * 4);
+		if (cc==ComplementaryChannel::Ch){
+			TIM{{ id }}->CCER |= (TIM_CCER_CC1E) << (channel * 4);
+		}
+		else{
+			TIM1->CCER |= (TIM_CCER_CC1NE) << (channel * 4);
+		}
 	}
 }
 

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -376,7 +376,7 @@ public:
 
 	static void
 	configureOutputChannel(uint32_t channel, OutputCompareMode mode,
-			Value compareValue, PinState out = PinState::Enable);
+			Value compareValue, PinState out = PinState::Enable, ComplementaryChannel cc = ComplementaryChannel::Ch);
 	// TODO: Maybe add some functionality from the configureOutput
 	//       function below...
 
@@ -386,7 +386,8 @@ public:
 			Value compareValue, PinState out = PinState::Enable)
 	{
 		constexpr auto channel = signalToChannel<Peripheral::Tim{{ id }}, Signal>();
-		configureOutputChannel(channel, mode, compareValue, out);
+		constexpr auto cc = signalIsComplementaryChannel<Peripheral::Tim{{ id }}, Signal>();
+		configureOutputChannel(channel, mode, compareValue, out, cc);
 	}
 
 	/*

--- a/src/modm/platform/timer/stm32/advanced_base.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced_base.hpp.in
@@ -63,6 +63,11 @@ public:
 		SetComgOrRisingTrigEdge = TIM_CR2_CCUS
 	};
 
+	enum class ComplementaryChannel : bool{
+		Ch = false,
+		ChN = true
+	};
+
 %% if advanced_extended
 	enum class MasterMode2 : uint32_t
 	{
@@ -122,6 +127,24 @@ public:
 		Reset = 0,
 		Set   = TIM_CR2_OIS1,
 	};
+
+protected:
+	template<Peripheral p, typename Signal>
+	static consteval ComplementaryChannel
+	signalIsComplementaryChannel()
+	{
+		modm::platform::detail::SignalConnection<Signal, p>{};
+		if constexpr ((Signal::Signal == Gpio::Signal::Ch1n)
+			|| (Signal::Signal == Gpio::Signal::Ch2n)
+			|| (Signal::Signal == Gpio::Signal::Ch3n)
+			|| (Signal::Signal == Gpio::Signal::Ch4n))
+		{
+			return ComplementaryChannel::ChN;
+		}
+		else {
+			return ComplementaryChannel::Ch;
+		}
+	}
 };
 
 }	// namespace platform

--- a/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose_base.hpp.in
@@ -275,11 +275,11 @@ protected:
 	signalToChannel()
 	{
 		modm::platform::detail::SignalConnection<Signal, p>{};
-		if constexpr (Signal::Signal == Gpio::Signal::Ch1) {
+		if constexpr ((Signal::Signal == Gpio::Signal::Ch1) || (Signal::Signal == Gpio::Signal::Ch1n)) {
 			return 1;
-		} else if constexpr (Signal::Signal == Gpio::Signal::Ch2) {
+		} else if constexpr ((Signal::Signal == Gpio::Signal::Ch2)  || (Signal::Signal == Gpio::Signal::Ch2n)) {
 			return 2;
-		} else if constexpr (Signal::Signal == Gpio::Signal::Ch3) {
+		} else if constexpr ((Signal::Signal == Gpio::Signal::Ch3)  || (Signal::Signal == Gpio::Signal::Ch3n)) {
 			return 3;
 %% if target.family != "l0" or target.pin != "d"
 		} else if constexpr (Signal::Signal == Gpio::Signal::Ch4) {


### PR DESCRIPTION
Proposed fix for #1011

I'm not sure, for which STM32 to add this functionality. Since the `configureOutputChannel` function is also enabled for all advanced timers, I would propose doing the same...