### PR TITLE
[fiber] Add more concurrency classes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1 # saves time
           brew update
-          brew unlink gcc
+          # brew unlink gcc
           brew install doxygen boost gcc@12 avr-gcc@12 arm-gcc-bin@12 cmake || true
           brew link --force avr-gcc@12
           # brew upgrade boost gcc git || true

--- a/.gitmodules
+++ b/.gitmodules
@@ -48,4 +48,4 @@
 	url = https://github.com/modm-ext/cmsis-dsp-partial.git
 [submodule "ext/nlohmann/json"]
 	path = ext/nlohmann/json
-	url = git@github.com:modm-ext/json-partial.git
+	url = https://github.com/modm-ext/json-partial.git

--- a/examples/avr/fiber/main.cpp
+++ b/examples/avr/fiber/main.cpp
@@ -24,14 +24,14 @@ void
 fiber_function1()
 {
 	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-	while (++f1counter < cycles) { modm::fiber::yield(); total_counter++; }
+	while (++f1counter < cycles) { modm::this_fiber::yield(); total_counter++; }
 }
 
 void
 fiber_function2(uint32_t cyc)
 {
 	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-	while (++f2counter < cyc) { modm::fiber::yield(); total_counter++; }
+	while (++f2counter < cyc) { modm::this_fiber::yield(); total_counter++; }
 }
 
 struct Test
@@ -40,14 +40,14 @@ struct Test
 	fiber_function3()
 	{
 		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-		while (++f3counter < cycles) { modm::fiber::yield(); total_counter++; }
+		while (++f3counter < cycles) { modm::this_fiber::yield(); total_counter++; }
 	}
 
 	void
 	fiber_function4(uint32_t cyc)
 	{
 		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-		while (++f4counter < cyc) { modm::fiber::yield(); total_counter++; }
+		while (++f4counter < cyc) { modm::this_fiber::yield(); total_counter++; }
 	}
 
 	volatile uint32_t f3counter{0};

--- a/examples/generic/fiber/main.cpp
+++ b/examples/generic/fiber/main.cpp
@@ -26,14 +26,14 @@ void
 fiber_function1()
 {
 	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-	while (++f1counter < cycles) { modm::fiber::yield(); total_counter++; }
+	while (++f1counter < cycles) { modm::this_fiber::yield(); total_counter++; }
 }
 
 void
 fiber_function2(uint32_t cyc)
 {
 	MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-	while (++f2counter < cyc) { modm::fiber::yield(); total_counter++; }
+	while (++f2counter < cyc) { modm::this_fiber::yield(); total_counter++; }
 }
 
 struct Test
@@ -42,14 +42,14 @@ struct Test
 	fiber_function3()
 	{
 		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-		while (++f3counter < cycles) { modm::fiber::yield(); total_counter++; }
+		while (++f3counter < cycles) { modm::this_fiber::yield(); total_counter++; }
 	}
 
 	void
 	fiber_function4(uint32_t cyc)
 	{
 		MODM_LOG_INFO << MODM_FILE_INFO << modm::endl;
-		while (++f4counter < cyc) { modm::fiber::yield(); total_counter++; }
+		while (++f4counter < cyc) { modm::this_fiber::yield(); total_counter++; }
 	}
 
 	volatile uint32_t f3counter{0};
@@ -57,8 +57,8 @@ struct Test
 } test;
 
 // Single purpose fibers to time the yield
-modm_faststack modm::Fiber<> fiber_y1([](){ modm::fiber::yield();  counter.stop(); });
-modm_faststack modm::Fiber<> fiber_y2([](){ counter.start(); modm::fiber::yield(); });
+modm_faststack modm::Fiber<> fiber_y1([](){ modm::this_fiber::yield();  counter.stop(); });
+modm_faststack modm::Fiber<> fiber_y2([](){ counter.start(); modm::this_fiber::yield(); });
 
 modm_faststack modm::Fiber<> fiber1(fiber_function1, modm::fiber::Start::Later);
 modm_faststack modm::Fiber<> fiber2([](){ fiber_function2(cycles); }, modm::fiber::Start::Later);
@@ -71,12 +71,12 @@ extern modm::Fiber<> fiber_pong;
 extern modm::Fiber<> fiber_ping;
 modm_faststack modm::Fiber<> fiber_ping([](){
 	MODM_LOG_INFO << "ping = " << fiber_ping.stack_usage() << modm::endl;
-	modm::fiber::sleep(1s);
+	modm::this_fiber::sleep_for(1s);
 	fiber_pong.start();
 }, modm::fiber::Start::Later);
 modm_faststack modm::Fiber<> fiber_pong([](){
 	MODM_LOG_INFO << "pong = " << fiber_pong.stack_usage() << modm::endl;
-	modm::fiber::sleep(1s);
+	modm::this_fiber::sleep_for(1s);
 	fiber_ping.start();
 }, modm::fiber::Start::Later);
 

--- a/examples/linux/fiber/main.cpp
+++ b/examples/linux/fiber/main.cpp
@@ -17,7 +17,7 @@ void hello()
 	for(int ii=0; ii<10; ii++)
 	{
 		MODM_LOG_INFO << "Hello ";
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 	}
 }
 
@@ -28,7 +28,7 @@ struct Test
 		for(int ii=0; ii<10; ii++)
 		{
 			MODM_LOG_INFO << arg << modm::endl;
-			modm::fiber::yield();
+			modm::this_fiber::yield();
 		}
 	}
 } test;

--- a/examples/nucleo_f429zi/spi_flash_fatfs/main.cpp
+++ b/examples/nucleo_f429zi/spi_flash_fatfs/main.cpp
@@ -319,7 +319,7 @@ modm_faststack modm::Fiber<> blinkyFiber([]()
     while(true)
     {
         Board::Leds::toggle();
-        modm::fiber::sleep(200ms);
+        modm::this_fiber::sleep_for(200ms);
     }
 });
 

--- a/examples/rp_pico/fiber/main.cpp
+++ b/examples/rp_pico/fiber/main.cpp
@@ -42,7 +42,7 @@ fiber_function1(CoreData& d)
 {
 	while (++d.f1counter < cycles)
 	{
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 		d.total_counter++;
 	}
 }
@@ -52,7 +52,7 @@ fiber_function2(CoreData& d)
 {
 	while (++d.f2counter < cycles)
 	{
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 		d.total_counter++;
 	}
 }

--- a/examples/stm32f3_discovery/rotation/main.cpp
+++ b/examples/stm32f3_discovery/rotation/main.cpp
@@ -69,7 +69,7 @@ modm_faststack modm::Fiber<> fiber_gyro([]()
 		}
 
 		// repeat every 5 ms
-		modm::fiber::sleep(5ms);
+		modm::this_fiber::sleep_for(5ms);
 	}
 });
 
@@ -78,7 +78,7 @@ modm_faststack modm::Fiber<> fiber_blinky([]()
 	while (true)
 	{
 		Board::LedSouth::toggle();
-		modm::fiber::sleep(1s);
+		modm::this_fiber::sleep_for(1s);
 	}
 });
 

--- a/examples/stm32f469_discovery/touchscreen/main.cpp
+++ b/examples/stm32f469_discovery/touchscreen/main.cpp
@@ -96,7 +96,7 @@ modm_faststack modm::Fiber<> fiber_blinky([]()
 	while(true)
 	{
 		Board::LedGreen::toggle();
-		modm::fiber::sleep(20ms);
+		modm::this_fiber::sleep_for(20ms);
 	}
 });
 

--- a/ext/gcc/assert.cpp.in
+++ b/ext/gcc/assert.cpp.in
@@ -76,5 +76,9 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	void
 	__throw_bad_any_cast()
 	{ __modm_stdcpp_failure("bad_any_cast"); }
+
+	void
+	__throw_system_error(int errc __attribute__((unused)))
+	{ __modm_stdcpp_failure("system_error"); }
 _GLIBCXX_END_NAMESPACE_VERSION
 } // namespace

--- a/ext/gcc/cxxabi.cpp.in
+++ b/ext/gcc/cxxabi.cpp.in
@@ -27,6 +27,9 @@ void __cxa_deleted_virtual()
 
 %% if with_threadsafe_statics
 #include <atomic>
+%% if with_fibers
+#include <modm/processing/fiber.hpp>
+%% endif
 %% if is_avr
 %#
 // Even thought the actual guard size is uint64_t on AVR, we only need to access
@@ -71,6 +74,10 @@ __cxa_guard_acquire(guard_type *guard)
 			// We got called from inside an interrupt, but we cannot yield back
 			modm_assert(not is_in_irq, "stat.rec",
 					"Recursive initialization of a function static!", guard);
+%% if with_fibers
+			// we're not in an interrupt, try to yield back to the initializing fiber
+			modm::this_fiber::yield();
+%% endif
 		}
 		value = UNINITIALIZED;
 	}

--- a/ext/gcc/module_c++.lb
+++ b/ext/gcc/module_c++.lb
@@ -92,6 +92,7 @@ def build(env):
         "with_threadsafe_statics": with_threadsafe_statics,
         "with_memory_traits": env.has_module(":architecture:memory"),
         "with_heap": env.has_module(":platform:heap"),
+        "with_fibers": env.has_module(":processing:fiber"),
         "is_avr": is_avr,
         "is_cortex_m": is_cortex_m,
     }

--- a/src/modm/architecture/detect.hpp
+++ b/src/modm/architecture/detect.hpp
@@ -203,15 +203,19 @@
 #	define MODM_CPU_ARM		1
 #	define MODM_ALIGNMENT	4
 #	if defined __ARM_ARCH_6SM__ || defined __ARM_ARCH_6M__
+#		define MODM_CPU_CORTEX_M	1
 #		define MODM_CPU_CORTEX_M0	1
 #		define MODM_CPU_STRING		"ARM Cortex-M0"
 #	elif defined __ARM_ARCH_7M__
+#		define MODM_CPU_CORTEX_M	1
 #		define MODM_CPU_CORTEX_M3	1
 #		define MODM_CPU_STRING		"ARM Cortex-M3"
 #	elif defined __ARM_ARCH_7EM__
+#		define MODM_CPU_CORTEX_M	1
 #		define MODM_CPU_CORTEX_M4	1
 #		define MODM_CPU_STRING		"ARM Cortex-M4"
 #	elif defined __ARM_ARCH_8M_MAIN__
+#		define MODM_CPU_CORTEX_M	1
 #		define MODM_CPU_CORTEX_M33	1
 #		define MODM_CPU_STRING		"ARM Cortex-M33"
 #	elif defined __ARM_ARCH_ISA_A64

--- a/src/modm/driver/inertial/bmi088_impl.hpp
+++ b/src/modm/driver/inertial/bmi088_impl.hpp
@@ -225,7 +225,7 @@ void
 Bmi088<Transport>::timerWait()
 {
 	while (timer_.isArmed()) {
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 	}
 }
 

--- a/src/modm/driver/inertial/bmi088_transport_impl.hpp
+++ b/src/modm/driver/inertial/bmi088_transport_impl.hpp
@@ -57,7 +57,7 @@ Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::readRegisters(uint8_t startReg,
 	}
 
 	while (!this->acquireMaster()) {
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 	}
 	Cs::reset();
 
