### PR TITLE
[cortex] Remove -fsingle-precision-constant default option

### DIFF
--- a/examples/nucleo_f042k6/tmp12x/main.cpp
+++ b/examples/nucleo_f042k6/tmp12x/main.cpp
@@ -44,7 +44,7 @@ main()
 	while(true) {
 		if (timer.execute()) {
 			const modm::Tmp123Temperature temperature = RF_CALL_BLOCKING(sensor.read());
-			MODM_LOG_INFO.printf("Temperature %2.2f\n", temperature.getTemperatureFloat());
+			MODM_LOG_INFO.printf("Temperature %2.2f\n", (double)temperature.getTemperatureFloat());
 		}
 	}
 }

--- a/examples/nucleo_f303re/temperature_mcp990x/main.cpp
+++ b/examples/nucleo_f303re/temperature_mcp990x/main.cpp
@@ -50,7 +50,7 @@ int main()
 		{
 			if (RF_CALL_BLOCKING(sensor.readInternalTemperature()))
 			{
-				MODM_LOG_INFO.printf("temperature: %3.3f\n °C\n", data.getTemperature());
+				MODM_LOG_INFO.printf("temperature: %3.3f\n °C\n", (double)data.getTemperature());
 			}
 			else
 			{

--- a/examples/nucleo_g474re/adc_basic/main.cpp
+++ b/examples/nucleo_g474re/adc_basic/main.cpp
@@ -42,7 +42,7 @@ main()
 		MODM_LOG_INFO << "adcValue=" << adcValue;
 		float voltage = adcValue * 3.3 / 0xfff;
 		MODM_LOG_INFO << " voltage=";
-		MODM_LOG_INFO.printf("%.3f\n", voltage);
+		MODM_LOG_INFO.printf("%.3f\n", (double)voltage);
 		modm::delay(500ms);
 	}
 

--- a/examples/nucleo_g474re/ads7828/main.cpp
+++ b/examples/nucleo_g474re/ads7828/main.cpp
@@ -47,84 +47,84 @@ public:
             MODM_LOG_INFO << "-------------------------------" << modm::endl << modm::endl;
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch0 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch0 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch1));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch1 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch1 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch2));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch2 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch2 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch3));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch3 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch3 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch4));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch4 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch4 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch5));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch5 measuremnt is  \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch5 measuremnt is  \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch6));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch6 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch6 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch7));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch7 measuremnt is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch7 measuremnt is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             MODM_LOG_INFO << "----Diff Inputs-------------" << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0Ch1));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch0 - Ch1 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch0 - Ch1 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch2Ch3));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch2 - Ch3 is\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch2 - Ch3 is\t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch4Ch5));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch4 - Ch5 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch4 - Ch5 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch6Ch7));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch6 - Ch7 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch6 - Ch7 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch1Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch1 - Ch0 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch1 - Ch0 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch3Ch2));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch3 - Ch2 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch3 - Ch2 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch5Ch4));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch5 - Ch4 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch5 - Ch4 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch7Ch6));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Ch7 - Ch6 is \t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Ch7 - Ch6 is \t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             MODM_LOG_INFO << "---Toggling Power Down and Internal Ref----" << modm::endl;
@@ -132,25 +132,25 @@ public:
             PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOffAdcConverterOff));
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Default: \t\t\t\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("Default: \t\t\t\t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOnAdcConverterOff));
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Internal ref on:  \t\t\t %.4f", data.getVoltage(2.5f));
+            MODM_LOG_INFO.printf("Internal ref on:  \t\t\t %.4f", (double)data.getVoltage(2.5f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOffAdcConverterOn));
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("No power down \t\t\t\t %.4f", data.getVoltage(3.3f));
+            MODM_LOG_INFO.printf("No power down \t\t\t\t %.4f", (double)data.getVoltage(3.3f));
             MODM_LOG_INFO << modm::endl;
 
             PT_CALL(adc.setPowerDownSelection(modm::ads7828::PowerDown::InternalReferenceOnAdcConverterOn));
             PT_CALL(adc.startMeasurement(modm::ads7828::InputChannel::Ch0));
             PT_CALL(adc.readConversionResult());
-            MODM_LOG_INFO.printf("Internal ref on, no power down: \t %.4f", data.getVoltage(2.5f));
+            MODM_LOG_INFO.printf("Internal ref on, no power down: \t %.4f", (double)data.getVoltage(2.5f));
             MODM_LOG_INFO << modm::endl;
 
             MODM_LOG_INFO << "-------------------------------" << modm::endl << modm::endl;

--- a/examples/nucleo_g474re/imu_lsm6dso/main.cpp
+++ b/examples/nucleo_g474re/imu_lsm6dso/main.cpp
@@ -103,7 +103,7 @@ main()
 		}
 
 		// print data anyways
