### PR TITLE
[test] Remove fiber availability on ARM64 targets

### DIFF
--- a/src/modm/processing/fiber/module.lb
+++ b/src/modm/processing/fiber/module.lb
@@ -20,10 +20,7 @@ def init(module):
 def prepare(module, options):
     module.depends(":processing:timer")
     # No ARM64 support yet!
-    core = options[":target"].get_driver("core")["type"]
-    return ((core.startswith("cortex-m") or
-             core.startswith("avr") or
-             "x86_64" in core))
+    return "arm64" not in options[":target"].get_driver("core")["type"]
 
 
 def build(env):

--- a/test/modm/processing/module.lb
+++ b/test/modm/processing/module.lb
@@ -22,14 +22,18 @@ def prepare(module, options):
         "modm:math:utils",
         "modm:math:filter",
         "modm:processing:protothread",
-        "modm:processing:fiber",
         "modm:processing:resumable",
         "modm:processing:timer",
         "modm:processing:scheduler",
         ":mock:clock")
+    if "arm64" not in options[":target"].get_driver("core")["type"]:
+        module.depends("modm:processing:fiber")
     return True
 
 
 def build(env):
     env.outbasepath = "modm-test/src/modm-test/processing"
-    env.copy('.')
+    if "arm64" in env[":target"].get_driver("core")["type"]:
+        env.copy('.', ignore=env.ignore_paths("fiber"))
+    else:
+        env.copy('.')


### PR DESCRIPTION
Accidentally forgot about ARM64 Raspberry Pi targets and the docs generator ran into an lbuild assertion.