### PR TITLE
[stm32] EXTI fixes 

### DIFF
--- a/src/modm/platform/extint/stm32/exti.cpp.in
+++ b/src/modm/platform/extint/stm32/exti.cpp.in
@@ -20,6 +20,11 @@ Exti::handlers[Exti::Lines] modm_fastdata;
 void Exti::irq(uint32_t mask)
 {
 	uint32_t flags = EXTI->IMR{{"1" if (extended or separate_flags) else ""}} & mask;
+%% if separate_flags
+	flags &= (EXTI->FPR1 & EXTI->FTSR1) | (EXTI->RPR1 & EXTI->RTSR1);
+%% else
+	flags &= EXTI->PR{{"1" if extended else ""}};
+%% endif
 	while(flags)
 	{
 		const uint8_t lmb = 31ul - __builtin_clz(flags);

--- a/src/modm/platform/extint/stm32/exti.hpp.in
+++ b/src/modm/platform/extint/stm32/exti.hpp.in
@@ -268,7 +268,7 @@ public:
 		NVIC_DisableIRQ(IRQn_Type(vector));
 	}
 	template< class Pin > static void
-	disableVector(uint8_t priority) { disableVector(getVectorForLine(Pin::pin)); }
+	disableVector() { disableVector(getVectorForLine(Pin::pin)); }
 
 	inline static void
 	disableVectors(MaskType mask)


### PR DESCRIPTION
Fix spurious EXTI interrupts with multiple enabled lines sharing the same IRQ
Fix compilation of Exti::disconnect()

These commits were cherry-picked from #1052