### PR TITLE
Improve file names processing in clang-format.sh

### DIFF
--- a/tools/scripts/clang-format.sh
+++ b/tools/scripts/clang-format.sh
@@ -8,4 +8,4 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #----------------------------------------------------------------------------
 
-git diff --name-only --diff-filter=A -C -M develop | grep -e "\.\(c\|h\|hpp\|cpp\)\$" | xargs clang-format -i "$@"
+git diff --name-only --diff-filter=A -C -M develop | grep -e "\.\(c\|h\|cc\|hh\|hpp\|cpp\)\$" | xargs -r clang-format -i "$@"


### PR DESCRIPTION
- Process .cc and .hh files.
- Ignore empty file list.