### PR TITLE
[driver] Set can_message.dlc field when receiving

### DIFF
--- a/src/modm/driver/can/can_lawicel_formatter.cpp
+++ b/src/modm/driver/can/can_lawicel_formatter.cpp
@@ -39,6 +39,7 @@ modm::CanLawicelFormatter::convertToCanMessage(const char* in, can::Message& out
 
 	// get the number of data-bytes for this message
 	out.length = in[dlc_pos] - '0';
+	out.dlc = out.length;
 	if (out.length > 8)
 		return false;		// too many data-bytes
 

--- a/test/modm/driver/can/can_lawicel_formatter_test.cpp
+++ b/test/modm/driver/can/can_lawicel_formatter_test.cpp
@@ -104,6 +104,7 @@ CanLawicelFormatterTest::testStringToMessage()
 	TEST_ASSERT_TRUE(modm::CanLawicelFormatter::convertToCanMessage(input, output));
 
 	TEST_ASSERT_EQUALS(output.identifier, 0x00001610U);
+	TEST_ASSERT_EQUALS(output.dlc, 8U);
 	TEST_ASSERT_EQUALS(output.length, 8U);
 	TEST_ASSERT_EQUALS(output.flags.extended, true);
 	TEST_ASSERT_EQUALS(output.flags.rtr, false);
@@ -154,6 +155,7 @@ CanLawicelFormatterTest::testRoudtripString()
 	TEST_ASSERT_TRUE(modm::CanLawicelFormatter::convertToCanMessage(buffer, myMsg));
 
 	TEST_ASSERT_EQUALS(msg.identifier, myMsg.identifier);
+	TEST_ASSERT_EQUALS(msg.dlc, myMsg.dlc);
 	TEST_ASSERT_EQUALS(msg.length, myMsg.length);
 	TEST_ASSERT_EQUALS(msg.flags.extended, myMsg.flags.extended);
 	TEST_ASSERT_EQUALS(msg.flags.rtr, myMsg.flags.rtr);


### PR DESCRIPTION
The Lawicel ASCII protocol does not support CAN-FD at all.

e4b1a4a added dlc and length field and this might have been overlooked.