@@ -95,7 +95,7 @@ bool
 Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::writeRegister(uint8_t reg, uint8_t data)
 {
 	while (!this->acquireMaster()) {
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 	}
 	Cs::reset();
 

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
@@ -45,7 +45,7 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 	// start transfer by copying data into register
 	SPDR{{ id }} = data;
 
-	do modm::fiber::yield();
+	do modm::this_fiber::yield();
 	while (!(SPSR{{ id }} & (1 << SPIF{{ id }})));
 
 	return SPDR{{ id }};

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
@@ -62,7 +62,7 @@ modm::platform::UartSpiMaster{{id}}::transfer(uint8_t data)
 %% if use_fiber
 	// wait for transmit register empty
 	while (!((UCSR{{id}}A & (1 << UDRE{{id}}))))
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 %% if not extended
 	if(dataOrder == DataOrder::MsbFirst) {
@@ -72,7 +72,7 @@ modm::platform::UartSpiMaster{{id}}::transfer(uint8_t data)
 	UDR{{id}} = data;
 
 	// wait for receive register not empty
-	do modm::fiber::yield();
+	do modm::this_fiber::yield();
 	while (!((UCSR{{id}}A & (1 << RXC{{id}}))));
 
 	data = UDR{{id}};

--- a/src/modm/platform/spi/rp/spi_master.cpp.in
+++ b/src/modm/platform/spi/rp/spi_master.cpp.in
@@ -30,12 +30,12 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 {
 %% if use_fiber
 	// wait for previous transfer to finish
-	while (txFifoFull()) modm::fiber::yield();
+	while (txFifoFull()) modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	write(data);
 
-	while (rxFifoEmpty()) modm::fiber::yield();
+	while (rxFifoEmpty()) modm::this_fiber::yield();
 
 	return read();
 %% else

--- a/src/modm/platform/spi/rp/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/rp/spi_master_dma_impl.hpp.in
@@ -123,16 +123,16 @@ modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
 	startTransfer(tx, rx, length);
 
 	while (Dma::TxChannel::isBusy() or (rx and Dma::RxChannel::isBusy()))
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	while (!txFifoEmpty() or (rx and !rxFifoEmpty()) or isBusy())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	if (!rx) {
 		// Drain RX FIFO, then wait for shifting to finish (which
 		// may be *after* TX FIFO drains), then drain RX FIFO again
 		while (!rxFifoEmpty()) read();
-		while (isBusy()) modm::fiber::yield();
+		while (isBusy()) modm::this_fiber::yield();
 
 		// Don't leave overrun flag set
 		spi{{ id }}_hw->icr = SPI_SSPICR_RORIC_BITS;

--- a/src/modm/platform/spi/sam/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam/spi_master.cpp.in
@@ -26,14 +26,14 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 
 	// wait for previous transfer to finish
 	while (!isTransmitDataRegisterEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	write(data);
 
 	// wait for current transfer to finish
 	while(!isReceiveDataRegisterFull())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	return read();
 %% else

--- a/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
@@ -23,14 +23,14 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 %% if use_fiber
 	// wait for previous transfer to finish
 	while(!(SpiHal{{ id }}::readStatusFlags() & StatusFlag::TxRegisterEmpty))
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	SpiHal{{ id }}::write(data);
 
 	// wait for current transfer to finish
 	while(!(SpiHal{{ id }}::readStatusFlags() & StatusFlag::RxRegisterFull))
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// read the received byte
 	SpiHal{{ id }}::read(data);

--- a/src/modm/platform/spi/stm32/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.cpp.in
@@ -22,14 +22,14 @@ modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 %% if use_fiber
 	// wait for previous transfer to finish
 	while(!SpiHal{{ id }}::isTransmitRegisterEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	SpiHal{{ id }}::write(data);
 
 	// wait for current transfer to finish
 	while(!SpiHal{{ id }}::isReceiveRegisterNotEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// read the received byte
 	SpiHal{{ id }}::read(data);

--- a/src/modm/platform/spi/stm32/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master_dma_impl.hpp.in
@@ -61,14 +61,14 @@ modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(uint
 
 	// wait for previous transfer to finish
 	while(!SpiHal{{ id }}::isTransmitRegisterEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	SpiHal{{ id }}::write(data);
 
 	// wait for current transfer to finish
 	while(!SpiHal{{ id }}::isReceiveRegisterNotEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// read the received byte
 	SpiHal{{ id }}::read(data);
@@ -146,14 +146,14 @@ modm::platform::SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
 	{
 		if (dmaError) break;
 		else if (not dmaTransmitComplete and not dmaReceiveComplete)
-			modm::fiber::yield();
+			modm::this_fiber::yield();
 %% if "fifo" in features
 		else if (SpiHal{{ id }}::getInterruptFlags() & (SpiBase::InterruptFlag::Busy
 				| SpiBase::InterruptFlag::FifoTxLevel | SpiBase::InterruptFlag::FifoRxLevel))
 %% else
 		else if (SpiHal{{ id }}::getInterruptFlags() & SpiBase::InterruptFlag::Busy)
 %% endif
-			modm::fiber::yield();
+			modm::this_fiber::yield();
 		else break;
 	}
 

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
@@ -31,7 +31,7 @@ modm::platform::UartSpiMaster{{ id }}::transfer(uint8_t data)
 %% if use_fiber
 	// wait for previous transfer to finish
 	while (!UsartHal{{ id }}::isTransmitRegisterEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	// start transfer by copying data into register
 	if(dataOrder == DataOrder::MsbFirst)
@@ -40,7 +40,7 @@ modm::platform::UartSpiMaster{{ id }}::transfer(uint8_t data)
 
 	// wait for current transfer to finish
 	while (!UsartHal{{ id }}::isReceiveRegisterNotEmpty())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	UsartHal{{ id }}::read(data);
 

--- a/src/modm/platform/spi/stm32h7/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master.cpp.in
@@ -25,12 +25,12 @@ SpiMaster{{ id }}::transfer(uint8_t data)
 {
 %% if use_fiber
 	while (Hal::isTxFifoFull())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	Hal::write(data);
 
 	while (!Hal::isRxDataAvailable())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	return Hal::read();
 %% else
@@ -83,7 +83,7 @@ SpiMaster{{ id }}::transfer(
 			++rxIndex;
 		}
 		if (rxIndex < length) {
-			modm::fiber::yield();
+			modm::this_fiber::yield();
 		}
 	}
 %% else

--- a/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
@@ -66,7 +66,7 @@ SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(uint8_t data)
 
 	// wait for transfer to complete
 	while (!Hal::isTransferCompleted())
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 
 	data = SpiHal{{ id }}::read();
 	finishTransfer();
@@ -174,7 +174,7 @@ SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
 				break;
 			}
 		}
-		modm::fiber::yield();
+		modm::this_fiber::yield();
 	}
 	finishTransfer();
 %% else

--- a/src/modm/processing/fiber/barrier.hpp
+++ b/src/modm/processing/fiber/barrier.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include <limits>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+/// Implements the `std::barrier` interface for fibers.
+/// @warning This implementation is not interrupt-safe!
+/// @see https://en.cppreference.com/w/cpp/thread/barrier
+template< class CompletionFunction = decltype([]{}) >
+class barrier
+{
+	barrier(const barrier&) = delete;
+	barrier& operator=(const barrier&) = delete;
+	using count_t = uint16_t;
+
+	const CompletionFunction completion;
+	count_t expected;
+	count_t count;
+	count_t sequence{};
+
+public:
+	using arrival_token = count_t;
+
+	constexpr explicit
+	barrier(std::ptrdiff_t expected, CompletionFunction f = CompletionFunction())
+	: completion(std::move(f)), expected(expected), count(expected) {}
+
+	[[nodiscard]]
+	static constexpr std::ptrdiff_t
+	max() { return std::numeric_limits<count_t>::max(); }
+
+	[[nodiscard]]
+	arrival_token
+	arrive(count_t n=1)
+	{
+		count_t last_arrival{sequence};
+		if (n < count) count -= n;
+		else
+		{
+			count = expected;
+			sequence++;
+			completion();
+		}
+		return last_arrival;
+	}
+
+	void
+	wait(arrival_token arrival) const
+	{
+		while (arrival == sequence) modm::this_fiber::yield();
+	}
+
+	void
+	arrive_and_wait()
+	{
+		wait(arrive());
+	}
+
+	void
+	arrive_and_drop()
+	{
+		if (expected) expected--;
+		(void) arrive();
+	}
+};
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/condition_variable.hpp
+++ b/src/modm/processing/fiber/condition_variable.hpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include "stop_token.hpp"
+#include <atomic>
+
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+enum class
+cv_status
+{
+	no_timeout,
+	timeout
+};
+
+/// Implements the `std::condition_variable_any` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/condition_variable
+class condition_variable_any
+{
+	condition_variable_any(const condition_variable_any&) = delete;
+	condition_variable_any& operator=(const condition_variable_any&) = delete;
+
+	std::atomic<uint16_t> sequence{};
+
+	const auto inline wait_on_sequence()
+	{
+		return [this, poll_sequence = sequence.load(std::memory_order_acquire)]
+		{ return poll_sequence != sequence.load(std::memory_order_acquire); };
+	}
+public:
+	constexpr condition_variable_any() = default;
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	notify_one()
+	{
+		sequence.fetch_add(1, std::memory_order_release);
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	notify_any()
+	{
+		notify_one();
+	}
+
+
+	template< class Lock >
+	void
+	wait(Lock& lock)
+	{
+		lock.unlock();
+		this_fiber::poll(wait_on_sequence());
+		lock.lock();
+	}
+
+	template< class Lock, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	void
+	wait(Lock& lock, Predicate&& pred)
+	{
+		while (not std::forward<Predicate>(pred)()) wait(lock);
+	}
+
+	template< class Lock, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	bool
+	wait(Lock& lock, stop_token stoken, Predicate&& pred)
+	{
+		while (not stoken.stop_requested())
+		{
+			if (std::forward<Predicate>(pred)()) return true;
+			wait(lock);
+		}
+		return std::forward<Predicate>(pred)();
+	}
+
+
+	template< class Lock, class Rep, class Period >
+	cv_status
+	wait_for(Lock& lock, std::chrono::duration<Rep, Period> rel_time)
+	{
+		lock.unlock();
+		const bool result = this_fiber::poll_for(rel_time, wait_on_sequence());
+		lock.lock();
+		return result ? cv_status::no_timeout : cv_status::timeout;
+	}
+
+	template< class Lock, class Rep, class Period, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	bool
+	wait_for(Lock& lock, std::chrono::duration<Rep, Period> rel_time, Predicate&& pred)
+	{
+		while (not std::forward<Predicate>(pred)())
+		{
+			if (wait_for(lock, rel_time) == cv_status::timeout)
+				return std::forward<Predicate>(pred)();
+		}
+		return true;
+	}
+
+	template< class Lock, class Rep, class Period, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	bool
+	wait_for(Lock& lock, stop_token stoken,
+			 std::chrono::duration<Rep, Period> rel_time, Predicate&& pred)
+	{
+		while (not stoken.stop_requested())
+		{
+			if (std::forward<Predicate>(pred)()) return true;
+			if (wait_for(lock, rel_time) == cv_status::timeout)
+				return std::forward<Predicate>(pred)();
+		}
+		return std::forward<Predicate>(pred)();
+	}
+
+
+	template< class Lock, class Clock, class Duration >
+	cv_status
+	wait_until(Lock& lock, std::chrono::time_point<Clock, Duration> abs_time)
+	{
+		lock.unlock();
+		const bool result = this_fiber::poll_until(abs_time, wait_on_sequence());
+		lock.lock();
+		return result ? cv_status::no_timeout : cv_status::timeout;
+	}
+
+	template< class Lock, class Clock, class Duration, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	bool
+	wait_until(Lock& lock, std::chrono::time_point<Clock, Duration> abs_time, Predicate&& pred)
+	{
+		while (not std::forward<Predicate>(pred)())
+		{
+			if (wait_until(lock, abs_time) == cv_status::timeout)
+				return std::forward<Predicate>(pred)();
+		}
+		return true;
+	}
+
+	template< class Lock, class Clock, class Duration, class Predicate >
+	requires requires { std::is_invocable_r_v<bool, Predicate, void>; }
+	bool
+	wait_until(Lock& lock, stop_token stoken,
+			   std::chrono::time_point<Clock, Duration> abs_time, Predicate&& pred)
+	{
+		while (not stoken.stop_requested())
+		{
+			if (std::forward<Predicate>(pred)()) return true;
+			if (wait_until(lock, abs_time) == cv_status::timeout)
+				return std::forward<Predicate>(pred)();
+		}
+		return std::forward<Predicate>(pred)();
+	}
+};
+
+/// There is no specialization for `std::unique_lock<fiber::mutex>`.
+using condition_variable = condition_variable_any;
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/functions.hpp
+++ b/src/modm/processing/fiber/functions.hpp
@@ -42,6 +42,13 @@ yield()
 	modm::fiber::Scheduler::instance().yield();
 }
 
+/// Returns the id of the current fiber
+inline modm::fiber::id
+get_id()
+{
+	return modm::fiber::Scheduler::instance().get_id();
+}
+
 /**
  * Yields the current fiber until the time interval has elapsed.
  * This functionality is a convenience wrapper around `modm::Timeout`

--- a/src/modm/processing/fiber/functions.hpp
+++ b/src/modm/processing/fiber/functions.hpp
@@ -16,7 +16,7 @@
 #include "scheduler.hpp"
 #include <modm/processing/timer.hpp>
 
-namespace modm::fiber
+namespace modm::this_fiber
 {
 
 /// @ingroup modm_processing_fiber
@@ -39,7 +39,7 @@ namespace modm::fiber
 inline void
 yield()
 {
-	Scheduler::instance().yield();
+	modm::fiber::Scheduler::instance().yield();
 }
 
 /**
@@ -53,7 +53,7 @@ yield()
  */
 template< typename Rep, typename Period >
 void
-sleep(std::chrono::duration<Rep, Period> interval)
+sleep_for(std::chrono::duration<Rep, Period> interval)
 {
 	// Only choose the microsecond clock if necessary
 	using TimeoutType = std::conditional_t<
@@ -70,4 +70,21 @@ sleep(std::chrono::duration<Rep, Period> interval)
 
 /// @}
 
-} // namespace modm::fiber
+} // namespace modm::this_fiber
+
+/// @cond
+// DEPRECATE: 2025q2
+namespace modm::fiber
+{
+
+[[deprecated("Use `modm::this_fiber::yield()` instead!")]]
+void inline yield()
+{ this_fiber::yield(); }
+
+template< class Rep, class Period >
+[[deprecated("Use `modm::this_fiber::sleep_for()` instead!")]]
+void sleep(std::chrono::duration<Rep, Period> sleep_duration)
+{ this_fiber::sleep_for(sleep_duration); }
+
+}
+/// @endcond

--- a/src/modm/processing/fiber/latch.hpp
+++ b/src/modm/processing/fiber/latch.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include <limits>
+#include <atomic>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+/// Implements the `std::latch` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/latch
+class latch
+{
+	latch(const latch&) = delete;
+	latch& operator=(const latch&) = delete;
+
+	using count_t = uint16_t;
+	std::atomic<count_t> count;
+
+public:
+	constexpr explicit
+	latch(std::ptrdiff_t expected)
+	: count(expected) {}
+
+	[[nodiscard]]
+	static constexpr std::ptrdiff_t
+	max() { return std::numeric_limits<count_t>::max(); }
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	count_down(count_t n=1)
+	{
+		// ensure we do not underflow the counter!
+		count_t value = count.load(std::memory_order_relaxed);
+		do if (value == 0) return;
+		while (not count.compare_exchange_weak(value, value >= n ? value - n : 0,
+					std::memory_order_acquire, std::memory_order_relaxed));
+	}
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_wait() const
+	{
+		return count.load(std::memory_order_relaxed) == 0;
+	}
+
+	void inline
+	wait() const
+	{
+		while(not try_wait()) modm::this_fiber::yield();
+	}
+
+	void inline
+	arrive_and_wait(std::ptrdiff_t n=1)
+	{
+		count_down(n);
+		wait();
+	}
+};
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/module.lb
+++ b/src/modm/processing/fiber/module.lb
@@ -21,7 +21,7 @@ def is_enabled(env):
         not env.has_module(":processing:protothread")
 
 def prepare(module, options):
-    module.depends(":processing:timer")
+    module.depends(":processing:timer", ":architecture:atomic")
 
     module.add_query(
         EnvironmentQuery(name="__enabled", factory=is_enabled))
@@ -47,6 +47,7 @@ def build(env):
         "with_fpu": with_fpu,
         "target": env[":target"].identifier,
         "multicore": env.has_module(":platform:multicore"),
+        "num_cores": 1,
     }
     if env.has_module(":platform:multicore"):
         cores = int(env[":target"].identifier.cores)
@@ -78,3 +79,11 @@ def build(env):
     env.copy("task.hpp")
     env.copy("functions.hpp")
     env.copy("fiber.hpp")
+
+    env.copy("mutex.hpp")
+    env.copy("shared_mutex.hpp")
+    env.copy("semaphore.hpp")
+    env.copy("latch.hpp")
+    env.copy("barrier.hpp")
+    env.copy("stop_token.hpp")
+    env.copy("condition_variable.hpp")

--- a/src/modm/processing/fiber/module.lb
+++ b/src/modm/processing/fiber/module.lb
@@ -27,6 +27,7 @@ def prepare(module, options):
         EnvironmentQuery(name="__enabled", factory=is_enabled))
 
     core = options[":target"].get_driver("core")["type"]
+    if core.startswith("cortex-m"): module.depends(":cmsis:device")
     return (core.startswith("cortex-m") or core.startswith("avr") or
             "x86_64" in core or "arm64" in core)
 

--- a/src/modm/processing/fiber/module.md
+++ b/src/modm/processing/fiber/module.md
@@ -7,11 +7,11 @@ simple round-robin scheduler. Here is a minimal example that blinks an LED:
 modm::Fiber<> fiber([]()
 {
 	Board::LedBlue::setOutput();
-	modm::fiber::yield();
+	modm::this_fiber::yield();
 	while(true)
 	{
 		Board::LedBlue::toggle();
-		modm::fiber::sleep(1s);
+		modm::this_fiber::sleep_for(1s);
 	}
 });
 int main(void)
@@ -80,7 +80,7 @@ modm::Fiber<> fiber(function, false);
 // fiber2 is automatically executing
 modm::Fiber<> fiber2([&]()
 {
-	modm::fiber::sleep(1s);
+	modm::this_fiber::sleep_for(1s);
 	fiber.start();
 });
 modm::fiber::Scheduler::run();
@@ -194,7 +194,7 @@ registers contain the watermark value.
 
 Fibers are implemented by saving callee registers to the current stack, then
 switching to a new stack and restoring callee registers from this stack.
-The static `modm::fiber::yield()` function wraps this functionality in a
+The static `modm::this_fiber::yield()` function wraps this functionality in a
 transparent way.
 
 ### AVR

--- a/src/modm/processing/fiber/mutex.hpp
+++ b/src/modm/processing/fiber/mutex.hpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include <modm/architecture/interface/atomic_lock.hpp>
+#include <limits>
+#include <atomic>
+#include <mutex>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+/// Implements the `std::mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/mutex
+class mutex
+{
+	mutex(const mutex&) = delete;
+	mutex& operator=(const mutex&) = delete;
+
+	std::atomic_bool locked{false};
+public:
+	constexpr mutex() = default;
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_lock()
+	{
+		return not locked.exchange(true, std::memory_order_acquire);
+	}
+
+	void inline
+	lock()
+	{
+		while(not try_lock()) modm::this_fiber::yield();
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	unlock()
+	{
+		locked.store(false, std::memory_order_release);
+	}
+};
+
+/// Implements the `std::timed_mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/timed_mutex
+class timed_mutex : public mutex
+{
+public:
+	template< typename Rep, typename Period >
+	[[nodiscard]]
+	bool
+	try_lock_for(std::chrono::duration<Rep, Period> sleep_duration)
+	{
+		return this_fiber::poll_for(sleep_duration, [this]{ return try_lock(); });
+	}
+
+	template< class Clock, class Duration >
+	[[nodiscard]]
+	bool
+	try_lock_until(std::chrono::time_point<Clock, Duration> sleep_time)
+	{
+		return this_fiber::poll_until(sleep_time, [this]{ return try_lock(); });
+	}
+};
+
+/// Implements the `std::recursive_mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/recursive_mutex
+class recursive_mutex
+{
+	recursive_mutex(const recursive_mutex&) = delete;
+	recursive_mutex& operator=(const recursive_mutex&) = delete;
+	using count_t = uint16_t;
+
+	static constexpr fiber::id NoOwner{fiber::id(-1)};
+	volatile fiber::id owner{NoOwner};
+	static constexpr count_t countMax{count_t(-1)};
+	volatile count_t count{1};
+
+public:
+	constexpr recursive_mutex() = default;
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_lock()
+	{
+		const auto id = modm::this_fiber::get_id();
+		modm::atomic::Lock _;
+		if (owner == NoOwner) {
+			owner = id;
+			// count = 1; is implicit
+			return true;
+		}
+		if (owner == id and count < countMax) {
+			count++;
+			return true;
+		}
+		return false;
+	}
+
+	void inline
+	lock()
+	{
+		while(not try_lock()) modm::this_fiber::yield();
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	unlock()
+	{
+		modm::atomic::Lock _;
+		if (count > 1) count--;
+		else {
+			// count = 1; is implicit
+			owner = NoOwner;
+		}
+	}
+};
+
+/// Implements the `std::recursive_timed_mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/recursive_timed_mutex
+class recursive_timed_mutex : public recursive_mutex
+{
+public:
+	template< typename Rep, typename Period >
+	[[nodiscard]]
+	bool
+	try_lock_for(std::chrono::duration<Rep, Period> sleep_duration)
+	{
+		return this_fiber::poll_for(sleep_duration, [this]{ return try_lock(); });
+	}
+
+	template< class Clock, class Duration >
+	[[nodiscard]]
+	bool
+	try_lock_until(std::chrono::time_point<Clock, Duration> sleep_time)
+	{
+		return this_fiber::poll_until(sleep_time, [this]{ return try_lock(); });
+	}
+};
+
+
+
+/// Implements the `std::once_flag` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/once_flag
+class once_flag
+{
+	template<typename Callable, typename... Args>
+	friend void call_once(once_flag&, Callable&&, Args&&...);
+
+	once_flag(const once_flag&) = delete;
+	once_flag& operator=(const once_flag&) = delete;
+
+	std::atomic_flag state{};
+	inline bool try_call() { return not state.test_and_set(std::memory_order_acquire); }
+
+public:
+	constexpr once_flag() = default;
+};
+
+/// Implements the `std::call_once` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/call_once
+template<typename Callable, typename... Args>
+void
+call_once(once_flag& flag, Callable&& f, Args&&... args)
+{
+	if (flag.try_call()) std::forward<Callable>(f)(std::forward<Args>(args)...);
+}
+
+// Reuse the stdlibc++ implementation for the rest
+
+/// @see https://en.cppreference.com/w/cpp/thread/lock_guard
+using ::std::lock_guard;
+
+/// @see https://en.cppreference.com/w/cpp/thread/scoped_lock
+using ::std::scoped_lock;
+/// @see https://en.cppreference.com/w/cpp/thread/unique_lock
+using ::std::unique_lock;
+
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag_t
+using ::std::defer_lock_t;
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag_t
+using ::std::try_to_lock_t;
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag_t
+using ::std::adopt_lock_t;
+
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag
+using ::std::defer_lock;
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag
+using ::std::try_to_lock;
+/// @see https://en.cppreference.com/w/cpp/thread/lock_tag
+using ::std::adopt_lock;
+
+/// @see https://en.cppreference.com/w/cpp/thread/try_lock
+using ::std::try_lock;
+/// @see https://en.cppreference.com/w/cpp/thread/lock
+using ::std::lock;
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/scheduler.hpp.in
+++ b/src/modm/processing/fiber/scheduler.hpp.in
@@ -13,11 +13,14 @@
 
 #pragma once
 
-#include "fiber.hpp"
+#include "task.hpp"
 #include <modm/processing/timer.hpp>
 %% if multicore
 #include <modm/platform/core/multicore.hpp>
 %% endif
+
+// forward declaration
+namespace modm::this_fiber { void yield(); }
 
 namespace modm::fiber
 {
@@ -33,7 +36,7 @@ namespace modm::fiber
 class Scheduler
 {
 	friend class Task;
-	friend void yield();
+	friend void modm::this_fiber::yield();
 	Scheduler(const Scheduler&) = delete;
 	Scheduler& operator=(const Scheduler&) = delete;
 

--- a/src/modm/processing/fiber/scheduler.hpp.in
+++ b/src/modm/processing/fiber/scheduler.hpp.in
@@ -18,9 +18,12 @@
 %% if multicore
 #include <modm/platform/core/multicore.hpp>
 %% endif
+%% if core.startswith("cortex-m")
+#include <modm/platform/device.hpp>
+%% endif
 
 // forward declaration
-namespace modm::this_fiber { void yield(); }
+namespace modm::this_fiber { void yield(); modm::fiber::id get_id(); }
 
 namespace modm::fiber
 {
@@ -37,12 +40,23 @@ class Scheduler
 {
 	friend class Task;
 	friend void modm::this_fiber::yield();
+	friend modm::fiber::id modm::this_fiber::get_id();
 	Scheduler(const Scheduler&) = delete;
 	Scheduler& operator=(const Scheduler&) = delete;
 
 protected:
 	Task* last{nullptr};
 	Task* current{nullptr};
+
+	uintptr_t
+	get_id() const
+	{
+%% if core.startswith("cortex-m")
+		// Ensure that calling this in an interrupt gives a different ID
+		if (const auto irq = __get_IPSR(); irq) return irq;
+%% endif
+		return reinterpret_cast<uintptr_t>(current);
+	}
 
 	void
 	runNext(Task* task)

--- a/src/modm/processing/fiber/scheduler.hpp.in
+++ b/src/modm/processing/fiber/scheduler.hpp.in
@@ -58,6 +58,16 @@ protected:
 		return reinterpret_cast<uintptr_t>(current);
 	}
 
+	static bool
+	isInsideInterrupt()
+	{
+%% if core.startswith("cortex-m")
+		return __get_IPSR();
+%% else
+		return false;
+%% endif
+	}
+
 	void
 	runNext(Task* task)
 	{
@@ -161,6 +171,12 @@ protected:
 
 public:
 	constexpr Scheduler() = default;
+
+	static constexpr unsigned int
+	hardware_concurrency()
+	{
+		return {{num_cores}};
+	}
 
 	/// Runs the currently active scheduler.
 	static void

--- a/src/modm/processing/fiber/semaphore.hpp
+++ b/src/modm/processing/fiber/semaphore.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include <limits>
+#include <atomic>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+/// Implements the `std::counting_semaphore` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/counting_semaphore
+template< std::ptrdiff_t LeastMaxValue = 255 >
+class counting_semaphore
+{
+	counting_semaphore(const counting_semaphore&) = delete;
+	counting_semaphore& operator=(const counting_semaphore&) = delete;
+
+	static_assert(LeastMaxValue <= uint16_t(-1), "counting_semaphore uses a 16-bit counter!");
+	using count_t = std::conditional_t<(LeastMaxValue < 256), uint8_t, uint16_t>;
+	std::atomic<count_t> count{};
+
+public:
+	constexpr explicit
+	counting_semaphore(std::ptrdiff_t desired)
+	: count(desired) {}
+
+	[[nodiscard]]
+	static constexpr std::ptrdiff_t
+	max() { return std::numeric_limits<count_t>::max(); }
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_acquire()
+	{
+		count_t current = count.load(std::memory_order_relaxed);
+		do if (current == 0) return false;
+		while(not count.compare_exchange_weak(current, current - 1,
+						std::memory_order_acquire, std::memory_order_relaxed));
+		return true;
+	}
+
+	void inline
+	acquire()
+	{
+		while(not try_acquire()) modm::this_fiber::yield();
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	release()
+	{
+		count.fetch_add(1, std::memory_order_release);
+	}
+
+	template< typename Rep, typename Period >
+	[[nodiscard]]
+	bool
+	try_acquire_for(std::chrono::duration<Rep, Period> sleep_duration)
+	{
+		return this_fiber::poll_for(sleep_duration, [this]{ return try_acquire(); });
+	}
+
+	template< class Clock, class Duration >
+	[[nodiscard]]
+	bool
+	try_acquire_until(std::chrono::time_point<Clock, Duration> sleep_time)
+	{
+		return this_fiber::poll_until(sleep_time, [this]{ return try_acquire(); });
+	}
+};
+
+/// Implements the `std::binary_semaphore` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/counting_semaphore
+using binary_semaphore = counting_semaphore<1>;
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/shared_mutex.hpp
+++ b/src/modm/processing/fiber/shared_mutex.hpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "fiber.hpp"
+#include <atomic>
+#include <shared_mutex>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+/// Implements the `std::shared_mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/shared_mutex
+class shared_mutex
+{
+	shared_mutex(const shared_mutex&) = delete;
+	shared_mutex& operator=(const shared_mutex&) = delete;
+
+	static constexpr fiber::id NoOwner{fiber::id(-1)};
+	static constexpr fiber::id SharedOwner{fiber::id(-2)};
+	std::atomic<fiber::id> owner{NoOwner};
+public:
+	constexpr shared_mutex() = default;
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_lock()
+	{
+		const fiber::id new_owner = modm::this_fiber::get_id();
+		fiber::id expected{NoOwner};
+		return owner.compare_exchange_strong(expected, new_owner,
+				std::memory_order_acquire, std::memory_order_relaxed);
+	}
+
+	void inline
+	lock()
+	{
+		while(not try_lock()) modm::this_fiber::yield();
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	unlock()
+	{
+		owner.store(NoOwner, std::memory_order_release);
+	}
+
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	try_lock_shared()
+	{
+		fiber::id current = owner.load(std::memory_order_relaxed);
+		do if (current < SharedOwner) return false;
+		while(not owner.compare_exchange_weak(current, SharedOwner,
+				std::memory_order_acquire, std::memory_order_relaxed));
+		return true;
+	}
+
+	void inline
+	lock_shared()
+	{
+		while(not try_lock_shared()) modm::this_fiber::yield();
+	}
+
+	/// @note This function can be called from an interrupt.
+	void inline
+	unlock_shared()
+	{
+		owner.store(NoOwner, std::memory_order_release);
+	}
+};
+
+/// Implements the `std::shared_timed_mutex` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/shared_timed_mutex
+class shared_timed_mutex : public shared_mutex
+{
+public:
+	template< typename Rep, typename Period >
+	[[nodiscard]]
+	bool
+	try_lock_for(std::chrono::duration<Rep, Period> sleep_duration)
+	{
+		return this_fiber::poll_for(sleep_duration, [this]{ return try_lock(); });
+	}
+
+	template< class Clock, class Duration >
+	[[nodiscard]]
+	bool
+	try_lock_until(std::chrono::time_point<Clock, Duration> sleep_time)
+	{
+		return this_fiber::poll_until(sleep_time, [this]{ return try_lock(); });
+	}
+
+	template< typename Rep, typename Period >
+	[[nodiscard]]
+	bool
+	try_lock_shared_for(std::chrono::duration<Rep, Period> sleep_duration)
+	{
+		return this_fiber::poll_for(sleep_duration, [this]{ return try_lock_shared(); });
+	}
+
+	template< class Clock, class Duration >
+	[[nodiscard]]
+	bool
+	try_lock_shared_until(std::chrono::time_point<Clock, Duration> sleep_time)
+	{
+		return this_fiber::poll_until(sleep_time, [this]{ return try_lock_shared(); });
+	}
+};
+
+
+// Reuse the stdlibc++ implementation
+using ::std::shared_lock;
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/stop_token.hpp
+++ b/src/modm/processing/fiber/stop_token.hpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <atomic>
+#include <utility>
+
+namespace modm::fiber
+{
+
+/// @ingroup modm_processing_fiber
+/// @{
+
+class stop_source;
+class stop_token;
+
+/**
+ * Provides the implementation and memory storage for the stop request.
+ * You must allocate this object yourself and derive the token and source then
+ * from this object. This manual memory management differs from the `std`
+ * interface.
+ *
+ * @warning The lifetime of this object must be longer or equal to the lifetime
+ *          of the derived `stop_token` and `stop_source`.
+ */
+class stop_state
+{
+	std::atomic_bool requested{false};
+
+public:
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]]
+	bool inline
+	stop_requested() const
+	{
+		return requested.load(std::memory_order_relaxed);
+	}
+
+	/// @note This function can be called from an interrupt.
+	bool inline
+	request_stop()
+	{
+		return not requested.exchange(true, std::memory_order_relaxed);
+	}
+
+	constexpr stop_source
+	get_source();
+
+	constexpr stop_token
+	get_token();
+};
+
+/// Implements the `std::stop_token` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/stop_token
+class stop_token
+{
+	friend class stop_state;
+	const stop_state *state{nullptr};
+
+	constexpr explicit stop_token(const stop_state *state) : state(state) {}
+public:
+	constexpr stop_token() = default;
+	constexpr stop_token(const stop_token&) = default;
+	constexpr stop_token(stop_token&&) = default;
+	constexpr ~stop_token() = default;
+	constexpr stop_token& operator=(const stop_token&) = default;
+	constexpr stop_token& operator=(stop_token&&) = default;
+
+	[[nodiscard]]
+	bool inline
+	stop_possible() const
+	{
+		return state;
+	}
+
+	[[nodiscard]]
+	bool inline
+	stop_requested() const
+	{
+		return stop_possible() and state->stop_requested();
+	}
+
+	void inline
+	swap(stop_token& rhs)
+	{
+		std::swap(state, rhs.state);
+	}
+
+	[[nodiscard]]
+	friend bool inline
+	operator==(const stop_token& a, const stop_token& b)
+	{
+		return a.state == b.state;
+	}
+
+	friend void inline
+	swap(stop_token& lhs, stop_token& rhs)
+	{
+		lhs.swap(rhs);
+	}
+};
+
+/// Implements the `std::stop_source` interface for fibers.
+/// @see https://en.cppreference.com/w/cpp/thread/stop_source
+class stop_source
+{
+	friend class stop_state;
+	stop_state *state{nullptr};
+	explicit constexpr stop_source(stop_state *state) : state(state) {}
+
+public:
+	constexpr stop_source() = default;
+	constexpr stop_source(const stop_source&) = default;
+	constexpr stop_source(stop_source&&) = default;
+	constexpr ~stop_source() = default;
+	constexpr stop_source& operator=(const stop_source&) = default;
+	constexpr stop_source& operator=(stop_source&&) = default;
+
+	[[nodiscard]]
+	constexpr bool
+	stop_possible() const
+	{
+		return state;
+	}
+
+	[[nodiscard]]
+	bool inline
+	stop_requested() const
+	{
+		return stop_possible() and state->stop_requested();
+	}
+
+	bool inline
+	request_stop()
+	{
+		return stop_possible() and state->request_stop();
+	}
+
+	[[nodiscard]]
+	stop_token inline
+	get_token() const
+	{
+		return state->get_token();
+	}
+
+	void inline
+	swap(stop_source& rhs)
+	{
+		std::swap(state, rhs.state);
+	}
+
+	[[nodiscard]]
+	friend bool inline
+	operator==(const stop_source& a, const stop_source& b)
+	{
+		return a.state == b.state;
+	}
+
+	friend void inline
+	swap(stop_source& lhs, stop_source& rhs)
+	{
+		lhs.swap(rhs);
+	}
+};
+
+/// @cond
+constexpr stop_source
+stop_state::get_source()
+{
+	return stop_source{this};
+}
+
+constexpr stop_token
+stop_state::get_token()
+{
+	return stop_token{this};
+}
+/// @endcond
+
+/// @}
+
+}

--- a/src/modm/processing/fiber/task.hpp
+++ b/src/modm/processing/fiber/task.hpp
@@ -29,6 +29,10 @@ Start
 	Later,	// Manually add the fiber to a scheduler.
 };
 
+/// Identifier of a fiber task.
+/// @ingroup modm_processing_fiber
+using id = uintptr_t;
+
 /**
  * The fiber task connects the callable fiber object with the fiber context and
  * scheduler. It constructs the fiber function on the stack if necessary, and
@@ -74,7 +78,7 @@ public:
 
 	/// @returns the stack usage as measured by a watermark level.
 	/// @see `modm_context_stack_usage()`.
-	size_t
+	[[nodiscard]] size_t
 	stack_usage() const
 	{
 		return modm_context_stack_usage(&ctx);
@@ -82,7 +86,7 @@ public:
 
 	/// @returns if the bottom word on the stack has been overwritten.
 	/// @see `modm_context_stack_overflow()`.
-	bool
+	[[nodiscard]] bool
 	stack_overflow() const
 	{
 		return modm_context_stack_overflow(&ctx);
@@ -94,7 +98,7 @@ public:
 	start();
 
 	/// @returns if the fiber is attached to a scheduler.
-	bool
+	[[nodiscard]] bool
 	isRunning() const
 	{
 		return scheduler;

--- a/src/modm/processing/fiber/task.hpp
+++ b/src/modm/processing/fiber/task.hpp
@@ -13,11 +13,16 @@
 
 #include "stack.hpp"
 #include "context.h"
+#include "stop_token.hpp"
 #include <type_traits>
+
+// forward declaration
+namespace modm::this_fiber { void yield(); }
 
 namespace modm::fiber
 {
 
+// forward declaration
 class Scheduler;
 
 /// The Fiber scheduling policy.
@@ -44,6 +49,7 @@ using id = uintptr_t;
  * managing a fiber. You may therefore place objects of this class in fast
  * core-local memory, while the stack must remain in DMA-able memory!
  *
+ * @see https://en.cppreference.com/w/cpp/thread/jthread
  * @author Erik Henriksson
  * @author Niklas Hauser
  * @ingroup modm_processing_fiber
@@ -60,17 +66,72 @@ class Task
 	modm_context_t ctx;
 	Task* next;
 	Scheduler *scheduler{nullptr};
+	stop_state stop{};
 
 public:
 	/// @param stack	A stack object that is *NOT* shared with other tasks.
-	/// @param closure	A callable object of signature `void(*)()`.
+	/// @param closure	A callable object of signature `void()`.
 	/// @param start	When to start this task.
-	template<size_t Size, class T>
-	Task(Stack<Size>& stack, T&& closure, Start start=Start::Now);
+	template<size_t Size, class Callable>
+	Task(Stack<Size>& stack, Callable&& closure, Start start=Start::Now);
+
+	inline
+	~Task()
+	{
+		request_stop();
+		join();
+	}
+
+	/// Returns the number of concurrent threads supported by the implementation.
+	[[nodiscard]] static constexpr unsigned int
+	hardware_concurrency();
+
+	/// Returns a value of std::thread::id identifying the thread associated
+	/// with `*this`.
+	/// @note This function can be called from an interrupt.
+	[[nodiscard]] modm::fiber::id inline
+	get_id() const
+	{
+		return reinterpret_cast<id>(this);
+	}
+
+	/// Checks if the Task object identifies an active fiber of execution.
+	[[nodiscard]] bool
+	joinable() const;
+
+	/// Blocks the current fiber until the fiber identified by `*this`
+	/// finishes its execution. Returns immediately if the thread is not joinable.
+	void inline
+	join()
+	{
+		if (joinable()) while(isRunning()) modm::this_fiber::yield();
+	}
+
+	[[nodiscard]]
+	stop_source inline
+	get_stop_source()
+	{
+		return stop.get_source();
+	}
+
+	[[nodiscard]]
+	stop_token inline
+	get_stop_token()
+	{
+		return stop.get_token();
+	}
+
+	/// @note This function can be called from an interrupt.
+	bool inline
+	request_stop()
+	{
+		return stop.request_stop();
+	}
+
 
 	/// Watermarks the stack to measure `stack_usage()` later.
 	/// @see `modm_context_watermark()`.
-	void
+	void inline
 	watermark_stack()
 	{
 		modm_context_watermark(&ctx);
@@ -78,7 +139,7 @@ public:
 
 	/// @returns the stack usage as measured by a watermark level.
 	/// @see `modm_context_stack_usage()`.
-	[[nodiscard]] size_t
+	[[nodiscard]] size_t inline
 	stack_usage() const
 	{
 		return modm_context_stack_usage(&ctx);
@@ -86,7 +147,7 @@ public:
 
 	/// @returns if the bottom word on the stack has been overwritten.
 	/// @see `modm_context_stack_overflow()`.
-	[[nodiscard]] bool
+	[[nodiscard]] bool inline
 	stack_overflow() const
 	{
 		return modm_context_stack_overflow(&ctx);
@@ -98,7 +159,7 @@ public:
 	start();
 
 	/// @returns if the fiber is attached to a scheduler.
-	[[nodiscard]] bool
+	[[nodiscard]] bool inline
 	isRunning() const
 	{
 		return scheduler;
@@ -117,16 +178,21 @@ namespace modm::fiber
 template<size_t Size, class T>
 Task::Task(Stack<Size>& stack, T&& closure, Start start)
 {
-	if constexpr (std::is_convertible_v<T, void(*)()>)
+	constexpr bool with_stop_token = std::is_invocable_r_v<void, T, stop_token>;
+	if constexpr (std::is_convertible_v<T, void(*)()> or
+				  std::is_convertible_v<T, void(*)(stop_token)>)
 	{
 		// A plain function without closure
-		auto caller = (uintptr_t) +[](void(*fn)())
+		using Callable = std::conditional_t<with_stop_token, void(*)(stop_token), void(*)()>;
+		auto caller = (uintptr_t) +[](Callable fn)
 		{
-			fn();
+			if constexpr (with_stop_token) {
+				fn(fiber::Scheduler::instance().current->get_stop_token());
+			} else fn();
 			fiber::Scheduler::instance().unschedule();
 		};
 		modm_context_init(&ctx, stack.memory, stack.memory + stack.words,
-						  caller, (uintptr_t) static_cast<void(*)()>(closure));
+						  caller, (uintptr_t) static_cast<Callable>(closure));
 	}
 	else
 	{
@@ -134,7 +200,7 @@ Task::Task(Stack<Size>& stack, T&& closure, Start start)
 		constexpr size_t align_mask = std::max(StackAlignment, alignof(std::decay_t<T>)) - 1u;
 		constexpr size_t closure_size = (sizeof(std::decay_t<T>) + align_mask) & ~align_mask;
 		static_assert(Size >= closure_size + StackSizeMinimum,
-					  "Stack size must ≥({{min_stack_size}}B + aligned sizeof(closure))!");
+				"Stack size must be larger than minimum stack size + aligned sizeof(closure))!");
 		// Find a suitable aligned area at the top of stack to allocate the closure
 		const uintptr_t ptr = uintptr_t(stack.memory + stack.words) - closure_size;
 		// construct closure in place
@@ -142,7 +208,9 @@ Task::Task(Stack<Size>& stack, T&& closure, Start start)
 		// Encapsulate the proper ABI function call into a simpler function
 		auto caller = (uintptr_t) +[](std::decay_t<T>* closure)
 		{
-			(*closure)();
+			if constexpr (with_stop_token) {
+				(*closure)(fiber::Scheduler::instance().current->get_stop_token());
+			} else (*closure)();
 			fiber::Scheduler::instance().unschedule();
 		};
 		// initialize the stack below the allocated closure
@@ -156,8 +224,22 @@ Task::start()
 {
 	if (isRunning()) return false;
 	modm_context_reset(&ctx);
-	fiber::Scheduler::instance().add(*this);
+	Scheduler::instance().add(*this);
 	return true;
+}
+
+constexpr unsigned int
+Task::hardware_concurrency()
+{
+	return Scheduler::hardware_concurrency();
+}
+
+bool inline
+Task::joinable() const
+{
+	if (not isRunning()) return false;
+	if (Scheduler::isInsideInterrupt()) return false;
+	return get_id() != Scheduler::instance().get_id();
 }
 
 }

--- a/src/modm/processing/protothread/macros_fiber.hpp
+++ b/src/modm/processing/protothread/macros_fiber.hpp
@@ -39,7 +39,7 @@
 /// Yield protothread till next call to its run().
 /// \hideinitializer
 #define PT_YIELD() \
-	modm::fiber::yield()
+	modm::this_fiber::yield()
 
 /// Cause protothread to wait **while** given condition is true.
 /// \hideinitializer

--- a/src/modm/processing/protothread/module.md
+++ b/src/modm/processing/protothread/module.md
@@ -83,11 +83,11 @@ option, which replaces the preprocessor macros and C++ implementations of this
 and the `modm:processing:resumable` module with a fiber version.
 
 Specifically, the `PT_*` and `RF_*` macros are now forwarding their arguments
-unmodified and instead relying on `modm::fiber::yield()` for context switching:
+unmodified and instead relying on `modm::this_fiber::yield()` for context switching:
 
 ```cpp
-#define PT_YIELD() modm::fiber::yield()
-#define PT_WAIT_WHILE(cond) while(cond) { modm::fiber::yield(); }
+#define PT_YIELD() modm::this_fiber::yield()
+#define PT_WAIT_WHILE(cond) while(cond) { modm::this_fiber::yield(); }
 #define PT_CALL(func) func
 ```
 

--- a/src/modm/processing/protothread/protothread_fiber.hpp
+++ b/src/modm/processing/protothread/protothread_fiber.hpp
@@ -30,7 +30,7 @@ class Protothread : public modm::Fiber< MODM_PROTOTHREAD_STACK_SIZE >
 {
 public:
 	Protothread(modm::fiber::Start start=modm::fiber::Start::Now)
-	:	Fiber([this](){ while(update()) modm::fiber::yield(); }, start)
+	:	Fiber([this](){ while(update()) modm::this_fiber::yield(); }, start)
 	{}
 
 	void restart() { this->start(); }

--- a/src/modm/processing/resumable/macros_fiber.hpp
+++ b/src/modm/processing/resumable/macros_fiber.hpp
@@ -52,7 +52,7 @@
 /// Yield resumable function until next invocation.
 /// @hideinitializer
 #define RF_YIELD() \
-	modm::fiber::yield()
+	modm::this_fiber::yield()
 
 /// Cause resumable function to wait until given child protothread completes.
 /// @hideinitializer

--- a/src/modm/processing/resumable/module.md
+++ b/src/modm/processing/resumable/module.md
@@ -164,17 +164,17 @@ preprocessor macros and C++ implementations of this and the
 `modm:processing:protothreads` module with a fiber version.
 
 Specifically, the `PT_*` and `RF_*` macros are now forwarding their arguments
-unmodified and instead relying on `modm::fiber::yield()` for context switching:
+unmodified and instead relying on `modm::this_fiber::yield()` for context switching:
 
 ```cpp
-#define RF_YIELD() modm::fiber::yield()
-#define RF_WAIT_WHILE(cond) while(cond) { modm::fiber::yield(); }
+#define RF_YIELD() modm::this_fiber::yield()
+#define RF_WAIT_WHILE(cond) while(cond) { modm::this_fiber::yield(); }
 #define RF_CALL(func) func
 #define RF_RETURN(value) return value
 ```
 
 You may call `RF_CALL_BLOCKING(resumable)` outside a fiber context, in which
-case the `modm::fiber::yield()` will return immediately, which is the same
+case the `modm::this_fiber::yield()` will return immediately, which is the same
 behavior as before.
 
 However, the `modm::ResumableResult`, `modm::Resumable`, and `modm::NestedResumable`

--- a/test/modm/processing/fiber/fiber_condition_variable_test.cpp
+++ b/test/modm/processing/fiber/fiber_condition_variable_test.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber_condition_variable_test.hpp"
+#include "shared.hpp"
+#include <modm/processing/fiber/condition_variable.hpp>
+
+static struct
+{
+	uint8_t lock_count{0}, unlock_count{0};
+	void inline reset() { lock_count = 0; unlock_count = 0; }
+	void inline lock() { lock_count++; }
+	void inline unlock() { unlock_count++; }
+} elock;
+
+bool predicate_value{false};
+static bool predicate() { return predicate_value; }
+
+void
+ConditionVariableTest::setUp()
+{
+	state = 0;
+	elock.reset();
+	predicate_value = false;
+}
+
+// ========================== CONDITION VARIABLE WAIT =========================
+static modm::fiber::condition_variable cv;
+
+static void
+f1()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+
+	cv.wait(elock); // goto 1
+
+	TEST_ASSERT_EQUALS(elock.lock_count, 1u);
+	TEST_ASSERT_EQUALS(elock.unlock_count, 1u);
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+}
+
+static void
+f2()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	// let f1 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	cv.notify_one();
+	modm::this_fiber::yield(); // goto 3
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+}
+
+void
+ConditionVariableTest::testConditionVariableWait()
+{
+	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Scheduler::run();
+}
+
+// ===================== CONDITION VARIABLE WAIT PREDICATE ====================
+static void
+f3()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+
+	cv.wait(elock, predicate); // goto 1
+
+	TEST_ASSERT_EQUALS(elock.lock_count, 4u);
+	TEST_ASSERT_EQUALS(elock.unlock_count, 4u);
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+}
+
+static void
+f4()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	// let f3 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	cv.notify_one();
+	modm::this_fiber::yield();
+	cv.notify_any();
+	modm::this_fiber::yield();
+	cv.notify_one();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	predicate_value = true;
+	cv.notify_one();
+	modm::this_fiber::yield(); // goto 4
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+}
+
+void
+ConditionVariableTest::testConditionVariableWaitPredicate()
+{
+	modm::fiber::Task fiber1(stack1, f3), fiber2(stack2, f4);
+	modm::fiber::Scheduler::run();
+}
+
+// ===================== CONDITION VARIABLE WAIT PREDICATE ====================
+static modm::fiber::stop_state stop;
+
+static void
+f5()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+
+	cv.wait(elock, stop.get_token(), predicate); // goto 1
+
+	TEST_ASSERT_EQUALS(elock.lock_count, 4u);
+	TEST_ASSERT_EQUALS(elock.unlock_count, 4u);
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+}
+
+static void
+f6()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	// let f3 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	cv.notify_one();
+	modm::this_fiber::yield();
+	cv.notify_any();
+	modm::this_fiber::yield();
+	cv.notify_one();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	stop.request_stop();
+	cv.notify_one();
+	modm::this_fiber::yield(); // goto 4
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+}
+
+void
+ConditionVariableTest::testConditionVariableWaitStopTokenPredicate()
+{
+	modm::fiber::Task fiber1(stack1, f5), fiber2(stack2, f6);
+	modm::fiber::Scheduler::run();
+}

--- a/test/modm/processing/fiber/fiber_condition_variable_test.hpp
+++ b/test/modm/processing/fiber/fiber_condition_variable_test.hpp
@@ -14,33 +14,18 @@
 #include <unittest/testsuite.hpp>
 
 /// @ingroup modm_test_test_architecture
-class FiberTest : public unittest::TestSuite
+class ConditionVariableTest : public unittest::TestSuite
 {
 public:
 	void
 	setUp();
 
 	void
-	testOneFiber();
+	testConditionVariableWait();
 
 	void
-	testTwoFibers();
+	testConditionVariableWaitPredicate();
 
 	void
-	testYieldFromSubroutine();
-
-	void
-	testPollFor();
-
-	void
-	testPollUntil();
-
-	void
-	testSleepFor();
-
-	void
-	testSleepUntil();
-
-	void
-	testStopToken();
+	testConditionVariableWaitStopTokenPredicate();
 };

--- a/test/modm/processing/fiber/fiber_guard_test.hpp
+++ b/test/modm/processing/fiber/fiber_guard_test.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, Erik Henriksson
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_architecture
+class FiberGuardTest : public unittest::TestSuite
+{
+public:
+	void
+	setUp();
+
+	void
+	testGuard();
+
+	void
+	testConstructor();
+};

--- a/test/modm/processing/fiber/fiber_latch_barrier_test.cpp
+++ b/test/modm/processing/fiber/fiber_latch_barrier_test.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber_latch_barrier_test.hpp"
+#include "shared.hpp"
+#include <modm/processing/fiber/latch.hpp>
+#include <modm/processing/fiber/barrier.hpp>
+
+void
+LatchBarrierTest::setUp()
+{
+	state = 0;
+}
+
+// ================================== LATCH ===================================
+void
+LatchBarrierTest::testLatch0()
+{
+	modm::fiber::latch latch{0};
+	TEST_ASSERT_TRUE(latch.try_wait());
+	latch.count_down(1);
+	TEST_ASSERT_TRUE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+}
+
+void
+LatchBarrierTest::testLatch1()
+{
+	modm::fiber::latch latch{1};
+	TEST_ASSERT_FALSE(latch.try_wait());
+	latch.count_down(1);
+	TEST_ASSERT_TRUE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+}
+
+void
+LatchBarrierTest::testLatch2()
+{
+	modm::fiber::latch latch{2};
+	TEST_ASSERT_FALSE(latch.try_wait());
+	latch.count_down(1);
+	TEST_ASSERT_FALSE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+}
+
+void
+LatchBarrierTest::testLatch10()
+{
+	modm::fiber::latch latch{10};
+	TEST_ASSERT_FALSE(latch.try_wait());
+	latch.count_down(1);
+	TEST_ASSERT_FALSE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+	latch.count_down(100);
+	TEST_ASSERT_TRUE(latch.try_wait());
+}
+
+static modm::fiber::latch ltc{3};
+
+static void
+f1()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+	TEST_ASSERT_FALSE(ltc.try_wait());
+
+	ltc.wait(); // goto 1
+
+	TEST_ASSERT_TRUE(ltc.try_wait());
+	TEST_ASSERT_EQUALS(state++, 4u);
+}
+
+static void
+f2()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	// let f1 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	ltc.count_down();
+	TEST_ASSERT_FALSE(ltc.try_wait());
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	ltc.count_down(2);
+	TEST_ASSERT_TRUE(ltc.try_wait());
+	modm::this_fiber::yield(); // goto 4
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+}
+
+void
+LatchBarrierTest::testLatchWait()
+{
+	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Scheduler::run();
+}
+
+// ================================= BARRIER ==================================
+
+static modm::fiber::id completion_id;
+static void on_completion()
+{
+	state++;
+	completion_id = modm::this_fiber::get_id();
+}
+
+void
+LatchBarrierTest::testBarrier()
+{
+	modm::fiber::barrier bar{2, on_completion};
+
+	TEST_ASSERT_EQUALS(bar.arrive(0), 0u);
+	TEST_ASSERT_EQUALS(state, 0u);
+	TEST_ASSERT_EQUALS(bar.arrive(), 0u);
+	TEST_ASSERT_EQUALS(state, 0u);
+	TEST_ASSERT_EQUALS(bar.arrive(1), 0u);
+	TEST_ASSERT_EQUALS(state, 1u);
+	TEST_ASSERT_EQUALS(completion_id, 0u);
+
+	TEST_ASSERT_EQUALS(bar.arrive(2), 1u);
+	TEST_ASSERT_EQUALS(state, 2u);
+
+	TEST_ASSERT_EQUALS(bar.arrive(10), 2u);
+	TEST_ASSERT_EQUALS(state, 3u);
+
+	bar.arrive_and_drop(); // expected=1
+	TEST_ASSERT_EQUALS(state, 3u);
+	TEST_ASSERT_EQUALS(bar.arrive(), 3u);
+	TEST_ASSERT_EQUALS(state, 4u);
+
+	TEST_ASSERT_EQUALS(bar.arrive(), 4u);
+	TEST_ASSERT_EQUALS(state, 5u);
+
+	bar.arrive_and_drop(); // expected=0
+	TEST_ASSERT_EQUALS(state, 6u);
+
+	TEST_ASSERT_EQUALS(bar.arrive(), 6u);
+	TEST_ASSERT_EQUALS(state, 7u);
+}
+
+
+static modm::fiber::barrier brr{2, on_completion};
+static modm::fiber::id f3_id, f4_id;
+
+static void
+f3()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+	const auto token = brr.arrive();
+	TEST_ASSERT_EQUALS(token, 0u);
+
+	TEST_ASSERT_EQUALS(state++, 1u);
+	brr.wait(token); // goto 2
+	TEST_ASSERT_EQUALS(completion_id, f4_id);
+
+	const auto token2 = brr.arrive();
+	// on_completion() called: state++
+	TEST_ASSERT_EQUALS(token2, 1u);
+
+	TEST_ASSERT_EQUALS(state++, 7u);
+	brr.wait(token2); // does not wait
+	TEST_ASSERT_EQUALS(completion_id, f3_id);
+
+	TEST_ASSERT_EQUALS(state++, 8u);
+}
+
+static void
+f4()
+{
+	TEST_ASSERT_EQUALS(state++, 2u);
+	// let f3 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+
+	const auto token = brr.arrive();
+	// on_completion() called: state++
+	TEST_ASSERT_EQUALS(token, 0u);
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+	brr.wait(token); // does not wait
+	TEST_ASSERT_EQUALS(completion_id, f4_id);
+
+	const auto token2 = brr.arrive();
+	TEST_ASSERT_EQUALS(token2, 1u);
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+	brr.wait(token2); // goto 6
+	TEST_ASSERT_EQUALS(completion_id, f3_id);
+
+	TEST_ASSERT_EQUALS(state++, 9u);
+}
+
+
+void
+LatchBarrierTest::testBarrierWait()
+{
+	modm::fiber::Task fiber1(stack1, f3), fiber2(stack2, f4);
+	f3_id = fiber1.get_id();
+	f4_id = fiber2.get_id();
+	modm::fiber::Scheduler::run();
+}

--- a/test/modm/processing/fiber/fiber_latch_barrier_test.hpp
+++ b/test/modm/processing/fiber/fiber_latch_barrier_test.hpp
@@ -14,33 +14,30 @@
 #include <unittest/testsuite.hpp>
 
 /// @ingroup modm_test_test_architecture
-class FiberTest : public unittest::TestSuite
+class LatchBarrierTest : public unittest::TestSuite
 {
 public:
 	void
 	setUp();
 
 	void
-	testOneFiber();
+	testLatch0();
 
 	void
-	testTwoFibers();
+	testLatch1();
 
 	void
-	testYieldFromSubroutine();
+	testLatch2();
 
 	void
-	testPollFor();
+	testLatch10();
 
 	void
-	testPollUntil();
+	testLatchWait();
 
 	void
-	testSleepFor();
+	testBarrier();
 
 	void
-	testSleepUntil();
-
-	void
-	testStopToken();
+	testBarrierWait();
 };

--- a/test/modm/processing/fiber/fiber_mutex_test.cpp
+++ b/test/modm/processing/fiber/fiber_mutex_test.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber_mutex_test.hpp"
+#include "shared.hpp"
+#include <modm/processing/fiber/mutex.hpp>
+#include <modm/processing/fiber/shared_mutex.hpp>
+
+void
+FiberMutexTest::setUp()
+{
+	state = 0;
+}
+
+// ================================== MUTEX ===================================
+static modm::fiber::mutex mtx;
+
+static void
+f1()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+	TEST_ASSERT_TRUE(mtx.try_lock());
+	TEST_ASSERT_FALSE(mtx.try_lock());
+	TEST_ASSERT_FALSE(mtx.try_lock());
+	mtx.unlock();
+	mtx.unlock();
+
+	TEST_ASSERT_EQUALS(state++, 1u);
+	mtx.lock(); // should not yield
+	TEST_ASSERT_EQUALS(state++, 2u);
+	mtx.lock(); // goto 3
+
+	mtx.unlock();
+	mtx.unlock();
+	TEST_ASSERT_EQUALS(state++, 5u);
+	mtx.lock(); // should not yield
+	TEST_ASSERT_EQUALS(state++, 6u);
+	mtx.lock(); // goto 7
+
+	TEST_ASSERT_EQUALS(state++, 8u);
+}
+
+static void
+f2()
+{
+	TEST_ASSERT_EQUALS(state++, 3u);
+	// let f1 wait for a while
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	TEST_ASSERT_EQUALS(state++, 4u);
+	mtx.unlock();
+	modm::this_fiber::yield(); // goto 5
+
+	TEST_ASSERT_EQUALS(state++, 7u);
+	mtx.unlock();
+	modm::this_fiber::yield(); // goto 8
+	TEST_ASSERT_EQUALS(state++, 9u);
+}
+
+void
+FiberMutexTest::testMutex()
+{
+	// should not block
+	TEST_ASSERT_TRUE(mtx.try_lock());
+	TEST_ASSERT_FALSE(mtx.try_lock());
+	TEST_ASSERT_FALSE(mtx.try_lock());
+	mtx.unlock();
+	// multiple unlock calls should be fine too
+	mtx.unlock();
+	mtx.unlock();
+	mtx.unlock();
+	// shouldn't block without scheduler
+	mtx.lock();
+	mtx.unlock();
+
+	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Scheduler::run();
+}
+
+// ============================== RECURSIVE MUTEX =============================
+static modm::fiber::recursive_mutex rc_mtx;
+
+static void
+f3()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	modm::this_fiber::yield(); // goto 1
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	rc_mtx.unlock();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+	rc_mtx.unlock();
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+	rc_mtx.unlock();
+	rc_mtx.unlock(); // more than necessary
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+	modm::this_fiber::yield(); // goto 6
+
+	TEST_ASSERT_EQUALS(state++, 7u);
+	rc_mtx.lock(); // goto 8
+
+	TEST_ASSERT_EQUALS(state++, 11u);
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+
+	TEST_ASSERT_EQUALS(state++, 12u);
+}
+
+static void
+f4()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	TEST_ASSERT_FALSE(rc_mtx.try_lock());
+	TEST_ASSERT_FALSE(rc_mtx.try_lock());
+	TEST_ASSERT_FALSE(rc_mtx.try_lock());
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	rc_mtx.lock(); // goto 3
+
+	TEST_ASSERT_EQUALS(state++, 6u);
+	rc_mtx.lock();
+	rc_mtx.lock();
+	modm::this_fiber::yield(); // goto 7
+
+	TEST_ASSERT_EQUALS(state++, 8u);
+	rc_mtx.unlock();
+	modm::this_fiber::yield();
+	TEST_ASSERT_EQUALS(state++, 9u);
+	rc_mtx.unlock();
+	modm::this_fiber::yield();
+	TEST_ASSERT_EQUALS(state++, 10u);
+	rc_mtx.unlock();
+	modm::this_fiber::yield(); // goto 11
+
+	TEST_ASSERT_EQUALS(state++, 13u);
+}
+
+void
+FiberMutexTest::testRecursiveMutex()
+{
+	// this should also work without scheduler, since fiber id is zero then
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+	// more unlocks should be fine
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+
+	// should not block either without scheduler
+	rc_mtx.lock();
+	rc_mtx.lock();
+	rc_mtx.lock();
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+
+	modm::fiber::Task fiber1(stack1, f3), fiber2(stack2, f4);
+	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+}
+
+// =============================== SHARED MUTEX ===============================
+static modm::fiber::shared_mutex sh_mtx;
+
+static void
+f5()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+	// get the exclusive lock
+	sh_mtx.lock();
+	TEST_ASSERT_FALSE(sh_mtx.try_lock());
+	modm::this_fiber::yield(); // goto 1
+
+	TEST_ASSERT_EQUALS(state++, 2u);
+	sh_mtx.unlock();
+	modm::this_fiber::yield(); // goto 3
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+	// get the shared lock
+	sh_mtx.lock_shared();
+	sh_mtx.lock_shared();
+	modm::this_fiber::yield(); // goto 5
+
+	TEST_ASSERT_EQUALS(state++, 6u);
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	modm::this_fiber::yield();
+	// still locked
+	sh_mtx.unlock_shared();
+	modm::this_fiber::yield(); // goto 7
+
+	TEST_ASSERT_EQUALS(state++, 9u);
+}
+
+static void
+f6()
+{
+	TEST_ASSERT_EQUALS(state++, 1u);
+	// cannot get exclusive lock
+	sh_mtx.lock(); // goto 2
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	TEST_ASSERT_FALSE(sh_mtx.try_lock());
+	sh_mtx.unlock();
+	modm::this_fiber::yield(); // goto 4
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+	// can get shared lock
+	sh_mtx.lock_shared();
+	sh_mtx.lock_shared();
+	// cannot get exclusive lock
+	sh_mtx.lock(); // goto 6
+
+	TEST_ASSERT_EQUALS(state++, 7u);
+	sh_mtx.unlock();
+
+	TEST_ASSERT_EQUALS(state++, 8u);
+}
+
+void
+FiberMutexTest::testSharedMutex()
+{
+	TEST_ASSERT_TRUE(sh_mtx.try_lock());
+	TEST_ASSERT_FALSE(sh_mtx.try_lock());
+	TEST_ASSERT_FALSE(sh_mtx.try_lock());
+	sh_mtx.unlock();
+	// more unlocks should be fine
+	sh_mtx.unlock();
+	sh_mtx.unlock();
+
+	TEST_ASSERT_TRUE(sh_mtx.try_lock_shared());
+	TEST_ASSERT_TRUE(sh_mtx.try_lock_shared());
+	TEST_ASSERT_TRUE(sh_mtx.try_lock_shared());
+	sh_mtx.unlock();
+	// more unlocks should be fine
+	sh_mtx.unlock();
+	sh_mtx.unlock();
+
+
+	modm::fiber::Task fiber1(stack1, f5), fiber2(stack2, f6);
+	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_TRUE(rc_mtx.try_lock());
+	rc_mtx.unlock();
+	rc_mtx.unlock();
+}
+
+// =============================== TIMED MUTEX ================================
+// =========================== TIMED RECURSIVE MUTEX ==========================
+// ============================ TIMED SHARED MUTEX ============================
+// All implementations only add poll_for/_until with try_lock*() function.
+// Explicit tests are omitted, since they are tested in FiberTest::testSleep*().
+
+void
+FiberMutexTest::testCallOnce()
+{
+	modm::fiber::once_flag flag;
+	uint8_t ii = 0;
+	while(++ii < 10) modm::fiber::call_once(flag, []{ state++; });
+	modm::fiber::call_once(flag, [&]{
+		modm::fiber::call_once(flag, [&]{
+			modm::fiber::call_once(flag, []{ state++; });
+		});
+	});
+	TEST_ASSERT_EQUALS(ii, 10u);
+	TEST_ASSERT_EQUALS(state, 1u);
+}

--- a/test/modm/processing/fiber/fiber_mutex_test.hpp
+++ b/test/modm/processing/fiber/fiber_mutex_test.hpp
@@ -14,33 +14,21 @@
 #include <unittest/testsuite.hpp>
 
 /// @ingroup modm_test_test_architecture
-class FiberTest : public unittest::TestSuite
+class FiberMutexTest : public unittest::TestSuite
 {
 public:
 	void
 	setUp();
 
 	void
-	testOneFiber();
+	testMutex();
 
 	void
-	testTwoFibers();
+	testRecursiveMutex();
 
 	void
-	testYieldFromSubroutine();
+	testSharedMutex();
 
 	void
-	testPollFor();
-
-	void
-	testPollUntil();
-
-	void
-	testSleepFor();
-
-	void
-	testSleepUntil();
-
-	void
-	testStopToken();
+	testCallOnce();
 };

--- a/test/modm/processing/fiber/fiber_semaphore_test.cpp
+++ b/test/modm/processing/fiber/fiber_semaphore_test.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "fiber_semaphore_test.hpp"
+#include "shared.hpp"
+#include <modm/processing/fiber/semaphore.hpp>
+
+void
+FiberSemaphoreTest::setUp()
+{
+	state = 0;
+}
+
+// ================================== MUTEX ===================================
+static modm::fiber::counting_semaphore sem{3};
+
+static void
+f1()
+{
+	TEST_ASSERT_EQUALS(state++, 0u);
+	TEST_ASSERT_TRUE(sem.try_acquire()); // 2
+	TEST_ASSERT_TRUE(sem.try_acquire()); // 1
+	TEST_ASSERT_TRUE(sem.try_acquire()); // 0
+	TEST_ASSERT_FALSE(sem.try_acquire()); // 0
+	TEST_ASSERT_FALSE(sem.try_acquire()); // 0
+	sem.release(); // 1
+	sem.acquire(); // 0
+	TEST_ASSERT_EQUALS(state++, 1u);
+	sem.acquire(); // goto 2, 0
+
+	TEST_ASSERT_EQUALS(state++, 4u);
+	sem.release(); // 1
+	sem.release(); // 2
+	modm::this_fiber::yield(); // goto 5
+
+	TEST_ASSERT_EQUALS(state++, 6u);
+	sem.acquire();
+	sem.acquire(); // goto 7, 0
+
+	TEST_ASSERT_EQUALS(state++, 9u);
+}
+
+static void
+f2()
+{
+	TEST_ASSERT_EQUALS(state++, 2u);
+	modm::this_fiber::yield();
+
+	TEST_ASSERT_EQUALS(state++, 3u);
+	sem.release(); // 1
+	modm::this_fiber::yield(); // goto 4
+
+	TEST_ASSERT_EQUALS(state++, 5u);
+	sem.acquire(); // 1
+	modm::this_fiber::yield(); // goto 6
+
+	TEST_ASSERT_EQUALS(state++, 7u);
+	sem.release(); // 1
+	sem.release(); // 2
+	sem.release(); // 3
+
+	TEST_ASSERT_EQUALS(state++, 8u);
+}
+
+void
+FiberSemaphoreTest::testCountingSemaphore()
+{
+	// should not block
+	TEST_ASSERT_TRUE(sem.try_acquire());
+	TEST_ASSERT_TRUE(sem.try_acquire());
+	TEST_ASSERT_TRUE(sem.try_acquire());
+	TEST_ASSERT_FALSE(sem.try_acquire());
+	TEST_ASSERT_FALSE(sem.try_acquire());
+	sem.release();
+	// shouldn't block without scheduler
+	sem.acquire();
+	sem.release();
+	sem.release();
+	sem.release();
+
+	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Scheduler::run();
+}
+

--- a/test/modm/processing/fiber/fiber_semaphore_test.hpp
+++ b/test/modm/processing/fiber/fiber_semaphore_test.hpp
@@ -14,33 +14,12 @@
 #include <unittest/testsuite.hpp>
 
 /// @ingroup modm_test_test_architecture
-class FiberTest : public unittest::TestSuite
+class FiberSemaphoreTest : public unittest::TestSuite
 {
 public:
 	void
 	setUp();
 
 	void
-	testOneFiber();
-
-	void
-	testTwoFibers();
-
-	void
-	testYieldFromSubroutine();
-
-	void
-	testPollFor();
-
-	void
-	testPollUntil();
-
-	void
-	testSleepFor();
-
-	void
-	testSleepUntil();
-
-	void
-	testStopToken();
+	testCountingSemaphore();
 };

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -44,7 +44,7 @@ void
 f1()
 {
 	ADD_STATE(F1_START);
-	modm::fiber::yield();
+	modm::this_fiber::yield();
 	ADD_STATE(F1_END);
 }
 
@@ -52,7 +52,7 @@ void
 f2()
 {
 	ADD_STATE(F2_START);
-	modm::fiber::yield();
+	modm::this_fiber::yield();
 	ADD_STATE(F2_END);
 }
 
@@ -88,7 +88,7 @@ __attribute__((noinline)) void
 subroutine()
 {
 	ADD_STATE(SUBROUTINE_START);
-	modm::fiber::yield();
+	modm::this_fiber::yield();
 	ADD_STATE(SUBROUTINE_END);
 }
 

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -24,8 +24,12 @@ enum State
 {
 	INVALID,
 	F1_START,
+	F1_YIELD1,
+	F1_YIELD2,
+	F1_YIELD3,
 	F1_END,
 	F2_START,
+	F2_JOIN,
 	F2_END,
 	F3_START,
 	F3_END,
@@ -40,6 +44,12 @@ enum State
 	F6_SLEEP1,
 	F6_SLEEP2,
 	F6_END,
+	F7_START,
+	F7_YIELD,
+	F7_END,
+	F8_START,
+	F8_REQUEST_STOP,
+	F8_END,
 	SUBROUTINE_START,
 	SUBROUTINE_END,
 	CONSUMER_START,
@@ -61,20 +71,16 @@ f1()
 	ADD_STATE(F1_END);
 }
 
-static void
-f2()
-{
-	ADD_STATE(F2_START);
-	modm::this_fiber::yield();
-	ADD_STATE(F2_END);
-}
-
 void
 FiberTest::testOneFiber()
 {
 	states_pos = 0;
 	modm::fiber::Task fiber(stack1, f1);
+	TEST_ASSERT_DIFFERS(fiber.get_id(), modm::fiber::id(0));
+	TEST_ASSERT_TRUE(fiber.joinable());
 	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_FALSE(fiber.joinable());
 	TEST_ASSERT_EQUALS(states_pos, 2u);
 	TEST_ASSERT_EQUALS(states[0], F1_START);
 	TEST_ASSERT_EQUALS(states[1], F1_END);
@@ -84,13 +90,38 @@ void
 FiberTest::testTwoFibers()
 {
 	states_pos = 0;
-	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f2);
+	modm::fiber::Task fiber1(stack1, [&]
+	{
+		ADD_STATE(F1_START);
+		modm::this_fiber::yield();
+		ADD_STATE(F1_YIELD1);
+		modm::this_fiber::yield();
+		ADD_STATE(F1_YIELD2);
+		modm::this_fiber::yield();
+		ADD_STATE(F1_YIELD3);
+		modm::this_fiber::yield();
+		ADD_STATE(F1_END);
+	});
+	modm::fiber::Task fiber2(stack2, [&]
+	{
+		ADD_STATE(F2_START);
+		TEST_ASSERT_TRUE(fiber1.joinable());
+		TEST_ASSERT_FALSE(fiber2.joinable());
+		fiber1.join(); // should wait
+		ADD_STATE(F2_JOIN);
+		fiber2.join(); // should not hang
+		ADD_STATE(F2_END);
+	});
 	modm::fiber::Scheduler::run();
-	TEST_ASSERT_EQUALS(states_pos, 4u);
+	TEST_ASSERT_EQUALS(states_pos, 8u);
 	TEST_ASSERT_EQUALS(states[0], F1_START);
 	TEST_ASSERT_EQUALS(states[1], F2_START);
-	TEST_ASSERT_EQUALS(states[2], F1_END);
-	TEST_ASSERT_EQUALS(states[3], F2_END);
+	TEST_ASSERT_EQUALS(states[2], F1_YIELD1);
+	TEST_ASSERT_EQUALS(states[3], F1_YIELD2);
+	TEST_ASSERT_EQUALS(states[4], F1_YIELD3);
+	TEST_ASSERT_EQUALS(states[5], F1_END);
+	TEST_ASSERT_EQUALS(states[6], F2_JOIN);
+	TEST_ASSERT_EQUALS(states[7], F2_END);
 }
 
 static __attribute__((noinline)) void
@@ -101,19 +132,18 @@ subroutine()
 	ADD_STATE(SUBROUTINE_END);
 }
 
-static void
-f3()
-{
-	ADD_STATE(F3_START);
-	subroutine();
-	ADD_STATE(F3_END);
-}
-
 void
 FiberTest::testYieldFromSubroutine()
 {
 	states_pos = 0;
-	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, f3);
+	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, [&]
+	{
+		ADD_STATE(F3_START);
+		TEST_ASSERT_TRUE(fiber1.joinable());
+		subroutine();
+		TEST_ASSERT_FALSE(fiber1.joinable());
+		ADD_STATE(F3_END);
+	});
 	modm::fiber::Scheduler::run();
 	TEST_ASSERT_EQUALS(states_pos, 6u);
 	TEST_ASSERT_EQUALS(states[0], F1_START);
@@ -233,4 +263,42 @@ FiberTest::testSleepUntil()
 {
 	runSleepUntil(1502);
 	runSleepUntil(0xffff'ffff - 30);
+}
+
+static void
+f7(modm::fiber::stop_token stoken)
+{
+	ADD_STATE(F7_START);
+	while(not stoken.stop_requested())
+	{
+		ADD_STATE(F7_YIELD);
+		modm::this_fiber::yield();
+	}
+	ADD_STATE(F7_END);
+}
+
+void
+FiberTest::testStopToken()
+{
+	states_pos = 0;
+	modm::fiber::Task fiber1(stack1, f7);
+	modm::fiber::Task fiber2(stack2, [&](modm::fiber::stop_token stoken)
+	{
+		ADD_STATE(F8_START);
+		modm::this_fiber::yield();
+		ADD_STATE(F8_REQUEST_STOP);
+		fiber1.request_stop();
+		modm::this_fiber::yield();
+		ADD_STATE(F8_END);
+	});
+	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_EQUALS(states_pos, 7u);
+	TEST_ASSERT_EQUALS(states[0], F7_START);
+	TEST_ASSERT_EQUALS(states[1], F7_YIELD);
+	TEST_ASSERT_EQUALS(states[2], F8_START);
+	TEST_ASSERT_EQUALS(states[3], F7_YIELD);
+	TEST_ASSERT_EQUALS(states[4], F8_REQUEST_STOP);
+	TEST_ASSERT_EQUALS(states[5], F7_END);
+	TEST_ASSERT_EQUALS(states[6], F8_END);
 }

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -11,147 +11,92 @@
 // ----------------------------------------------------------------------------
 
 #include "fiber_test.hpp"
+#include "shared.hpp"
 
-#include <array>
-#include <modm/debug/logger.hpp>
-#include <modm/processing/fiber.hpp>
 #include <modm-test/mock/clock.hpp>
 
 using namespace std::chrono_literals;
 using test_clock = modm_test::chrono::milli_clock;
 
-enum State
+void
+FiberTest::setUp()
 {
-	INVALID,
-	F1_START,
-	F1_YIELD1,
-	F1_YIELD2,
-	F1_YIELD3,
-	F1_END,
-	F2_START,
-	F2_JOIN,
-	F2_END,
-	F3_START,
-	F3_END,
-	F4_START,
-	F4_END,
-	F5_START,
-	F5_INCR10,
-	F5_INCR20,
-	F5_INCR30,
-	F5_END,
-	F6_START,
-	F6_SLEEP1,
-	F6_SLEEP2,
-	F6_END,
-	F7_START,
-	F7_YIELD,
-	F7_END,
-	F8_START,
-	F8_REQUEST_STOP,
-	F8_END,
-	SUBROUTINE_START,
-	SUBROUTINE_END,
-	CONSUMER_START,
-	CONSUMER_END,
-	PRODUCER_START,
-	PRODUCER_END,
-};
+	state = 0;
+}
 
-static std::array<State, 10> states = {};
-static size_t states_pos = 0;
-static modm::fiber::Stack<1024> stack1, stack2;
-#define ADD_STATE(state) states[states_pos++] = state;
-
+// ================================== FIBER ===================================
 static void
 f1()
 {
-	ADD_STATE(F1_START);
+	TEST_ASSERT_EQUALS(state++, 0u);
 	modm::this_fiber::yield();
-	ADD_STATE(F1_END);
+	TEST_ASSERT_EQUALS(state++, 1u);
 }
 
 void
 FiberTest::testOneFiber()
 {
-	states_pos = 0;
 	modm::fiber::Task fiber(stack1, f1);
 	TEST_ASSERT_DIFFERS(fiber.get_id(), modm::fiber::id(0));
 	TEST_ASSERT_TRUE(fiber.joinable());
 	modm::fiber::Scheduler::run();
-
 	TEST_ASSERT_FALSE(fiber.joinable());
-	TEST_ASSERT_EQUALS(states_pos, 2u);
-	TEST_ASSERT_EQUALS(states[0], F1_START);
-	TEST_ASSERT_EQUALS(states[1], F1_END);
 }
 
 void
 FiberTest::testTwoFibers()
 {
-	states_pos = 0;
-	modm::fiber::Task fiber1(stack1, [&]
+	modm::fiber::Task fiber1(stack1, []
 	{
-		ADD_STATE(F1_START);
+		TEST_ASSERT_EQUALS(state++, 0u);
+		modm::this_fiber::yield(); // goto 1
+		TEST_ASSERT_EQUALS(state++, 2u);
 		modm::this_fiber::yield();
-		ADD_STATE(F1_YIELD1);
+		TEST_ASSERT_EQUALS(state++, 3u);
 		modm::this_fiber::yield();
-		ADD_STATE(F1_YIELD2);
+		TEST_ASSERT_EQUALS(state++, 4u);
 		modm::this_fiber::yield();
-		ADD_STATE(F1_YIELD3);
-		modm::this_fiber::yield();
-		ADD_STATE(F1_END);
+		TEST_ASSERT_EQUALS(state++, 5u);
 	});
 	modm::fiber::Task fiber2(stack2, [&]
 	{
-		ADD_STATE(F2_START);
+		TEST_ASSERT_EQUALS(state++, 1u);
 		TEST_ASSERT_TRUE(fiber1.joinable());
 		TEST_ASSERT_FALSE(fiber2.joinable());
-		fiber1.join(); // should wait
-		ADD_STATE(F2_JOIN);
+		fiber1.join(); // goto 2
+		TEST_ASSERT_EQUALS(state++, 6u);
 		fiber2.join(); // should not hang
-		ADD_STATE(F2_END);
+		TEST_ASSERT_EQUALS(state++, 7u);
 	});
 	modm::fiber::Scheduler::run();
-	TEST_ASSERT_EQUALS(states_pos, 8u);
-	TEST_ASSERT_EQUALS(states[0], F1_START);
-	TEST_ASSERT_EQUALS(states[1], F2_START);
-	TEST_ASSERT_EQUALS(states[2], F1_YIELD1);
-	TEST_ASSERT_EQUALS(states[3], F1_YIELD2);
-	TEST_ASSERT_EQUALS(states[4], F1_YIELD3);
-	TEST_ASSERT_EQUALS(states[5], F1_END);
-	TEST_ASSERT_EQUALS(states[6], F2_JOIN);
-	TEST_ASSERT_EQUALS(states[7], F2_END);
 }
 
 static __attribute__((noinline)) void
 subroutine()
 {
-	ADD_STATE(SUBROUTINE_START);
-	modm::this_fiber::yield();
-	ADD_STATE(SUBROUTINE_END);
+	TEST_ASSERT_EQUALS(state++, 2u);
+	modm::this_fiber::yield(); // goto 3
+	TEST_ASSERT_EQUALS(state++, 4u);
 }
 
 void
 FiberTest::testYieldFromSubroutine()
 {
-	states_pos = 0;
-	modm::fiber::Task fiber1(stack1, f1), fiber2(stack2, [&]
+	modm::fiber::Task fiber1(stack1, []
 	{
-		ADD_STATE(F3_START);
+		TEST_ASSERT_EQUALS(state++, 0u);
+		modm::this_fiber::yield(); // goto 1
+		TEST_ASSERT_EQUALS(state++, 3u);
+	});
+	modm::fiber::Task fiber2(stack2, [&]
+	{
+		TEST_ASSERT_EQUALS(state++, 1u);
 		TEST_ASSERT_TRUE(fiber1.joinable());
 		subroutine();
 		TEST_ASSERT_FALSE(fiber1.joinable());
-		ADD_STATE(F3_END);
+		TEST_ASSERT_EQUALS(state++, 5u);
 	});
 	modm::fiber::Scheduler::run();
-	TEST_ASSERT_EQUALS(states_pos, 6u);
-	TEST_ASSERT_EQUALS(states[0], F1_START);
-	TEST_ASSERT_EQUALS(states[1], F3_START);
-	TEST_ASSERT_EQUALS(states[2], SUBROUTINE_START);
-	TEST_ASSERT_EQUALS(states[3], F1_END);
-	TEST_ASSERT_EQUALS(states[4], SUBROUTINE_END);
-	TEST_ASSERT_EQUALS(states[5], F3_END);
 }
 
 
@@ -177,46 +122,36 @@ FiberTest::testPollUntil()
 static void
 f4()
 {
-	ADD_STATE(F4_START);
-	modm::this_fiber::sleep_for(50ms);
-	ADD_STATE(F4_END);
+	TEST_ASSERT_EQUALS(state++, 0u);
+	modm::this_fiber::sleep_for(50ms); // goto 1
+	TEST_ASSERT_EQUALS(state++, 5u);
 }
 
 static void
 f5()
 {
-	ADD_STATE(F5_START);
+	TEST_ASSERT_EQUALS(state++, 1u);
 	test_clock::increment(10);
-	ADD_STATE(F5_INCR10);
+	TEST_ASSERT_EQUALS(state++, 2u);
 	modm::this_fiber::yield();
 
 	test_clock::increment(20);
-	ADD_STATE(F5_INCR20);
+	TEST_ASSERT_EQUALS(state++, 3u);
 	modm::this_fiber::yield();
 
 	test_clock::increment(30);
-	ADD_STATE(F5_INCR30);
-	modm::this_fiber::yield();
+	TEST_ASSERT_EQUALS(state++, 4u);
+	modm::this_fiber::yield(); // goto 5
 
-	ADD_STATE(F5_END);
+	TEST_ASSERT_EQUALS(state++, 6u);
 }
 
 static void
 runSleepFor(uint32_t startTime)
 {
 	test_clock::setTime(startTime);
-	states_pos = 0;
 	modm::fiber::Task fiber1(stack1, f4), fiber2(stack2, f5);
 	modm::fiber::Scheduler::run();
-
-	TEST_ASSERT_EQUALS(states_pos, 7u);
-	TEST_ASSERT_EQUALS(states[0], F4_START);
-	TEST_ASSERT_EQUALS(states[1], F5_START);
-	TEST_ASSERT_EQUALS(states[2], F5_INCR10);
-	TEST_ASSERT_EQUALS(states[3], F5_INCR20);
-	TEST_ASSERT_EQUALS(states[4], F5_INCR30);
-	TEST_ASSERT_EQUALS(states[5], F4_END);
-	TEST_ASSERT_EQUALS(states[6], F5_END);
 }
 
 
@@ -224,81 +159,66 @@ void
 FiberTest::testSleepFor()
 {
 	runSleepFor(16203);
+	state = 0;
 	runSleepFor(0xffff'ffff - 30);
 }
 
 static void
 f6()
 {
-	ADD_STATE(F6_START);
-	ADD_STATE(F6_SLEEP1);
+	TEST_ASSERT_EQUALS(state++, 0u); // goto 1
 	modm::this_fiber::sleep_until(modm::Clock::now() + 50ms);
-	ADD_STATE(F6_SLEEP2);
+	TEST_ASSERT_EQUALS(state++, 5u);
+	modm::this_fiber::yield(); // goto 6
 	modm::this_fiber::sleep_until(modm::Clock::now() - 50ms);
-	ADD_STATE(F6_END);
+	TEST_ASSERT_EQUALS(state++, 7u);
 }
 
 static void
 runSleepUntil(uint32_t startTime)
 {
 	test_clock::setTime(startTime);
-	states_pos = 0;
 	modm::fiber::Task fiber1(stack1, f6), fiber2(stack2, f5);
 	modm::fiber::Scheduler::run();
-
-	TEST_ASSERT_EQUALS(states_pos, 9u);
-	TEST_ASSERT_EQUALS(states[0], F6_START);
-	TEST_ASSERT_EQUALS(states[1], F6_SLEEP1);
-	TEST_ASSERT_EQUALS(states[2], F5_START);
-	TEST_ASSERT_EQUALS(states[3], F5_INCR10);
-	TEST_ASSERT_EQUALS(states[4], F5_INCR20);
-	TEST_ASSERT_EQUALS(states[5], F5_INCR30);
-	TEST_ASSERT_EQUALS(states[6], F6_SLEEP2);
-	TEST_ASSERT_EQUALS(states[7], F5_END);
-	TEST_ASSERT_EQUALS(states[8], F6_END);
 }
 
 void
 FiberTest::testSleepUntil()
 {
 	runSleepUntil(1502);
+	state = 0;
 	runSleepUntil(0xffff'ffff - 30);
 }
 
 static void
 f7(modm::fiber::stop_token stoken)
 {
-	ADD_STATE(F7_START);
+	TEST_ASSERT_EQUALS(state++, 0u);
+	TEST_ASSERT_TRUE(stoken.stop_possible());
+	TEST_ASSERT_FALSE(stoken.stop_requested());
 	while(not stoken.stop_requested())
 	{
-		ADD_STATE(F7_YIELD);
-		modm::this_fiber::yield();
+		modm::this_fiber::yield(); // goto 1
+		state++; // 2, 4
 	}
-	ADD_STATE(F7_END);
+	TEST_ASSERT_TRUE(stoken.stop_requested());
+	TEST_ASSERT_EQUALS(state++, 5u);
 }
 
 void
 FiberTest::testStopToken()
 {
-	states_pos = 0;
 	modm::fiber::Task fiber1(stack1, f7);
 	modm::fiber::Task fiber2(stack2, [&](modm::fiber::stop_token stoken)
 	{
-		ADD_STATE(F8_START);
-		modm::this_fiber::yield();
-		ADD_STATE(F8_REQUEST_STOP);
+		TEST_ASSERT_EQUALS(state++, 1u);
+		TEST_ASSERT_TRUE(stoken.stop_possible());
+		TEST_ASSERT_FALSE(stoken.stop_requested());
+		modm::this_fiber::yield(); // goto 2
+		TEST_ASSERT_EQUALS(state++, 3u);
 		fiber1.request_stop();
-		modm::this_fiber::yield();
-		ADD_STATE(F8_END);
+		modm::this_fiber::yield(); // goto 4
+		TEST_ASSERT_EQUALS(state++, 6u);
 	});
 	modm::fiber::Scheduler::run();
-
-	TEST_ASSERT_EQUALS(states_pos, 7u);
-	TEST_ASSERT_EQUALS(states[0], F7_START);
-	TEST_ASSERT_EQUALS(states[1], F7_YIELD);
-	TEST_ASSERT_EQUALS(states[2], F8_START);
-	TEST_ASSERT_EQUALS(states[3], F7_YIELD);
-	TEST_ASSERT_EQUALS(states[4], F8_REQUEST_STOP);
-	TEST_ASSERT_EQUALS(states[5], F7_END);
-	TEST_ASSERT_EQUALS(states[6], F8_END);
 }

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Erik Henriksson
+ * Copyright (c) 2024, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -14,9 +15,10 @@
 #include <array>
 #include <modm/debug/logger.hpp>
 #include <modm/processing/fiber.hpp>
+#include <modm-test/mock/clock.hpp>
 
-namespace
-{
+using namespace std::chrono_literals;
+using test_clock = modm_test::chrono::milli_clock;
 
 enum State
 {
@@ -27,6 +29,17 @@ enum State
 	F2_END,
 	F3_START,
 	F3_END,
+	F4_START,
+	F4_END,
+	F5_START,
+	F5_INCR10,
+	F5_INCR20,
+	F5_INCR30,
+	F5_END,
+	F6_START,
+	F6_SLEEP1,
+	F6_SLEEP2,
+	F6_END,
 	SUBROUTINE_START,
 	SUBROUTINE_END,
 	CONSUMER_START,
@@ -35,12 +48,12 @@ enum State
 	PRODUCER_END,
 };
 
-std::array<State, 6> states = {};
-size_t states_pos = 0;
-
+static std::array<State, 10> states = {};
+static size_t states_pos = 0;
+static modm::fiber::Stack<1024> stack1, stack2;
 #define ADD_STATE(state) states[states_pos++] = state;
 
-void
+static void
 f1()
 {
 	ADD_STATE(F1_START);
@@ -48,17 +61,13 @@ f1()
 	ADD_STATE(F1_END);
 }
 
-void
+static void
 f2()
 {
 	ADD_STATE(F2_START);
 	modm::this_fiber::yield();
 	ADD_STATE(F2_END);
 }
-
-modm::fiber::Stack<1024> stack1, stack2;
-
-}  // namespace
 
 void
 FiberTest::testOneFiber()
@@ -84,7 +93,7 @@ FiberTest::testTwoFibers()
 	TEST_ASSERT_EQUALS(states[3], F2_END);
 }
 
-__attribute__((noinline)) void
+static __attribute__((noinline)) void
 subroutine()
 {
 	ADD_STATE(SUBROUTINE_START);
@@ -92,7 +101,7 @@ subroutine()
 	ADD_STATE(SUBROUTINE_END);
 }
 
-void
+static void
 f3()
 {
 	ADD_STATE(F3_START);
@@ -113,4 +122,115 @@ FiberTest::testYieldFromSubroutine()
 	TEST_ASSERT_EQUALS(states[3], F1_END);
 	TEST_ASSERT_EQUALS(states[4], SUBROUTINE_END);
 	TEST_ASSERT_EQUALS(states[5], F3_END);
+}
+
+
+void
+FiberTest::testPollFor()
+{
+	test_clock::setTime(1251);
+	TEST_ASSERT_TRUE(modm::this_fiber::poll_for(20ms, []{ return true; }));
+	// timeout is tested in the SleepFor() test
+}
+
+
+void
+FiberTest::testPollUntil()
+{
+	test_clock::setTime(451250);
+	TEST_ASSERT_TRUE(modm::this_fiber::poll_until(modm::Clock::now() + 20ms, []{ return true; }));
+	TEST_ASSERT_TRUE(modm::this_fiber::poll_until(modm::Clock::now() - 20ms, []{ return true; }));
+	// timeout is tested in the SleepUntil() tests
+}
+
+
+static void
+f4()
+{
+	ADD_STATE(F4_START);
+	modm::this_fiber::sleep_for(50ms);
+	ADD_STATE(F4_END);
+}
+
+static void
+f5()
+{
+	ADD_STATE(F5_START);
+	test_clock::increment(10);
+	ADD_STATE(F5_INCR10);
+	modm::this_fiber::yield();
+
+	test_clock::increment(20);
+	ADD_STATE(F5_INCR20);
+	modm::this_fiber::yield();
+
+	test_clock::increment(30);
+	ADD_STATE(F5_INCR30);
+	modm::this_fiber::yield();
+
+	ADD_STATE(F5_END);
+}
+
+static void
+runSleepFor(uint32_t startTime)
+{
+	test_clock::setTime(startTime);
+	states_pos = 0;
+	modm::fiber::Task fiber1(stack1, f4), fiber2(stack2, f5);
+	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_EQUALS(states_pos, 7u);
+	TEST_ASSERT_EQUALS(states[0], F4_START);
+	TEST_ASSERT_EQUALS(states[1], F5_START);
+	TEST_ASSERT_EQUALS(states[2], F5_INCR10);
+	TEST_ASSERT_EQUALS(states[3], F5_INCR20);
+	TEST_ASSERT_EQUALS(states[4], F5_INCR30);
+	TEST_ASSERT_EQUALS(states[5], F4_END);
+	TEST_ASSERT_EQUALS(states[6], F5_END);
+}
+
+
+void
+FiberTest::testSleepFor()
+{
+	runSleepFor(16203);
+	runSleepFor(0xffff'ffff - 30);
+}
+
+static void
+f6()
+{
+	ADD_STATE(F6_START);
+	ADD_STATE(F6_SLEEP1);
+	modm::this_fiber::sleep_until(modm::Clock::now() + 50ms);
+	ADD_STATE(F6_SLEEP2);
+	modm::this_fiber::sleep_until(modm::Clock::now() - 50ms);
+	ADD_STATE(F6_END);
+}
+
+static void
+runSleepUntil(uint32_t startTime)
+{
+	test_clock::setTime(startTime);
+	states_pos = 0;
+	modm::fiber::Task fiber1(stack1, f6), fiber2(stack2, f5);
+	modm::fiber::Scheduler::run();
+
+	TEST_ASSERT_EQUALS(states_pos, 9u);
+	TEST_ASSERT_EQUALS(states[0], F6_START);
+	TEST_ASSERT_EQUALS(states[1], F6_SLEEP1);
+	TEST_ASSERT_EQUALS(states[2], F5_START);
+	TEST_ASSERT_EQUALS(states[3], F5_INCR10);
+	TEST_ASSERT_EQUALS(states[4], F5_INCR20);
+	TEST_ASSERT_EQUALS(states[5], F5_INCR30);
+	TEST_ASSERT_EQUALS(states[6], F6_SLEEP2);
+	TEST_ASSERT_EQUALS(states[7], F5_END);
+	TEST_ASSERT_EQUALS(states[8], F6_END);
+}
+
+void
+FiberTest::testSleepUntil()
+{
+	runSleepUntil(1502);
+	runSleepUntil(0xffff'ffff - 30);
 }

--- a/test/modm/processing/fiber/fiber_test.hpp
+++ b/test/modm/processing/fiber/fiber_test.hpp
@@ -17,10 +17,6 @@
 class FiberTest : public unittest::TestSuite
 {
 public:
-
-	void
-	subroutine();
-
 	void
 	testOneFiber();
 
@@ -29,4 +25,16 @@ public:
 
 	void
 	testYieldFromSubroutine();
+
+	void
+	testPollFor();
+
+	void
+	testPollUntil();
+
+	void
+	testSleepFor();
+
+	void
+	testSleepUntil();
 };

--- a/test/modm/processing/fiber/fiber_test.hpp
+++ b/test/modm/processing/fiber/fiber_test.hpp
@@ -37,4 +37,7 @@ public:
 
 	void
 	testSleepUntil();
+
+	void
+	testStopToken();
 };

--- a/test/modm/processing/fiber/shared.hpp
+++ b/test/modm/processing/fiber/shared.hpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <array>
+#include <modm/processing/fiber.hpp>
+
+// shared objects to reduce memory consumption
+[[maybe_unused]] static inline modm::fiber::Stack<> stack1, stack2;
+[[maybe_unused]] static inline uint8_t state;

--- a/tools/scripts/generate_module_docs.py
+++ b/tools/scripts/generate_module_docs.py
@@ -88,6 +88,7 @@ def get_modules(builder, limit=None):
         modules = {"modm": DeviceTree("modm", target)}
         modules["modm"].addSortKey(lambda mo: (mo.name, mo["filename"]))
         for init in imodules:
+            if init.name.startswith("__"): continue
             if init.name.isdigit(): continue;
             m = modules[init.parent].addChild(init.fullname.split(":")[-1])
             modules[init.fullname] = m
@@ -102,6 +103,7 @@ def get_modules(builder, limit=None):
 
             num_options.append(len(init._options))
             for o in init._options:
+                if o.name.startswith("__"): continue
                 op = m.addChild(o.fullname.split(":")[-1])
                 op.addSortKey(lambda oo: (oo.name, oo["type"], oo.get("value", "")))
                 op.setAttribute("type", type(o).__name__)
@@ -123,6 +125,7 @@ def get_modules(builder, limit=None):
                                 opdep.setValue("{} -> [{}]".format(valin, vconcat))
 
             for c in init._collectors:
+                if c.name.startswith("__"): continue
                 cp = m.addChild(c.fullname.split(":")[-1])
                 cp.addSortKey(lambda cc: (cc.name))
                 cp.setAttribute("type", type(c).__name__)
@@ -131,6 +134,7 @@ def get_modules(builder, limit=None):
                 opvals.setValue(c.format_values())
 
             for q in init._queries:
+                if q.name.startswith("__"): continue
                 qp = m.addChild(q.fullname.split(":")[-1])
                 qp.addSortKey(lambda qq: (qq.name))
                 qp.setAttribute("type", type(q).__name__)


### PR DESCRIPTION
Fibers need a standard set of efficient constructs.
I modelled these classes after the C++ thread concurrency interfaces. Not sure if useful, but also probably not really much room for improvement anyways.

- [x] https://github.com/modm-io/avr-libstdcpp/pull/35
- [x] `modm::fiber::sleep` -> `modm::this_fiber::sleep_for`
- [x] `modm::this_fiber::sleep_until`
- [x] `modm::this_fiber::get_id`
- [x] Align `modm::fiber::Task` to `std::jthread` interface, incl. stop_token.
- [x] stop_token and stop_source (simplified)
- [x] mutex
- [x] timed_mutex
- [x] recursive_mutex
- [x] recursive_timed_mutex
- [x] counting_semaphore (=binary_semaphore)
- [x] shared_mutex
- [x] shared_timed_mutex
- [x] once_flag
- [x] call_once
- [x] latch
- [x] barrier
- [x] condition_variable
- [x] unit tests
- [x] More documentation
- [x] Hardware testing
  - [x] STM32F723
  - [x] STM32G071
  - [x] ATmega2650