### PR TITLE
Cmake: fix slashes in Windows paths

### DIFF
--- a/repo.lb
+++ b/repo.lb
@@ -244,16 +244,15 @@ def init(repo):
     # Add Jinja2 filters commonly used in this repository
     if 'Windows' in platform.platform():
         def windowsify(path, escape_level):
-            path = normpath(path)
             escaped = "\\" * (2 ** escape_level)
             return path.replace("\\", escaped)
         def posixify(path):
-            return normpath(path).replace("\\", "/")
+            return path.replace("\\", "/")
     else:
         def windowsify(path, escape_level):
-            return normpath(path)
+            return path
         def posixify(path):
-            return normpath(path)
+            return path
     repo.add_filter("modm.windowsify", windowsify)
     repo.add_filter("modm.posixify", posixify)
     repo.add_filter("modm.ord", lambda letter: ord(letter[0].lower()) - ord("a"))

--- a/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
+++ b/tools/build_script_generator/cmake/resources/CMakeLists.txt.in
@@ -14,7 +14,7 @@ include(cmake/ModmConfiguration.cmake)
 %% if asm_sources | length
 set_source_files_properties(
 %% for file in asm_sources | sort
-  {{ file | relocate }}
+  {{ file | relocate | modm.posixify  }}
 %% endfor
   PROPERTIES LANGUAGE CXX
 )
@@ -24,7 +24,7 @@ set_source_files_properties(
 %% if sources | length
 add_library(modm OBJECT
 %% for file, flags in sources | sort
-  {{ file | relocate }}
+  {{ file | relocate | modm.posixify  }}
 %% endfor
 )
 
@@ -32,7 +32,7 @@ add_library(modm OBJECT
 
 %% if per_file_attr | length
 %% for section in per_file_attr | sort
-{{ section }}
+{{ section | modm.posixify }}
 %% endfor
 
 %% endif
@@ -46,7 +46,7 @@ modm_target_config_create(modm modm_arch_options modm_options modm_warnings)
 %% if include_paths | length
 target_include_directories(modm SYSTEM PUBLIC
 %% for path in include_paths | sort
-  {{ path | relocate }}
+  {{ path | relocate | modm.posixify  }}
 %% endfor
 )
 

--- a/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
+++ b/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
@@ -99,7 +99,7 @@ function(modm_target_config_create target target_arch target_options target_warn
 %% macro generate_flags_for_profile(name, profile)
 set({{ name | upper }}{{ "_" ~ (profile | upper) if profile | length else "" }}
 %% for flag in flags[name][profile] | sort
-    {{ flag | flags_format }}
+    {{ flag | flags_format | modm.posixify }}
 %% endfor
   )
 %% endmacro


### PR DESCRIPTION
When CMakeList files were generated in windows, the slashes were always wrong, and cmake could not parse them. 