### PR TITLE
STM32H7 BDMA driver

### DIFF
--- a/src/modm/platform/dac/stm32/dac_dma.hpp.in
+++ b/src/modm/platform/dac/stm32/dac_dma.hpp.in
@@ -127,8 +127,8 @@ public:
 		 * @param circularMode DMA circular mode setting
 		 * @param priority DMA transfer priority
 		 */
-		static void configure(const void* data, size_t dataSize, DmaBase::CircularMode circularMode,
-							  DmaBase::Priority priority = DmaBase::Priority::Medium);
+		static void configure(const void* data, size_t dataSize, DmaChannel::CircularMode circularMode,
+							  DmaChannel::Priority priority = DmaChannel::Priority::Medium);
 
 		/**
 		 * Set data to transfer

--- a/src/modm/platform/dac/stm32/dac_dma_impl.hpp.in
+++ b/src/modm/platform/dac/stm32/dac_dma_impl.hpp.in
@@ -107,26 +107,26 @@ bool
 
 template<typename DmaChannel>
 void
-{{ channel }}::configure(const void* data, size_t dataLength, DmaBase::CircularMode circularMode,
-						 DmaBase::Priority priority)
+{{ channel }}::configure(const void* data, size_t dataLength, DmaChannel::CircularMode circularMode,
+						 DmaChannel::Priority priority)
 {
 %% if target.family in ["f2", "f4", "f7"]
-	using RequestMapping = typename DmaChannel::RequestMapping<Peripheral::Dac{{ id }}, DmaBase::Signal::Dac{{ channel_id }}>;
+	using RequestMapping = typename DmaChannel::RequestMapping<Peripheral::Dac{{ id }}, DmaChannel::Signal::Dac{{ channel_id }}>;
 %% else
-	using RequestMapping = typename DmaChannel::RequestMapping<Peripheral::Dac{{ id }}, DmaBase::Signal::Ch{{ channel_id }}>;
+	using RequestMapping = typename DmaChannel::RequestMapping<Peripheral::Dac{{ id }}, DmaChannel::Signal::Ch{{ channel_id }}>;
 %% endif
 	constexpr auto request = RequestMapping::Request;
 
 	DmaChannel::configure(
-		DmaBase::DataTransferDirection::MemoryToPeripheral,
-		DmaBase::MemoryDataSize::HalfWord,
+		DmaChannel::DataTransferDirection::MemoryToPeripheral,
+		DmaChannel::MemoryDataSize::HalfWord,
 %% if target.family in ["f0", "f2", "f3", "f4", "f7", "h7"]
-		DmaBase::PeripheralDataSize::HalfWord,
+		DmaChannel::PeripheralDataSize::HalfWord,
 %% else
-		DmaBase::PeripheralDataSize::Word,
+		DmaChannel::PeripheralDataSize::Word,
 %% endif
-		DmaBase::MemoryIncrementMode::Increment,
-		DmaBase::PeripheralIncrementMode::Fixed,
+		DmaChannel::MemoryIncrementMode::Increment,
+		DmaChannel::PeripheralIncrementMode::Fixed,
 		priority,
 		circularMode
 	);

--- a/src/modm/platform/dma/stm32-bdma/bdma.cpp.in
+++ b/src/modm/platform/dma/stm32-bdma/bdma.cpp.in
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+%% if instance == ""
+#include "bdma.hpp"
+%% else
+#include "bdma_{{ instance }}.hpp"
+%% endif
+
+%% if instance == "1"
+MODM_ISR(BDMA1)
+{
+	using modm::platform::Bdma1;
+%% for channel in range(0, channel_count)
+	Bdma1::Channel{{ channel }}::interruptHandler();
+%% endfor
+}
+%% else
+%% for channel in range(0, channel_count)
+MODM_ISR(BDMA{{ instance }}_Channel{{ channel }})
+{
+	using modm::platform::Bdma{{ instance }};
+	Bdma{{ instance }}::Channel{{ channel }}::interruptHandler();
+}
+%% endfor
+%% endif

--- a/src/modm/platform/dma/stm32-bdma/bdma.hpp.in
+++ b/src/modm/platform/dma/stm32-bdma/bdma.hpp.in
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2014, Kevin Läufer
+ * Copyright (c) 2014-2017, Niklas Hauser
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2021, Raphael Lehmann
+ * Copyright (c) 2021-2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_BDMA_HPP
+#define MODM_STM32_BDMA_HPP
+
+#include <cstdint>
+#include <algorithm>
+#include <array>
+#include <modm/platform/clock/rcc.hpp>
+#include "../device.hpp"
+#include "bdma_hal.hpp"
+
+namespace modm::platform
+{
+
+%% if instance in ["", "2"]
+/// @cond
+namespace bdma
+{
+	template <typename ChannelT, Peripheral peripheral, BdmaBase::Signal signal>
+	struct RequestMapping;
+}
+/// @endcond
+%% endif
+
+/**
+ * Basic DMA controller {{ instance }}
+ *
+ * @ingroup	modm_platform_dma
+ */
+class Bdma{{ instance }} : public BdmaBase
+{
+public:
+	static void
+	enable()
+	{
+		Rcc::enable<Peripheral::Bdma{{ instance }}>();
+	}
+
+	static void
+	disable()
+	{
+		Rcc::disable<Peripheral::Bdma{{ instance }}>();
+	}
+
+	template <BdmaBase::Channel Id>
+	class Channel : public BdmaBase
+	{
+		static_assert(int(Id) >= 0 and int(Id) < {{ channel_count }}, "invalid channel");
+
+		static constexpr uint32_t ChannelBase = BDMA{{ instance }}_Channel0_BASE +
+			uint32_t(Id) * (BDMA{{ instance }}_Channel1_BASE - BDMA{{ instance }}_Channel0_BASE);
+
+		using Hal = BdmaChannelHal<ChannelBase>;
+
+	public:
+		/**
+		 * Configure the DMA channel
+		 *
+		 * Stops the DMA channel and writes the new values to its control register.
+		 *
+		 * @param[in] direction Direction of the DMA channel
+		 * @param[in] memoryDataSize Size of data in memory (byte, halfword, word)
+		 * @param[in] peripheralDataSize Size of data in peripheral (byte, halfword, word)
+		 * @param[in] memoryIncrement Defines whether the memory address is incremented
+		 * 			  after a transfer completed
+		 * @param[in] peripheralIncrement Defines whether the peripheral address is
+		 * 			  incremented after a transfer completed
+		 * @param[in] priority Priority of the DMA channel
+		 * @param[in] circularMode Transfer data in circular mode?
+		 */
+		static void
+		configure(DataTransferDirection direction, MemoryDataSize memoryDataSize,
+				PeripheralDataSize peripheralDataSize,
+				MemoryIncrementMode memoryIncrement,
+				PeripheralIncrementMode peripheralIncrement,
+				Priority priority = Priority::Medium,
+				CircularMode circularMode = CircularMode::Disabled)
+		{
+			Hal::configure(direction, memoryDataSize, peripheralDataSize,
+						   memoryIncrement, peripheralIncrement, priority, circularMode);
+		}
+
+		/**
+		 * Start the transfer of the DMA channel and clear all interrupt flags.
+		 */
+		static void
+		start()
+		{
+			clearInterruptFlags();
+			Hal::start();
+		}
+
+		/**
+		 * Stop a DMA channel transfer
+		 */
+		static void
+		stop()
+		{
+			Hal::stop();
+		}
+
+		/**
+		 * Get the direction of the data transfer
+		 */
+		static DataTransferDirection
+		getDataTransferDirection()
+		{
+			return Hal::getDataTransferDirection();
+		}
+
+		/**
+		 * Set the memory address of the DMA channel
+		 *
+		 * @note In Mem2Mem mode use this method to set the memory source address.
+		 *
+		 * @param[in] address Source address
+		 */
+		static void
+		setMemoryAddress(uintptr_t address)
+		{
+			Hal::setMemoryAddress(address);
+		}
+		/**
+		 * Set the peripheral address of the DMA channel
+		 *
+		 * @note In Mem2Mem mode use this method to set the memory destination address.
+		 *
+		 * @param[in] address Destination address
+		 */
+		static void
+		setPeripheralAddress(uintptr_t address)
+		{
+			Hal::setPeripheralAddress(address);
+		}
+
+		/**
+		 * Enable/disable memory increment
+		 *
+		 * When enabled, the memory address is incremented by the size of the data
+		 * (e.g. 1 for byte transfers, 4 for word transfers) after the transfer
+		 * completed.
+		 *
+		 * @param[in] increment Enable/disable
+		 */
+		static void
+		setMemoryIncrementMode(bool increment)
+		{
+			Hal::setMemoryIncrementMode(increment);
+		}
+		/**
+		 * Enable/disable peripheral increment
+		 *
+		 * When enabled, the peripheral address is incremented by the size of the data
+		 * (e.g. 1 for byte transfers, 4 for word transfers) after the transfer
+		 * completed.
+		 *
+		 * @param[in] increment Enable/disable
+		 */
+		static void
+		setPeripheralIncrementMode(bool increment)
+		{
+			Hal::setPeripheralIncrementMode(increment);
+		}
+
+		/**
+		 * Set the length of data to be transfered
+		 */
+		static void
+		setDataLength(std::size_t length)
+		{
+			Hal::setDataLength(length);
+		}
+
+		/**
+		 * Set the IRQ handler for transfer errors
+		 *
+		 * The handler will be called from the channels IRQ handler function
+		 * when the IRQ status indicates an error occured.
+		 */
+		static void
+		setTransferErrorIrqHandler(IrqHandler irqHandler)
+		{
+			transferError = irqHandler;
+		}
+		/**
+		 * Set the IRQ handler for half transfer complete
+		 *
+		 * Called by the channels IRQ handler when the transfer is half complete.
+		 */
+		static void
+		setHalfTransferCompleteIrqHandler(IrqHandler irqHandler)
+		{
+			halfTransferComplete = irqHandler;
+		}
+		/**
+		 * Set the IRQ handler for transfer complete
+		 *
+		 * Called by the channels IRQ handler when the transfer is complete.
+		 */
+		static void
+		setTransferCompleteIrqHandler(IrqHandler irqHandler)
+		{
+			transferComplete = irqHandler;
+		}
+
+%% if instance in ["", "2"]
+		/**
+		 * Set the peripheral that operates the channel
+		 */
+		template <Request dmaRequest>
+		static void
+		setPeripheralRequest()
+		{
+			constexpr auto muxChannel = std::find_if(muxChannels.begin(), muxChannels.end(), [](MuxChannel ch) {
+%% if instance == ""
+				return ch.dmaChannel == static_cast<uint32_t>(Id);
+%% else
+				return (ch.dmaInstance == {{ instance }}) && (ch.dmaChannel == uint32_t(Id));
+%% endif
+			})->muxChannel;
+			auto* channel = DMAMUX2_Channel0 + muxChannel;
+			channel->CCR = (channel->CCR & ~DMAMUX_CxCR_DMAREQ_ID) | uint32_t(dmaRequest);
+		}
+%% endif
+
+		/**
+		 * IRQ handler of the DMA channel
+		 *
+		 * Reads the IRQ status and checks for error or transfer complete. In case
+		 * of error the DMA channel will be disabled.
+		 */
+		modm_always_inline static void
+		interruptHandler()
+		{
+			const auto flags = getInterruptFlags();
+			if (flags & InterruptFlags::Error) {
+				disable();
+				if (transferError)
+					transferError();
+			}
+			if (halfTransferComplete and (flags & InterruptFlags::HalfTransferComplete)) {
+				halfTransferComplete();
+			}
+			if (transferComplete and (flags & InterruptFlags::TransferComplete)) {
+				transferComplete();
+			}
+
+			// only clear flags that have been handled
+			// otherwise interrupts that occur while inside the handler could be discarded
+			clearInterruptFlags(flags & ~InterruptFlags::Global);
+		}
+
+		/**
+		 * Read channel status flags when channel interrupts are disabled.
+		 * This function is useful to query the transfer state when the use of
+		 * the channel interrupt is not required for the application.
+		 *
+		 * @warning Flags are automatically cleared in the ISR if the channel
+		 * 			interrupt is enabled or when start() is called.
+		 */
+		static InterruptFlags_t
+		getInterruptFlags()
+		{
+			const auto globalFlags = BDMA{{ instance }}->ISR;
+			const auto mask = static_cast<uint8_t>(InterruptFlags::All);
+			const auto shift = static_cast<uint32_t>(Id) * 4;
+			const auto channelFlags = static_cast<uint8_t>((globalFlags >> shift) & mask);
+			return InterruptFlags_t{channelFlags};
+		}
+
+		/**
+		 * Clear channel interrupt flags.
+		 * Use only when the channel interrupt is disabled.
+		 *
+		 * @warning Flags are automatically cleared in the ISR if the channel
+		 * 			interrupt is enabled or when start() is called.
+		 */
+		static void
+		clearInterruptFlags(InterruptFlags_t flags = InterruptFlags::All)
+		{
+			BDMA{{ instance }}->IFCR = flags.value << (static_cast<uint32_t>(Id) * 4);
+		}
+
+		/**
+		 * Enable the IRQ vector of the channel
+		 *
+		 * @param[in] priority Priority of the IRQ
+		 */
+		static void
+		enableInterruptVector(uint32_t priority = 1)
+		{
+%% if instance == "1"
+			NVIC_SetPriority(BDMA1_IRQn, priority);
+			NVIC_EnableIRQ(BDMA1_IRQn);
+%% else
+			NVIC_SetPriority(irqs[uint32_t(Id)], priority);
+			NVIC_EnableIRQ(irqs[uint32_t(Id)]);
+%% endif
+		}
+		/**
+		 * Disable the IRQ vector of the channel
+		 */
+		static void
+		disableInterruptVector()
+		{
+%% if instance == "1"
+			NVIC_DisableIRQ(BDMA1_IRQn);
+%% else
+			NVIC_DisableIRQ(irqs[uint32_t(Id)]);
+%% endif
+		}
+
+		/**
+		 * Enable the specified interrupt of the channel
+		 */
+		static void
+		enableInterrupt(InterruptEnable_t irq)
+		{
+			Hal::enableInterrupt(irq);
+		}
+		/**
+		 * Disable the specified interrupt of the channel
+		 */
+		static void
+		disableInterrupt(InterruptEnable_t irq)
+		{
+			Hal::disableInterrupt(irq);
+		}
+
+%% if instance in ["", "2"]
+		template <Peripheral peripheral, Signal signal = Signal::NoSignal>
+		using RequestMapping = bdma::RequestMapping<Channel, peripheral, signal>;
+
+		static constexpr IRQn_Type irqs[] = {
+%% for channel in range(0, channel_count)
+			BDMA{{ instance }}_Channel{{ channel }}_IRQn{% if not loop.last %},{% endif %}
+%% endfor
+		};
+%% endif
+
+	private:
+		static inline BdmaBase::IrqHandler transferError { nullptr };
+		static inline BdmaBase::IrqHandler halfTransferComplete { nullptr };
+		static inline BdmaBase::IrqHandler transferComplete { nullptr };
+
+%% if instance in ["", "2"]
+		struct MuxChannel
+		{
+			uint8_t muxChannel;
+%% if instance != ""
+			uint8_t dmaInstance;
+%% endif
+			uint8_t dmaChannel;
+		};
+
+		static constexpr std::array muxChannels = {
+%% for channel in dma["mux-channels"][0]["mux-channel"]
+%% if instance == ""
+			MuxChannel({{ channel.position }}, {{ channel["dma-channel"] }}){{ "," if not loop.last }}
+%% else
+			MuxChannel({{ channel.position }}, {{ channel["dma-instance"] }}, {{ channel["dma-channel"] }}){{ "," if not loop.last }}
+%% endif
+%% endfor
+		};
+%% endif
+	};
+%% for channel in range(0, channel_count)
+	using Channel{{ channel }} = Channel<BdmaBase::Channel::Channel{{ channel }}>;
+%% endfor
+};
+
+%% if instance in ["", "2"]
+/// @cond
+/*
+ * Specialization of the RequestMapping. For all hardware supported by DMA the
+ * RequestMapping structure defines the channel and the Request. It can be used
+ * by hardware classes to verify that the provIded channel is valId and to
+ * get the value to set in setPeripheralRequest().
+ *
+ * Example:
+ * template <class DmaRx, class DmaTx>
+ * class SpiMaster1_Dma : public SpiMaster1
+ * {
+ *     using RxChannel = typename DmaRx::template RequestMapping<Peripheral::Spi1, DmaRx::Signal::Rx>::Channel;
+ * 	   using TxChannel = typename DmaTx::template RequestMapping<Peripheral::Spi1, DmaTx::Signal::Tx>::Channel;
+ * 	   static constexpr DmaRx::Request RxRequest = DmaRx::template RequestMapping<Peripheral::Spi1, DmaRx::Signal::Rx>::Request;
+ * 	   static constexpr DmaTx::Request TxRequest = DmaTx::template RequestMapping<Peripheral::Spi1, DmaTx::Signal::Tx>::Request;
+ *
+ *     ...
+ * };
+ */
+namespace bdma
+{
+
+%% for request in dma["requests"][0]["request"]
+
+%% for signal in request.signal
+%% if signal.name is defined
+%% set request_signal = "BdmaBase::Signal::" + signal.name.capitalize()
+%% else
+%% set request_signal = "BdmaBase::Signal::NoSignal"
+%% endif
+
+%% set peripheral = signal.driver.capitalize()
+%% if signal.instance is defined
+	%% set peripheral = peripheral ~ signal.instance
+%% endif
+%% if peripheral == "Bdma" and instance in ["2"]
+	%% set peripheral = peripheral ~ instance
+%% endif
+
+	template <typename ChannelT>
+	struct RequestMapping<ChannelT, Peripheral::{{ peripheral }}, {{ request_signal }}>
+	{
+		using Channel = ChannelT;
+		static constexpr BdmaBase::Request Request = BdmaBase::Request::Request{{ request.position }};
+	};
+%% endfor
+%% endfor
+}
+
+/// @endcond
+%% endif
+
+}	// namespace modm::platform
+
+#endif	// MODM_STM32_BDMA_HPP

