### PR TITLE
Fix float casting 

### DIFF
--- a/src/modm/math/algorithm/prescaler.hpp
+++ b/src/modm/math/algorithm/prescaler.hpp
@@ -146,7 +146,7 @@ public:
 		const uint32_t prescaler_ceiling = std::min(uint32_t(desired) + 1, end);
 		const T baud_lower = input_frequency / prescaler_ceiling;
 		const T baud_upper = input_frequency / prescaler_floor;
-		const double baud_middle = (baud_upper + baud_lower) / 2.0;
+		const float baud_middle = static_cast<float>((baud_upper + baud_lower) / 2.0);
 		if (desired_frequency <= baud_middle)
 			return {input_frequency, desired_frequency, prescaler_ceiling - begin, prescaler_ceiling};
 		return {input_frequency, desired_frequency, prescaler_floor - begin, prescaler_floor};

--- a/src/modm/platform/core/cortex/delay_ns.hpp.in
+++ b/src/modm/platform/core/cortex/delay_ns.hpp.in
@@ -21,7 +21,7 @@ void delay_ns(uint32_t ns);
 constexpr uint16_t
 computeDelayNsPerLoop(uint32_t hz)
 {
-	return std::round({{loop}}'000'000'000.0 / hz);
+	return std::round(static_cast<float>({{loop}}'000'000'000.0 / hz));
 }
 
 }


### PR DESCRIPTION
Correctly casts to float before calling std::round in delay function