### PR TITLE
STM32 FDCAN: Get all messages from FIFO in RX ISR

### DIFF
--- a/src/modm/platform/can/stm32-fdcan/can.cpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.cpp.in
@@ -135,7 +135,7 @@ sendMsg(const modm::can::Message& message)
 {
 	using namespace modm::platform;
 
-	if (!Fdcan{{ id }}::isReadyToSend()) {
+	if (isHardwareTxQueueFull()) {
 		return false;
 	}
 
@@ -215,20 +215,25 @@ modm::platform::Fdcan{{ id }}::initializeWithPrescaler(
 MODM_ISR({{ reg }}_IT0)
 {
 %% if options["buffer.tx"] > 0
-	if (txQueue.isNotEmpty()) {
-		sendMsg(txQueue.get());
-		txQueue.pop();
+	if ({{ reg }}->IR & FDCAN_IR_TC) {
+		{{ reg }}->IR = FDCAN_IR_TC;
+		if (txQueue.isNotEmpty()) {
+			const bool success = sendMsg(txQueue.get());
+			if (success) {
+				txQueue.pop();
+			}
+		}
 	}
 %% endif
 
-	const auto callback = modm::platform::Fdcan{{ id }}::getErrorInterruptCallback();
-	if (callback) {
-		const bool hasErrorInterrupt = ({{ reg }}->IR & (FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP));
-		if (hasErrorInterrupt) {
+	const bool hasErrorInterrupt = ({{ reg }}->IR & (FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP));
+	if (hasErrorInterrupt) {
+		const auto callback = modm::platform::Fdcan{{ id }}::getErrorInterruptCallback();
+		if (callback) {
 			callback();
 		}
+		{{ reg }}->IR = FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP;
 	}
-	{{ reg }}->IR = FDCAN_IR_TC | FDCAN_IR_BO | FDCAN_IR_EW | FDCAN_IR_EP;
 }
 
 
@@ -258,7 +263,7 @@ MODM_ISR({{ reg }}_IT1)
 			"CAN receive software buffer full, not reading new message(s)!");
 		// disable rx ISR until we read data from the rxQueue (IST for tx remains active)
 		// The interrupt remains unacknowledged, so it fires again after the read.
-		{{ reg }}->ILE = FDCAN_ILE_EINT0;
+		{{ reg }}->ILE &= ~FDCAN_ILE_EINT1;
 	} else {
 		{{ reg }}->IR = FDCAN_IR_RF0N | FDCAN_IR_RF1N;  // acknowledge interrupt flags
 	}
@@ -402,10 +407,27 @@ modm::platform::Fdcan{{ id }}::isReadyToSend()
 %% endif
 }
 
-
 bool
 modm::platform::Fdcan{{ id }}::sendMessage(const can::Message& message)
 {
+%% if options["buffer.tx"] > 0
+	/* Disable CAN interrupts to prevent race condition:
+	 * sendMsg() could be called concurrently from the TX interrupt and
+	 * simultaneously access the same TX buffer.
+	 * isHardwareTxQueueFull() must be checked while interrupts are off to
+	 * prevent a "time-of-check to time-of-use" bug. */
+	struct Lock
+	{
+		const uint32_t flags;
+		/* An edge case could occur where the RX interrupt gets disabled
+		 * in the RX handler when the queue is full between reading ILE and
+		 * writing ILE = 0. This will invoke the RX handler once
+		 * after sendMessage() but not cause any further issues. */
+		Lock() : flags({{ reg }}->ILE) { {{ reg }}->ILE = 0; }
+		~Lock() { {{ reg }}->ILE = flags; }
+	} lock;
+%% endif
+
 	if (isHardwareTxQueueFull()) {
 %% if options["buffer.tx"] > 0
 		if (txQueue.isFull()) {

--- a/src/modm/platform/can/stm32-fdcan/can.cpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.cpp.in
@@ -237,24 +237,30 @@ MODM_ISR({{ reg }}_IT0)
 MODM_ISR({{ reg }}_IT1)
 {
 %% if options["buffer.rx"] > 0
+	int_fast16_t msgRetrieveLimit = rxQueue.getMaxSize() - rxQueue.getSize();
+
 	RxMessage rxMessage;
 
-	if (rxFifo0HasMessage()) {
+	while (rxFifo0HasMessage() && (msgRetrieveLimit > 0)) {
 		readMsg(rxMessage.message, 0, &rxMessage.filter_id, &rxMessage.timestamp);
-		// acknowledge interrupt flag
-		{{ reg }}->IR = FDCAN_IR_RF0N;
-
-		modm_assert_continue_ignore(rxQueue.push(rxMessage), "fdcan.rx.buffer",
-			"CAN receive software buffer overflowed!", {{ id }});
+		rxQueue.push(rxMessage);
+		msgRetrieveLimit--;
 	}
 
-	if (rxFifo1HasMessage()) {
+	while (rxFifo1HasMessage() && (msgRetrieveLimit > 0)) {
 		readMsg(rxMessage.message, 1, &rxMessage.filter_id, &rxMessage.timestamp);
-		// acknowledge interrupt flag
-		{{ reg }}->IR = FDCAN_IR_RF1N;
+		rxQueue.push(rxMessage);
+		msgRetrieveLimit--;
+	}
 
-		modm_assert_continue_ignore(rxQueue.push(rxMessage), "fdcan.rx.buffer",
-			"CAN receive software buffer overflowed!", {{ id }});
+	if (rxQueue.isFull()){
+		modm_assert_continue_ignore(false, "fdcan.rx.buffer",
+			"CAN receive software buffer full, not reading new message(s)!");
+		// disable rx ISR until we read data from the rxQueue (IST for tx remains active)
+		// The interrupt remains unacknowledged, so it fires again after the read.
+		{{ reg }}->ILE = FDCAN_ILE_EINT0;
+	} else {
+		{{ reg }}->IR = FDCAN_IR_RF0N | FDCAN_IR_RF1N;  // acknowledge interrupt flags
 	}
 %% endif
 }
@@ -369,6 +375,7 @@ modm::platform::Fdcan{{ id }}::getMessage(can::Message& message, uint8_t *filter
 			(*timestamp) = rxMessage.timestamp;
 		}
 		rxQueue.pop();
+		{{ reg }}->ILE = FDCAN_ILE_EINT1 | FDCAN_ILE_EINT0; // reenable ISR, in case it was disabled due to rxQueue full
 		return true;
 	}
 %% else

--- a/src/modm/platform/can/stm32-fdcan/can.hpp.in
+++ b/src/modm/platform/can/stm32-fdcan/can.hpp.in
@@ -14,6 +14,8 @@
 #ifndef MODM_STM32_FDCAN{{ id }}_HPP
 #define MODM_STM32_FDCAN{{ id }}_HPP
 
+#include <optional>
+
 #include <modm/architecture/interface/can.hpp>
 #include <modm/architecture/interface/can_filter.hpp>
 #include <modm/platform/gpio/connector.hpp>

--- a/test/modm/platform/fdcan/fdcan_test.cpp
+++ b/test/modm/platform/fdcan/fdcan_test.cpp
@@ -86,8 +86,9 @@ FdcanTest::testBuffers()
 
 	modm::can::Message message{0x4711, 0};
 	for (uint_fast16_t i = 0; i <= numberOfMsgs; ++i) {
-		message.setLength(i % 8);
-		for (uint_fast8_t dataIndex = 0; dataIndex < i; ++dataIndex) {
+		uint_fast8_t length = i % 8;
+		message.setLength(length);
+		for (uint_fast8_t dataIndex = 0; dataIndex < length; ++dataIndex) {
 			message.data[dataIndex] = i;
 		}
 		Fdcan1::sendMessage(message);
@@ -101,9 +102,9 @@ FdcanTest::testBuffers()
 		TEST_ASSERT_TRUE(Fdcan1::getMessage(receivedMessage));
 
 		TEST_ASSERT_EQUALS(receivedMessage.getIdentifier(), 0x4711u);
-		TEST_ASSERT_EQUALS(receivedMessage.getLength(), (i % 8));
-
-		for (uint_fast8_t dataIndex = 0; dataIndex < i; ++dataIndex) {
+		uint_fast8_t length = i % 8;
+		TEST_ASSERT_EQUALS(receivedMessage.getLength(), length);
+		for (uint_fast8_t dataIndex = 0; dataIndex < length; ++dataIndex) {
 			TEST_ASSERT_EQUALS(receivedMessage.data[dataIndex], i);
 		}
 	}

--- a/test/modm/platform/fdcan/fdcan_test.hpp
+++ b/test/modm/platform/fdcan/fdcan_test.hpp
@@ -16,9 +16,6 @@ class FdcanTest : public unittest::TestSuite
 {
 public:
 	void
-	setUp() override;
-
-	void
 	testSendReceive();
 
 	void


### PR DESCRIPTION
1. In cases, when a new message comes during RX ISR execution, it would not be processed until a next message arrives. Critical for request-response protocols.
2. The header file missed a dependency