--- a/src/modm/platform/dma/stm32-bdma/bdma_base.hpp.in
+++ b/src/modm/platform/dma/stm32-bdma/bdma_base.hpp.in
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2014, Kevin Läufer
+ * Copyright (c) 2014-2017, Niklas Hauser
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2021, Raphael Lehmann
+ * Copyright (c) 2021-2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_BDMA_BASE_HPP
+#define MODM_STM32_BDMA_BASE_HPP
+
+#include <cstdint>
+#include <cstddef>
+
+#include "../device.hpp"
+
+#include <modm/architecture/interface/interrupt.hpp>
+#include <modm/architecture/interface/register.hpp>
+
+namespace modm::platform
+{
+
+%% set reg_prefix = "BDMA_CCR"
+
+/**
+ * Common BDMA definitions
+ *
+ * @ingroup	modm_platform_dma
+ */
+class BdmaBase
+{
+public:
+	enum class
+	Channel
+	{
+	%% for channel in range(0, channel_count)
+		Channel{{ channel }}{% if loop.first %} = 0{% endif %},
+	%% endfor
+	};
+
+	%% set request_count = namespace(max_requests = 0)
+	%% for request in dma["requests"][0]["request"]
+		%% if request_count.max_requests < request.position | int
+			%% set request_count.max_requests = request.position | int
+		%% endif
+	%% endfor
+
+	enum class
+	Request
+	{
+		None = 0,
+	%% for request in range(1, request_count.max_requests + 1)
+		Request{{ request }},
+	%% endfor
+	};
+
+	enum class
+	Priority : uint32_t
+	{
+		Low 		= 0,
+		Medium  	= {{ reg_prefix }}_PL_0,
+		High 		= {{ reg_prefix }}_PL_1,
+		VeryHigh 	= {{ reg_prefix }}_PL_1 | {{ reg_prefix }}_PL_0,
+	};
+
+	enum class
+	MemoryDataSize : uint32_t
+	{
+		Byte 		= 0,
+		Bit8 		= Byte,
+		HalfWord 	= {{ reg_prefix }}_MSIZE_0,
+		Bit16 		= HalfWord,
+		Word 		= {{ reg_prefix }}_MSIZE_1,
+		Bit32 		= Word,
+	};
+
+	enum class
+	PeripheralDataSize : uint32_t
+	{
+		Byte 		= 0,
+		Bit8 		= Byte,
+		HalfWord 	= {{ reg_prefix }}_PSIZE_0,
+		Bit16 		= HalfWord,
+		Word 		= {{ reg_prefix }}_PSIZE_1,
+		Bit32 		= Word,
+	};
+
+	enum class
+	MemoryIncrementMode : uint32_t
+	{
+		Fixed 		= 0,
+		Increment 	= {{ reg_prefix }}_MINC, ///< incremented according to MemoryDataSize
+	};
+
+	enum class
+	PeripheralIncrementMode : uint32_t
+	{
+		Fixed 		= 0,
+		Increment 	= {{ reg_prefix }}_PINC, ///< incremented according to PeripheralDataSize
+	};
+
+	enum class
+	CircularMode : uint32_t
+	{
+		Disabled 	= 0,
+		Enabled 	= {{ reg_prefix }}_CIRC, ///< circular mode
+	};
+
+	enum class
+	DataTransferDirection : uint32_t
+	{
+		/// Source: DMA_CPARx; Sink: DMA_CMARx
+		PeripheralToMemory 	= 0,
+		/// Source: DMA_CMARx; Sink: DMA_CPARx
+		MemoryToPeripheral 	= {{ reg_prefix }}_DIR,
+		/// Source: DMA_CPARx; Sink: DMA_CMARx
+		MemoryToMemory 		= {{ reg_prefix }}_MEM2MEM,
+	};
+
+	/**
+	 * Peripheral signals that can be used in DMA channels
+	 */
+	enum class
+	Signal : uint8_t
+	{
+		NoSignal,
+%% for signal in dma_signals
+		{{ signal }},
+%% endfor
+	};
+
+	enum class InterruptEnable : uint32_t
+	{
+		TransferComplete	= {{ reg_prefix }}_TCIE,
+		HalfTransfer		= {{ reg_prefix }}_HTIE,
+		TransferError		= {{ reg_prefix }}_TEIE,
+	};
+	MODM_FLAGS32(InterruptEnable);
+
+	enum class InterruptFlags : uint8_t
+	{
+		Global = 0b0001,
+		TransferComplete = 0b0010,
+		HalfTransferComplete = 0b0100,
+		Error = 0b1000,
+		All = 0b1111,
+	};
+	MODM_FLAGS32(InterruptFlags);
+
+	using IrqHandler = void (*)(void);
+};
+
+}	// namespace modm::platform
+
+#endif	// MODM_STM32_BDMA_BASE_HPP

