### PR TITLE
[board] Default putchar_ to use the board logger

### DIFF
--- a/examples/stm32f469_discovery/printf/main.cpp
+++ b/examples/stm32f469_discovery/printf/main.cpp
@@ -11,16 +11,6 @@
 
 #include <modm/board.hpp>
 
-extern "C"
-void putchar_(char c)
-{
-	// Redirect the printf output to UART.
-	Board::stlink::Uart::write(c);
-	// or IOStream if the board already has a logger
-	// MODM_LOG_INFO << c;
-}
-
-// ----------------------------------------------------------------------------
 int
 main()
 {

--- a/src/modm/board/board.cpp.in
+++ b/src/modm/board/board.cpp.in
@@ -14,7 +14,7 @@
 %% if with_assert
 #include <modm/architecture/interface/assert.hpp>
 %% endif
-
+%#
 %% if with_logger
 Board::LoggerDevice loggerDevice;
 
@@ -23,8 +23,15 @@ modm::log::Logger modm::log::debug(loggerDevice);
 modm::log::Logger modm::log::info(loggerDevice);
 modm::log::Logger modm::log::warning(loggerDevice);
 modm::log::Logger modm::log::error(loggerDevice);
-%% endif
 
+// Default all calls to printf to the UART
+modm_extern_c void
+putchar_(char c)
+{
+	loggerDevice.write(c);
+}
+%% endif
+%#
 %% if with_assert
 modm_extern_c void
 modm_abandon(const modm::AssertionInfo &info)

--- a/src/modm/board/module.md
+++ b/src/modm/board/module.md
@@ -25,7 +25,8 @@ The BSPs all use a common interface within a top-level `namespace Board`:
   `modm::platform::Gpio{port}{pin}`.
 
 If the board supports a dedicated serial logging output the BSP redirects the
-`modm:debug` module debug stream `MODM_LOG_INFO` etc.
+`modm:debug` module debug stream `MODM_LOG_INFO` as well as the output of the
+standalone `printf` function.
 
 Please note that YOU must explicitly call the `Board` functions to initialize
 your hardware, just including the board module is not enough.


### PR DESCRIPTION
This defines a `putchar_` function to redirect any `printf` calls to the board logger.
Not sure why this was missing, but better late than never.