### PR TITLE
[stm32] Place stack in SRAM by default on H7, add lbuild option

### DIFF
--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -31,7 +31,11 @@ SECTIONS
 %% set dtcm_section = "DTCM"
 %% endif
 
+%% if stack_in_dtcm
 {{ linker.section_stack(dtcm_section) }}
+%% else
+{{ linker.section_stack(cont_ram.cont_name|upper) }}
+%% endif
 
 %% if "dtcm" in cont_ram.cont_name
 {{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -30,6 +30,15 @@ def prepare(module, options):
                 default="rom")
             )
 
+    if options[":target"].identifier.family == "h7":
+        module.add_option(
+            EnumerationOption(
+                name="main_stack_location",
+                description="SRAM (default) or DTCM (faster, but not DMA-capable)",
+                enumeration=["sram", "dtcm"],
+                default="sram")
+            )
+
     module.depends(":platform:cortex-m")
     return True
 
@@ -100,5 +109,6 @@ def post_build(env):
                 linkerscript = "dccm.ld.in"
         elif memory["name"] == "dtcm":
             # Executable ITCM and DTCM (Tightly-Coupled Memory)
+            env.substitutions["stack_in_dtcm"] = env.get(":platform:core:main_stack_location", "dtcm") == "dtcm"
             linkerscript = "idtcm.ld.in"
     env.template(linkerscript, "linkerscript.ld")

--- a/tools/build_script_generator/scons/site_tools/xpcc_generator.py
+++ b/tools/build_script_generator/scons/site_tools/xpcc_generator.py
@@ -135,13 +135,14 @@ def xpcc_communication_header(env, xmlfile, container, path=None, dtdPath=None, 
 # -----------------------------------------------------------------------------
 def generate(env, **kw):
 	env.SetDefault(XPCC_SYSTEM_DESIGN_SCANNERS = {})
+	env.SetDefault(PYTHON3 = sys.executable)
 	env['XPCC_SYSTEM_DESIGN_SCANNERS']['XML'] = SCons.Script.Scanner(
 					function = xml_include_scanner,
 					skeys = ['.xml'])
 	env['BUILDERS']['SystemCppPackets'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_packets.py" ' \
+				'$PYTHON3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_packets.py" ' \
 					'--source_path ${TARGETS[0].dir} ' \
 					'--header_path ${TARGETS[1].dir} ' \
 					'--dtdpath "${dtdPath}" ' \
@@ -158,7 +159,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppIdentifier'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_identifier.py" ' \
+				'$PYTHON3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_identifier.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \
@@ -174,7 +175,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppPostman'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_postman.py" ' \
+				'$PYTHON3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_postman.py" ' \
 					'--container "${container}" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
@@ -191,7 +192,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppCommunication'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_communication.py" ' \
+				'$PYTHON3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_communication.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \
@@ -207,7 +208,7 @@ def generate(env, **kw):
 	env['BUILDERS']['SystemCppXpccTaskCaller'] = \
 		SCons.Script.Builder(
 			action = SCons.Action.Action(
-				'python3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_xpcc_task_caller.py" ' \
+				'$PYTHON3 "${XPCC_SYSTEM_DESIGN}/builder/cpp_xpcc_task_caller.py" ' \
 					'--outpath ${TARGET.dir} ' \
 					'--dtdpath "${dtdPath}" ' \
 					'--namespace "${namespace}" ' \


### PR DESCRIPTION
The DTCM is not accessible by regular DMA on H7 devices, which leads to DMA transfer errors when DMA buffers are allocated on the stack. The default stack location is changed to the D1 SRAM. An lbuild option is added to select the stack location between SRAM and DTCM.