### PR TITLE
Fix incorrect register indices in HMC58x3-based drivers

### DIFF
--- a/src/modm/driver/inertial/hmc58x3.hpp
+++ b/src/modm/driver/inertial/hmc58x3.hpp
@@ -47,9 +47,9 @@ protected:
 		DataZ_Lsb = 0x07,
 		DataZ_Msb = 0x08,
 		Status = 0x09,
-		IdA = 0x10,
-		IdB = 0x11,
-		IdC = 0x12,
+		IdA = 0x0a,
+		IdB = 0x0b,
+		IdC = 0x0c,
 	};
 	/// @endcond
 


### PR DESCRIPTION
Fixed according to the datasheet which can be found at https://cdn-shop.adafruit.com/datasheets/HMC5883L_3-Axis_Digital_Compass_IC.pdf