### PR TITLE
[driver] Adding SpiStack Flash

### DIFF
--- a/examples/nucleo_f429zi/spi_flash/main.cpp
+++ b/examples/nucleo_f429zi/spi_flash/main.cpp
@@ -107,24 +107,24 @@ main()
 	std::memset(bufferB, 0x55, BlockSize);
 
 	bool initializeSuccess = false;
-
-	MODM_LOG_INFO << "Erasing complete flash chip... (This may take a while)" << modm::endl;
-
-	if(!RF_CALL_BLOCKING(storageDevice.initialize())) {
+	if (RF_CALL_BLOCKING(storageDevice.initialize())) {
+		MODM_LOG_INFO << "Erasing complete flash chip... (This may take a while)" << modm::endl;
+		if (RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
+			RF_CALL_BLOCKING(storageDevice.waitWhileBusy());
+			initializeSuccess = true;
+		} else {
+			MODM_LOG_INFO << "Error: Unable to erase device.";
+		}
+	} else {
 		MODM_LOG_INFO << "Error: Unable to initialize device.";
 	}
-	else if(!RF_CALL_BLOCKING(storageDevice.erase(0, MemorySize))) {
-		MODM_LOG_INFO << "Error: Unable to erase device.";
-	}
-	else {
+
+	if (initializeSuccess) {
 		auto id = RF_CALL_BLOCKING(storageDevice.readId());
 		MODM_LOG_INFO << "deviceId=" << id.deviceId << " manufacturerId=" << id.manufacturerId;
-		MODM_LOG_INFO << " deviceType=" << id.deviceType << modm::endl;
-
+		MODM_LOG_INFO << "deviceType=" << id.deviceType << modm::endl;
 		MODM_LOG_INFO << "status=" << static_cast<uint8_t>(RF_CALL_BLOCKING(storageDevice.readStatus())) << modm::endl;
-
 		MODM_LOG_INFO << "Press USER button to start the memory test." << modm::endl;
-		initializeSuccess = true;
 	}
 
 	while (true)

--- a/examples/nucleo_f429zi/spistack_flash/main.cpp
+++ b/examples/nucleo_f429zi/spistack_flash/main.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2023, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+#include <modm/driver/storage/block_device_spiflash.hpp>
+#include <modm/driver/storage/block_device_spistack_flash.hpp>
+
+using namespace Board;
+
+void printMemoryContent(const uint8_t* address, std::size_t size) {
+	for (std::size_t i = 0; i < size; i++) {
+		MODM_LOG_INFO.printf("%x", address[i]);
+	}
+}
+
+using SpiMaster = SpiMaster1;
+
+// Spi flash chip wiring:
+using Cs = GpioA4;
+using Mosi = GpioB5;
+using Miso = GpioB4;
+using Sck = GpioB3;
+// Connect WP and HOLD pins to +3V3
+// and of course Vdd to +3V3 and Vss to GND
+
+
+constexpr uint32_t BlockSize = 256;
+constexpr uint32_t DieSize = 32*1024*1024;
+constexpr uint32_t DieCount = 2;
+constexpr uint32_t MemorySize = DieCount * DieSize;
+constexpr uint32_t TestMemorySize = 4*1024;
+constexpr uint32_t TestMemoryAddress[] = {0, DieSize - TestMemorySize, DieSize, MemorySize - TestMemorySize};
+
+uint8_t bufferA[BlockSize];
+uint8_t bufferB[BlockSize];
+uint8_t bufferC[BlockSize];
+
+using BdSpiFlash = modm::BdSpiFlash<SpiMaster, Cs, DieSize>;
+using BdSpiStackFlash = modm::BdSpiStackFlash<BdSpiFlash, DieCount>;
+
+BdSpiFlash storageDevice;
+BdSpiStackFlash storageDeviceStack;
+
+void doMemoryTest()
+{
+	LedBlue::set();
+	MODM_LOG_INFO << "Starting memory test!" << modm::endl;
+
+		for(uint16_t iteration = 0; iteration < 4; iteration++) {
+
+		for(const uint32_t address : TestMemoryAddress) {
+
+			auto dv = std::ldiv(address, DieSize);
+			uint8_t* pattern = (iteration % 2 == dv.quot) ? bufferA : bufferB;
+			if(!RF_CALL_BLOCKING(storageDeviceStack.erase(address, TestMemorySize))) {
+				MODM_LOG_INFO << "Error: Unable to erase device.";
+				return;
+			}
+
+			for(uint32_t i = 0; i < TestMemorySize; i += BlockSize) {
+				if(!RF_CALL_BLOCKING(storageDeviceStack.program(pattern, address + i, BlockSize))) {
+					MODM_LOG_INFO << "Error: Unable to write data.";
+					return;
+				}
+				MODM_LOG_INFO << ".";
+			}
+		}
+
+		for(const uint32_t address : TestMemoryAddress) {
+
+			auto dv = std::ldiv(address, DieSize);
+			uint8_t* pattern = (iteration % 2 == dv.quot) ? bufferA : bufferB;
+			for(uint32_t i = 0; i < TestMemorySize; i += BlockSize) {
+				if(!RF_CALL_BLOCKING(storageDeviceStack.read(bufferC, address + i, BlockSize))) {
+					MODM_LOG_INFO << "Error: Unable to read data.";
+					return;
+				}
+				else if(std::memcmp(pattern, bufferC, BlockSize)) {
+					MODM_LOG_INFO << "i=" << i << modm::endl;
+					MODM_LOG_INFO << "Error: Read '";
+					printMemoryContent(bufferC, BlockSize);
+					MODM_LOG_INFO << "', expected: '";
+					printMemoryContent(pattern, BlockSize);
+					MODM_LOG_INFO << "'." << modm::endl;
+					return;
+				}
+			}
+		}
+
+		MODM_LOG_INFO << "." << modm::endl;
+	}
+
+	MODM_LOG_INFO << modm::endl << "Finished!" << modm::endl;
+	LedBlue::reset();
+}
+
+int
+main()
+{
+	/**
+	 * This example/test writes alternating patterns to a 256 MBit
+	 * stacked die flash chip (W25M512VJ) attached to SPI0 using the
+	 * `modm::BdSpiStackFlash` block device interface.
+	 * The memory content is afterwards read and compared
+	 * to the pattern.
+	 * Write and read operations are done on 64 byte blocks.
+	 *
+	 * See above for how to wire the flash chip.
+	 */
+
+	// initialize board and SPI
+	Board::initialize();
+	SpiMaster::connect<Mosi::Mosi, Miso::Miso, Sck::Sck>();
+	SpiMaster::initialize<Board::SystemClock, 11_MHz>();
+
+	std::memset(bufferA, 0xAA, BlockSize);
+	std::memset(bufferB, 0x55, BlockSize);
+
+	bool initializeSuccess = false;
+	if (RF_CALL_BLOCKING(storageDeviceStack.initialize())) {
+		MODM_LOG_INFO << "Erasing complete flash chip... (This may take a while)" << modm::endl;
+		if (RF_CALL_BLOCKING(storageDeviceStack.erase(0, MemorySize))) {
+			RF_CALL_BLOCKING(storageDeviceStack.waitWhileBusy());
+			initializeSuccess = true;
+		} else {
+			MODM_LOG_INFO << "Error: Unable to erase device.";
+		}
+	} else {
+		MODM_LOG_INFO << "Error: Unable to initialize device.";
+	}
+
+	if (initializeSuccess) {
+		auto id = RF_CALL_BLOCKING(storageDevice.readId());
+		MODM_LOG_INFO << "deviceId=" << id.deviceId << " manufacturerId=" << id.manufacturerId;
+		MODM_LOG_INFO << "deviceType=" << id.deviceType << modm::endl;
+		MODM_LOG_INFO << "status=" << static_cast<uint8_t>(RF_CALL_BLOCKING(storageDevice.readStatus())) << modm::endl;
+		MODM_LOG_INFO << "Press USER button to start the memory test." << modm::endl;
+	}
+
+	while (true)
+	{
+		if(initializeSuccess && Button::read())
+		{
+			doMemoryTest();
+		}
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f429zi/spistack_flash/project.xml
+++ b/examples/nucleo_f429zi/spistack_flash/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-f429zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f429zi/spistack_flash</option>
+  </options>
+  <modules>
+    <module>modm:driver:block.device:spi.flash</module>
+    <module>modm:driver:block.device:spi.stack.flash</module>
+    <module>modm:platform:spi:1</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/driver/storage/block_device.lb
+++ b/src/modm/driver/storage/block_device.lb
@@ -71,6 +71,21 @@ Microchip SST26VF064B 64MBit flash chip in SOIJ-8, WDFN-8 or SOIC-16.
         env.copy("block_device_spiflash_impl.hpp")
 # -----------------------------------------------------------------------------
 
+class BlockDeviceSpiStackFlash(Module):
+    def init(self, module):
+        module.name = "spi.stack.flash"
+        module.description = "SpiStack homogeneous flash memory"
+
+    def prepare(self, module, options):
+        module.depends(":architecture:block.device")
+        return True
+
+    def build(self, env):
+        env.outbasepath = "modm/src/modm/driver/storage"
+        env.copy("block_device_spistack_flash.hpp")
+        env.copy("block_device_spistack_flash_impl.hpp")
+# -----------------------------------------------------------------------------
+
 def init(module):
     module.name = ":driver:block.device"
     module.description = "Block Devices"
@@ -80,6 +95,7 @@ def prepare(module, options):
     module.add_submodule(BlockDeviceHeap())
     module.add_submodule(BlockDeviceMirror())
     module.add_submodule(BlockDeviceSpiFlash())
+    module.add_submodule(BlockDeviceSpiStackFlash())
     return True
 
 def build(env):

--- a/src/modm/driver/storage/block_device_spiflash_impl.hpp
+++ b/src/modm/driver/storage/block_device_spiflash_impl.hpp
@@ -118,12 +118,17 @@ modm::BdSpiFlash<Spi, Cs, flashSize>::erase(bd_address_t address, bd_size_t size
 		RF_RETURN(false);
 	}
 
-	index = 0;
-	while(index < size) {
-		RF_CALL(spiOperation(Instruction::WE));
-		RF_CALL(spiOperation(Instruction::SE, address + index));
+	if (address == 0 && size == flashSize) {
+		RF_CALL(spiOperation(Instruction::CE));
 		RF_CALL(waitWhileBusy());
-		index += BlockSizeErase;
+	} else {
+		index = 0;
+		while(index < size) {
+			RF_CALL(spiOperation(Instruction::WE));
+			RF_CALL(spiOperation(Instruction::SE, address + index));
+			RF_CALL(waitWhileBusy());
+			index += BlockSizeErase;
+		}
 	}
 
 	RF_END_RETURN(true);

--- a/src/modm/driver/storage/block_device_spiflash_impl.hpp
+++ b/src/modm/driver/storage/block_device_spiflash_impl.hpp
@@ -77,6 +77,8 @@ modm::BdSpiFlash<Spi, Cs, flashSize>::read(uint8_t* buffer, bd_address_t address
 
 	if((size == 0) || (size % BlockSizeRead != 0) || (address + size > flashSize)) {
 		RF_RETURN(false);
+	} else {
+		RF_CALL(waitWhileBusy());
 	}
 
 	RF_CALL(spiOperation(Instruction::FR, address, nullptr, buffer, size, 1));
@@ -93,13 +95,14 @@ modm::BdSpiFlash<Spi, Cs, flashSize>::program(const uint8_t* buffer, bd_address_
 
 	if((size == 0) || (size % BlockSizeWrite != 0) || (address + size > flashSize)) {
 		RF_RETURN(false);
+	} else {
+		RF_CALL(waitWhileBusy());
 	}
 
 	index = 0;
 	while(index < size) {
 		RF_CALL(spiOperation(Instruction::WE));
 		RF_CALL(spiOperation(Instruction::PP, address + index, &buffer[index], nullptr, BlockSizeWrite));
-		RF_CALL(waitWhileBusy());
 		index += BlockSizeWrite;
 	}
 
@@ -116,17 +119,17 @@ modm::BdSpiFlash<Spi, Cs, flashSize>::erase(bd_address_t address, bd_size_t size
 
 	if((size == 0) || (size % BlockSizeErase != 0) || (address + size > flashSize)) {
 		RF_RETURN(false);
+	} else {
+		RF_CALL(waitWhileBusy());
 	}
 
 	if (address == 0 && size == flashSize) {
 		RF_CALL(spiOperation(Instruction::CE));
-		RF_CALL(waitWhileBusy());
 	} else {
 		index = 0;
 		while(index < size) {
 			RF_CALL(spiOperation(Instruction::WE));
 			RF_CALL(spiOperation(Instruction::SE, address + index));
-			RF_CALL(waitWhileBusy());
 			index += BlockSizeErase;
 		}
 	}
@@ -175,6 +178,8 @@ modm::BdSpiFlash<Spi, Cs, flashSize>::selectDie(uint8_t die)
 	RF_BEGIN();
 
 	RF_CALL(spiOperation(Instruction::SDS, &die, nullptr, 1));
+	RF_CALL(waitWhileBusy());
+
 	RF_CALL(spiOperation(Instruction::WE));
 	RF_CALL(spiOperation(Instruction::GBU));
 	RF_CALL(waitWhileBusy());

--- a/src/modm/driver/storage/block_device_spistack_flash.hpp
+++ b/src/modm/driver/storage/block_device_spistack_flash.hpp
@@ -1,0 +1,125 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2018, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_BLOCK_DEVICE_SPISTACK_FLASH_HPP
+#define MODM_BLOCK_DEVICE_SPISTACK_FLASH_HPP
+
+#include <algorithm>
+#include <cstdlib>
+
+#include <modm/architecture/interface/block_device.hpp>
+#include <modm/processing/resumable.hpp>
+
+namespace modm
+{
+
+/**
+ * \brief	SpiStack homogenoues memory
+ *
+ * The `read()`, `erase()`,`program()` and `write()` methodes wait for
+ * the chip to finish writing to the flash.
+ *
+ * \tparam SpiBlockDevice		Base SPI block device of the homogenous stack
+ *
+ * \ingroup	modm_driver_block_device_spi_stack_flash
+ * \author	Rasmus Kleist Hørlyck Sørensen
+ */
+template <typename SpiBlockDevice, uint8_t DieCount>
+class BdSpiStackFlash : public modm::BlockDevice, protected NestedResumable<3>
+{
+public:
+	/// Initializes the storage hardware
+	modm::ResumableResult<bool>
+	initialize();
+
+	/// Deinitializes the storage hardware
+	modm::ResumableResult<bool>
+	deinitialize();
+
+	/** Read data from one or more blocks
+	 *
+	 *  @param buffer	Buffer to read data into
+	 *  @param address	Address to begin reading from
+	 *  @param size		Size to read in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	modm::ResumableResult<bool>
+	read(uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Program blocks with data
+	 *
+	 *  Any block has to be erased prior to being programmed
+	 *
+	 *  @param buffer	Buffer of data to write to blocks
+	 *  @param address	Address of first block to begin writing to
+	 *  @param size		Size to write in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	modm::ResumableResult<bool>
+	program(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+	/** Erase blocks
+	 *
+	 *  The state of an erased block is undefined until it has been programmed
+	 *
+	 *  @param address	Address of block to begin erasing
+	 *  @param size		Size to erase in bytes (multiple of read block size)
+	 *  @return			True on success
+	 */
+	modm::ResumableResult<bool>
+	erase(bd_address_t address, bd_size_t size);
+
+	/** Writes data to one or more blocks after erasing them
+	*
+	*  The blocks are erased prior to being programmed
+	*
+	*  @param buffer	Buffer of data to write to blocks
+	*  @param address	Address of first block to begin writing to
+	*  @param size		Size to write in bytes (multiple of read block size)
+	*  @return			True on success
+	*/
+	modm::ResumableResult<bool>
+	write(const uint8_t* buffer, bd_address_t address, bd_size_t size);
+
+public:
+	/** Check if device is busy
+	 *
+	 * @return True if any die in the stack is busy.
+	 */
+	modm::ResumableResult<bool>
+	isBusy();
+
+	/** This function can be used in another resumable function
+	 * to wait until the flash operation is finished.
+	 */
+	modm::ResumableResult<void>
+	waitWhileBusy();
+
+public:
+	static constexpr bd_size_t BlockSizeRead = SpiBlockDevice::BlockSizeRead;
+	static constexpr bd_size_t BlockSizeWrite = SpiBlockDevice::BlockSizeWrite;
+	static constexpr bd_size_t BlockSizeErase = SpiBlockDevice::BlockSizeErase;
+	static constexpr bd_size_t DieSize = SpiBlockDevice::DeviceSize;
+	static constexpr bd_size_t DeviceSize = DieCount * DieSize;
+
+private:
+	std::ldiv_t dv;
+	uint32_t index;
+	uint8_t currentDie;
+	SpiBlockDevice spiBlockDevice;
+};
+
+} // namespace modm
+
+#include "block_device_spistack_flash_impl.hpp"
+
+#endif // MODM_BLOCK_DEVICE_SPISTACK_FLASH_HPP

--- a/src/modm/driver/storage/block_device_spistack_flash_impl.hpp
+++ b/src/modm/driver/storage/block_device_spistack_flash_impl.hpp
@@ -1,0 +1,180 @@
+// coding: utf-8
+/*
+ * Copyright (c) 2023, Rasmus Kleist Hørlyck Sørensen
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_BLOCK_DEVICE_SPISTACK_FLASH_HPP
+#error	"Don't include this file directly, use 'block_device_spistack_flash.hpp' instead!"
+#endif
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::initialize()
+{
+	RF_BEGIN();
+
+	if (RF_CALL(spiBlockDevice.initialize())) {
+		RF_CALL(spiBlockDevice.selectDie(currentDie = 0x00));
+		RF_RETURN(true);
+	}
+
+	RF_END_RETURN(false);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::deinitialize()
+{
+	RF_BEGIN();
+	RF_END_RETURN_CALL(spiBlockDevice.deinitialize());
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::read(uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeRead != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	index = 0;
+	while (index < size) {
+		dv = std::ldiv(index + address, DieSize); // dv.quot = die #ID, dv.rem = die address
+		if (currentDie != dv.quot) {
+			RF_CALL(spiBlockDevice.selectDie(currentDie = dv.quot));
+		}
+		if (RF_CALL(spiBlockDevice.read(&buffer[index], dv.rem, std::min(size - index, DieSize - dv.rem)))) {
+			index += DieSize - dv.rem; // size - index <= DieSize - dv.rem only on last iteration!
+		} else {
+			RF_RETURN(false);
+		}
+	}
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::program(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	index = 0;
+	while (index < size) {
+		dv = std::ldiv(index + address, DieSize); // dv.quot = die #ID, dv.rem = die address
+		if (currentDie != dv.quot) {
+			RF_CALL(spiBlockDevice.selectDie(currentDie = dv.quot));
+		}
+		if (RF_CALL(spiBlockDevice.program(&buffer[index], dv.rem, std::min(size - index, DieSize - dv.rem)))) {
+			index += DieSize - dv.rem; // size - index <= DieSize - dv.rem only on last iteration!
+		} else {
+			RF_RETURN(false);
+		}
+	}
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::erase(bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	index = 0;
+	while (index < size) {
+		dv = std::ldiv(index + address, DieSize); // dv.quot = die #ID, dv.rem = die address
+		if (currentDie != dv.quot) {
+			RF_CALL(spiBlockDevice.selectDie(currentDie = dv.quot));
+		}
+		if (RF_CALL(spiBlockDevice.erase(dv.rem, std::min(size - index, DieSize - dv.rem)))) {
+			index += DieSize - dv.rem; // size - index <= DieSize - dv.rem only on last iteration!
+		} else {
+			RF_RETURN(false);
+		}
+	}
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::write(const uint8_t* buffer, bd_address_t address, bd_size_t size)
+{
+	RF_BEGIN();
+
+	if((size == 0) || (size % BlockSizeErase != 0) || (size % BlockSizeWrite != 0) || (address + size > DeviceSize)) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->erase(address, size))) {
+		RF_RETURN(false);
+	}
+
+	if(!RF_CALL(this->program(buffer, address, size))) {
+		RF_RETURN(false);
+	}
+
+	RF_END_RETURN(true);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<bool>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::isBusy()
+{
+	RF_BEGIN();
+
+	currentDie = DieCount;
+	while (currentDie > 0) {
+		RF_CALL(spiBlockDevice.selectDie(--currentDie));
+		if (RF_CALL(spiBlockDevice.isBusy())) {
+			RF_RETURN(true);
+		}
+	}
+
+	RF_END_RETURN(false);
+}
+
+// ----------------------------------------------------------------------------
+
+template <typename SpiBlockDevice, uint8_t DieCount>
+modm::ResumableResult<void>
+modm::BdSpiStackFlash<SpiBlockDevice, DieCount>::waitWhileBusy()
+{
+	RF_BEGIN();
+	while(RF_CALL(isBusy())) {
+		RF_YIELD();
+	}
+	RF_END();
+}

--- a/tools/scripts/synchronize_docs.py
+++ b/tools/scripts/synchronize_docs.py
@@ -77,7 +77,7 @@ def name(raw_name):
                    .replace("SPI-FLASH", "SPI Flash")\
                    .replace("-SPI", "")
     if result in ["DEVICE", "LIS3-TRANSPORT", "MEMORY-BUS", "TERMINAL", "ALLOCATOR",
-                  "MIRROR", "ADC-SAMPLER", "FAT", "HEAP", "--PYCACHE--", "FILE"]:
+                  "MIRROR", "ADC-SAMPLER", "FAT", "HEAP", "--PYCACHE--", "FILE", "SPI-STACK-FLASH"]:
         return None
     return result
 


### PR DESCRIPTION
I have changed the implementation of the BdSpiFlash to use the W25M512JV instruction set as discussed in #890. In addition, I have added a wrapper that makes the stacked die seem like a contiguous piece of memory for homogenous storage devices. This was also discussed in #890, although my implementation is somewhat different. 

Currently, the dieSelect function does more than I probably want it to, so I would like your opinion on the following alternative implementation.

1. Set/reset ADP bit before device reset inside the initialize function. I believe that this should cause all dies to enter the desired addressing mode upon device reset. However, not all devices implement WSR3 command, but in those cases this will probably be a NOP. Alternatively, the ADP bit can be set only for devices larger than 16MB. 
2. Do not reset the device inside the initialize function and implement a seperate reset function. With the stacked dies a reset casues all dies to enter the addressing mode specified by the ADP bit. In the initialize function the device should then enter 4B addressing, and inside BdSpiStack, a loop should then initialize all dies. Here En4BAM is only called when the device size is larger than 16MB
3. Enter/Exit 4B addressing on every die select depending on the device size as currently implemented. This does add some overhead on each dieSelect.
4. Use 4B commands e.g. PP4BA for devices larger than 16MB. This makes it very explicit to the device that 4B addressing is being used. However, logic will have to be implemented in both the spiOperations function and the read, program and erase functions.
5. Use extended address register for 4B addressing. This is only for backward compatability with devices prior to 2011, so I think it is not worth considering.

Finally, the current implementation waits for the BUSY bit to clear after issuing a command. Although I do find it nice that the operation finishes before returning, it does block the driver from issuing commands that can be done while busy. For example with the SpiStack concurrent operations can be performed. Therefore I like your opinion on waiting for the BUSY bit to clear in the program and erase function before issuing the command? Thereby I can select another die and double the troughput. However, I should add that the performance gain is probably very small in practice unless I change the BdSpiStack addressing to be modulo erase block. This could possibly double the throughput, but since I do not know my own throughput at the moment, this is possibly better suited for a later PR!
