### PR TITLE
LM75 temp sensor: fix utils/endianness dependency

### DIFF
--- a/src/modm/driver/temperature/lm75.hpp
+++ b/src/modm/driver/temperature/lm75.hpp
@@ -16,6 +16,7 @@
 
 #include <modm/architecture/interface/register.hpp>
 #include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/math/utils/endianness.hpp>
 
 namespace modm
 {

--- a/src/modm/driver/temperature/lm75.lb
+++ b/src/modm/driver/temperature/lm75.lb
@@ -29,7 +29,8 @@ hardcoded into the sensor and cannot be changed.
 def prepare(module, options):
     module.depends(
         ":architecture:i2c.device",
-        ":architecture:register")
+        ":architecture:register",
+        ":math:utils")
     return True
 
 def build(env):


### PR DESCRIPTION
The `#include <.../utils/endianness.hpp>`  and lbuild dependency was missing.