-		MODM_LOG_INFO.printf("TEMP=%+2.1f degC, ", (static_cast<int16_t>(data[0] | data[1] << 8) / 256.f) + 25.f);
+		MODM_LOG_INFO.printf("TEMP=%+2.1f degC, ", (double)((static_cast<int16_t>(data[0] | data[1] << 8) / 256.f) + 25.f));
 		MODM_LOG_INFO.printf("G_X=%+05i, ", static_cast<int16_t>(data[ 2] | data[ 3] << 8));
 		MODM_LOG_INFO.printf("G_Y=%+05i, ", static_cast<int16_t>(data[ 4] | data[ 5] << 8));
 		MODM_LOG_INFO.printf("G_Z=%+05i, ", static_cast<int16_t>(data[ 6] | data[ 7] << 8));

--- a/examples/nucleo_g474re/timer_input_capture/main.cpp
+++ b/examples/nucleo_g474re/timer_input_capture/main.cpp
@@ -25,7 +25,7 @@ using namespace Board;
 constexpr uint16_t 	input_capture_overflow 		= 0xFFFF;
 constexpr float 	input_capture_freq_hz 		= 3000.00;	// Hz
 constexpr uint16_t 	input_capture_prescaler 	= SystemClock::Frequency / input_capture_freq_hz;
-constexpr float 	input_capture_ms_per_tick 	= ( 1.0 / input_capture_freq_hz ) * 1000.0;
+constexpr float 	input_capture_ms_per_tick 	= ( 1.0f / input_capture_freq_hz ) * 1000.0;
 
 // PWM Generator Timer Configuration
 constexpr uint16_t 	pwm_gen_overflow 		= 0xFFFF;
@@ -36,7 +36,7 @@ constexpr float 	pwm_gen_pulse_width_ms 	= 1.5f;		// Milliseconds
 // Desired PWM Freq = Clock Freq / Timer Prescaler / Overflow Value
 // Timer Prescaler = Clock Freq / (Desired PWM Freq * Overflow Value)
 constexpr uint16_t 	pwm_gen_prescaler 			= SystemClock::Frequency / ( pwm_gen_frequency_hz * pwm_gen_overflow );
-constexpr float 	pwm_gen_period_ms			= ( 1.0 / pwm_gen_frequency_hz ) * 1000;
+constexpr float 	pwm_gen_period_ms			= ( 1.0f / pwm_gen_frequency_hz ) * 1000;
 constexpr uint16_t 	pwm_gen_ticks_per_period 	= pwm_gen_overflow / pwm_gen_period_ms;
 constexpr uint16_t 	pwm_pulse_width_in_ticks 	= pwm_gen_ticks_per_period * pwm_gen_pulse_width_ms;
 // --------------------------------------------------------------------------

--- a/examples/nucleo_l552ze-q/adc_basic/main.cpp
+++ b/examples/nucleo_l552ze-q/adc_basic/main.cpp
@@ -44,7 +44,7 @@ main()
 		MODM_LOG_INFO << "adcValue=" << adcValue;
 		const float voltage = adcValue * 3.3 / 0xfff;
 		MODM_LOG_INFO << " voltage=";
-		MODM_LOG_INFO.printf("%.3f\n", voltage);
+		MODM_LOG_INFO.printf("%.3f\n", (double)voltage);
 		Board::Leds::toggle();
 		modm::delay(500ms);
 	}

