### PR TITLE
modm CMake module aspart of a multi application project

### DIFF
--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -91,7 +91,7 @@ def build(env):
 
     def flag_format(flag):
         subs = {
-            "target_base": "${CMAKE_PROJECT_NAME}",
+            "target_base": "${PROJECT_NAME}",
             "project_source_dir": "${CMAKE_SOURCE_DIR}",
             "gccpath": "${MODM_GCC_PATH}",
         }


### PR DESCRIPTION
# WIP - no merge

CMAKE_PROJECT_NAME is a "global" project name while PROJECT_NAME is the current (local) project name.