### PR TITLE
STM32H7 SPI + Exti fixes + BMI088 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/README.md
+++ b/README.md
@@ -723,96 +723,97 @@ your specific needs.
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-block-device-spi-flash">SPI Flash</a></td>
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bme280">BME280</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-bmi088">BMI088</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bmp085">BMP085</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bno055">BNO055</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-cat24aa">CAT24AA</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-cycle_counter">CYCLE-COUNTER</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-drv832x_spi">DRV832X</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-drv832x_spi">DRV832X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1302">DS1302</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1631">DS1631</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds18b20">DS18B20</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ea_dog">EA-DOG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input">Encoder Input</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input-bitbang">Encoder Input BitBang</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input-bitbang">Encoder Input BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_output-bitbang">Encoder Output BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ft245">FT245</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ft6x06">FT6x06</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-gpio_sampler">Gpio Sampler</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hclax">HCLAx</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-hd44780">HD44780</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-hd44780">HD44780</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc58x">HMC58x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc6343">HMC6343</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hx711">HX711</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-i2c-eeprom">I2C-EEPROM</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ili9341">ILI9341</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-is31fl3733">IS31FL3733</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-is31fl3733">IS31FL3733</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-itg3200">ITG3200</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ixm42xxx">IXM42XXX</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-l3gd20">L3GD20</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lan8720a">LAN8720A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lawicel">LAWICEL</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lis302dl">LIS302DL</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lis302dl">LIS302DL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3dsh">LIS3DSH</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3mdl">LIS3MDL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lm75">LM75</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lp503x">LP503x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm303a">LSM303A</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6ds33">LSM6DS33</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6ds33">LSM6DS33</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6dso">LSM6DSO</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ltc2984">LTC2984</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max31855">MAX31855</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max31865">MAX31865</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max6966">MAX6966</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-max7219">MAX7219</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-max7219">MAX7219</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp23x17">MCP23x17</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp2515">MCP2515</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp3008">MCP3008</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp7941x">MCP7941x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp990x">MCP990X</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-mmc5603">MMC5603</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-mmc5603">MMC5603</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5611">MS5611</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5837">MS5837</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nokia5110">NOKIA5110</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nrf24">NRF24</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-parallel_tft_display">TFT-DISPLAY</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-pat9125el">PAT9125EL</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-pat9125el">PAT9125EL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca8574">PCA8574</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9535">PCA9535</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9548a">PCA9548A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9685">PCA9685</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-qmc5883l">QMC5883L</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sh1106">SH1106</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sh1106">SH1106</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s65">SIEMENS-S65</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s75">SIEMENS-S75</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sk6812">SK6812</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ssd1306">SSD1306</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-st7586s">ST7586S</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-st7586s">ST7586S</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-st7789">ST7789</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stts22h">STTS22H</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stusb4500">STUSB4500</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sx128x">SX128X</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3472">TCS3472</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tlc594x">TLC594x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp102">TMP102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp12x">TMP12x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl53l0">VL53L0</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl6180">VL6180</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ws2812">WS2812</a></td>