--- a/examples/stm32f3_discovery/accelerometer/main.cpp
+++ b/examples/stm32f3_discovery/accelerometer/main.cpp
@@ -42,11 +42,11 @@ public:
 			averageY.update(accelerometer.getData().getY());
 
 			{
-				bool xs = averageX.getValue() < -0.2;
-				bool xn = averageX.getValue() >  0.2;
+				bool xs = averageX.getValue() < -0.2f;
+				bool xn = averageX.getValue() >  0.2f;
 
-				bool xe = averageY.getValue() < -0.2;
-				bool xw = averageY.getValue() >  0.2;
+				bool xe = averageY.getValue() < -0.2f;
+				bool xw = averageY.getValue() >  0.2f;
 
 				Board::LedNorth::set(xn and not (xe or xw));
 				Board::LedNorthEast::set(xn and xe);

--- a/examples/stm32f4_discovery/accelerometer/main.cpp
+++ b/examples/stm32f4_discovery/accelerometer/main.cpp
@@ -87,10 +87,10 @@ public:
 			averageY.update(accel.getData().getY());
 #endif
 
-			Board::LedOrange::set(averageX.getValue() < -0.2);
-			Board::LedBlue::set(averageX.getValue() > 0.2);
-			Board::LedGreen::set(averageY.getValue() < -0.2);
-			Board::LedRed::set(averageY.getValue() > 0.2);
+			Board::LedOrange::set(averageX.getValue() < -0.2f);
+			Board::LedBlue::set(averageX.getValue() > 0.2f);
+			Board::LedGreen::set(averageY.getValue() < -0.2f);
+			Board::LedRed::set(averageY.getValue() > 0.2f);
 
 			timeout.restart(5ms);
 			PT_WAIT_UNTIL(timeout.isExpired());

--- a/src/modm/board/disco_f746ng/board.hpp
+++ b/src/modm/board/disco_f746ng/board.hpp
@@ -208,7 +208,7 @@ initialize()
 inline void
 initializeUsbFs(uint8_t priority=3)
 {
-	usb_fs::Device::initialize<SystemClock>();
+	usb_fs::Device::initialize<SystemClock>(priority);
 	usb_fs::Device::connect<usb_fs::Dm::Dm, usb_fs::Dp::Dp, usb_fs::Id::Id>();
 
 	USB_OTG_DeviceTypeDef *dev = (USB_OTG_DeviceTypeDef *) (USB_OTG_FS_PERIPH_BASE + USB_OTG_DEVICE_BASE);
@@ -223,9 +223,9 @@ initializeUsbFs(uint8_t priority=3)
 }
 
 inline void
-initializeUsbHs()
+initializeUsbHs(uint8_t priority=3)
 {
-	usb_hs::Device::initialize<SystemClock>();
+	usb_hs::Device::initialize<SystemClock>(priority);
 	usb_hs::Device::connect<
 		usb_hs::Ck::Ulpick,	usb_hs::Stp::Ulpistp,
 		usb_hs::Dir::Ulpidir, usb_hs::Nxt::Ulpinxt,

--- a/src/modm/driver/inertial/bno055.hpp
+++ b/src/modm/driver/inertial/bno055.hpp
@@ -657,7 +657,7 @@ protected:
 			this->transaction.configureWrite(buffer, 2);
 			buffer[2] = RF_CALL( this->runTransaction() );
 			if (buffer[2]) prev_reg = reg;
-			RF_RETURN(buffer[2]);
+			RF_RETURN((bool)buffer[2]);
 		}
 
 		RF_END_RETURN(true);

--- a/src/modm/driver/position/vl6180_impl.hpp
+++ b/src/modm/driver/position/vl6180_impl.hpp
@@ -58,7 +58,7 @@ modm::Vl6180<I2cMaster>::initialize()
 		if (!logicBuffer.byte[0]) RF_RETURN(false);
 	}
 
-	RF_END_RETURN(logicBuffer.byte[0]);
+	RF_END_RETURN((bool)logicBuffer.byte[0]);
 }
 
 template < typename I2cMaster >