--- a/src/modm/platform/dma/stm32-bdma/bdma_hal.hpp
+++ b/src/modm/platform/dma/stm32-bdma/bdma_hal.hpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2020, Mike Wolfram
+ * Copyright (c) 2021, Raphael Lehmann
+ * Copyright (c) 2023, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_BDMA_HAL_HPP
+#define MODM_STM32_BDMA_HAL_HPP
+
+#include "bdma_base.hpp"
+
+namespace modm::platform
+{
+
+/**
+ * BDMA channel low-level register abstraction
+ *
+ * @tparam base_addr base address of the channel registers
+ *
+ * @ingroup	modm_platform_dma
+ */
+template<uintptr_t base_addr>
+class BdmaChannelHal : public BdmaBase
+{
+	static BDMA_Channel_TypeDef*
+	reg()
+	{
+		return reinterpret_cast<BDMA_Channel_TypeDef*>(base_addr);
+	}
+
+public:
+	/**
+	 * Configure the DMA channel (HAL)
+	 *
+	 * Stops the DMA channel and writes the new values to its control register.
+	 *
+	 * @param[in] direction Direction of the DMA channel
+	 * @param[in] memoryDataSize Size of data in memory (byte, halfword, word)
+	 * @param[in] peripheralDataSize Size of data in peripheral (byte, halfword, word)
+	 * @param[in] memoryIncrement Defines whether the memory address is incremented
+	 * 			  after a transfer completed
+	 * @param[in] peripheralIncrement Defines whether the peripheral address is
+	 * 			  incremented after a transfer completed
+	 * @param[in] priority Priority of the DMA channel
+	 * @param[in] circularMode Transfer data in circular mode?
+	 */
+	static void
+	configure(DataTransferDirection direction, MemoryDataSize memoryDataSize,
+			PeripheralDataSize peripheralDataSize,
+			MemoryIncrementMode memoryIncrement,
+			PeripheralIncrementMode peripheralIncrement,
+			Priority priority = Priority::Medium,
+			CircularMode circularMode = CircularMode::Disabled)
+	{
+		stop();
+
+		reg()->CCR = uint32_t(direction) | uint32_t(memoryDataSize) |
+				uint32_t(peripheralDataSize) | uint32_t(memoryIncrement) |
+				uint32_t(peripheralIncrement) | uint32_t(priority) |
+				uint32_t(circularMode);
+	}
+
+	/**
+	 * Start the transfer of the DMA channel
+	 */
+	static void
+	start()
+	{
+		reg()->CCR |= BDMA_CCR_EN;
+	}
+
+	/**
+	 * Stop a DMA channel transfer
+	 */
+	static void
+	stop()
+	{
+		reg()->CCR &= ~BDMA_CCR_EN;
+		while (reg()->CCR & BDMA_CCR_EN); // wait for stream to be stopped
+	}
+
+	static DataTransferDirection
+	getDataTransferDirection()
+	{
+		return static_cast<DataTransferDirection>(
+			reg()->CCR & (BDMA_CCR_MEM2MEM | BDMA_CCR_DIR));
+	}
+
+	/**
+	 * Set the memory address of the DMA channel
+	 *
+	 * @note In Mem2Mem mode use this method to set the memory source address.
+	 *
+	 * @param[in] address Source address
+	 */
+	static void
+	setMemoryAddress(uintptr_t address)
+	{
+		reg()->CM0AR = address;
+	}
+
+	/**
+	 * Set the peripheral address of the DMA channel
+	 *
+	 * @note In Mem2Mem mode use this method to set the memory destination address.
+	 *
+	 * @param[in] address Destination address
+	 */
+	static void
+	setPeripheralAddress(uintptr_t address)
+	{
+		reg()->CPAR = address;
+	}
+
+	/**
+	 * Enable/disable memory increment
+	 *
+	 * When enabled, the memory address is incremented by the size of the data
+	 * (e.g. 1 for byte transfers, 4 for word transfers) after the transfer
+	 * completed.
+	 *
+	 * @param[in] increment Enable/disable
+	 */
+	static void
+	setMemoryIncrementMode(bool increment)
+	{
+		if (increment)
+			reg()->CCR |= uint32_t(MemoryIncrementMode::Increment);
+		else
+			reg()->CCR &= ~uint32_t(MemoryIncrementMode::Increment);
+	}
+
+	/**
+	 * Enable/disable peripheral increment
+	 *
+	 * When enabled, the peripheral address is incremented by the size of the data
+	 * (e.g. 1 for byte transfers, 4 for word transfers) after the transfer
+	 * completed.
+	 *
+	 * @param[in] increment Enable/disable
+	 */
+	static void
+	setPeripheralIncrementMode(bool increment)
+	{
+		if (increment)
+			reg()->CCR |= uint32_t(PeripheralIncrementMode::Increment);
+		else
+			reg()->CCR &= ~uint32_t(PeripheralIncrementMode::Increment);
+	}
+
+	/**
+	 * Set length of data to transfer
+	 */
+	static void
+	setDataLength(std::size_t length)
+	{
+		reg()->CNDTR = length;
+	}
+
+	/**
+	 * Enable IRQ of this DMA channel (e.g. transfer complete or error)
+	 */
+	static void
+	enableInterrupt(InterruptEnable_t irq)
+	{
+		reg()->CCR |= irq.value;
+	}
+	/**
+	 * Disable IRQ of this DMA channel (e.g. transfer complete or error)
+	 */
+	static void
+	disableInterrupt(InterruptEnable_t irq)
+	{
+		reg()->CCR &= ~(irq.value);
+	}
+};
+
+} // namespace modm::platform
+
+#endif // MODM_STM32_BDMA_HAL_HPP

