### PR TITLE
[driver] Compare calculated crc with MS5611 prom

### DIFF
--- a/examples/nucleo_g474re/ms5611/main.cpp
+++ b/examples/nucleo_g474re/ms5611/main.cpp
@@ -32,7 +32,7 @@ public:
     {
         PT_BEGIN();
 
-        while (PT_CALL(barometer.initialize()) == 0)
+        while (PT_CALL(barometer.initialize()) == false)
         {
             MODM_LOG_ERROR << "Ms5611 PROM CRC failed" << modm::endl;
             timeout.restart(std::chrono::milliseconds(1000));

--- a/src/modm/driver/pressure/ms5611.hpp
+++ b/src/modm/driver/pressure/ms5611.hpp
@@ -90,7 +90,7 @@ public:
 
     /// Call this function before using the device to read the factory calibration
     /// @warning calls to this function resets the device
-    modm::ResumableResult<uint16_t>
+    modm::ResumableResult<bool>
     initialize();
 
     /// Do a readout sequence to convert and read temperature and then pressure from sensor

--- a/src/modm/driver/pressure/ms5611_impl.hpp
+++ b/src/modm/driver/pressure/ms5611_impl.hpp
@@ -28,7 +28,7 @@ Ms5611<SpiMaster,Cs>::Ms5611(DataBase &data) : data(data)
 // -----------------------------------------------------------------------------
 
 template <typename SpiMaster, typename Cs>
-modm::ResumableResult<uint16_t>
+modm::ResumableResult<bool>
 Ms5611<SpiMaster,Cs>::initialize()
 {
     RF_BEGIN();
@@ -67,7 +67,7 @@ Ms5611<SpiMaster,Cs>::initialize()
     data.prom.data[6] = modm::fromBigEndian(RF_CALL(readProm(6)));
     data.prom.data[7] = modm::fromBigEndian(RF_CALL(readProm(7)));
 
-    RF_END_RETURN(data.prom.calculateCrc());
+    RF_END_RETURN(data.prom.calculateCrc() == (data.prom.data[7] & 0x000F));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
It occured to me that in application code we only validate that the CRC is nonzero. I have updated the driver so it now compares the calculated CRC with the prom. I have tested this implementation with three barometers. Hopefully this will be the final update to this driver!