--- a/src/modm/math/geometry/angle.cpp
+++ b/src/modm/math/geometry/angle.cpp
@@ -22,13 +22,13 @@ modm::Angle::normalize(float angle)
 {
 	if (isPositive(angle))
 	{
-		while (angle > M_PI) {
-			angle -= 2 * M_PI;
+		while (angle > std::numbers::pi_v<float>) {
+			angle -= 2 * std::numbers::pi_v<float>;
 		}
 	}
 	else {
-		while (angle < -M_PI) {
-			angle += 2 * M_PI;
+		while (angle < -std::numbers::pi_v<float>) {
+			angle += 2 * std::numbers::pi_v<float>;
 		}
 	}
 
@@ -41,10 +41,10 @@ modm::Angle::reverse(float angle)
 {
 	if (isPositive(angle))
 	{
-		angle -= M_PI;
+		angle -= std::numbers::pi_v<float>;
 	}
 	else {
-		angle += M_PI;
+		angle += std::numbers::pi_v<float>;
 	}
 
 	return angle;
@@ -56,10 +56,10 @@ modm::Angle::perpendicular(float angle, const bool cw)
 {
 	if (cw)
 	{
-		angle = modm::Angle::normalize(angle - M_PI_2);
+		angle = modm::Angle::normalize(angle - std::numbers::pi_v<float>/2);
 	}
 	else {
-		angle = modm::Angle::normalize(angle + M_PI_2);
+		angle = modm::Angle::normalize(angle + std::numbers::pi_v<float>/2);
 	}
 
 	return angle;

--- a/src/modm/math/geometry/angle.hpp
+++ b/src/modm/math/geometry/angle.hpp
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <math.h>
+#include <numbers>
 
 // The circumference of a circle with diameter 1
 #ifndef M_PI
@@ -55,14 +56,14 @@ namespace modm
 	static constexpr float
 	toRadian(float angle)
 	{
-		return (angle * M_PI) / 180.f;
+		return (angle * std::numbers::pi_v<float>) / 180.f;
 	}
 
 	/// @ingroup modm_math_geometry
 	static constexpr float
 	toDegree(float angle)
 	{
-		return (angle * 180.f) / M_PI;
+		return (angle * 180.f) / std::numbers::pi_v<float>;
 	}
 
 	/**

--- a/src/modm/platform/can/common/can_bit_timings.hpp
+++ b/src/modm/platform/can/common/can_bit_timings.hpp
@@ -63,7 +63,7 @@ private:
 	static constexpr uint32_t round_uint32(float f)
 	{
 		uint32_t f_int = (uint32_t) f;
-		if(f - f_int > 0.5)
+		if(f - f_int > 0.5f)
 			return f_int + 1;
 		else
 			return f_int;

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -370,5 +370,4 @@ def build(env):
         env.collect(":build:archflags", "-mfloat-abi={}".format(env["float-abi"]), fpu_spec)
         single_precision = ("-sp-" in fpu_spec)
     if single_precision:
-        env.collect(":build:ccflags", "-fsingle-precision-constant",
-                                      "-Wdouble-promotion")
+        env.collect(":build:ccflags", "-Wdouble-promotion")

--- a/src/modm/platform/core/cortex/module.md
+++ b/src/modm/platform/core/cortex/module.md
@@ -327,8 +327,15 @@ This module adds these architecture specific [compiler options][options]:
 - `-mthumb`: only Thumb2 instruction set is supported.
 - `-mfloat-abi={soft, softfp, hard}`: the FPU ABI: `hard` is fastest.
 - `-mfpu=fpv{4, 5}-{sp}-d16`: single or double precision FPU.
-- `-fsingle-precision-constant`: if SP-FPU, treat all FP constants as SP.
-- `-Wdouble-promotion`: if SP-FPU, warn if FPs are promoted to doubles.
+- `-Wdouble-promotion`: if SP-FPU, warn if FPs are promoted to doubles. Note
+  that unless you use the `.f` suffix or explicitly cast floating point
+  operations to `float`, floating point constants are of `double` type, whose
+  storage can result in an increased binary size. While you can add the
+  `-fsingle-precision-constant` compiler flag to implicitly cast all doubles to
+  floats, this also impacts compile time computations and may reduce accuracy.
+  Therefore it is not enabled by default and you should carefully watch for any
+  unwanted numeric side effects if you use this compiler option.
+  See [Semantics of Floating Point Math in GCC][gcc_math].
 
 In addition, these linker options are added:
 
@@ -336,3 +343,4 @@ In addition, these linker options are added:
 - `-wrap,_{calloc, malloc, realloc, free}_r`: reimplemented Newlib with our own allocator.
 
 [options]: https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
+[gcc_math]: https://gcc.gnu.org/wiki/FloatingPointMath

--- a/src/modm/ui/color/brightness.hpp
+++ b/src/modm/ui/color/brightness.hpp
@@ -75,8 +75,8 @@ public:
 	 */
 	template<std::unsigned_integral U>
 	constexpr BrightnessT(RgbT<U> rgb)
-		: value((0.2125 * float(rgb.red)) + (0.7154 * float(rgb.green)) +
-				(0.0721 * float(rgb.blue)))
+		: value((0.2125f * float(rgb.red)) + (0.7154f * float(rgb.green)) +
+				(0.0721f * float(rgb.blue)))
 	{}
 
 	/**


### PR DESCRIPTION
Follow up to #990, the compiler option is removed and its behavior is documented.

- [x] Fix double promotion warnings.

cc @victorandrehc  @rleh