--- a/src/modm/platform/dma/stm32-bdma/module.lb
+++ b/src/modm/platform/dma/stm32-bdma/module.lb
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+# Copyright (c) 2020, Mike Wolfram
+# Copyright (c) 2021, Raphael Lehmann
+# Copyright (c) 2021-2023, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+from collections import defaultdict
+import re
+
+def _get_signal_names(driver):
+    signal_names = {}
+    for request_data in driver["requests"]:
+        for request in request_data["request"]:
+            for signal in request["signal"]:
+                if "name" in signal:
+                    signal_name = signal["name"].capitalize()
+                    signal_names[signal_name] = 1
+    return sorted(list(set(signal_names)))
+
+
+def _validate_channel_count(driver):
+    channel_count = 8
+    assert len(driver["mux-channels"]) == 1  # only one DMAMUX instance is supported
+    channels = driver["mux-channels"][0]["mux-channel"]
+    instance_channels = defaultdict(list)
+    for channel in channels:
+        instance_channels[channel.get("dma-instance")].append(channel["dma-channel"])
+    for instance in instance_channels:
+        channel_list = [int(c) for c in instance_channels[instance]]
+        channel_list.sort()
+        assert channel_list == list(range(0, channel_count))
+
+
+def _get_substitutions(device, instance = ""):
+    dma = device.get_driver("bdma")
+    return {
+        "target" : device.identifier,
+        "dma" : dma,
+        "dma_signals" : _get_signal_names(dma),
+        "channel_count" : 8,
+        "instance" : instance
+    }
+
+
+class Instance(Module):
+    def __init__(self, instance):
+        self.instance = instance
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "Instance {}".format(self.instance)
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        device = env[":target"]
+        driver = device.get_driver("bdma")
+
+        env.substitutions = _get_substitutions(device, str(self.instance))
+        env.outbasepath = "modm/src/modm/platform/dma"
+
+        env.template("bdma.hpp.in", "bdma_{}.hpp".format(self.instance))
+        env.template("bdma.cpp.in", "bdma_{}.cpp".format(self.instance))
+
+
+def init(module):
+    module.name = ":platform:bdma"
+    module.description = "Basic Direct Memory Access Controller (BDMA)"
+
+
+def prepare(module, options):
+    device = options[":target"]
+    module.depends(":cmsis:device", ":platform:rcc")
+
+    if not device.identifier.platform == "stm32":
+        return False
+    if not device.has_driver("bdma"):
+        return False
+
+    driver = device.get_driver("bdma")
+    if "instance" in driver:
+        for instance in listify(driver["instance"]):
+            module.add_submodule(Instance(int(instance)))
+
+    return True
+
+
+def build(env):
+    device = env[":target"]
+    driver = device.get_driver("bdma")
+
+    _validate_channel_count(driver)
+
+    env.substitutions = _get_substitutions(device)
+    env.outbasepath = "modm/src/modm/platform/dma"
+
+    env.copy("bdma_hal.hpp")
+    env.template("bdma_base.hpp.in")
+    if "instance" not in driver:
+        env.template("bdma.hpp.in")
+        env.template("bdma.cpp.in")

