### PR TITLE
[ci] Update CI for faster default runners

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [labeled]
 
+env:
+  SCONSFLAGS: -j8
+  MAKEFLAGS: -j8
+
 jobs:
   avr-compile-all:
     if: github.event.label.name == 'ci:hal'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,10 @@ name: Run tests on Linux
 
 on: [pull_request]
 
+env:
+  SCONSFLAGS: -j8
+  MAKEFLAGS: -j8
+
 jobs:
   unittests-linux-generic:
     runs-on: ubuntu-22.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: macos-13
 
     steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
+        with:
+          comment_on_pr: false
+          metric_frequency: 3
 
       - name: Setup environment - Brew tap
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,11 @@ jobs:
       PYTHONIOENCODING: "utf-8"
 
     steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
+        with:
+          comment_on_pr: false
+          metric_frequency: 3
 
       # Disabling snake-oil for performance reasons
       - name: Disable Windows Defender


### PR DESCRIPTION
[GitHub doubled the default runner resources](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/), let's check if we can do more faster.

- [x] Instrument the Workflows
- [ ] Optimized number of jobs