### PR TITLE
[stm32] Fix STM32G0 ADC

### DIFF
--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -28,6 +28,11 @@ modm::platform::Adc{{ id }}::initialize()
 {
 	Rcc::enable<Peripheral::Adc{{ id }}>();
 
+%% if target.family in ["g0"]
+	ADC1->CR |= ADC_CR_ADVREGEN;
+	modm::delay_us(20);
+%% endif
+
 	if constexpr (mode == ClockMode::Synchronous) {
 		constexpr auto result = Prescaler::from_power(
 				SystemClock::Apb, frequency, {{2 if target.family in ["f0"] else 1}}, 4);


### PR DESCRIPTION
The driver has probably never been tested with G0. The ADC voltage regulator is not enabled and calibration never completes.