--- a/src/modm/platform/dma/stm32-bdma/module.lb
+++ b/src/modm/platform/dma/stm32-bdma/module.lb
@@ -18,14 +18,14 @@ from collections import defaultdict
 import re
 
 def _get_signal_names(driver):
-    signal_names = {}
+    signal_names = set()
     for request_data in driver["requests"]:
         for request in request_data["request"]:
             for signal in request["signal"]:
                 if "name" in signal:
                     signal_name = signal["name"].capitalize()
-                    signal_names[signal_name] = 1
-    return sorted(list(set(signal_names)))
+                    signal_names.add(signal_name)
+    return sorted(list(signal_names))
 
 
 def _validate_channel_count(driver):
@@ -42,7 +42,7 @@ def _validate_channel_count(driver):
 
 
 def _get_substitutions(device, instance = ""):
-    dma = device.get_driver("bdma")
+    dma = device.get_driver("bdma:stm32*")
     return {
         "target" : device.identifier,
         "dma" : dma,

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -95,7 +95,7 @@ public:
 	 * Class representing a DMA channel/stream
 	 */
 	template <DmaBase::Channel ChannelID>
-	class Channel
+	class Channel : public DmaBase
 	{
 		static_assert(
 %% for controller in dmaController

--- a/src/modm/platform/spi/stm32h7/spi_master_dma.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master_dma.hpp.in
@@ -37,14 +37,12 @@ class SpiMaster{{ id }}_Dma : public modm::SpiMaster,
 {
 protected:
 	struct Dma {
-		using RxChannel = typename DmaChannelRx::template RequestMapping<
-				Peripheral::Spi{{ id }}, DmaBase::Signal::Rx>::Channel;
-		using TxChannel = typename DmaChannelTx::template RequestMapping<
-				Peripheral::Spi{{ id }}, DmaBase::Signal::Tx>::Channel;
-		static constexpr DmaBase::Request RxRequest = DmaChannelRx::template RequestMapping<
-				Peripheral::Spi{{ id }}, DmaBase::Signal::Rx>::Request;
-		static constexpr DmaBase::Request TxRequest = DmaChannelTx::template RequestMapping<
-				Peripheral::Spi{{ id }}, DmaBase::Signal::Tx>::Request;
+		using RxChannel = DmaChannelRx;
+		using TxChannel = DmaChannelTx;
+		static constexpr DmaChannelRx::Request RxRequest = DmaChannelRx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaChannelRx::Signal::Rx>::Request;
+		static constexpr DmaChannelTx::Request TxRequest = DmaChannelTx::template RequestMapping<
+				Peripheral::Spi{{ id }}, DmaChannelTx::Signal::Tx>::Request;
 	};
 
 %% if not use_fiber

--- a/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master_dma_impl.hpp.in
@@ -22,21 +22,24 @@ template <class SystemClock, modm::baudrate_t baudrate, modm::percent_t toleranc
 void
 SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::initialize()
 {
-	Dma::RxChannel::configure(DmaBase::DataTransferDirection::PeripheralToMemory,
-			DmaBase::MemoryDataSize::Byte, DmaBase::PeripheralDataSize::Byte,
-			DmaBase::MemoryIncrementMode::Increment, DmaBase::PeripheralIncrementMode::Fixed,
-			DmaBase::Priority::Medium);
-	Dma::RxChannel::disableInterruptVector();
-	Dma::RxChannel::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::receiveRegister()));
-	Dma::RxChannel::template setPeripheralRequest<Dma::RxRequest>();
+	using Rx = Dma::RxChannel;
+	using Tx = Dma::TxChannel;
 
-	Dma::TxChannel::configure(DmaBase::DataTransferDirection::MemoryToPeripheral,
-			DmaBase::MemoryDataSize::Byte, DmaBase::PeripheralDataSize::Byte,
-			DmaBase::MemoryIncrementMode::Increment, DmaBase::PeripheralIncrementMode::Fixed,
-			DmaBase::Priority::Medium);
-	Dma::TxChannel::disableInterruptVector();
-	Dma::TxChannel::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::transmitRegister()));
-	Dma::TxChannel::template setPeripheralRequest<Dma::TxRequest>();
+	Rx::configure(Rx::DataTransferDirection::PeripheralToMemory,
+			Rx::MemoryDataSize::Byte, Rx::PeripheralDataSize::Byte,
+			Rx::MemoryIncrementMode::Increment, Rx::PeripheralIncrementMode::Fixed,
+			Rx::Priority::Medium);
+	Rx::disableInterruptVector();
+	Rx::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::receiveRegister()));
+	Rx::template setPeripheralRequest<Dma::RxRequest>();
+
+	Tx::configure(Tx::DataTransferDirection::MemoryToPeripheral,
+			Tx::MemoryDataSize::Byte, Tx::PeripheralDataSize::Byte,
+			Tx::MemoryIncrementMode::Increment, Tx::PeripheralIncrementMode::Fixed,
+			Tx::Priority::Medium);
+	Tx::disableInterruptVector();
+	Tx::setPeripheralAddress(reinterpret_cast<uint32_t>(Hal::transmitRegister()));
+	Tx::template setPeripheralRequest<Dma::TxRequest>();
 
 %% if not use_fiber
 	state = 0;
