### PR TITLE
[stm32] Place .data section into D1_SRAM instead of DTCM for H7

### DIFF
--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -5,6 +5,7 @@
  * Copyright (c) 2012, 2015-2022, Niklas Hauser
  * Copyright (c) 2013, Sascha Schade
  * Copyright (c) 2013, 2015, Kevin Läufer
+ * Copyright (c) 2023, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -172,15 +173,16 @@ MAIN_STACK_SIZE = {{ options[":platform:cortex-m:main_stack_size"] }};
 
 
 %% macro all_heap_sections(table_copy, table_zero, table_heap, props={})
+	%% set ram_first_index = cont_ram["contains"][0]["index"]
 	%% for cont_region in cont_ram_regions
 		%% for region in cont_region.contains
 	/* Sections in {{ region.name|upper }} */
-			%% if region.index
+			%% if region.index != ram_first_index
 {{ section_load(cont_region.cont_name|upper + " AT >FLASH", table_copy, sections=["data_"+region.name]) }}
 				%% do table_zero.append("bss_"+region.name)
 			%% endif
 {{ section_heap(region.name|upper, "heap_"+region.name, cont_region.cont_name|upper,
-				sections=(["bss_"+region.name] if region.index else []) + ["noinit_"+region.name]) }}
+				sections=(["bss_"+region.name] if region.index != ram_first_index else []) + ["noinit_"+region.name]) }}
 			%% for name, value in props.items() if name in region.name
 				%% do table_heap.insert(region.index, {"name": "heap_"+region.name, "prop": value})
 			%% else

--- a/src/modm/platform/core/cortex/ram.ld.in
+++ b/src/modm/platform/core/cortex/ram.ld.in
@@ -20,15 +20,15 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section_stack(cont_ram_regions[0].cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
+{{ linker.section_stack(cont_ram.cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
-                      sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["fastdata", "fastcode", "data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}

--- a/src/modm/platform/core/stm32/dccm.ld.in
+++ b/src/modm/platform/core/stm32/dccm.ld.in
@@ -20,15 +20,15 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section_stack(cont_ram_regions[0].cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
+{{ linker.section_stack(cont_ram.cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram_regions[0].cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
-                      sections_data=["fastcode", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["fastcode", "data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}

--- a/src/modm/platform/core/stm32/iccm.ld.in
+++ b/src/modm/platform/core/stm32/iccm.ld.in
@@ -15,11 +15,11 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section_stack(cont_ram_regions[0].cont_name|upper) }}
+{{ linker.section_stack(cont_ram.cont_name|upper) }}
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
-                      sections_data=["data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}

--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -26,15 +26,25 @@ SECTIONS
 %% do table_heap.append({"name": "heap_itcm", "prop": "0x2005"})
 
 %% if cont_ram_regions[0].cont_name == "cont_dtcm"
-{{ linker.section_stack("CONT_DTCM") }}
+%% set dtcm_section = "CONT_DTCM"
 %% else
-{{ linker.section_stack("DTCM") }}
+%% set dtcm_section = "DTCM"
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
-                      sections_data=["fastdata", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+{{ linker.section_stack(dtcm_section) }}
+
+%% if "dtcm" in cont_ram.cont_name
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["fastdata", "data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
+%% else
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
+                      sections_noinit=["faststack"]) }}
+{{ linker.section_load(dtcm_section + " AT >FLASH", table_copy, sections=["fastdata"]) }}
+%% endif
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap, props={"dtcm": "0x2023" if target.family == "h7" else "0x202b"}) }}
 %% if with_crashcatcher

--- a/src/modm/platform/core/stm32/module.md
+++ b/src/modm/platform/core/stm32/module.md
@@ -255,8 +255,7 @@ not DMA-able.
 ### Tightly-Coupled RAM (TCM)
 
 The STM32F7 devices include an Instruction TCM (ITCM) and a data TCM (DTCM).
-Note that the TCMs are DMA-able, but only the MDMA. Note that DTCM but will
-overflow into the SRAM1/2 sections.
+Note that the DTCM section will overflow into the SRAM1/2 sections.
 
 ```
             ┌────────────────────────┐◄ __backup_end
@@ -332,7 +331,8 @@ overflow into the SRAM1/2 sections.
 
 The STM32H7 memory map is more complex with multiple SRAM regions in seperate
 power domains D1, D2 and D3. Note that the main `.data` and `.bss` sections are
-placed into the 128kB DTCM, but cannot overflow into D1_SRAM section.
+placed into the D1_SRAM section because the TCMs can't be accessed by
+peripheral DMA transfers, but only the MDMA.
 
 ```
             ┌────────────────────────┐◄ __backup_end
@@ -379,18 +379,19 @@ placed into the 128kB DTCM, but cannot overflow into D1_SRAM section.
 0x2404 0000 ├────────────────────────┤◄ __d1_sram1_end, __d1_sram2_start
             │  +HEAP_D1_SRAM1        │
             │  .noinit_d1_sram1      │
+            │  .noinit               │
+            │  .faststack            │
             │  .bss_d1_sram1         │
-  D1_SRAM1  │  .data_d1_sram1        │
+            │  .bss                  │
+            │  .data_d1_sram1        │
+  D1_SRAM1  │  .data                 │
 0x2400 0000 └────────────────────────┘◄ __d1_sram1_start
 
             ┌────────────────────────┐◄ __dtcm_end
             │  +HEAP_DTCM            │
-            │  .noinit_dtcm          │
-            │  .noinit               │
-            │  .faststack            │
-   D-Code   │  .bss_dtcm             │
-    only    │  .data_dtcm            │
-   access   │  .data                 │
+   D-Code   │  .noinit_dtcm          │
+    only    │  .bss_dtcm             │
+   access   │  .data_dtcm            │
             │  .fastdata             │
     DTCM    │  +MAIN_STACK_SIZE      │◄ __main_stack_top
 0x2000 0000 └────────────────────────┘◄ __dtcm_start

--- a/src/modm/platform/core/stm32/ram_remap_vector_table.ld.in
+++ b/src/modm/platform/core/stm32/ram_remap_vector_table.ld.in
@@ -14,13 +14,13 @@ SECTIONS
 
 {{ linker.section_rom("FLASH") }}
 
-{{ linker.section_vector_ram(cont_ram_regions[0].cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
 
-{{ linker.section_stack(cont_ram_regions[0].cont_name|upper) }}
+{{ linker.section_stack(cont_ram.cont_name|upper) }}
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
-                      sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
-                      sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
+{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+                      sections_data=["fastdata", "fastcode", "data_" + cont_ram.contains[0].name],
+                      sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
 {{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}


### PR DESCRIPTION
This changes the method for choosing the memory that will contain the RAM data sections. Previously the first memory of the contiguous region with the lowest address was selected. Now the first memory of the largest region will be selected instead.

On STM32H7 the `.data` and `.bss` sections were previously put into the DTCM which is not accessible by peripheral DMA transfers. They will now be placed into the D1 AXI SRAM with the updated selection method.

For all other supported Cortex-M devices the generated linker script will be identical. All targets except STM32H7, STM32U5 and SAMD/E5x only have one contiguous region anyway and for STM32U5 and SAMD/E5x the set contains the main RAM region and additional small SRAMs.
I have verified at least one generated linker script for every linker script template and only copyright headers and white space changed.