--- a/examples/nucleo_h723zg/bmi088/i2c/main.cpp
+++ b/examples/nucleo_h723zg/bmi088/i2c/main.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/driver/inertial/bmi088.hpp>
+
+#include <modm/board.hpp>
+#include <atomic>
+
+using namespace Board;
+
+using I2c = I2cMaster1;
+using Scl = GpioB8;  // D15
+using Sda = GpioB9;  // D14
+
+using AccInt1 = GpioC6;
+using GyroInt3 = GpioB15;
+
+using Transport = modm::Bmi088I2cTransport<I2c>;
+using Imu = modm::Bmi088<Transport>;
+
+constexpr uint8_t AccAddress = 0x18;
+constexpr uint8_t GyroAddress = 0x68;
+Imu imu{AccAddress, GyroAddress};
+
+void initializeImu()
+{
+	AccInt1::setInput(AccInt1::InputType::PullDown);
+	GyroInt3::setInput(GyroInt3::InputType::PullDown);
+
+	constexpr bool selfTest = true;
+	while (!imu.initialize(selfTest)) {
+		MODM_LOG_ERROR << "Initialization failed, retrying ...\n";
+		modm::delay(500ms);
+	}
+
+	bool ok = imu.setAccRate(Imu::AccRate::Rate12Hz_Bw5Hz);
+	ok &= imu.setAccRange(Imu::AccRange::Range3g);
+
+	const auto int1Config = (Imu::AccGpioConfig::ActiveHigh | Imu::AccGpioConfig::EnableOutput);
+	ok &= imu.setAccInt1GpioConfig(int1Config);
+	ok &= imu.setAccGpioMap(Imu::AccGpioMap::Int1DataReady);
+
+	ok &= imu.setGyroRate(Imu::GyroRate::Rate100Hz_Bw12Hz);
+	ok &= imu.setGyroRange(Imu::GyroRange::Range250dps);
+	ok &= imu.setGyroGpioConfig(Imu::GyroGpioConfig::Int3ActiveHigh);
+	ok &= imu.setGyroGpioMap(Imu::GyroGpioMap::Int3DataReady);
+
+	if (!ok) {
+		MODM_LOG_ERROR << "Configuration failed!\n";
+	}
+}
+
+int main()
+{
+	Board::initialize();
+	Leds::setOutput();
+	I2c::connect<Scl::Scl, Sda::Sda>(I2c::PullUps::Internal);
+	I2c::initialize<Board::SystemClock, 100_kHz, 10_pct>();
+
+	MODM_LOG_INFO << "BMI088 I2C Test\n";
+	initializeImu();
+
+	std::atomic_bool accReady = false;
+	std::atomic_bool gyroReady = false;
+
+	Exti::connect<AccInt1>(Exti::Trigger::RisingEdge, [&accReady](auto){
+		accReady = true;
+	});
+
+	Exti::connect<GyroInt3>(Exti::Trigger::RisingEdge, [&gyroReady](auto){
+		gyroReady = true;
+	});
+
+	while (true)
+	{
+		while(!accReady or !gyroReady);
+
+		const std::optional accResult = imu.readAccData();
+		accReady = false;
+		const std::optional gyroResult = imu.readGyroData();
+		gyroReady = false;
+
+		if (accResult) {
+			const modm::Vector3f data = accResult->getFloat();
+			MODM_LOG_INFO.printf("Acc  [mg]\tx:\t%5.1f\ty: %5.1f\tz: %5.1f\n", data[0], data[1], data[2]);
+		}
+		if (gyroResult) {
+			const modm::Vector3f data = gyroResult->getFloat();
+			MODM_LOG_INFO.printf("Gyro [deg/s]\tx:\t%5.2f\ty: %5.2f\tz: %5.2f\n", data[0], data[1], data[2]);
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_h723zg/bmi088/i2c/project.xml
+++ b/examples/nucleo_h723zg/bmi088/i2c/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_h723zg/bmi088_i2c</option>
+    <option name="modm:processing:protothread:use_fiber">yes</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:fiber</module>
+    <module>modm:platform:exti</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:driver:bmi088</module>
+  </modules>
+</library>

--- a/examples/nucleo_h723zg/bmi088/spi/main.cpp
+++ b/examples/nucleo_h723zg/bmi088/spi/main.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/driver/inertial/bmi088.hpp>
+
+#include <modm/board.hpp>
+#include <atomic>
+
+using namespace Board;
+
+using Spi = SpiMaster2_Dma<Dma1::Channel0, Dma1::Channel1>;
+using CsGyro = GpioC0;
+using CsAcc = GpioD6;
+using Mosi = GpioC3;
+using Miso = GpioC2;
+using Sck = GpioD3;
+
+using AccInt1 = GpioC8;
+using GyroInt3 = GpioC9;
+
+using Transport = modm::Bmi088SpiTransport<Spi, CsAcc, CsGyro>;
+using Imu = modm::Bmi088<Transport>;
+Imu imu;
+
+void initializeImu()
+{
+	AccInt1::setInput(AccInt1::InputType::PullDown);
+	GyroInt3::setInput(GyroInt3::InputType::PullDown);
+
+	constexpr bool selfTest = true;
+	while (!imu.initialize(selfTest)) {
+		MODM_LOG_ERROR << "Initialization failed, retrying ...\n";
+		modm::delay(500ms);
+	}
+
+	bool ok = imu.setAccRate(Imu::AccRate::Rate12Hz_Bw5Hz);
+	ok &= imu.setAccRange(Imu::AccRange::Range3g);
+
+	const auto int1Config = (Imu::AccGpioConfig::ActiveHigh | Imu::AccGpioConfig::EnableOutput);
+	ok &= imu.setAccInt1GpioConfig(int1Config);
+	ok &= imu.setAccGpioMap(Imu::AccGpioMap::Int1DataReady);
+
+	ok &= imu.setGyroRate(Imu::GyroRate::Rate100Hz_Bw12Hz);
+	ok &= imu.setGyroRange(Imu::GyroRange::Range250dps);
+	ok &= imu.setGyroGpioConfig(Imu::GyroGpioConfig::Int3ActiveHigh);
+	ok &= imu.setGyroGpioMap(Imu::GyroGpioMap::Int3DataReady);
+
+	if (!ok) {
+		MODM_LOG_ERROR << "Configuration failed!\n";
+	}
+}
+
+int main()
+{
+	Board::initialize();
+	Leds::setOutput();
+	Dma1::enable();
+	Spi::connect<Sck::Sck, Mosi::Mosi, Miso::Miso>();
+	Spi::initialize<Board::SystemClock, 9_MHz, 10_pct>();
+
+	MODM_LOG_INFO << "BMI088 SPI Test\n";
+	initializeImu();
+
+	std::atomic_bool accReady = false;
+	std::atomic_bool gyroReady = false;
+
+	Exti::connect<AccInt1>(Exti::Trigger::RisingEdge, [&accReady](auto){
+		accReady = true;
+	});
+
+	Exti::connect<GyroInt3>(Exti::Trigger::RisingEdge, [&gyroReady](auto){
+		gyroReady = true;
+	});
+
+	while (true)
+	{
+		while(!accReady or !gyroReady);
+
+		const std::optional accResult = imu.readAccData();
+		accReady = false;
+		const std::optional gyroResult = imu.readGyroData();
+		gyroReady = false;
+
+		if (accResult) {
+			const modm::Vector3f data = accResult->getFloat();
+			MODM_LOG_INFO.printf("Acc  [mg]\tx:\t%5.1f\ty: %5.1f\tz: %5.1f\n", data[0], data[1], data[2]);
+		}
+		if (gyroResult) {
+			const modm::Vector3f data = gyroResult->getFloat();
+			MODM_LOG_INFO.printf("Gyro [deg/s]\tx:\t%5.2f\ty: %5.2f\tz: %5.2f\n", data[0], data[1], data[2]);
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_h723zg/bmi088/spi/project.xml
+++ b/examples/nucleo_h723zg/bmi088/spi/project.xml
@@ -1,0 +1,15 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_h723zg/bmi088_spi</option>
+    <option name="modm:processing:protothread:use_fiber">yes</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:processing:fiber</module>
+    <module>modm:platform:dma</module>
+    <module>modm:platform:exti</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:driver:bmi088</module>
+  </modules>
+</library>

--- a/src/modm/architecture/interface/spi_lock.hpp
+++ b/src/modm/architecture/interface/spi_lock.hpp
@@ -1,0 +1,84 @@
+/*
+* Copyright (c) 2014-2017, Niklas Hauser
+* Copyright (c) 2023, Christopher Durand
+*
+* This file is part of the modm project.
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_INTERFACE_SPI_LOCK_HPP
+#define MODM_INTERFACE_SPI_LOCK_HPP
+
+#include <cstdint>
+#include <modm/architecture/interface/spi.hpp>
+
+namespace modm
+{
+
+/**
+ * Helper class to implement the synchronization mechanism of @ref modm::SpiMaster
+ * in SPI device drivers.
+ *
+ * Inherit from this class publicly and pass the derived class as the template
+ * argument, as in `class SpiMaster1 : public modm::SpiLock<SpiMaster1>`.
+ *
+ * @tparam	Derived SPI master derived class
+ * @ingroup	modm_architecture_spi
+ */
+template<typename Derived>
+class SpiLock
+{
+public:
+	static uint8_t
+	acquire(void* ctx, Spi::ConfigurationHandler handler);
+
+	static uint8_t
+	release(void* ctx);
+
+private:
+	static inline uint8_t count{0};
+	static inline void* context{nullptr};
+	static inline Spi::ConfigurationHandler configuration{nullptr};
+};
+
+template<typename Derived>
+uint8_t
+SpiLock<Derived>::acquire(void* ctx, Spi::ConfigurationHandler handler)
+{
+	if (context == nullptr)
+	{
+		context = ctx;
+		count = 1;
+		// if handler is not nullptr and is different from previous configuration
+		if (handler and configuration != handler) {
+			configuration = handler;
+			configuration();
+		}
+		return 1;
+	}
+
+	if (ctx == context)
+		return ++count;
+
+	return 0;
+}
+
+template<typename Derived>
+uint8_t
+SpiLock<Derived>::release(void* ctx)
+{
+	if (ctx == context)
+	{
+		if (--count == 0)
+			context = nullptr;
+	}
+	return count;
+}
+
+} // namespace modm
+
+#endif // MODM_INTERFACE_SPI_LOCK_HPP

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -310,6 +310,7 @@ class Spi(Module):
         env.outbasepath = "modm/src/modm/architecture"
         env.copy("interface/spi.hpp")
         env.copy("interface/spi_master.hpp")
+        env.copy("interface/spi_lock.hpp")
 # -----------------------------------------------------------------------------
 
 class SpiDevice(Module):

--- a/src/modm/board/nucleo_h723zg/board.hpp
+++ b/src/modm/board/nucleo_h723zg/board.hpp
@@ -32,6 +32,7 @@ struct SystemClock
 {
 	// Max 550MHz
 	static constexpr uint32_t SysClk = 550_MHz;
+	static constexpr uint32_t Pll1Q = SysClk / 4;
 	// Max 550MHz
 	static constexpr uint32_t Hclk = SysClk / 1; // D1CPRE
 	static constexpr uint32_t Frequency = Hclk;
@@ -53,9 +54,9 @@ struct SystemClock
 
 	static constexpr uint32_t Dac1 = Apb1;
 
-	static constexpr uint32_t Spi1 = Apb2;
-	static constexpr uint32_t Spi2 = Apb1;
-	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Spi1 = Pll1Q;
+	static constexpr uint32_t Spi2 = Pll1Q;
+	static constexpr uint32_t Spi3 = Pll1Q;
 	static constexpr uint32_t Spi4 = Apb2;
 	static constexpr uint32_t Spi5 = Apb2;
 	static constexpr uint32_t Spi6 = Apb4;
@@ -115,9 +116,9 @@ struct SystemClock
 			.range = Rcc::PllInputRange::MHz1_2,
 			.pllM  = 4,		//   8 MHz / 4   =   2 MHz
 			.pllN  = 275,	//   2 MHz * 275 = 550 MHz
-			.pllP  = 1,		// 500 MHz / 1   = 550 MHz
-			.pllQ  = 2,		// 500 MHz / 2   = 275 MHz
-			.pllR  = 2,		// 500 MHz / 2   = 275 MHz
+			.pllP  = 1,		// 550 MHz / 1   = 550 MHz
+			.pllQ  = 4,		// 550 MHz / 4   = 137.5 MHz
+			.pllR  = 2,		// 550 MHz / 2   = 275 MHz
 		};
 		Rcc::enablePll1(Rcc::PllSource::Hse, pllFactors1);
 		Rcc::setFlashLatency<Ahb>();

--- a/src/modm/driver/inertial/bmi088.hpp
+++ b/src/modm/driver/inertial/bmi088.hpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_BMI088_HPP
+#define MODM_BMI088_HPP
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <modm/architecture/interface/spi_device.hpp>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/gpio.hpp>
+#include <modm/processing/timer/timeout.hpp>
+#include <modm/math/geometry/vector3.hpp>
+#include "bmi088_transport.hpp"
+
+namespace modm
+{
+
+/// @ingroup modm_driver_bmi088
+struct bmi088
+{
+	enum class AccRange : uint8_t
+	{
+		Range3g  = 0x00, //< +- 3g
+		Range6g  = 0x01, //< +- 6g (default)
+		Range12g = 0x02, //< +- 12g
+		Range24g = 0x03  //< +- 24g
+	};
+
+	enum class GyroRange : uint8_t
+	{
+		Range2000dps = 0x00, //< +- 2000 deg/s (default)
+		Range1000dps = 0x01, //< +- 1000 deg/s
+		Range500dps  = 0x02, //< +- 500 deg/s
+		Range250dps  = 0x03, //< +- 250 deg/s
+		Range125dps  = 0x04  //< +- 125 deg/s
+	};
+
+	struct AccData
+	{
+		/// acceleration in milli-g
+		Vector3f getFloat() const;
+
+		Vector3i raw;
+		AccRange range;
+	};
+
+	struct GyroData
+	{
+		/// angular rate in deg/s
+		Vector3f getFloat() const;
+
+		Vector3i raw;
+		GyroRange range;
+	};
+
+	/// Accelerometer data rate and filter bandwidth config
+	enum class AccRate : uint8_t
+	{
+		Rate12Hz_Bw5Hz     = 0x5 | 0xA0,
+		Rate12Hz_Bw2Hz     = 0x5 | 0x90,
+		Rate12Hz_Bw1Hz     = 0x5 | 0x80,
+		Rate25Hz_Bw10Hz    = 0x6 | 0xA0,
+		Rate25Hz_Bw5Hz     = 0x6 | 0x90,
+		Rate25Hz_Bw3Hz     = 0x6 | 0x80,
+		Rate50Hz_Bw20Hz    = 0x7 | 0xA0,
+		Rate50Hz_Bw9Hz     = 0x7 | 0x90,
+		Rate50Hz_Bw5Hz     = 0x7 | 0x80,
+		Rate100Hz_Bw40Hz   = 0x8 | 0xA0,
+		Rate100Hz_Bw19Hz   = 0x8 | 0x90,
+		Rate100Hz_Bw10Hz   = 0x8 | 0x80,
+		Rate200Hz_Bw80Hz   = 0x9 | 0xA0,
+		Rate200Hz_Bw38Hz   = 0x9 | 0x90,
+		Rate200Hz_Bw20Hz   = 0x9 | 0x80,
+		Rate400Hz_Bw145Hz  = 0xA | 0xA0,
+		Rate400Hz_Bw75Hz   = 0xA | 0x90,
+		Rate400Hz_Bw40Hz   = 0xA | 0x80,
+		Rate800Hz_Bw230Hz  = 0xB | 0xA0,
+		Rate800Hz_Bw140Hz  = 0xB | 0x90,
+		Rate800Hz_Bw80Hz   = 0xB | 0x80,
+		Rate1600Hz_Bw280Hz = 0xC | 0xA0,
+		Rate1600Hz_Bw234Hz = 0xC | 0x90,
+		Rate1600Hz_Bw145Hz = 0xC | 0x80
+	};
+
+	enum class AccGpioConfig : uint8_t
+	{
+		ActiveHigh = Bit1,		//< Set GPIO polarity
+		OpenDrain  = Bit2,		//< Configure open-drain mode, push-pull if not set
+		EnableOutput = Bit3,	//< Activate GPIO output function
+		EnableInput = Bit4		//< Activate GPIO intput function
+	};
+	MODM_FLAGS8(AccGpioConfig);
+
+	/// Configuration flags to map accelerometer interrupt signal to GPIO
+	enum class AccGpioMap : uint8_t
+	{
+		Int1FifoFull = Bit0,
+		Int1FifoWatermark = Bit1,
+		Int1DataReady = Bit2,
+		Int2FifoFull = Bit4,
+		Int2FifoWatermark = Bit5,
+		Int2DataReady = Bit6
+	};
+	MODM_FLAGS8(AccGpioMap);
+
+	enum class AccStatus : uint8_t
+	{
+		DataReady = Bit7
+	};
+	MODM_FLAGS8(AccStatus);
+
+	enum class AccPowerConf : uint8_t
+	{
+		Active = 0x00,
+		Suspend = 0x03
+	};
+
+	enum class AccPowerControl : uint8_t
+	{
+		Off = 0x00,
+		On = 0x04
+	};
+
+	enum class AccSelfTest : uint8_t
+	{
+		Off = 0x00,
+		Positive = 0x0D,
+		Negative = 0x09
+	};
+
+	/// Gyroscope data rate and filter bandwidth config
+	enum class GyroRate : uint8_t
+	{
+		Rate2000Hz_Bw532Hz = 0x00,
+		Rate2000Hz_Bw230Hz = 0x01,
+		Rate1000Hz_Bw116Hz = 0x02,
+		Rate400Hz_Bw47Hz   = 0x03,
+		Rate200Hz_Bw23Hz   = 0x04,
+		Rate100Hz_Bw12Hz   = 0x05,
+		Rate200Hz_Bw64Hz   = 0x06,
+		Rate100Hz_Bw32Hz   = 0x07
+	};
+
+	enum class GyroGpioConfig : uint8_t
+	{
+		Int3ActiveHigh = Bit0,
+		Int3OpenDrain  = Bit1,
+		Int4ActiveHigh = Bit2,
+		Int4OpenDrain  = Bit3
+	};
+	MODM_FLAGS8(GyroGpioConfig);
+
+	enum class GyroGpioMap : uint8_t
+	{
+		Int3DataReady = Bit0,
+		Int3FifoInterrupt = Bit2,
+		Int4FifoInterrupt = Bit5,
+		Int4DataReady = Bit7
+	};
+	MODM_FLAGS8(GyroGpioMap);
+
+	enum class GyroSelfTest : uint8_t
+	{
+		// read-only bits
+		RateOk = Bit4,
+		Fail = Bit2,
+		Ready = Bit1,
+		// write-only bit
+		Trigger = Bit0
+	};
+	MODM_FLAGS8(GyroSelfTest);
+
+	enum class GyroStatus : uint8_t
+	{
+		DataReady = Bit7,
+		FifoInterrupt = Bit4
+	};
+	MODM_FLAGS8(GyroStatus);
+
+	enum class GyroInterruptControl : uint8_t
+	{
+		Fifo = Bit6,
+		DataReady = Bit7
+	};
+	MODM_FLAGS8(GyroInterruptControl);
+};
+
+/**
+ * Bosch BMI088 IMU
+ *
+ * The device contains an accelerometer and a gyroscope which operate
+ * independently.
+ *
+ * The device supports both I2C and SPI. For applications with high data
+ * rates or strict timing requirements SPI is recommended.
+ *
+ * The "MM Feature Set" accelerometer functions are not supported yet.
+ *
+ * @tparam Transport Transport layer (use @ref Bmi088SpiTransport or @ref Bmi088I2cTransport)
+ * @ingroup modm_driver_bmi088
+ */
+template<Bmi088Transport Transport>
+class Bmi088 : public bmi088, public Transport
+{
+public:
+	/// @arg transportArgs	Arguments to transport layer.
+	///						Pass addresses for I2C, none for SPI.
+	template<typename... Args>
+	Bmi088(Args... transportArgs);
+
+	/// Initialize device. Call before any other member function.
+	/// @return true on success, false on error
+	bool
+	initialize(bool runSelfTest);
+
+	// Accelerometer functions
+
+	std::optional<AccData>
+	readAccData();
+
+	/// Read data ready flag from ACC_STATUS register. Cleared on data read.
+	bool
+	readAccDataReady();
+
+	/// Read and clear data ready flag in ACC_INT_STAT_1 register. Not cleared on data read.
+	bool
+	clearAccDataReadyInterrupt();
+
+	/// @return true on success, false on error
+	bool
+	setAccRate(AccRate config);
+
+	/// @return true on success, false on error
+	bool
+	setAccRange(AccRange range);
+
+	/// @return true on success, false on error
+	bool
+	setAccInt1GpioConfig(AccGpioConfig_t config);
+
+	/// @return true on success, false on error
+	bool
+	setAccInt2GpioConfig(AccGpioConfig_t config);
+
+	/// @return true on success, false on error
+	bool
+	setAccGpioMap(AccGpioMap_t map);
+
+	// Gyroscope functions
+
+	std::optional<GyroData>
+	readGyroData();
+
+	/**
+	 * Read Data ready interrupt status.
+	 * @warning The interrupt is cleared automatically after 280-400 μs.
+	 * @return true on success, false on error
+	 */
+	bool
+	readGyroDataReady();
+
+	/// @return true on success, false on error
+	bool
+	setGyroRate(GyroRate config);
+
+	/// @return true on success, false on error
+	bool
+	setGyroRange(GyroRange range);
+
+	/// @return true on success, false on error
+	bool
+	setGyroGpioConfig(GyroGpioConfig_t config);
+
+	/// @return true on success, false on error
+	bool
+	setGyroGpioMap(GyroGpioMap_t map);
+
+private:
+	using AccRegister = Transport::AccRegister;
+	using GyroRegister = Transport::GyroRegister;
+
+	static constexpr std::chrono::milliseconds ResetTimeout{30};
+	static constexpr std::chrono::microseconds WriteTimeout{2};
+	static constexpr std::chrono::microseconds AccSuspendTimeout{450};
+
+	static constexpr uint8_t ResetCommand{0xB6};
+	static constexpr uint8_t AccChipId{0x1E};
+	static constexpr uint8_t GyroChipId{0x0F};
+
+	bool
+	checkChipId();
+
+	bool
+	reset();
+
+	bool
+	selfTest();
+
+	bool
+	enableAccelerometer();
+
+	void
+	timerWait();
+
+	std::optional<uint8_t>
+	readRegister(auto reg);
+
+	modm::PreciseTimeout timer_;
+	AccRange accRange_{AccRange::Range6g};
+	GyroRange gyroRange_{GyroRange::Range2000dps};
+};
+
+
+} // modm namespace
+
+#include "bmi088_impl.hpp"
+
+#endif // MODM_ADIS16470_HPP

--- a/src/modm/driver/inertial/bmi088.lb
+++ b/src/modm/driver/inertial/bmi088.lb
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":driver:bmi088"
+    module.description = """\
+# BMI088 Inertial Measurement Unit
+
+[Datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi088-ds001.pdf)
+"""
+
+def prepare(module, options):
+    module.depends(
+        ":architecture:gpio",
+        ":architecture:register",
+        ":architecture:spi.device",
+        ":architecture:i2c.device",
+        ":math:geometry",
+        ":processing:fiber",
+        ":processing:timer")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/inertial"
+    env.copy("bmi088.hpp")
+    env.copy("bmi088_impl.hpp")
+    env.copy("bmi088_transport.hpp")
+    env.copy("bmi088_transport_impl.hpp")

--- a/src/modm/driver/inertial/bmi088_impl.hpp
+++ b/src/modm/driver/inertial/bmi088_impl.hpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <cstdint>
+#ifndef MODM_BMI088_HPP
+#error "Don't include this file directly, use 'bmi088.hpp' instead!"
+#endif
+
+#include <modm/math/utils.hpp>
+
+namespace modm
+{
+
+template<Bmi088Transport Transport>
+template<typename... Args>
+Bmi088<Transport>::Bmi088(Args... transportArgs)
+	: Transport{transportArgs...}
+{
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::initialize(bool runSelfTest)
+{
+	Transport::initialize();
+
+	if (!checkChipId() or !reset() or !enableAccelerometer()) {
+		return false;
+	}
+
+	if (runSelfTest and !selfTest()) {
+		return false;
+	}
+
+	timerWait();
+	const bool ok = this->writeRegister(GyroRegister::InterruptControl,
+										uint8_t(GyroInterruptControl::DataReady));
+	timer_.restart(WriteTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+std::optional<bmi088::AccData>
+Bmi088<Transport>::readAccData()
+{
+	const auto data = this->readRegisters(AccRegister::DataXLow, 6);
+
+	if (data.empty()) {
+		return {};
+	}
+
+	return AccData {
+		.raw = Vector3i(
+			data[0] | data[1] << 8,
+			data[2] | data[3] << 8,
+			data[4] | data[5] << 8
+		),
+		.range = accRange_
+	};
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::readAccDataReady()
+{
+	const auto value = readRegister(AccRegister::Status).value_or(0);
+	return value & uint8_t(AccStatus::DataReady);
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::clearAccDataReadyInterrupt()
+{
+	const auto result = readRegister(AccRegister::InterruptStatus).value_or(0);
+	return result & uint8_t(AccStatus::DataReady);
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setAccRate(AccRate config)
+{
+	timerWait();
+	const bool ok = this->writeRegister(AccRegister::Config, uint8_t(config));
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setAccRange(AccRange range)
+{
+	timerWait();
+	const bool ok = this->writeRegister(AccRegister::Range, uint8_t(range));
+	timer_.restart(ResetTimeout);
+	if (ok) {
+		accRange_ = range;
+		return true;
+	}
+	return false;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setAccInt1GpioConfig(AccGpioConfig_t config)
+{
+	timerWait();
+	const bool ok = this->writeRegister(AccRegister::Int1Control, config.value);
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setAccInt2GpioConfig(AccGpioConfig_t config)
+{
+	timerWait();
+	const bool ok = this->writeRegister(AccRegister::Int2Control, config.value);
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setAccGpioMap(AccGpioMap_t map)
+{
+	timerWait();
+	const bool ok = this->writeRegister(AccRegister::IntMap, map.value);
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+std::optional<bmi088::GyroData>
+Bmi088<Transport>::readGyroData()
+{
+	const auto data = this->readRegisters(GyroRegister::RateXLow, 6);
+
+	if (data.empty()) {
+		return {};
+	}
+
+	return GyroData {
+		.raw = Vector3i(
+			data[0] | data[1] << 8,
+			data[2] | data[3] << 8,
+			data[4] | data[5] << 8
+		),
+		.range = gyroRange_
+	};
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::readGyroDataReady()
+{
+	const auto value = readRegister(GyroRegister::InterruptStatus).value_or(0);
+	return bool(GyroStatus_t{value} & GyroStatus::DataReady);
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setGyroRate(GyroRate rate)
+{
+	timerWait();
+	const bool ok = this->writeRegister(GyroRegister::Bandwidth, uint8_t(rate));
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setGyroRange(GyroRange range)
+{
+	timerWait();
+	const bool ok = this->writeRegister(GyroRegister::Range, uint8_t(range));
+	timer_.restart(ResetTimeout);
+	if (ok) {
+		gyroRange_ = range;
+		return true;
+	}
+	return false;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setGyroGpioConfig(GyroGpioConfig_t config)
+{
+	timerWait();
+	const bool ok = this->writeRegister(GyroRegister::Int3Int4Conf, config.value);
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::setGyroGpioMap(GyroGpioMap_t map)
+{
+	timerWait();
+	const bool ok = this->writeRegister(GyroRegister::Int3Int4Map, map.value);
+	timer_.restart(ResetTimeout);
+	return ok;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::checkChipId()
+{
+	const std::optional gyroId = readRegister(GyroRegister::ChipId);
+	const std::optional accId = readRegister(AccRegister::ChipId);
+	const bool gyroIdValid = gyroId.value_or(0) == GyroChipId;
+	const bool accIdValid = accId.value_or(0) == AccChipId;
+	return gyroIdValid and accIdValid;
+}
+
+template<Bmi088Transport Transport>
+void
+Bmi088<Transport>::timerWait()
+{
+	while (timer_.isArmed()) {
+		modm::fiber::yield();
+	}
+}
+
+template<Bmi088Transport Transport>
+std::optional<uint8_t>
+Bmi088<Transport>::readRegister(auto reg)
+{
+	const auto data = this->readRegisters(reg, 1);
+	if (data.empty()) {
+		return std::nullopt;
+	} else {
+		return data[0];
+	}
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::reset()
+{
+	const bool gyroOk = this->writeRegister(GyroRegister::SoftReset, ResetCommand);
+	const bool accOk = this->writeRegister(AccRegister::SoftReset, ResetCommand);
+
+	if (!gyroOk or !accOk) {
+		return false;
+	}
+	accRange_ = AccRange::Range6g;
+	gyroRange_ = GyroRange::Range2000dps;
+
+	timer_.restart(ResetTimeout);
+	timerWait();
+
+	// required to switch the accelerometer to SPI mode if SPI is used
+	Transport::initialize();
+
+	return true;
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::selfTest()
+{
+	bool ok = setAccRange(AccRange::Range24g);
+	ok &= setAccRate(AccRate::Rate1600Hz_Bw280Hz);
+	if (!ok) {
+		return false;
+	}
+	timer_.restart(2ms);
+	timerWait();
+	ok = this->writeRegister(AccRegister::SelfTest, uint8_t(AccSelfTest::Positive));
+	if (!ok) {
+		return false;
+	}
+	timer_.restart(50ms);
+	timerWait();
+	const auto positiveData = readAccData();
+	if (!positiveData) {
+		return false;
+	}
+	ok = this->writeRegister(AccRegister::SelfTest, uint8_t(AccSelfTest::Negative));
+	if (!ok) {
+		return false;
+	}
+	timer_.restart(50ms);
+	timerWait();
+	const auto negativeData = readAccData();
+	if (!negativeData) {
+		return false;
+	}
+	const Vector3f diff = positiveData->getFloat() - negativeData->getFloat();
+	const bool accOk = (diff[0] >= 1000.f) and (diff[1] >= 1000.f) and (diff[2] >= 500.f);
+	this->writeRegister(AccRegister::SelfTest, uint8_t(AccSelfTest::Off));
+	if (!accOk) {
+		return false;
+	}
+	ok = this->writeRegister(GyroRegister::SelfTest, uint8_t(GyroSelfTest::Trigger));
+	if (!ok) {
+		return false;
+	}
+	timer_.restart(30ms);
+	timerWait();
+	const auto gyroTest = GyroSelfTest_t(readRegister(GyroRegister::SelfTest).value_or(0));
+	if (gyroTest != (GyroSelfTest::Ready | GyroSelfTest::RateOk)) {
+		return false;
+	}
+	return reset() and enableAccelerometer();
+}
+
+template<Bmi088Transport Transport>
+bool
+Bmi088<Transport>::enableAccelerometer()
+{
+	timerWait();
+	bool ok = this->writeRegister(AccRegister::PowerConfig, uint8_t(AccPowerConf::Active));
+	timer_.restart(AccSuspendTimeout);
+	if (!ok) {
+		return false;
+	}
+	timerWait();
+
+	ok = this->writeRegister(AccRegister::PowerControl, uint8_t(AccPowerControl::On));
+	timer_.restart(WriteTimeout);
+	return ok;
+}
+
+inline Vector3f
+bmi088::AccData::getFloat() const
+{
+	const float factor = (1500 << (int(range) + 1)) * (1 / 32768.f);
+	return Vector3f {
+		raw[0] * factor,
+		raw[1] * factor,
+		raw[2] * factor
+	};
+}
+
+inline Vector3f
+bmi088::GyroData::getFloat() const
+{
+	const float factor = (2000 >> int(range)) * (1 / 32768.f);
+	return Vector3f {
+		raw[0] * factor,
+		raw[1] * factor,
+		raw[2] * factor
+	};
+}
+
+} // namespace modm

--- a/src/modm/driver/inertial/bmi088_transport.hpp
+++ b/src/modm/driver/inertial/bmi088_transport.hpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_BMI088_TRANSPORT_HPP
+#define MODM_BMI088_TRANSPORT_HPP
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <modm/architecture/interface/delay.hpp>
+#include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/architecture/interface/spi_device.hpp>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/gpio.hpp>
+#include <modm/processing/timer/timeout.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_bmi088
+struct Bmi088TransportBase
+{
+	enum class
+	AccRegister : uint8_t
+	{
+		ChipId = 0x00,
+		// 0x01: reserved
+		Error = 0x02,
+		Status = 0x03,
+		// 0x04-0x11: reserved
+		DataXLow = 0x12,
+		DataXHigh = 0x13,
+		DataYLow = 0x14,
+		DataYHigh = 0x15,
+		DataZLow = 0x16,
+		DataZHigh = 0x17,
+		SensorTime0 = 0x18,
+		SensorTime1 = 0x19,
+		SensorTime2 = 0x1A,
+		// 0x1B-0x1C: reserved
+		InterruptStatus = 0x1D,
+		// 0x1E-0x21: reserved
+		TempHigh = 0x22,
+		TempLow = 0x23,
+		FifoLength0 = 0x24,
+		FifoLength1 = 0x25,
+		FifoData = 0x26,
+		// 0x27-0x3F: reserved
+		Config = 0x40,
+		Range = 0x41,
+		// 0x42-0x44: reserved
+		FifoDownsampling = 0x45,
+		FifoWatermark0 = 0x46,
+		FifoWatermark1 = 0x47,
+		FifoConfig0 = 0x48,
+		FifoConfig1 = 0x49,
+		// 0x4A-0x52: reserved
+		Int1Control = 0x53,
+		Int2Control = 0x54,
+		// 0x55-0x57: reserved
+		IntMap = 0x58,
+		// 0x59-0x6C: reserved
+		SelfTest = 0x6D,
+		// 0x6E-0x7B: reserved
+		PowerConfig = 0x7C,
+		PowerControl = 0x7D,
+		SoftReset = 0x7E
+	};
+
+	enum class
+	GyroRegister : uint8_t
+	{
+		ChipId = 0x00,
+		// 0x01: reserved
+		RateXLow = 0x02,
+		RateXHigh = 0x03,
+		RateYLow = 0x04,
+		RateYHigh = 0x05,
+		RateZLow = 0x06,
+		RateZHigh = 0x07,
+		// 0x08-0x09: reserved
+		InterruptStatus = 0x0A,
+		// 0x0B-0x0D: reserved
+		FifoStatus = 0x0E,
+		Range = 0x0F,
+		Bandwidth = 0x10,
+		LowPowerMode1 = 0x11,
+		// 0x12-0x13: reserved
+		SoftReset = 0x14,
+		InterruptControl = 0x15,
+		Int3Int4Conf = 0x16,
+		// 0x17: reserved
+		Int3Int4Map = 0x18,
+		// 0x19-0x1D: reserved
+		FifoWatermark = 0x1E,
+		// 0x1F-0x33: reserved
+		FifoExtInt = 0x34,
+		// 0x35-0x3B: reserved
+		SelfTest = 0x3C,
+		FifoConfig0 = 0x3D,
+		FifoConfig1 = 0x3E,
+		FifoData = 0x3F
+	};
+	static constexpr uint8_t MaxRegisterSequence{6};
+};
+
+/// @ingroup modm_driver_bmi088
+template <typename T>
+concept Bmi088Transport = requires(T& transport, Bmi088TransportBase::AccRegister reg1,
+					     Bmi088TransportBase::GyroRegister reg2, uint8_t data)
+{
+	{ transport.initialize() };
+	{ transport.readRegisters(reg1, /* count= */data) } -> std::same_as<std::span<uint8_t>>;
+	{ transport.readRegisters(reg2, /* count= */data) } -> std::same_as<std::span<uint8_t>>;
+	{ transport.writeRegister(reg1, data) } -> std::same_as<bool>;
+	{ transport.writeRegister(reg2, data) } -> std::same_as<bool>;
+};
+
+/**
+ * BMI088 SPI transport. Pass as template parameter to Bmi088 driver class to
+ * use the driver with SPI.
+ *
+ * The transport class contains internal buffers which allow to read all three
+ * gyroscope or accelerometer axes in a single DMA transaction.
+ *
+ * @tparam SpiMaster SPI master the device is connected to
+ * @tparam AccCs accelerometer chip-select GPIO
+ * @tparam GyroCs gyroscope chip-select GPIO
+ * @ingroup modm_driver_bmi088
+ */
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+class Bmi088SpiTransport : public Bmi088TransportBase,
+                           public SpiDevice<SpiMaster>
+{
+public:
+	Bmi088SpiTransport() = default;
+
+	Bmi088SpiTransport(const Bmi088SpiTransport&) = delete;
+
+	Bmi088SpiTransport&
+	operator=(const Bmi088SpiTransport&) = delete;
+
+	void
+	initialize();
+
+	std::span<uint8_t>
+	readRegisters(AccRegister startReg, uint8_t count);
+
+	std::span<uint8_t>
+	readRegisters(GyroRegister startReg, uint8_t count);
+
+	bool
+	writeRegister(AccRegister reg, uint8_t data);
+
+	bool
+	writeRegister(GyroRegister reg, uint8_t data);
+
+private:
+	template<typename Cs>
+	std::span<uint8_t>
+	readRegisters(uint8_t reg, uint8_t count, bool dummyByte);
+
+	template<typename Cs>
+	bool
+	writeRegister(uint8_t reg, uint8_t data);
+
+	static constexpr uint8_t ReadFlag{0b1000'0000};
+
+	std::array<uint8_t, MaxRegisterSequence + 2> rxBuffer_{};
+	std::array<uint8_t, MaxRegisterSequence + 2> txBuffer_{};
+};
+
+
+/**
+ * BMI088 I2C transport. Pass as template parameter to Bmi088 driver class to
+ * use the driver with I2C.
+ *
+ * @tparam I2cMaster I2c master the device is connected to
+ * @ingroup modm_driver_bmi088
+ */
+template<typename I2cMaster>
+class Bmi088I2cTransport : public Bmi088TransportBase, public I2cDevice<I2cMaster>
+{
+public:
+	Bmi088I2cTransport(uint8_t accAddress, uint8_t gyroAddress);
+
+	Bmi088I2cTransport(const Bmi088I2cTransport&) = delete;
+
+	Bmi088I2cTransport&
+	operator=(const Bmi088I2cTransport&) = delete;
+
+	void
+	initialize();
+
+	std::span<uint8_t>
+	readRegisters(AccRegister startReg, uint8_t count);
+
+	std::span<uint8_t>
+	readRegisters(GyroRegister startReg, uint8_t count);
+
+	bool
+	writeRegister(AccRegister reg, uint8_t data);
+
+	bool
+	writeRegister(GyroRegister reg, uint8_t data);
+
+private:
+	std::span<uint8_t>
+	readRegisters(uint8_t reg, uint8_t count);
+
+	bool
+	writeRegister(uint8_t reg, uint8_t data);
+
+	uint8_t accAddress_;
+	uint8_t gyroAddress_;
+	std::array<uint8_t, MaxRegisterSequence> buffer_{};
+};
+
+} // modm namespace
+
+#include "bmi088_transport_impl.hpp"
+
+#endif // MODM_BMI088_TRANSPORT_HPP

--- a/src/modm/driver/inertial/bmi088_transport_impl.hpp
+++ b/src/modm/driver/inertial/bmi088_transport_impl.hpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_BMI088_TRANSPORT_HPP
+#error "Don't include this file directly, use 'bmi088_transport.hpp' instead!"
+#endif
+
+#include <modm/processing/fiber.hpp>
+
+namespace modm
+{
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+void
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::initialize()
+{
+	// rising edge on CS required to enable accelerometer SPI mode
+	AccCs::setOutput(false);
+	modm::delay_ns(100);
+	AccCs::setOutput(true);
+
+	GyroCs::setOutput(true);
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+std::span<uint8_t>
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::readRegisters(AccRegister startReg,
+										uint8_t count)
+{
+	return readRegisters<AccCs>(static_cast<uint8_t>(startReg), count, true);
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+std::span<uint8_t>
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::readRegisters(GyroRegister startReg,
+										uint8_t count)
+{
+	return readRegisters<GyroCs>(static_cast<uint8_t>(startReg), count, false);
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+template<typename Cs>
+std::span<uint8_t>
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::readRegisters(uint8_t startReg,
+										uint8_t count, bool dummyByte)
+{
+	if (count > MaxRegisterSequence) {
+		return {};
+	}
+
+	while (!this->acquireMaster()) {
+		modm::fiber::yield();
+	}
+	Cs::reset();
+
+	const uint8_t dataOffset = (dummyByte ? 2 : 1);
+
+	txBuffer_[0] = startReg | ReadFlag;
+	txBuffer_[1] = 0;
+
+	SpiMaster::transfer(&txBuffer_[0], &rxBuffer_[0], count + dataOffset);
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	return std::span{&rxBuffer_[dataOffset], count};
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+bool
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::writeRegister(AccRegister reg, uint8_t data)
+{
+	return writeRegister<AccCs>(static_cast<uint8_t>(reg), data);
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+bool
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::writeRegister(GyroRegister reg, uint8_t data)
+{
+	return writeRegister<GyroCs>(static_cast<uint8_t>(reg), data);
+}
+
+template<typename SpiMaster, typename AccCs, typename GyroCs>
+template<typename Cs>
+bool
+Bmi088SpiTransport<SpiMaster, AccCs, GyroCs>::writeRegister(uint8_t reg, uint8_t data)
+{
+	while (!this->acquireMaster()) {
+		modm::fiber::yield();
+	}
+	Cs::reset();
+
+	txBuffer_[0] = reg;
+	txBuffer_[1] = data;
+	SpiMaster::transfer(&txBuffer_[0], nullptr, 2);
+
+	if (this->releaseMaster()) {
+		Cs::set();
+	}
+
+	return true;
+}
+
+// ------------------------------------------------------------------------------------------------
+
+template<typename I2cMaster>
+Bmi088I2cTransport<I2cMaster>::Bmi088I2cTransport(uint8_t accAddress, uint8_t gyroAddress)
+	: I2cDevice<I2cMaster>{accAddress}, accAddress_{accAddress}, gyroAddress_{gyroAddress}
+{
+}
+
+template<typename I2cMaster>
+void
+Bmi088I2cTransport<I2cMaster>::initialize()
+{
+}
+
+template<typename I2cMaster>
+std::span<uint8_t>
+Bmi088I2cTransport<I2cMaster>::readRegisters(AccRegister startReg, uint8_t count)
+{
+	this->transaction.setAddress(accAddress_);
+	return readRegisters(static_cast<uint8_t>(startReg), count);
+}
+
+template<typename I2cMaster>
+std::span<uint8_t>
+Bmi088I2cTransport<I2cMaster>::readRegisters(GyroRegister startReg, uint8_t count)
+{
+	this->transaction.setAddress(gyroAddress_);
+	return readRegisters(static_cast<uint8_t>(startReg), count);
+}
+
+template<typename I2cMaster>
+std::span<uint8_t>
+Bmi088I2cTransport<I2cMaster>::readRegisters(uint8_t startReg, uint8_t count)
+{
+	if (count > MaxRegisterSequence) {
+		return {};
+	}
+
+	this->transaction.configureWriteRead(&startReg, 1, &buffer_[0], count);
+	const bool success = this->runTransaction();
+
+	if (success) {
+		return std::span{&buffer_[0], count};
+	} else {
+		return {};
+	}
+}
+
+template<typename I2cMaster>
+bool
+Bmi088I2cTransport<I2cMaster>::writeRegister(AccRegister reg, uint8_t data)
+{
+	this->transaction.setAddress(accAddress_);
+	return writeRegister(static_cast<uint8_t>(reg), data);
+}
+
+template<typename I2cMaster>
+bool
+Bmi088I2cTransport<I2cMaster>::writeRegister(GyroRegister reg, uint8_t data)
+{
+	this->transaction.setAddress(gyroAddress_);
+	return writeRegister(static_cast<uint8_t>(reg), data);
+}
+
+template<typename I2cMaster>
+bool
+Bmi088I2cTransport<I2cMaster>::writeRegister(uint8_t reg, uint8_t data)
+{
+	buffer_[0] = reg;
+	buffer_[1] = data;
+	this->transaction.configureWrite(&buffer_[0], 2);
+
+	return this->runTransaction();
+}
+
+} // namespace modm

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017, Niklas Hauser
  * Copyright (c) 2020, Mike Wolfram
  * Copyright (c) 2021, Raphael Lehmann
- * Copyright (c) 2021, Christopher Durand
+ * Copyright (c) 2021-2023, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -116,6 +116,10 @@ public:
 
 		using ChannelHal = DmaChannelHal<ChannelID, CHANNEL_BASE>;
 
+%% if dmaType in ["stm32-stream-channel", "stm32-mux-stream"]
+		static constexpr uint8_t FlagOffsetLut[8] = {0, 6, 16, 22, 0+32, 6+32, 16+32, 22+32};
+%% endif
+
 	public:
 		/**
 		 * Configure the DMA channel
@@ -145,7 +149,7 @@ public:
 		}
 
 		/**
-		 * Start the transfer of the DMA channel
+		 * Start the transfer of the DMA channel and clear all interrupt flags.
 		 */
 		static void
 		start()
@@ -321,15 +325,14 @@ public:
 				uint32_t(InterruptFlags::Error) << (uint32_t(ChannelID) * 4)
 			};
 %% elif dmaType in ["stm32-stream-channel", "stm32-mux-stream"]
-			constexpr uint8_t offsetLut[8] = {0, 6, 16, 22, 0+32, 6+32, 16+32, 22+32};
 			static const uint64_t HT_Flag {
-				uint64_t(InterruptFlags::HalfTransferComplete) << offsetLut[uint32_t(ChannelID)]
+				uint64_t(InterruptFlags::HalfTransferComplete) << FlagOffsetLut[uint32_t(ChannelID)]
 			};
 			static const uint64_t TC_Flag {
-				uint64_t(InterruptFlags::TransferComplete) << offsetLut[uint32_t(ChannelID)]
+				uint64_t(InterruptFlags::TransferComplete) << FlagOffsetLut[uint32_t(ChannelID)]
 			};
 			static const uint64_t TE_Flag {
-				uint64_t(InterruptFlags::Error) << offsetLut[uint32_t(ChannelID)]
+				uint64_t(InterruptFlags::Error) << FlagOffsetLut[uint32_t(ChannelID)]
 			};
 %% endif
 
@@ -347,6 +350,41 @@ public:
 			}
 
 			ControlHal::clearInterruptFlags(InterruptFlags::Global, ChannelID);
+		}
+
+		/**
+		 * Read channel status flags when channel interrupts are disabled.
+		 * This function is useful to query the transfer state when the use of
+		 * the channel interrupt is not required for the application.
+		 *
+		 * @warning Flags are automatically cleared in the ISR if the channel
+		 * 			interrupt is enabled or when start() is called.
+		 */
+		static InterruptFlags_t
+		getInterruptFlags()
+		{
+			const auto globalFlags = ControlHal::getInterruptFlags();
+			const auto mask = static_cast<uint8_t>(InterruptFlags::All);
+%% if dmaType in ["stm32-channel-request", "stm32-channel", "stm32-mux"]
+			const auto shift = static_cast<uint32_t>(ChannelID) * 4;
+%% elif dmaType in ["stm32-stream-channel", "stm32-mux-stream"]
+			const auto shift = FlagOffsetLut[uint32_t(ChannelID)];
+%% endif
+			const auto channelFlags = static_cast<uint8_t>((globalFlags >> shift) & mask);
+			return InterruptFlags_t{channelFlags};
+		}
+
+		/**
+		 * Clear channel interrupt flags.
+		 * Use only when the channel interrupt is disabled.
+		 *
+		 * @warning Flags are automatically cleared in the ISR if the channel
+		 * 			interrupt is enabled or when start() is called.
+		 */
+		static void
+		clearInterruptFlags(InterruptFlags_t flags = InterruptFlags::All)
+		{
+			ControlHal::clearInterruptFlags(flags, ChannelID);
 		}
 
 		/**

--- a/src/modm/platform/dma/stm32/dma_base.hpp.in
+++ b/src/modm/platform/dma/stm32/dma_base.hpp.in
@@ -228,7 +228,7 @@ public:
 	};
 
 %% if dmaType in ["stm32-stream-channel", "stm32-mux-stream"]
-	enum class InterruptEnable {
+	enum class InterruptEnable : uint32_t {
 		DirectModeError		= DMA_SxCR_DMEIE,
 		TransferError		= DMA_SxCR_TEIE,
 		HalfTransfer		= DMA_SxCR_HTIE,
@@ -236,7 +236,7 @@ public:
 	};
 	MODM_FLAGS32(InterruptEnable);
 
-	enum class InterruptFlags {
+	enum class InterruptFlags : uint8_t {
 		FifoError = 0b00'0001,
 		DirectModeError = 0b00'0100,
 		Error = 0b00'1000,
@@ -247,14 +247,14 @@ public:
 	};
 	MODM_FLAGS32(InterruptFlags);
 %% elif dmaType in ["stm32-channel-request", "stm32-channel", "stm32-mux"]
-	enum class InterruptEnable {
+	enum class InterruptEnable : uint32_t {
 		TransferComplete	= DMA_CCR_TCIE,
 		HalfTransfer		= DMA_CCR_HTIE,
 		TransferError		= DMA_CCR_TEIE,
 	};
 	MODM_FLAGS32(InterruptEnable);
 
-	enum class InterruptFlags {
+	enum class InterruptFlags : uint8_t {
 		Global = 0b0001,
 		TransferComplete = 0b0010,
 		HalfTransferComplete = 0b0100,

--- a/src/modm/platform/spi/at90_tiny_mega/module.lb
+++ b/src/modm/platform/spi/at90_tiny_mega/module.lb
@@ -15,7 +15,7 @@ def get_properties(env):
     device = env[":target"]
     driver = device.get_driver("spi:avr")
     properties = {}
-    properties["use_fiber"] = env.get(":processing:protothread:use_fiber", False)
+    properties["use_fiber"] = env.query(":processing:fiber:__enabled", False)
     properties["target"] = device.identifier
     properties["partname"] = device.partname
     properties["driver"] = driver

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.cpp.in
@@ -19,19 +19,6 @@
 #include <modm/math/utils/bit_constants.hpp>
 #include <modm/architecture/interface/atomic_lock.hpp>
 
-// bit 7 (0x80) is used for transfer 1 byte
-// bit 6 (0x40) is used for transfer multiple byte
-// bit 5-0 (0x3f) are used to store the acquire count
-uint8_t
-modm::platform::SpiMaster{{ id }}::state(0);
-
-void *
-modm::platform::SpiMaster{{ id }}::context(nullptr);
-
-modm::Spi::ConfigurationHandler
-modm::platform::SpiMaster{{ id }}::configuration(nullptr);
-// ----------------------------------------------------------------------------
-
 void
 modm::platform::SpiMaster{{ id }}::initialize(Prescaler prescaler)
 {
@@ -39,42 +26,8 @@ modm::platform::SpiMaster{{ id }}::initialize(Prescaler prescaler)
 
 	SPCR{{ id }} = (1 << SPE{{ id }}) | (1 << MSTR{{ id }}) | (static_cast<uint8_t>(prescaler) & ~0x80);
 	SPSR{{ id }} = (static_cast<uint8_t>(prescaler) & 0x80) ? (1 << SPI2X{{ id }}) : 0;
-	state &= 0x3f;
+	state = 0;
 }
-// ----------------------------------------------------------------------------
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		state = (state & ~0x3f) | 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return (++state & 0x3f);
-
-	return 0;
-}
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if ((--state & 0x3f) == 0)
-			context = nullptr;
-	}
-	return (state & 0x3f);
-}
-// ----------------------------------------------------------------------------
 
 modm::ResumableResult<uint8_t>
 modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)

--- a/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega/spi_master.hpp.in
@@ -16,6 +16,7 @@
 
 #include <avr/io.h>
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
 #include <modm/platform/gpio/connector.hpp>
@@ -50,11 +51,8 @@ namespace platform
  * @ingroup		modm_platform_spi modm_platform_spi_{{id}}
  * @author		Niklas Hauser
  */
-class SpiMaster{{ id }} : public ::modm::SpiMaster, private Spi
+class SpiMaster{{ id }} : public ::modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>, private Spi
 {
-	static uint8_t state;
-	static void *context;
-	static ConfigurationHandler configuration;
 public:
 	/// Spi Data Mode, Mode0 is the most common mode
 	enum class
@@ -120,14 +118,6 @@ public:
 		}
 	}
 
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
-
-
 	static uint8_t
 	transferBlocking(uint8_t data)
 	{
@@ -158,6 +148,11 @@ public:
 protected:
 	static void
 	initialize(Prescaler prescaler);
+
+private:
+	// bit 7 (0x80) is used for transfer 1 byte
+	// bit 6 (0x40) is used for transfer multiple byte
+	static inline uint8_t state{};
 };
 
 } // namespace platform

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.cpp.in
@@ -21,24 +21,6 @@
 #include <modm/math/utils/bit_operation.hpp>
 #include <modm/math/utils/bit_constants.hpp>
 
-%% if not extended
-modm::platform::UartSpiMaster{{id}}::DataOrder
-modm::platform::UartSpiMaster{{id}}::dataOrder = DataOrder::MsbFirst;
-%% endif
-
-// bit 7 (0x80) is used for transfer 1 byte
-// bit 6 (0x40) is used for transfer multiple byte
-// bit 5-0 (0x3f) are used to store the acquire count
-uint8_t
-modm::platform::UartSpiMaster{{id}}::state(0);
-
-void *
-modm::platform::UartSpiMaster{{id}}::context(nullptr);
-
-modm::Spi::ConfigurationHandler
-modm::platform::UartSpiMaster{{id}}::configuration(nullptr);
-// ----------------------------------------------------------------------------
-
 void
 modm::platform::UartSpiMaster{{id}}::initialize(uint16_t prescaler)
 {
@@ -71,42 +53,8 @@ modm::platform::UartSpiMaster{{id}}::initialize(uint16_t prescaler)
 %% if not extended
 	dataOrder = DataOrder::MsbFirst;
 %% endif
-	state &= 0x3f;
+	state = 0;
 }
-// ----------------------------------------------------------------------------
-
-uint8_t
-modm::platform::UartSpiMaster{{id}}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		state = (state & ~0x3f) | 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return (++state & 0x3f);
-
-	return 0;
-}
-
-uint8_t
-modm::platform::UartSpiMaster{{id}}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if ((--state & 0x3f) == 0)
-			context = nullptr;
-	}
-	return (state & 0x3f);
-}
-// ----------------------------------------------------------------------------
 
 modm::ResumableResult<uint8_t>
 modm::platform::UartSpiMaster{{id}}::transfer(uint8_t data)

--- a/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/at90_tiny_mega_uart/uart_spi_master.hpp.in
@@ -16,6 +16,7 @@
 #include <avr/io.h>
 
 #include <modm/platform/uart/uart_defines.h>
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 
@@ -32,11 +33,8 @@ namespace platform
  * @ingroup		modm_platform_uart_spi modm_platform_uart_spi_{{id}}
  * @author		Niklas Hauser
  */
-class UartSpiMaster{{ id }} : public ::modm::SpiMaster
+class UartSpiMaster{{ id }} : public ::modm::SpiMaster, public SpiLock<UartSpiMaster{{ id }}>
 {
-	static uint8_t state;
-	static void *context;
-	static ConfigurationHandler configuration;
 public:
 	/// Spi Data Mode, Mode0 is the most common mode
 %% if not extended
@@ -144,14 +142,6 @@ public:
 %% endif
 	}
 
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
-
-
 	static uint8_t
 	transferBlocking(uint8_t data)
 	{
@@ -176,8 +166,12 @@ protected:
 	initialize(uint16_t prescaler);
 
 private:
+	// bit 7 (0x80) is used for transfer 1 byte
+	// bit 6 (0x40) is used for transfer multiple byte
+	static inline uint8_t state{};
+
 %% if not extended
-	static DataOrder dataOrder;
+	static inline DataOrder dataOrder = DataOrder::MsbFirst;
 %% endif
 };
 

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master.hpp
@@ -16,7 +16,8 @@
 #ifndef MODM_SOFTWARE_BITBANG_SPI_MASTER_HPP
 #define MODM_SOFTWARE_BITBANG_SPI_MASTER_HPP
 
-#include <stdint.h>
+#include <cstdint>
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/architecture/interface/delay.hpp>
 #include <modm/platform/gpio/connector.hpp>
@@ -41,7 +42,8 @@ namespace platform
 template< typename Sck,
 		  typename Mosi,
 		  typename Miso = GpioUnused >
-class BitBangSpiMaster : public ::modm::SpiMaster
+class BitBangSpiMaster : public ::modm::SpiMaster,
+                         public SpiLock<BitBangSpiMaster<Sck, Mosi, Miso>>
 {
 public:
 	template< class... Signals >
@@ -59,20 +61,11 @@ public:
 	static void
 	setDataOrder(DataOrder order);
 
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
-
-
 	static uint8_t
 	transferBlocking(uint8_t data);
 
 	static void
 	transferBlocking(const uint8_t *tx, uint8_t *rx, std::size_t length);
-
 
 	static modm::ResumableResult<uint8_t>
 	transfer(uint8_t data);

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
@@ -26,17 +26,6 @@ template <typename Sck, typename Mosi, typename Miso>
 uint8_t
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::operationMode(0);
 
-template <typename Sck, typename Mosi, typename Miso>
-uint8_t
-modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::count(0);
-
-template <typename Sck, typename Mosi, typename Miso>
-void *
-modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::context(nullptr);
-
-template <typename Sck, typename Mosi, typename Miso>
-modm::Spi::ConfigurationHandler
-modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::configuration(nullptr);
 // ----------------------------------------------------------------------------
 
 template <typename Sck, typename Mosi, typename Miso>
@@ -90,42 +79,6 @@ modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::setDataOrder(DataOrder order)
 	else
 		operationMode &= ~0b100;
 }
-// ----------------------------------------------------------------------------
-
-template <typename Sck, typename Mosi, typename Miso>
-uint8_t
-modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-template <typename Sck, typename Mosi, typename Miso>
-uint8_t
-modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
-// ----------------------------------------------------------------------------
 
 template <typename Sck, typename Mosi, typename Miso>
 uint8_t

--- a/src/modm/platform/spi/rp/module.lb
+++ b/src/modm/platform/spi/rp/module.lb
@@ -25,7 +25,7 @@ class Instance(Module):
     def build(self, env):
         env.substitutions = {
             "id": self.instance,
-            "use_fiber": env.get(":processing:protothread:use_fiber", False)
+            "use_fiber": env.query(":processing:fiber:__enabled", False)
         }
         env.outbasepath = "modm/src/modm/platform/spi"
 

--- a/src/modm/platform/spi/rp/spi_master.cpp.in
+++ b/src/modm/platform/spi/rp/spi_master.cpp.in
@@ -25,39 +25,6 @@ void modm::platform::SpiMaster{{ id }}::unreset()
 	Resets::unresetWait(RESETS_RESET_SPI{{ id }}_BITS);
 }
 
-uint8_t
-modm::platform::SpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
-// ----------------------------------------------------------------------------
-
 modm::ResumableResult<uint8_t>
 modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 {

--- a/src/modm/platform/spi/rp/spi_master.hpp.in
+++ b/src/modm/platform/spi/rp/spi_master.hpp.in
@@ -10,6 +10,7 @@
 // ----------------------------------------------------------------------------
 #pragma once
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
@@ -25,18 +26,13 @@ namespace modm::platform
  * @author	Andrey Kunitsyn
  * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
  */
-class SpiMaster{{ id }} : public modm::SpiMaster
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>
 {
 protected:
 	// Bit0: single transfer state
 	// Bit1: block transfer state
 	static inline uint8_t state{0};
-private:
-	static inline uint8_t count{0};
-	static inline void *context{nullptr};
-	static inline ConfigurationHandler configuration{nullptr};
 
-protected:
 	static inline bool isBusy() {
 		return (spi{{ id }}_hw->sr & SPI_SSPSR_BSY_BITS);
 	}
@@ -167,12 +163,6 @@ public:
 	{
 		modm_assert(order == DataOrder::MsbFirst, "SPI DataOrder", "SPI hardware does not support alternate transmit order");
 	}
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
 
 	static uint8_t
 	transferBlocking(uint8_t data)

--- a/src/modm/platform/spi/sam/module.lb
+++ b/src/modm/platform/spi/sam/module.lb
@@ -14,7 +14,7 @@ def get_properties(env):
     device = env[":target"]
     driver = device.get_driver("spi")
     properties = {}
-    properties["use_fiber"] = env.get(":processing:protothread:use_fiber", False)
+    properties["use_fiber"] = env.query(":processing:fiber:__enabled", False)
     properties["target"] = device.identifier
     properties["features"] = driver["feature"] if "feature" in driver else []
     return properties

--- a/src/modm/platform/spi/sam/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam/spi_master.cpp.in
@@ -17,41 +17,6 @@
 
 #include "spi_master_{{id}}.hpp"
 
-// ----------------------------------------------------------------------------
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
-// ----------------------------------------------------------------------------
-
 modm::ResumableResult<uint8_t>
 modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 {

--- a/src/modm/platform/spi/sam/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam/spi_master.hpp.in
@@ -10,6 +10,7 @@
 // ----------------------------------------------------------------------------
 #pragma once
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
@@ -23,13 +24,11 @@ namespace modm::platform {
  * @author	Jeff McBride
  * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
  */
-class SpiMaster{{ id }} : public modm::SpiMaster {
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>
+{
 	// Bit0: single transfer state
 	// Bit1: block transfer state
 	static inline uint8_t state{0};
-	static inline uint8_t count{0};
-	static inline void *context{nullptr};
-	static inline ConfigurationHandler configuration{nullptr};
 
 	// Work around a name collision between 'struct modm::Spi' and 'struct Spi'
 	// defined in the CMSIS headers
@@ -114,12 +113,6 @@ public:
 	setDataOrder(DataOrder order) {
 		modm_assert(order == DataOrder::MsbFirst, "SPI DataOrder", "SPI hardware does not support alternate transmit order");
 	}
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
 
 	static uint8_t
 	transferBlocking(uint8_t data) {

--- a/src/modm/platform/spi/sam_x7x/module.lb
+++ b/src/modm/platform/spi/sam_x7x/module.lb
@@ -15,7 +15,7 @@
 def get_properties(env):
     device = env[":target"]
     properties = {}
-    properties["use_fiber"] = env.get(":processing:protothread:use_fiber", False)
+    properties["use_fiber"] = env.query(":processing:fiber:__enabled", False)
     properties["target"] = device.identifier
     return properties
 

--- a/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.cpp.in
@@ -17,39 +17,6 @@
 
 #include "spi_master_{{id}}.hpp"
 
-uint8_t
-modm::platform::SpiMaster{{ id }}::acquire(void* ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::release(void* ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
-// ----------------------------------------------------------------------------
-
 modm::ResumableResult<uint8_t>
 modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 {

--- a/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
+++ b/src/modm/platform/spi/sam_x7x/spi_master.hpp.in
@@ -18,6 +18,7 @@
 #ifndef MODM_SAMX7X_SPI_MASTER{{ id }}_HPP
 #define MODM_SAMX7X_SPI_MASTER{{ id }}_HPP
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
@@ -33,15 +34,12 @@ namespace modm::platform
  *
  * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
  */
-class SpiMaster{{ id }} : public modm::SpiMaster, public SpiBase
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>, public SpiBase
 {
 private:
 	// Bit0: single transfer state
 	// Bit1: block transfer state
 	static inline uint8_t state{0};
-	static inline uint8_t count{0};
-	static inline void* context{nullptr};
-	static inline ConfigurationHandler configuration{nullptr};
 public:
 	using DataMode = SpiBase::DataMode;
 	using Hal = SpiHal{{ id }};
@@ -94,12 +92,6 @@ public:
 	{
 		SpiHal{{ id }}::setDataSize(size);
 	}
-
-	static uint8_t
-	acquire(void* ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void* ctx);
 
 	static uint8_t
 	transferBlocking(uint8_t data)

--- a/src/modm/platform/spi/stm32/module.lb
+++ b/src/modm/platform/spi/stm32/module.lb
@@ -16,7 +16,7 @@ def get_properties(env):
     device = env[":target"]
     driver = device.get_driver("spi")
     properties = {}
-    properties["use_fiber"] = env.get(":processing:protothread:use_fiber", False)
+    properties["use_fiber"] = env.query(":processing:fiber:__enabled", False)
     properties["target"] = device.identifier
     properties["features"] = driver["feature"] if "feature" in driver else []
     return properties

--- a/src/modm/platform/spi/stm32/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.cpp.in
@@ -16,39 +16,6 @@
 
 #include "spi_master_{{id}}.hpp"
 
-uint8_t
-modm::platform::SpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-uint8_t
-modm::platform::SpiMaster{{ id }}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
-// ----------------------------------------------------------------------------
-
 modm::ResumableResult<uint8_t>
 modm::platform::SpiMaster{{ id }}::transfer(uint8_t data)
 {

--- a/src/modm/platform/spi/stm32/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32/spi_master.hpp.in
@@ -18,6 +18,7 @@
 #ifndef MODM_STM32_SPI_MASTER{{ id }}_HPP
 #define MODM_STM32_SPI_MASTER{{ id }}_HPP
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
@@ -37,17 +38,13 @@ namespace platform
  * @author	Niklas Hauser
  * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
  */
-class SpiMaster{{ id }} : public modm::SpiMaster
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>
 {
 protected:
 	// `state` must be protected to allow access from SpiMasterDma subclass
 	// Bit0: single transfer state
 	// Bit1: block transfer state
 	static inline uint8_t state{0};
-private:
-	static inline uint8_t count{0};
-	static inline void* context{nullptr};
-	static inline ConfigurationHandler configuration{nullptr};
 public:
 	using Hal = SpiHal{{ id }};
 
@@ -126,14 +123,6 @@ public:
 		SpiHal{{ id }}::setDataSize(static_cast<SpiHal{{ id }}::DataSize>(size));
 		SpiHal{{ id }}::enableTransfer();
 	}
-
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
-
 
 	static uint8_t
 	transferBlocking(uint8_t data)

--- a/src/modm/platform/spi/stm32_uart/module.lb
+++ b/src/modm/platform/spi/stm32_uart/module.lb
@@ -17,7 +17,7 @@ def get_properties(env):
         "target": device.identifier,
         "driver": driver,
         "over8_sampling": ("feature" in driver) and ("over8" in driver["feature"]),
-        "use_fiber": env.get(":processing:protothread:use_fiber", False),
+        "use_fiber": env.query(":processing:fiber:__enabled", False)
     }
     return properties
 

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.cpp.in
@@ -23,47 +23,6 @@ modm::platform::UartSpiMaster{{ id }}::DataOrder
 uint8_t
 modm::platform::UartSpiMaster{{ id }}::state(0);
 
-uint8_t
-modm::platform::UartSpiMaster{{ id }}::count(0);
-
-void *
-modm::platform::UartSpiMaster{{ id }}::context(nullptr);
-
-modm::Spi::ConfigurationHandler
-modm::platform::UartSpiMaster{{ id }}::configuration(nullptr);
-// ----------------------------------------------------------------------------
-
-uint8_t
-modm::platform::UartSpiMaster{{ id }}::acquire(void *ctx, ConfigurationHandler handler)
-{
-	if (context == nullptr)
-	{
-		context = ctx;
-		count = 1;
-		// if handler is not nullptr and is different from previous configuration
-		if (handler and configuration != handler) {
-			configuration = handler;
-			configuration();
-		}
-		return 1;
-	}
-
-	if (ctx == context)
-		return ++count;
-
-	return 0;
-}
-
-uint8_t
-modm::platform::UartSpiMaster{{ id }}::release(void *ctx)
-{
-	if (ctx == context)
-	{
-		if (--count == 0)
-			context = nullptr;
-	}
-	return count;
-}
 // ----------------------------------------------------------------------------
 
 modm::ResumableResult<uint8_t>

--- a/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32_uart/uart_spi_master.hpp.in
@@ -14,6 +14,7 @@
 #ifndef MODM_STM32_UART_SPI_MASTER{{ id }}_HPP
 #define MODM_STM32_UART_SPI_MASTER{{ id }}_HPP
 
+#include <modm/architecture/interface/spi_lock.hpp>
 #include <modm/architecture/interface/spi_master.hpp>
 #include <modm/platform/gpio/connector.hpp>
 #include "../uart/uart_hal_{{ id }}.hpp"
@@ -33,7 +34,8 @@ namespace platform
  * @author		Niklas Hauser
  * @ingroup		modm_platform_uart_spi modm_platform_uart_spi_{{id}}
  */
-class UartSpiMaster{{ id }} : public modm::SpiMaster, public UartBase
+class UartSpiMaster{{ id }} : public modm::SpiMaster, public UartBase,
+                              public SpiLock<UartSpiMaster{{ id }}>
 {
 	static DataOrder dataOrder;
 	static uint8_t state;
@@ -102,14 +104,6 @@ public:
 	{
 		dataOrder = order;
 	}
-
-
-	static uint8_t
-	acquire(void *ctx, ConfigurationHandler handler = nullptr);
-
-	static uint8_t
-	release(void *ctx);
-
 
 	static uint8_t
 	transferBlocking(uint8_t data)

--- a/src/modm/platform/spi/stm32h7/module.lb
+++ b/src/modm/platform/spi/stm32h7/module.lb
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def get_properties(env):
+    device = env[":target"]
+    driver = device.get_driver("spi")
+    properties = {}
+    properties["use_fiber"] = env.query(":processing:fiber:__enabled", False)
+    properties["target"] = device.identifier
+
+    return properties
+
+class Instance(Module):
+    def __init__(self, driver, instance):
+        self.instance = int(instance)
+        self.driver = driver
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        module.depends(":platform:spi")
+        return True
+
+    def build(self, env):
+        properties = get_properties(env)
+        properties["id"] = self.instance
+
+        device = env[":target"]
+        if device.identifier.family in ["h7"]:
+            properties["fifo_size"] = 16 if self.instance in (1, 2, 3) else 8
+            properties["max_data_bits"] = 32 if self.instance in (1, 2, 3) else 16
+            properties["max_crc_bits"] = properties["max_data_bits"]
+            properties["max_transfer_size"] = 2**16 - 1  # is smaller for some instances on U5
+            properties["i2s"] = self.instance in (1, 2, 3, 6)
+        else:
+            raise NotImplementedError("Unsupported device")
+
+        env.substitutions = properties
+        env.outbasepath = "modm/src/modm/platform/spi"
+
+        env.template("spi_hal.hpp.in", "spi_hal_{}.hpp".format(self.instance))
+        env.template("spi_hal_impl.hpp.in", "spi_hal_{}_impl.hpp".format(self.instance))
+        env.template("spi_master.hpp.in", "spi_master_{}.hpp".format(self.instance))
+        env.template("spi_master.cpp.in", "spi_master_{}.cpp".format(self.instance))
+        if env.has_module(":platform:dma"):
+            env.template("spi_master_dma.hpp.in", "spi_master_{}_dma.hpp".format(self.instance))
+            env.template("spi_master_dma_impl.hpp.in", "spi_master_{}_dma_impl.hpp".format(self.instance))
+
+
+def init(module):
+    module.name = ":platform:spi"
+    module.description = "Serial Peripheral Interface (SPI)"
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("spi:stm32-extended"):
+        return False
+    if device.identifier.family not in ["h7"]:
+        # U5 is not supported yet
+        return False
+
+    module.depends(
+        ":architecture:register",
+        ":architecture:spi",
+        ":cmsis:device",
+        ":math:algorithm",
+        ":platform:gpio",
+        ":platform:rcc")
+
+    for driver in device.get_all_drivers("spi:stm32-extended"):
+        for instance in driver["instance"]:
+            module.add_submodule(Instance(driver, instance))
+
+    return True
+
+def build(env):
+    env.substitutions = get_properties(env)
+    env.outbasepath = "modm/src/modm/platform/spi"
+
+    env.template("spi_base.hpp.in")

--- a/src/modm/platform/spi/stm32h7/spi_base.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_base.hpp.in
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2013-2017, Niklas Hauser
+ * Copyright (c) 2014, Daniel Krebs
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_BASE_HPP
+#define MODM_STM32H7_SPI_BASE_HPP
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/architecture/interface/register.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Base class for the SPI classes
+ *
+ * Provides common definitions that do not depend on the specific SPI instance.
+ *
+ * @ingroup	modm_platform_spi
+ */
+class SpiBase
+{
+public:
+	enum class
+	Interrupt : uint32_t
+	{
+		RxPacketAvailable		= SPI_IER_RXPIE,
+		TxPacketSpaceAvailable	= SPI_IER_TXPIE,
+		DuplexPacket			= SPI_IER_DXPIE,
+		EndOfTransfer			= SPI_IER_EOTIE,
+		TxTransferFilled 		= SPI_IER_TXTFIE,
+		Underrun 				= SPI_IER_UDRIE,
+		Overrun 				= SPI_IER_OVRIE,
+		CrcError 				= SPI_IER_CRCEIE,
+		TiFrameError			= SPI_IER_TIFREIE,
+		ModeFault				= SPI_IER_MODFIE,
+		Reload					= SPI_IER_TSERFIE
+	};
+	MODM_FLAGS32(Interrupt);
+
+	enum class
+	StatusFlag : uint32_t
+	{
+		RxPacketAvailable		= SPI_SR_RXP,
+		TxPacketSpaceAvailable	= SPI_SR_TXP,
+		DuplexPacket			= SPI_SR_DXP,
+		EndOfTransfer			= SPI_SR_EOT,
+		TxTransferFilled 		= SPI_SR_TXTF,
+		Underrun 				= SPI_SR_UDR,
+		Overrun 				= SPI_SR_OVR,
+		CrcError 				= SPI_SR_CRCE,
+		TiFrameError			= SPI_SR_TIFRE,
+		ModeFault				= SPI_SR_MODF,
+		Reload					= SPI_SR_TSERF,
+		Suspension				= SPI_SR_SUSP,
+		TxTransferComplete		= SPI_SR_TXC,
+		RxFifoLevel1			= SPI_SR_RXPLVL_1,
+		RxFifoLevel0			= SPI_SR_RXPLVL_0,
+		RxFifoWordNotEmpty		= SPI_SR_RXWNE
+	};
+	MODM_FLAGS32(StatusFlag);
+
+	enum class
+	MasterSelection : uint32_t
+	{
+		Slave 	= 0,
+		Master 	= SPI_CFG2_MASTER,
+		Mask 	= Master,
+	};
+
+	enum class
+	DataMode : uint32_t
+	{
+		Mode0 = 0b00,			///< clock normal,   sample on rising  edge
+		Mode1 = SPI_CFG2_CPHA,	///< clock normal,   sample on falling edge
+		Mode2 = SPI_CFG2_CPOL,	///< clock inverted, sample on falling edge
+								///  clock inverted, sample on rising  edge
+		Mode3 = SPI_CFG2_CPOL | SPI_CFG2_CPHA,
+		Mask = Mode3
+	};
+
+	enum class
+	DataOrder : uint32_t
+	{
+		MsbFirst = 0b0,
+		LsbFirst = SPI_CFG2_LSBFRST,
+		Mask = LsbFirst,
+	};
+
+	enum class
+	Prescaler : uint32_t
+	{
+		Div2 	= 0,
+		Div4 	= SPI_CFG1_MBR_0,
+		Div8 	= SPI_CFG1_MBR_1,
+		Div16 	= SPI_CFG1_MBR_1 | SPI_CFG1_MBR_0,
+		Div32 	= SPI_CFG1_MBR_2,
+		Div64 	= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_0,
+		Div128 	= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_1,
+		Div256 	= SPI_CFG1_MBR_2 | SPI_CFG1_MBR_1 | SPI_CFG1_MBR_0
+	};
+
+	enum class
+	DataSize : uint32_t
+	{
+		Bit4 = 3,
+		Bit5 = 4,
+		Bit6 = 5,
+		Bit7 = 6,
+		Bit8 = 7,
+		Bit9 = 8,
+		Bit10 = 9,
+		Bit11 = 10,
+		Bit12 = 11,
+		Bit13 = 12,
+		Bit14 = 13,
+		Bit15 = 14,
+		Bit16 = 15,
+		Bit17 = 16,
+		Bit18 = 17,
+		Bit19 = 18,
+		Bit20 = 19,
+		Bit21 = 20,
+		Bit22 = 21,
+		Bit23 = 22,
+		Bit24 = 23,
+		Bit25 = 24,
+		Bit26 = 25,
+		Bit27 = 26,
+		Bit28 = 27,
+		Bit29 = 28,
+		Bit30 = 29,
+		Bit31 = 30,
+		Bit32 = 31
+	};
+	static_assert(SPI_CFG1_DSIZE_Pos == 0);
+
+	enum class DmaMode : uint32_t
+	{
+		None = 0,
+		Tx = SPI_CFG1_TXDMAEN,
+		Rx = SPI_CFG1_RXDMAEN,
+		Mask = SPI_CFG1_TXDMAEN | SPI_CFG1_RXDMAEN
+	};
+	MODM_FLAGS32(DmaMode);
+
+	enum class DuplexMode : uint32_t
+	{
+		FullDuplex = 0,
+		TransmitOnly = SPI_CFG2_COMM_0,
+		ReceiveOnly = SPI_CFG2_COMM_1,
+		HalfDuplex = SPI_CFG2_COMM_1 | SPI_CFG2_COMM_0,
+		Mask = HalfDuplex
+	};
+
+	enum class SlaveSelectMode
+	{
+		HardwareGpio,
+		Software = SPI_CFG2_SSM
+	};
+
+	enum class SlaveSelectPolarity
+	{
+		ActiveLow = 0,
+		ActiveHigh = SPI_CFG2_SSIOP
+	};
+
+	enum class CrcInit : uint32_t
+	{
+		AllZeros = 0,
+		AllOnes = SPI_CR1_TCRCINI | SPI_CR1_RCRCINI,
+		Mask = AllOnes
+	};
+};
+
+constexpr auto
+operator<=>(SpiBase::DataSize s0, SpiBase::DataSize s1)
+{
+    const auto v0 = static_cast<uint32_t>(s0);
+    const auto v1 = static_cast<uint32_t>(s1);
+    if (v0 < v1) {
+        return std::strong_ordering::less;
+    } else if (v0 > v1) {
+        return std::strong_ordering::greater;
+    } else {
+        return std::strong_ordering::equal;
+    }
+}
+
+} // namespace modm::platform
+
+#endif // MODM_STM32H7_SPI_BASE_HPP

--- a/src/modm/platform/spi/stm32h7/spi_hal.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_hal.hpp.in
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2013-2018, Niklas Hauser
+ * Copyright (c) 2014, Daniel Krebs
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_HAL{{ id }}_HPP
+#define MODM_STM32H7_SPI_HAL{{ id }}_HPP
+
+#include "spi_base.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * Serial peripheral interface (SPI{{ id }})
+ *
+ * @ingroup		modm_platform_spi modm_platform_spi_{{id}}
+ */
+class SpiHal{{ id }} : public SpiBase
+{
+public:
+	static constexpr auto peripheral = Peripheral::Spi{{ id }};
+
+	static constexpr DataSize MaxDataBits = DataSize::Bit{{ max_data_bits }};
+	static constexpr DataSize MaxCrcBits = DataSize::Bit{{ max_crc_bits }};
+
+	/// Maximum permitted size for fixed size transfers
+	static constexpr std::size_t MaxTransferSize = {{ max_transfer_size }};
+
+	/// Size of FIFO in bytes
+	static constexpr std::size_t FifoSize = {{ fifo_size }};
+
+	static void
+	enableClock();
+
+	static void
+	disableClock();
+
+	static void
+	initialize(Prescaler prescaler,
+			   MasterSelection masterSelection = MasterSelection::Master,
+			   DataMode dataMode = DataMode::Mode0,
+			   DataOrder dataOrder = DataOrder::MsbFirst,
+			   DataSize  dataSize  = DataSize::Bit8);
+
+	static void
+	enableTransfer();
+
+	static void
+	disableTransfer();
+
+	static bool
+	isTransferEnabled();
+
+	static void
+	startMasterTransfer();
+
+	static void
+	suspendMasterTransfer();
+
+	static void
+	setDataMode(DataMode dataMode);
+
+	static void
+	setDataOrder(DataOrder dataOrder);
+
+	static void
+	setDataSize(DataSize dataSize);
+
+	static void
+	setMasterSelection(MasterSelection masterSelection);
+
+	static void
+	setDuplexMode(DuplexMode mode);
+
+	static void
+	setCrcEnabled(bool enabled);
+
+	static void
+	setCrcSize(DataSize crcSize);
+
+	static void
+	setCrcPolynomial(uint32_t poly);
+
+	static void
+	setCrcInitialValue(CrcInit init);
+
+	static void
+	setDmaMode(DmaMode_t mode);
+
+	/**
+	 * Configure total amount of data items of transfer
+	 * Set size to 0 for unlimited transfers.
+	 * @param reload Next transfer size after reload
+	 */
+	static void
+	setTransferSize(uint16_t size, uint16_t reload = 0);
+
+	static void
+	setSlaveSelectMode(SlaveSelectMode mode);
+
+	static void
+	setSlaveSelectPolarity(SlaveSelectPolarity polarity);
+
+	static void
+	setSlaveSelectState(bool state);
+
+	static uint32_t
+	transmitCrc();
+
+	static uint32_t
+	receiveCrc();
+
+	static volatile uint32_t*
+	transmitRegister();
+
+	static const volatile uint32_t*
+	receiveRegister();
+
+	static StatusFlag_t
+	status();
+
+	/// @return true if SPI_SR_EOT is set
+	static bool
+	isTransferCompleted();
+
+	/// @return true if SPI_SR_TXC is set
+	static bool
+	isTxCompleted();
+
+	/// @return true if SPI_SR_TXP is not set
+	static bool
+	isTxFifoFull();
+
+	/// @return true if SPI_SR_RXP is set
+	static bool
+	isRxDataAvailable();
+
+	/**
+	 * Write up to 8 Bit to the transmit data register
+	 *
+	 * @warning Writing with a size smaller than the configured data size is not allowed.
+	 */
+	static void
+	write(uint8_t data);
+
+	/**
+	 * Write up to 16 Bit to the data register
+	 * @warning Writing with a size smaller than the configured data size is not allowed.
+	 */
+	static void
+	write16(uint16_t data);
+
+	/**
+	 * Write up to 32 Bit to the transmit data register
+	 */
+	static void
+	write32(uint32_t data);
+
+	/**
+	 * Read an 8-bit value from the receive data register.
+	 *
+	 * @warning Reading with a size smaller than the configured data size is not allowed.
+	 */
+	static uint8_t
+	read();
+
+	/**
+	 * Read a 16-bit value from the receive data register.
+	 *
+	 * @warning Reading with a size smaller than the configured data size is not allowed.
+	 */
+	static uint16_t
+	read16();
+
+	/**
+	 * Read a 32-bit value from the receive data register.
+	 */
+	static uint32_t
+	read32();
+
+	static void
+	enableInterruptVector(bool enable, uint32_t priority);
+
+	static void
+	enableInterrupt(Interrupt_t interrupt);
+
+	static void
+	disableInterrupt(Interrupt_t interrupt);
+
+	static void
+	acknowledgeInterruptFlags(StatusFlag_t flags);
+};
+
+} // namespace modm::platform
+
+#include "spi_hal_{{ id }}_impl.hpp"
+
+#endif // MODM_STM32H7_SPI_HAL{{ id }}_HPP

--- a/src/modm/platform/spi/stm32h7/spi_hal_impl.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_hal_impl.hpp.in
@@ -1,0 +1,353 @@
+/*
+* Copyright (c) 2013, Kevin Läufer
+* Copyright (c) 2013-2017, Niklas Hauser
+* Copyright (c) 2014, Daniel Krebs
+* Copyright (c) 2020, Mike Wolfram
+* Copyright (c) 2023, Christopher Durand
+*
+* This file is part of the modm project.
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_HAL{{ id }}_HPP
+#	error 	"Don't include this file directly, use 'spi_hal{{ id }}.hpp' instead!"
+#endif
+#include <modm/platform/clock/rcc.hpp>
+
+namespace modm::platform
+{
+
+inline void
+SpiHal{{ id }}::enableClock()
+{
+	Rcc::enable<Peripheral::Spi{{id}}>();
+}
+
+inline void
+SpiHal{{ id }}::disableClock()
+{
+	Rcc::disable<Peripheral::Spi{{id}}>();
+}
+
+inline void
+SpiHal{{ id }}::initialize(Prescaler prescaler,
+		MasterSelection masterSelection, DataMode dataMode,
+		DataOrder dataOrder, DataSize dataSize)
+{
+	enableClock();
+	disableTransfer();
+
+	acknowledgeInterruptFlags(
+		StatusFlag::EndOfTransfer |
+		StatusFlag::TxTransferFilled |
+		StatusFlag::Underrun |
+		StatusFlag::Overrun |
+		StatusFlag::CrcError |
+		StatusFlag::TiFrameError |
+		StatusFlag::ModeFault |
+		StatusFlag::Reload |
+		StatusFlag::Suspension
+	);
+
+	// initialize with unlimited transfer size
+	setTransferSize(0);
+
+	// Pause master transfer if RX FIFO is full
+	SPI{{ id }}->CR1 = SPI_CR1_MASRX;
+
+	SPI{{ id }}->CFG2 = static_cast<uint32_t>(dataMode)
+		| static_cast<uint32_t>(dataOrder)
+		| static_cast<uint32_t>(masterSelection)
+		| SPI_CFG2_SSOE; // disable multi-master support to prevent spurious mode fault
+
+	SPI{{ id }}->CFG1 = static_cast<uint32_t>(prescaler)
+		| static_cast<uint32_t>(dataSize);
+}
+
+inline void
+SpiHal{{ id }}::setDataMode(DataMode dataMode)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~static_cast<uint32_t>(DataMode::Mask))
+										| static_cast<uint32_t>(dataMode);
+}
+
+inline void
+SpiHal{{ id }}::setDataOrder(DataOrder dataOrder)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~static_cast<uint32_t>(DataOrder::Mask))
+										| static_cast<uint32_t>(dataOrder);
+}
+
+inline void
+SpiHal{{ id }}::setDataSize(DataSize dataSize)
+{
+	SPI{{ id }}->CFG1 = (SPI{{ id }}->CFG1 & ~SPI_CFG1_DSIZE_Msk)
+										| static_cast<uint32_t>(dataSize);
+}
+
+inline void
+SpiHal{{ id }}::setMasterSelection(MasterSelection masterSelection)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~static_cast<uint32_t>(MasterSelection::Mask))
+										| static_cast<uint32_t>(masterSelection);
+}
+
+inline void
+SpiHal{{ id }}::setDuplexMode(DuplexMode mode)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~static_cast<uint32_t>(DuplexMode::Mask))
+										| static_cast<uint32_t>(mode);
+}
+
+inline void
+SpiHal{{ id }}::setCrcEnabled(bool enabled)
+{
+	if (enabled) {
+		SPI{{ id }}->CFG1 |= SPI_CFG1_CRCEN;
+	} else {
+		SPI{{ id }}->CFG1 &= ~SPI_CFG1_CRCEN;
+	}
+}
+
+inline void
+SpiHal{{ id }}::setCrcSize(DataSize crcSize)
+{
+	if ((crcSize == DataSize::Bit16) or (crcSize == DataSize::Bit32)) {
+		SPI{{ id }}->CR1 |= SPI_CR1_CRC33_17;
+	} else {
+		SPI{{ id }}->CR1 &= ~SPI_CR1_CRC33_17;
+	}
+	SPI{{ id }}->CFG1 = (SPI{{ id }}->CFG1 & ~SPI_CFG1_CRCSIZE_Msk)
+										| (static_cast<uint32_t>(crcSize) << SPI_CFG1_CRCSIZE_Pos);
+}
+
+inline void
+SpiHal{{ id }}::setCrcPolynomial(uint32_t poly)
+{
+	SPI{{ id }}->CRCPOLY = poly;
+}
+
+inline void
+SpiHal{{ id }}::setCrcInitialValue(CrcInit init)
+{
+	SPI{{ id }}->CR1 = (SPI{{ id }}->CR1 & ~static_cast<uint32_t>(CrcInit::Mask)) |
+		static_cast<uint32_t>(init);
+}
+
+inline void
+SpiHal{{ id }}::setTransferSize(uint16_t size, uint16_t reload)
+{
+	static_assert(SPI_CR2_TSIZE_Pos == 0);
+	SPI{{ id }}->CR2 = (reload << SPI_CR2_TSER_Pos) | size;
+}
+
+inline void
+SpiHal{{ id }}::setDmaMode(DmaMode_t mode)
+{
+	SPI{{ id }}->CFG1 = (SPI{{ id }}->CFG1 & ~(DmaMode::Tx | DmaMode::Rx).value)
+										| mode.value;
+}
+
+inline void
+SpiHal{{ id }}::setSlaveSelectMode(SlaveSelectMode mode)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~SPI_CFG2_SSM_Msk)
+										| uint32_t(mode);
+}
+
+inline void
+SpiHal{{ id }}::setSlaveSelectPolarity(SlaveSelectPolarity polarity)
+{
+	SPI{{ id }}->CFG2 = (SPI{{ id }}->CFG2 & ~SPI_CFG2_SSIOP_Msk)
+										| uint32_t(polarity);
+}
+
+inline void
+SpiHal{{ id }}::setSlaveSelectState(bool state)
+{
+	if (state) {
+		SPI{{ id }}->CR1 |= SPI_CR1_SSI;
+	} else  {
+		SPI{{ id }}->CR1 &= ~SPI_CR1_SSI;
+	}
+}
+
+inline void
+SpiHal{{ id }}::write(uint8_t data)
+{
+	// Write with 8-bit access
+	auto* const ptr = reinterpret_cast<__IO uint8_t*>(&SPI{{ id }}->TXDR);
+	*ptr = data;
+}
+
+inline void
+SpiHal{{ id }}::write16(uint16_t data)
+{
+	// Write with 16-bit access
+	// SPI{{ id }}->TXDR is of type "volatile uint32_t".
+	// [[gnu::may_alias]] is required to avoid undefined behaviour due to strict aliasing violations.
+	auto* const [[gnu::may_alias]] ptr = reinterpret_cast<__IO uint16_t*>(&SPI{{ id }}->TXDR);
+	*ptr = data;
+}
+
+inline void
+SpiHal{{ id }}::write32(uint32_t data)
+{
+	SPI{{ id }}->TXDR = data;
+}
+
+inline uint8_t
+SpiHal{{ id }}::read()
+{
+	// Read with 8-bit access
+	return *reinterpret_cast<const __IO uint8_t*>(&SPI{{ id }}->RXDR);
+}
+
+inline uint16_t
+SpiHal{{ id }}::read16()
+{
+	// Read with 16-bit access
+	// SPI{{ id }}->RXDR is of type "const volatile uint32_t".
+	// [[gnu::may_alias]] is required to avoid undefined behaviour due to strict aliasing violations.
+	auto* const [[gnu::may_alias]] ptr = reinterpret_cast<const __IO uint16_t*>(&SPI{{ id }}->RXDR);
+	return *ptr;
+}
+
+inline uint32_t
+SpiHal{{ id }}::read32()
+{
+	return SPI{{ id }}->RXDR;
+}
+
+inline void
+SpiHal{{ id }}::enableInterruptVector(bool enable, uint32_t priority)
+{
+	if (enable) {
+		// Set priority for the interrupt vector
+		NVIC_SetPriority(SPI{{ id }}_IRQn, priority);
+		// register IRQ at the NVIC
+		NVIC_EnableIRQ(SPI{{ id }}_IRQn);
+	}
+	else {
+		NVIC_DisableIRQ(SPI{{ id }}_IRQn);
+	}
+}
+
+inline void
+SpiHal{{ id }}::enableInterrupt(Interrupt_t interrupt)
+{
+	SPI{{ id }}->IER |= interrupt.value;
+}
+
+inline void
+SpiHal{{ id }}::disableInterrupt(Interrupt_t interrupt)
+{
+	SPI{{ id }}->IER &= ~interrupt.value;
+}
+
+inline void
+SpiHal{{ id }}::acknowledgeInterruptFlags(StatusFlag_t flags)
+{
+	constexpr auto mask =
+		SPI_IFCR_EOTC |
+		SPI_IFCR_TXTFC |
+		SPI_IFCR_UDRC |
+		SPI_IFCR_OVRC |
+		SPI_IFCR_CRCEC |
+		SPI_IFCR_TIFREC |
+		SPI_IFCR_MODFC |
+		SPI_IFCR_TSERFC |
+		SPI_IFCR_SUSPC;
+
+	SPI{{ id }}->IFCR = flags.value & mask;
+}
+
+inline SpiHal{{ id }}::StatusFlag_t
+SpiHal{{ id }}::status()
+{
+	return StatusFlag_t(SPI{{ id }}->SR);
+}
+
+inline bool
+SpiHal{{ id }}::isTransferCompleted()
+{
+	return bool(status() & StatusFlag::EndOfTransfer);
+}
+
+inline bool
+SpiHal{{ id }}::isTxCompleted()
+{
+	return bool(status() & StatusFlag::TxTransferComplete);
+}
+
+inline bool
+SpiHal{{ id }}::isTxFifoFull()
+{
+	return !(status() & StatusFlag::TxPacketSpaceAvailable);
+}
+
+inline bool
+SpiHal{{ id }}::isRxDataAvailable()
+{
+	return bool(status() & StatusFlag::RxPacketAvailable);
+}
+
+inline void
+SpiHal{{ id }}::enableTransfer()
+{
+	SPI{{ id }}->CR1 |= SPI_CR1_SPE;
+}
+
+inline void
+SpiHal{{ id }}::disableTransfer()
+{
+	SPI{{ id }}->CR1 &= ~SPI_CR1_SPE;
+}
+
+inline bool
+SpiHal{{ id }}::isTransferEnabled()
+{
+	return (SPI{{ id }}->CR1 & SPI_CR1_SPE);
+}
+
+inline void
+SpiHal{{ id }}::startMasterTransfer()
+{
+	SPI{{ id }}->CR1 |= SPI_CR1_CSTART;
+}
+
+inline void
+SpiHal{{ id }}::suspendMasterTransfer()
+{
+	SPI{{ id }}->CR1 |= SPI_CR1_CSUSP;
+}
+
+inline uint32_t
+SpiHal{{ id }}::transmitCrc()
+{
+	return SPI{{ id }}->TXCRC;
+}
+
+inline uint32_t
+SpiHal{{ id }}::receiveCrc()
+{
+	return SPI{{ id }}->RXCRC;
+}
+
+inline volatile uint32_t*
+SpiHal{{ id }}::transmitRegister()
+{
+	return &SPI{{ id }}->TXDR;
+}
+
+inline const volatile uint32_t*
+SpiHal{{ id }}::receiveRegister()
+{
+	return &SPI{{ id }}->RXDR;
+}
+
+} // namespace modm::platform

--- a/src/modm/platform/spi/stm32h7/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master.cpp.in
@@ -1,0 +1,159 @@
+/*
+* Copyright (c) 2009, Martin Rosekeit
+* Copyright (c) 2009-2012, Fabian Greif
+* Copyright (c) 2010, Georgi Grinshpun
+* Copyright (c) 2012-2017, Niklas Hauser
+* Copyright (c) 2013, Kevin Läufer
+* Copyright (c) 2014, Sascha Schade
+* Copyright (c) 2023, Christopher Durand
+*
+* This file is part of the modm project.
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+// ----------------------------------------------------------------------------
+
+#include "spi_master_{{id}}.hpp"
+
+namespace modm::platform
+{
+
+modm::ResumableResult<uint8_t>
+SpiMaster{{ id }}::transfer(uint8_t data)
+{
+%% if use_fiber
+	while (Hal::isTxFifoFull())
+		modm::fiber::yield();
+
+	Hal::write(data);
+
+	while (!Hal::isRxDataAvailable())
+		modm::fiber::yield();
+
+	return Hal::read();
+%% else
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (LSB of state):
+	//   1. waiting to start, and
+	//   2. waiting to finish.
+
+	if (!(state & Bit0))
+	{
+		// wait for previous transfer to finish
+		if (Hal::isTxFifoFull())
+			return {modm::rf::Running};
+
+		Hal::write(data);
+
+		// set LSB = Bit0
+		state |= Bit0;
+	}
+
+	if (!Hal::isRxDataAvailable())
+		return {modm::rf::Running};
+
+	data = Hal::read();
+
+	state &= ~Bit0;
+	return {modm::rf::Stop, data};
+%% endif
+}
+
+modm::ResumableResult<void>
+SpiMaster{{ id }}::transfer(
+		const uint8_t* tx, uint8_t* rx, std::size_t length)
+{
+%% if use_fiber
+	std::size_t rxIndex = 0;
+	std::size_t txIndex = 0;
+
+	while (rxIndex < length) {
+		while ((txIndex < length) and !Hal::isTxFifoFull()) {
+			Hal::write(tx ? tx[txIndex] : 0);
+			++txIndex;
+		}
+		while ((rxIndex < length) and Hal::isRxDataAvailable()) {
+			const uint8_t data = Hal::read();
+			if (rx) {
+				rx[rxIndex] = data;
+			}
+			++rxIndex;
+		}
+		if (rxIndex < length) {
+			modm::fiber::yield();
+		}
+	}
+%% else
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (Bit1 of state):
+	//   1. initialize index, and
+	//   2. wait for transfer to finish.
+
+	// we need to globally remember which byte we are currently transferring
+	static std::size_t rxIndex = 0;
+	static std::size_t txIndex = 0;
+
+	// we are only interested in Bit1
+	switch(state & Bit1)
+	{
+		case 0:
+			// we will only visit this state once
+			state |= Bit1;
+
+			// initialize index and check range
+			rxIndex = 0;
+			txIndex = 0;
+			while (rxIndex < length) {
+		default:
+		{
+				while ((txIndex < length) and !Hal::isTxFifoFull()) {
+					Hal::write(tx ? tx[txIndex] : 0);
+					++txIndex;
+				}
+				while ((rxIndex < length) and Hal::isRxDataAvailable()) {
+					if (rx) {
+						rx[rxIndex] = Hal::read();
+					} else {
+						Hal::read();
+					}
+					++rxIndex;
+				}
+				if (rxIndex < length) {
+					return {modm::rf::Running};
+				}
+		}
+			}
+
+			// clear the state
+			state &= ~Bit1;
+			return {modm::rf::Stop};
+	}
+%% endif
+}
+
+void
+SpiMaster{{ id }}::finishTransfer()
+{
+	if (Hal::isTransferEnabled()) {
+		while (!(Hal::status() & Hal::StatusFlag::TxTransferComplete));
+		Hal::disableTransfer();
+	}
+
+	Hal::acknowledgeInterruptFlags(
+		Hal::StatusFlag::EndOfTransfer |
+		Hal::StatusFlag::TxTransferFilled |
+		Hal::StatusFlag::Underrun |
+		Hal::StatusFlag::Overrun |
+		Hal::StatusFlag::CrcError |
+		Hal::StatusFlag::TiFrameError |
+		Hal::StatusFlag::ModeFault |
+		Hal::StatusFlag::Reload |
+		Hal::StatusFlag::Suspension
+	);
+}
+
+} // namespace modm::platform

--- a/src/modm/platform/spi/stm32h7/spi_master.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master.hpp.in
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2009-2011, Fabian Greif
+ * Copyright (c) 2010, Martin Rosekeit
+ * Copyright (c) 2011-2017, Niklas Hauser
+ * Copyright (c) 2012, Georgi Grinshpun
+ * Copyright (c) 2013, Kevin Läufer
+ * Copyright (c) 2014, Sascha Schade
+ * Copyright (c) 2022-2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_MASTER{{ id }}_HPP
+#define MODM_STM32H7_SPI_MASTER{{ id }}_HPP
+
+#include <modm/architecture/interface/spi_lock.hpp>
+#include <modm/architecture/interface/spi_master.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/math/algorithm/prescaler.hpp>
+%% if use_fiber
+#include <modm/processing/fiber.hpp>
+%% endif
+#include "spi_hal_{{ id }}.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * Serial peripheral interface (SPI{{ id }}).
+ *
+ * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
+ */
+class SpiMaster{{ id }} : public modm::SpiMaster, public SpiLock<SpiMaster{{ id }}>
+{
+%% if not use_fiber
+	// Bit0: single transfer state
+	// Bit1: block transfer state
+	static inline uint8_t state{0};
+%% endif
+public:
+	using Hal = SpiHal{{ id }};
+
+	using DataMode = Hal::DataMode;
+	using DataOrder = Hal::DataOrder;
+	using DataSize = Hal::DataSize;
+
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Spi{{ id }}, Signals...>;
+		using Sck = typename Connector::template GetSignal<Gpio::Signal::Sck>;
+		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Mosi>;
+		using Miso = typename Connector::template GetSignal<Gpio::Signal::Miso>;
+
+		Sck::setOutput(Gpio::OutputType::PushPull);
+		Mosi::setOutput(Gpio::OutputType::PushPull);
+		Miso::setInput(Gpio::InputType::Floating);
+		Connector::connect();
+	}
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
+	static void
+	initialize()
+	{
+		constexpr auto result = modm::Prescaler::from_power(SystemClock::Spi{{ id }}, baudrate, 2, 256);
+		assertBaudrateInTolerance< result.frequency, baudrate, tolerance >();
+
+		// translate the prescaler into the bitmapping
+		constexpr Hal::Prescaler prescaler{result.index << SPI_CFG1_MBR_Pos};
+%% if not use_fiber
+		state = 0;
+%% endif
+
+		Hal::initialize(prescaler);
+		Hal::enableTransfer();
+		Hal::startMasterTransfer();
+	}
+
+	static void
+	setDataMode(DataMode mode)
+	{
+		finishTransfer();
+		Hal::setDataMode(mode);
+		Hal::enableTransfer();
+		Hal::startMasterTransfer();
+	}
+
+	static void
+	setDataOrder(DataOrder order)
+	{
+		finishTransfer();
+		Hal::setDataOrder(order);
+		Hal::enableTransfer();
+		Hal::startMasterTransfer();
+	}
+
+	static void
+	setDataSize(DataSize size)
+	{
+		finishTransfer();
+		Hal::setDataSize(static_cast<SpiHal{{ id }}::DataSize>(size));
+		Hal::enableTransfer();
+		Hal::startMasterTransfer();
+	}
+
+	static uint8_t
+	transferBlocking(uint8_t data)
+	{
+		return RF_CALL_BLOCKING(transfer(data));
+	}
+
+	static void
+	transferBlocking(const uint8_t* tx, uint8_t* rx, std::size_t length)
+	{
+		RF_CALL_BLOCKING(transfer(tx, rx, length));
+	}
+
+
+	static modm::ResumableResult<uint8_t>
+	transfer(uint8_t data);
+
+	static modm::ResumableResult<void>
+	transfer(const uint8_t* tx, uint8_t* rx, std::size_t length);
+
+private:
+	static void
+	finishTransfer();
+};
+
+} // namespace modm::platform
+
+#endif // MODM_STM32H7_SPI_MASTER{{ id }}_HPP

--- a/src/modm/platform/spi/stm32h7/spi_master_dma.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master_dma.hpp.in
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_MASTER{{ id }}_DMA_HPP
+#define MODM_STM32H7_SPI_MASTER{{ id }}_DMA_HPP
+
+#include <modm/platform/dma/dma.hpp>
+#include "spi_master_{{ id }}.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * Serial peripheral interface (SPI{{ id }}) with DMA support.
+ *
+ * This class uses the DMA controller for sending and receiving data, which
+ * greatly reduces the CPU load. Beside passing the DMA channels as template
+ * parameters the class can be used in the same way like the SpiMaster{{ id }}.
+ *
+ * @tparam DmaChannelRX DMA channel for receiving
+ * @tparam DmaChannelTX DMA channel for sending
+ *
+ * @ingroup	modm_platform_spi modm_platform_spi_{{id}}
+ */
+template <class DmaChannelRx, class DmaChannelTx>
+class SpiMaster{{ id }}_Dma : public modm::SpiMaster,
+                              public SpiLock<SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>>
+{
+protected:
+	struct Dma {
+		using RxChannel = typename DmaChannelRx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaBase::Signal::Rx>::Channel;
+		using TxChannel = typename DmaChannelTx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaBase::Signal::Tx>::Channel;
+		static constexpr DmaBase::Request RxRequest = DmaChannelRx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaBase::Signal::Rx>::Request;
+		static constexpr DmaBase::Request TxRequest = DmaChannelTx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaBase::Signal::Tx>::Request;
+	};
+
+%% if not use_fiber
+	// Bit0: single transfer state
+	// Bit1: block transfer state
+	// Bit2: block transfer rx dma transfer completed
+	static inline uint8_t state{0};
+%% endif
+public:
+	using Hal = SpiHal{{ id }};
+
+	using DataMode = Hal::DataMode;
+	using DataOrder = Hal::DataOrder;
+	using DataSize = Hal::DataSize;
+
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Spi{{ id }}, Signals...>;
+		using Sck = typename Connector::template GetSignal<Gpio::Signal::Sck>;
+		using Mosi = typename Connector::template GetSignal<Gpio::Signal::Mosi>;
+		using Miso = typename Connector::template GetSignal<Gpio::Signal::Miso>;
+
+		Sck::setOutput(Gpio::OutputType::PushPull);
+		Mosi::setOutput(Gpio::OutputType::PushPull);
+		Miso::setInput(Gpio::InputType::Floating);
+		Connector::connect();
+	}
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(5) >
+	static void
+	initialize();
+
+	static void
+	setDataMode(DataMode mode)
+	{
+		Hal::setDataMode(mode);
+	}
+
+	static void
+	setDataOrder(DataOrder order)
+	{
+		Hal::setDataOrder(order);
+	}
+
+	static void
+	setDataSize(DataSize size)
+	{
+		Hal::setDataSize(static_cast<SpiHal{{ id }}::DataSize>(size));
+	}
+
+	static uint8_t
+	transferBlocking(uint8_t data)
+	{
+		return RF_CALL_BLOCKING(transfer(data));
+	}
+
+	/// @pre At least one of tx or rx must not be nullptr
+	static void
+	transferBlocking(const uint8_t* tx, uint8_t* rx, std::size_t length)
+	{
+		RF_CALL_BLOCKING(transfer(tx, rx, length));
+	}
+
+	static modm::ResumableResult<uint8_t>
+	transfer(uint8_t data);
+
+	/// @pre At least one of tx or rx must not be nullptr
+	static modm::ResumableResult<void>
+	transfer(const uint8_t* tx, uint8_t* rx, std::size_t length);
+
+protected:
+	static void
+	finishTransfer();
+
+	static void
+	startDmaTransfer(const uint8_t* tx, uint8_t* rx, std::size_t length);
+};
+
+} // namespace modm::platform
+
+#include "spi_master_{{ id }}_dma_impl.hpp"
+
+#endif // MODM_STM32_SPI_MASTER{{ id }}_DMA_HPP

--- a/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32H7_SPI_MASTER{{ id }}_DMA_HPP
+#	error 	"Don't include this file directly, use 'spi_master_{{ id }}_dma.hpp' instead!"
+#endif
+
+namespace modm::platform
+{
+
+template <class DmaChannelRx, class DmaChannelTx>
+template <class SystemClock, modm::baudrate_t baudrate, modm::percent_t tolerance>
+void
+SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::initialize()
+{
+	Dma::RxChannel::configure(DmaBase::DataTransferDirection::PeripheralToMemory,
+			DmaBase::MemoryDataSize::Byte, DmaBase::PeripheralDataSize::Byte,
+			DmaBase::MemoryIncrementMode::Increment, DmaBase::PeripheralIncrementMode::Fixed,
+			DmaBase::Priority::Medium);
+	Dma::RxChannel::disableInterruptVector();
+	Dma::RxChannel::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::receiveRegister()));
+	Dma::RxChannel::template setPeripheralRequest<Dma::RxRequest>();
+
+	Dma::TxChannel::configure(DmaBase::DataTransferDirection::MemoryToPeripheral,
+			DmaBase::MemoryDataSize::Byte, DmaBase::PeripheralDataSize::Byte,
+			DmaBase::MemoryIncrementMode::Increment, DmaBase::PeripheralIncrementMode::Fixed,
+			DmaBase::Priority::Medium);
+	Dma::TxChannel::disableInterruptVector();
+	Dma::TxChannel::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::transmitRegister()));
+	Dma::TxChannel::template setPeripheralRequest<Dma::TxRequest>();
+
+%% if not use_fiber
+	state = 0;
+%% endif
+
+	constexpr auto result = modm::Prescaler::from_power(SystemClock::Spi{{ id }}, baudrate, 2, 256);
+	assertBaudrateInTolerance< result.frequency, baudrate, tolerance >();
+
+	constexpr Hal::Prescaler prescaler{result.index << SPI_CFG1_MBR_Pos};
+	Hal::initialize(prescaler);
+}
+
+template <class DmaChannelRx, class DmaChannelTx>
+modm::ResumableResult<uint8_t>
+SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(uint8_t data)
+{
+	// DMA is not used for single byte transfers
+%% if use_fiber
+	Hal::setDuplexMode(Hal::DuplexMode::FullDuplex);
+	Hal::setTransferSize(1);
+	Hal::enableTransfer();
+	Hal::write(data);
+	Hal::startMasterTransfer();
+
+	// wait for transfer to complete
+	while (!Hal::isTransferCompleted())
+		modm::fiber::yield();
+
+	data = SpiHal{{ id }}::read();
+	finishTransfer();
+
+	return data;
+%% else
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (LSB of state):
+	//   1. waiting to start, and
+	//   2. waiting to finish.
+	// LSB != Bit0 ?
+	if ( !(state & Bit0) )
+	{
+		Hal::setDuplexMode(Hal::DuplexMode::FullDuplex);
+		Hal::setTransferSize(1);
+		Hal::enableTransfer();
+		Hal::write(data);
+		Hal::startMasterTransfer();
+
+		// set LSB = Bit0
+		state |= Bit0;
+	}
+
+	if (!Hal::isTransferCompleted())
+		return {modm::rf::Running};
+
+	data = SpiHal{{ id }}::read();
+	finishTransfer();
+
+	// transfer finished
+	state &= ~Bit0;
+	return {modm::rf::Stop, data};
+%% endif
+}
+
+template <class DmaChannelRx, class DmaChannelTx>
+void
+SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::startDmaTransfer(
+		const uint8_t* tx, uint8_t* rx, std::size_t length)
+{
+	Hal::setTransferSize(length);
+
+	if (tx and rx) {
+		Hal::setDuplexMode(Hal::DuplexMode::FullDuplex);
+	} else if (rx) {
+		Hal::setDuplexMode(Hal::DuplexMode::ReceiveOnly);
+	} else { // tx only
+		Hal::setDuplexMode(Hal::DuplexMode::TransmitOnly);
+	}
+
+	/*
+	 * Required order of operations according to the reference manual:
+	 * 1. Enable SPI RX DMA
+	 * 2. Enable DMA channels
+	 * 3. Enable SPI TX DMA
+	 * 4. Start transfer
+	 */
+	if (rx) {
+		Dma::RxChannel::setMemoryAddress(reinterpret_cast<uint32_t>(rx));
+		Dma::RxChannel::setDataLength(length);
+		Hal::setDmaMode(Hal::DmaMode::Rx);
+		Dma::RxChannel::start();
+	}
+
+	if (tx) {
+		Dma::TxChannel::setMemoryAddress(reinterpret_cast<uint32_t>(tx));
+		Dma::TxChannel::setDataLength(length);
+		Dma::TxChannel::start();
+		if (rx) {
+			Hal::setDmaMode(Hal::DmaMode::Tx | Hal::DmaMode::Rx);
+		} else {
+			Hal::setDmaMode(Hal::DmaMode::Tx);
+		}
+	}
+
+	Hal::enableTransfer();
+	Hal::startMasterTransfer();
+}
+
+
+template <class DmaChannelRx, class DmaChannelTx>
+modm::ResumableResult<void>
+SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
+		const uint8_t* tx, uint8_t* rx, std::size_t length)
+{
+	using Flags = DmaBase::InterruptFlags;
+%% if use_fiber
+	startDmaTransfer(tx, rx, length);
+
+	bool dmaRxFinished = (rx == nullptr);
+	while (!Hal::isTransferCompleted() or !dmaRxFinished) {
+		if(rx) {
+			const auto flags = DmaChannelRx::getInterruptFlags();
+			if (flags & Flags::Error) {
+				break;
+			}
+			if (flags & Flags::TransferComplete) {
+				dmaRxFinished = true;
+			}
+		}
+		if(tx) {
+			const auto flags = DmaChannelTx::getInterruptFlags();
+			if (flags & Flags::Error) {
+				break;
+			}
+		}
+		modm::fiber::yield();
+	}
+	finishTransfer();
+%% else
+	// this is a manually implemented "fast resumable function"
+	// there is no context or nesting protection, since we don't need it.
+	// there are only two states encoded into 1 bit (Bit1 of state):
+	//   1. initialize index, and
+	//   2. wait for 1-byte transfer to finish.
+
+	// we are only interested in Bit1
+	switch(state & Bit1)
+	{
+	case 0:
+		// we will only visit this state once
+		state |= Bit1;
+		startDmaTransfer(tx, rx, length);
+		if (!rx) {
+			state |= Bit2;
+		}
+		[[fallthrough]];
+
+	default:
+		if (!Hal::isTransferCompleted() or !(state & Bit2)) {
+			if(rx) {
+				static DmaBase::InterruptFlags_t flags;
+				flags = DmaChannelRx::getInterruptFlags();
+				if (flags & Flags::Error) {
+					// abort on DMA error
+					finishTransfer();
+					state &= ~(Bit2 | Bit1);
+					return {modm::rf::Stop};
+				}
+				if (flags & Flags::TransferComplete) {
+					state |= Bit2;
+				}
+			}
+			if(tx) {
+				if (DmaChannelTx::getInterruptFlags() & Flags::Error) {
+					// abort on DMA error
+					finishTransfer();
+					state &= ~(Bit2 | Bit1);
+					return {modm::rf::Stop};
+				}
+			}
+			return { modm::rf::Running };
+		}
+
+		finishTransfer();
+
+		// clear the state
+		state &= ~(Bit2 | Bit1);
+		return {modm::rf::Stop};
+	}
+%% endif
+}
+
+template <class DmaChannelRx, class DmaChannelTx>
+void
+SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::finishTransfer()
+{
+	DmaChannelTx::stop();
+	DmaChannelRx::stop();
+
+	Hal::setDmaMode(Hal::DmaMode::None);
+	Hal::disableTransfer();
+
+	Hal::acknowledgeInterruptFlags(
+		Hal::StatusFlag::EndOfTransfer |
+		Hal::StatusFlag::TxTransferFilled |
+		Hal::StatusFlag::Underrun |
+		Hal::StatusFlag::Overrun |
+		Hal::StatusFlag::CrcError |
+		Hal::StatusFlag::TiFrameError |
+		Hal::StatusFlag::ModeFault |
+		Hal::StatusFlag::Reload |
+		Hal::StatusFlag::Suspension
+	);
+}
+
+} // namespace modm::platform

--- a/src/modm/processing/fiber/module.lb
+++ b/src/modm/processing/fiber/module.lb
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2020, Erik Henriksson
-# Copyright (c) 2021, Christopher Durand
+# Copyright (c) 2021-2023, Christopher Durand
 # Copyright (c) 2021, Niklas Hauser
 #
 # This file is part of the modm project.
@@ -16,9 +16,16 @@ def init(module):
     module.name = ":processing:fiber"
     module.description = FileReader("module.md")
 
+def is_enabled(env):
+    return env.get(":processing:protothread:use_fiber", False) or \
+        not env.has_module(":processing:protothread")
 
 def prepare(module, options):
     module.depends(":processing:timer")
+
+    module.add_query(
+        EnvironmentQuery(name="__enabled", factory=is_enabled))
+
     # No ARM64 support yet!
     return "arm64" not in options[":target"].get_driver("core")["type"]
 

--- a/src/modm/processing/resumable/module.lb
+++ b/src/modm/processing/resumable/module.lb
@@ -29,7 +29,7 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/processing/resumable"
-    if env.get(":processing:protothread:use_fiber", False):
+    if env.query(":processing:fiber:__enabled", False):
         env.copy("macros_fiber.hpp", "macros.hpp")
         env.copy("resumable_fiber.hpp", "resumable.hpp")
     else:


### PR DESCRIPTION
- [x] STM32H7 SPI with DMA
- [x] Add interface to DMA driver to read transfer status
- [x] BMI088 IMU
  - [x] Driver
  - [x] SPI example
  - [x] I²C example
  - [x] Add documentation
- [x] Fix spurious EXTI interrupts with multiple enabled lines sharing the same IRQ
- [x] Fix compilation of `Exti::disconnect()`
- [x] Move identical copy-pasted `SpiMaster::acquire()/release()` code out of drivers
- [x] Allow use of SPI with fibers without `:processing:protothread` module