@@ -150,7 +153,7 @@ modm::ResumableResult<void>
 SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
 		const uint8_t* tx, uint8_t* rx, std::size_t length)
 {
-	using Flags = DmaBase::InterruptFlags;
+	using Flags = DmaChannelRx::InterruptFlags;
 %% if use_fiber
 	startDmaTransfer(tx, rx, length);
 
@@ -196,7 +199,7 @@ SpiMaster{{ id }}_Dma<DmaChannelRx, DmaChannelTx>::transfer(
 	default:
 		if (!Hal::isTransferCompleted() or !(state & Bit2)) {
 			if(rx) {
-				static DmaBase::InterruptFlags_t flags;
+				static typename DmaChannelRx::InterruptFlags_t flags;
 				flags = DmaChannelRx::getInterruptFlags();
 				if (flags & Flags::Error) {
 					// abort on DMA error

--- a/test/modm/platform/spi/stm32h7/module.lb
+++ b/test/modm/platform/spi/stm32h7/module.lb
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2024, Christopher Durand
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def init(module):
+    module.name = ":test:platform:spi"
+    module.description = "STM32H7 SPI BDMA test"
+
+def prepare(module, options):
+    target = options[":target"]
+
+    identifier = target.identifier
+    if identifier.platform != "stm32" or identifier.family != "h7":
+        return False
+
+    module.depends(":platform:bdma", ":platform:dma", ":platform:spi:6")
+    return True
+
+def build(env):
+    if not env.has_module(":board:nucleo-h723zg"):
+        env.log.warn("The SPI test uses hardcoded GPIO pins."
+                     "Please make sure the pins are safe to use on other hardware.")
+        return
+
+    env.outbasepath = "modm-test/src/modm-test/platform/spi_test"
+    env.copy("spi_bdma_test.hpp")
+    env.copy("spi_bdma_test.cpp")

--- a/test/modm/platform/spi/stm32h7/spi_bdma_test.cpp
+++ b/test/modm/platform/spi/stm32h7/spi_bdma_test.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "spi_bdma_test.hpp"
+
+#include <modm/platform.hpp>
+#include <modm/board.hpp>
+
+using namespace modm::platform;
+
+using Spi = SpiMaster6_Dma<Bdma::Channel0, Bdma::Channel1>;
+using Miso = GpioA6;
+using Sck = GpioC12;
+
+void
+SpiBdmaTest::setUp()
+{
+	Bdma::enable();
+	Spi::connect<Miso::Miso, Sck::Sck>();
+	Spi::initialize<Board::SystemClock, 16_MHz, 10_pct>();
+}
+
+void
+SpiBdmaTest::testReceive()
+{
+	constexpr std::array<uint8_t, 4> ones{0xff, 0xff, 0xff, 0xff};
+	constexpr std::array<uint8_t, 4> zeros{};
+	modm_section(".data_d3_sram") static std::array<uint8_t, 4> buffer{};
+
+	Miso::configure(Miso::InputType::PullUp);
+	modm::delay_ns(500);
+	Spi::transferBlocking(nullptr, buffer.data(), buffer.size());
+	TEST_ASSERT_TRUE(buffer == ones);
+
+	Miso::configure(Miso::InputType::PullDown);
+	modm::delay_ns(500);
+	Spi::transferBlocking(nullptr, buffer.data(), buffer.size());
+	TEST_ASSERT_TRUE(buffer == zeros);
+
+	Miso::configure(Miso::InputType::PullUp);
+	modm::delay_ns(500);
+	Spi::transferBlocking(nullptr, buffer.data(), buffer.size());
+	TEST_ASSERT_TRUE(buffer == ones);
+
+	Miso::configure(Miso::InputType::Floating);
+}

--- a/test/modm/platform/spi/stm32h7/spi_bdma_test.hpp
+++ b/test/modm/platform/spi/stm32h7/spi_bdma_test.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <unittest/testsuite.hpp>
+
+/// @ingroup modm_test_test_platform_spi
+class SpiBdmaTest : public unittest::TestSuite
+{
+public:
+	void
+	setUp() override;
+
+	void
+	testReceive();
+};

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -76,7 +76,7 @@ def hal_get_modules():
 
         modules = set()
         # We only care about some modm:platform:* modules here
-        not_interested = {"bitbang", "common", "heap", "core", "fault", "cortex-m", "uart.spi", "itm", "rtt", "pwm"}
+        not_interested = {"bitbang", "common", "heap", "core", "fault", "cortex-m", "uart.spi", "itm", "rtt", "pwm", "bdma"}
         imodules = (m  for (repo, mfile) in mfiles  for m in lbuild.module.load_module_from_file(repo, mfile)
                     if m.available and m.fullname.startswith("modm:platform:") and
                     all(p not in m.fullname for p in not_interested) and


### PR DESCRIPTION
- [x] Add STM32H7 BDMA driver
- [x] Make DAC and SPI drivers compatible with BDMA
- [x] Add hardware unit test for BDMA and SPI6 on Nucleo-H723ZG 

A separate driver is added because the DMA type differs between BDMA and regular DMA instances on H7, but the driver assumes common bit definitions in `DmaBase`.

Direct dependencies to `DmaBase` must be removed from drivers for the same reason to be compatible to BDMA. Common definitions are accessed through the DMA channel types instead.