### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/src/modm/platform/adc/stm32f3/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc.hpp.in
@@ -163,8 +163,8 @@ public:
 	// ADCs clock source selection
 	enum class ClockSource : uint32_t
 	{
-		NoClock = 0, // No clock selected.
 %% if target["family"] in ["g4"]
+		NoClock = 0, // No clock selected.
 %% if id in [1, 2]
 		Pll = RCC_{{ ccipr }}_ADC12SEL_0, // PLL “P” clock selected as ADC clock
 		SystemClock = RCC_{{ ccipr }}_ADC12SEL_1 , // System clock selected as ADCs clock
@@ -172,7 +172,13 @@ public:
 		Pll = RCC_{{ ccipr }}_ADC345SEL_0, // PLL “P” clock selected as ADC clock
 		SystemClock = RCC_{{ ccipr }}_ADC345SEL_1 , // System clock selected as ADCs clock
 %% endif
+%% elif target["family"] in ["h7"]
+		Pll2P = 0,
+		Pll3R = RCC_{{ ccipr }}_ADCSEL_0,
+		PerClk = RCC_{{ ccipr }}_ADCSEL_1,
+		NoClock = PerClk, // for compatibility if sync. clock is used and setting is ignored
 %% else
+		NoClock = 0, // No clock selected.
 		PllSai1 = RCC_{{ ccipr }}_ADCSEL_0, // PLLSAI1 "R" clock (PLLADC1CLK) selected as ADCs clock
 %% if target["family"] != "l5"
 		PllSai2 = RCC_{{ ccipr }}_ADCSEL_1, // PLLSAI2 "R" clock (PLLADC2CLK) selected as ADCs clock
@@ -337,7 +343,11 @@ public:
 	static inline void
 	initialize(	const ClockMode clk = ClockMode::DoNotChange,
 %% if clock_mux
+%% if target["family"] == "h7"
+				const ClockSource clk_src = ClockSource::PerClk,
+%% else
 				const ClockSource clk_src = ClockSource::SystemClock,
+%% endif
 %% endif
 				const Prescaler pre = Prescaler::Disabled,
 				const CalibrationMode cal = CalibrationMode::DoNotCalibrate,

--- a/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f3/adc_impl.hpp.in
@@ -195,14 +195,14 @@ modm::platform::Adc{{ id }}::configureChannel(Channel channel,
 	uint32_t tmpreg = 0;
 	if (static_cast<uint8_t>(channel) < 10) {
 		tmpreg = ADC{{ id }}->SMPR1
-			& ((~ADC_SMPR1_SMP0) << (static_cast<uint8_t>(channel) * 3));
+			& ~((ADC_SMPR1_SMP0) << (static_cast<uint8_t>(channel) * 3));
 		tmpreg |= static_cast<uint32_t>(sampleTime) <<
 						(static_cast<uint8_t>(channel) * 3);
 		ADC{{ id }}->SMPR1 = tmpreg;
 	}
 	else {
 		tmpreg = ADC{{ id }}->SMPR2
-			& ((~ADC_SMPR2_SMP10) << ((static_cast<uint8_t>(channel)-10) * 3));
+			& ~((ADC_SMPR2_SMP10) << ((static_cast<uint8_t>(channel)-10) * 3));
 		tmpreg |= static_cast<uint32_t>(sampleTime) <<
 						((static_cast<uint8_t>(channel)-10) * 3);
 		ADC{{ id }}->SMPR2 = tmpreg;

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -155,6 +155,13 @@ def build(env):
         if "Fdcan1" in all_peripherals and per == "FDCAN":
             per = "FDCAN1"
             nper = "FDCAN"
+        # COMP12
+        if "Comp1" in all_peripherals and per == "COMP12":
+            per = "COMP1"
+            nper = "COMP12"
+        if "Comp2" in all_peripherals and per == "COMP12":
+            per = "COMP2"
+            nper = "COMP12"
         # DAC
         if "Dac1" in all_peripherals and per == "DAC":
             per = "DAC1"

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -384,7 +384,7 @@ public:
 		static void
 		clearInterruptFlags(InterruptFlags_t flags = InterruptFlags::All)
 		{
-			ControlHal::clearInterruptFlags(flags, ChannelID);
+			ControlHal::clearInterruptFlags(InterruptFlags(flags.value), ChannelID);
 		}
 
 		/**

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -295,7 +295,7 @@ public:
 %% endif
 			})->muxChannel;
 			auto* channel = DMAMUX1_Channel0 + muxChannel;
-			channel->CCR = (channel->CCR & DMAMUX_CxCR_DMAREQ_ID) | uint32_t(dmaRequest);
+			channel->CCR = (channel->CCR & ~DMAMUX_CxCR_DMAREQ_ID) | uint32_t(dmaRequest);
 %% elif dmaType in ["stm32-stream-channel"]
 			DMA_Channel_TypeDef *Channel = reinterpret_cast<DMA_Channel_TypeDef*>(CHANNEL_BASE);
 			Channel->CR = (Channel->CR & ~DMA_SxCR_CHSEL_Msk) | uint32_t(dmaRequest);

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -73,7 +73,7 @@ public:
 %% endif
 		}
 %% endif
-%% if dmaType in ["stm32-mux"]:
+%% if dmaType in ["stm32-mux"] and target.family != "g0":
 		Rcc::enable<Peripheral::Dmamux1>();
 %% endif
 	}

--- a/src/modm/platform/timer/stm32/advanced.hpp.in
+++ b/src/modm/platform/timer/stm32/advanced.hpp.in
@@ -255,6 +255,12 @@ public:
 		TIM{{ id }}->BDTR &= ~(TIM_BDTR_MOE);
 	}
 
+	static inline bool
+	isOutputEnabled()
+	{
+		return (TIM{{ id }}->BDTR & TIM_BDTR_MOE);
+	}
+
 	/*
 	 * Enable/Disable automatic set of MOE bit at the next update event
 	 */

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -110,8 +110,8 @@ public:
 	};
 
 	// This type is the internal size of the counter.
-%% if id in [2, 5] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4", "g4"])
-	// Timer 2 and 5 are the only one which have the size of 32 bit
+%% if id in [2, 5, 23, 24] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4", "g4", "h7"])
+	// Timer 2, 5, 23 and 24 are the only ones which have a 32 bit counter
 	using Value = uint32_t;
 
 %% else

--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -289,6 +289,12 @@ public:
 		TIM{{ id }}->BDTR &= ~(TIM_BDTR_MOE);
 	}
 
+	static inline bool
+	isOutputEnabled()
+	{
+		return (TIM{{ id }}->BDTR & TIM_BDTR_MOE);
+	}
+
 	/*
 	 * Enable/Disable automatic set of MOE bit at the next update event
 	 */

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -213,6 +213,7 @@ def common_compiler_flags(compiler, target):
         "-Werror=maybe-uninitialized",
         "-Werror=overflow",
         "-Werror=sign-compare",
+        "-Werror=return-type",
         "-Wextra",
         "-Wlogical-op",
         "-Wpointer-arith",

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -274,6 +274,7 @@ def common_compiler_flags(compiler, target):
         # "-Wold-style-cast",
         "-fstrict-enums",
         "-std=c++23",
+        "-Wno-psabi",
         "-Wno-volatile",  # volatile is deprecated in C++20 but lots of our external code uses it...
         # "-pedantic",
     ]

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -257,7 +257,7 @@ def post_build(env):
         has_rtt = env.has_module(":platform:rtt")
         env.substitutions["has_rtt"] = has_rtt
         if has_rtt:
-            env.substitutions["main_ram"] = linkerscript.get("cont_ram_regions", [{"start": 0x20000000, "size": 4096}])[0]
+            env.substitutions["main_ram"] = linkerscript.get("cont_ram", {"start": 0x20000000, "size": 4096})
             env.substitutions["rtt_channels"] = len(env.get(":platform:rtt:buffer.tx", []))
         env.template("openocd.cfg.in")
 

--- a/tools/modm_tools/unit_test.py
+++ b/tools/modm_tools/unit_test.py
@@ -91,7 +91,7 @@ def extract_tests(headers):
         name = name[0]
 
         functions = re.findall(
-            r"void\s+(test[A-Z]\w*)\s*\([\svoid]*\)\s*;", content)
+            r"void\s+(test[_a-zA-Z]\w*)\s*\([\svoid]*\)\s*;", content)
         if not functions:
             print("No tests found in {}!".format(header))
 


### PR DESCRIPTION
- [x] Fix `Rcc::enable` for STM32H7 comparator
- [x] Add STM32 advanced timer `isOutputEnabled()`
- [x] Suppress GCC ABI nuisance warning ("note: parameter passing for argument of type
    '...' when C++17 is enabled changed to match C++14 in GCC 10.1")
- [x] Fix RTT logger if data structure is not in RAM with lowest address
- [x] Allow unit test case names in snake_case (`test_foo()`)
- [x] Treat missing return in function as error (this is always undefined behaviour)
- [x] Fix compilation of STM32G0 DMA. The CI didn't catch it because the template function is never instantiated in the test suite.
- [x] Fix reconfiguring DMAMUX requests
- [x] Fix STM32H7 32-bit timer counter size
- [x] Fix STM32H7 ADC asynchronous clock
- [x] Fix sampling time configuration in STM32F3 ADC driver
- [x] Fix compilation of STM32 DMA channel `clearInterruptFlags()`