### PR TITLE
[stm32] Extend G0 adc to support adc dma

### DIFF
--- a/examples/nucleo_g070rb/adc_dma/adc_dma.hpp
+++ b/examples/nucleo_g070rb/adc_dma/adc_dma.hpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, Zühlke Engineering (Austria) GmbH
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef EXAMPLE_ADCDMA_HPP
+#define EXAMPLE_ADCDMA_HPP
+
+#include <modm/platform.hpp>
+#include <span>
+
+template<class Adc, class DmaChannel>
+class AdcDma
+{
+	struct Dma
+	{
+		using AdcChannel =
+			typename DmaChannel::template RequestMapping<modm::platform::Peripheral::Adc1>::Channel;
+		static constexpr modm::platform::DmaBase::Request AdcRequest =
+			DmaChannel::template RequestMapping<modm::platform::Peripheral::Adc1>::Request;
+	};
+
+public:
+	/**
+	 * \brief initialize both adc and dma
+	 * @tparam SystemClock
+	 */
+	template<class SystemClock>
+	static void
+	initialize(std::span<uint16_t> buffer,
+			   modm::platform::DmaBase::Priority priority = modm::platform::DmaBase::Priority::Low,
+			   modm::platform::DmaBase::CircularMode circularMode =
+				   modm::platform::DmaBase::CircularMode::Enabled,
+			   modm::platform::DmaBase::IrqHandler transferErrorCallback = nullptr,
+			   modm::platform::DmaBase::IrqHandler halfCompletedCallback = nullptr,
+			   modm::platform::DmaBase::IrqHandler completedCallback = nullptr)
+	{
+		Dma::AdcChannel::configure(
+			modm::platform::DmaBase::DataTransferDirection::PeripheralToMemory,
+			modm::platform::DmaBase::MemoryDataSize::HalfWord,
+			modm::platform::DmaBase::PeripheralDataSize::HalfWord,
+			modm::platform::DmaBase::MemoryIncrementMode::Increment,
+			modm::platform::DmaBase::PeripheralIncrementMode::Fixed, priority, circularMode);
+		Dma::AdcChannel::setPeripheralAddress(Adc::getDataRegisterAddress());
+		Dma::AdcChannel::setDataLength(buffer.size());
+		Dma::AdcChannel::setMemoryAddress(reinterpret_cast<uintptr_t>(buffer.data()));
+
+		setTransferErrorCallback(transferErrorCallback);
+		setHalfCompletedConversionCallback(halfCompletedCallback);
+		setCompletedConversionCallback(completedCallback);
+
+		Dma::AdcChannel::template setPeripheralRequest<Dma::AdcRequest>();
+		Adc::setDmaMode(Adc::DmaMode::Disabled);
+	}
+
+	static void
+	startDma()
+	{
+		Adc::setDmaMode(Adc::DmaMode::Circular);
+		DmaChannel::start();
+	}
+
+	static void
+	setTransferErrorCallback(modm::platform::DmaBase::IrqHandler transferErrorCallback)
+	{
+		if (transferErrorCallback == nullptr) { return; }
+		Dma::AdcChannel::enableInterruptVector();
+		Dma::AdcChannel::enableInterrupt(modm::platform::DmaBase::InterruptEnable::TransferError);
+		Dma::AdcChannel::setTransferErrorIrqHandler(transferErrorCallback);
+	}
+
+	static void
+	setHalfCompletedConversionCallback(modm::platform::DmaBase::IrqHandler halfCompletedCallback)
+	{
+		if (halfCompletedCallback == nullptr) { return; }
+		Dma::AdcChannel::enableInterruptVector();
+		Dma::AdcChannel::enableInterrupt(modm::platform::DmaBase::InterruptEnable::HalfTransfer);
+		Dma::AdcChannel::setHalfTransferCompleteIrqHandler(halfCompletedCallback);
+	}
+
+	static void
+	setCompletedConversionCallback(modm::platform::DmaBase::IrqHandler completedCallback)
+	{
+		if (completedCallback == nullptr) { return; }
+		Dma::AdcChannel::enableInterruptVector();
+		Dma::AdcChannel::enableInterrupt(
+			modm::platform::DmaBase::InterruptEnable::TransferComplete);
+		Dma::AdcChannel::setTransferCompleteIrqHandler(completedCallback);
+	}
+};
+
+#endif  // EXAMPLE_ADCDMA_HPP

--- a/examples/nucleo_g070rb/adc_dma/main.cpp
+++ b/examples/nucleo_g070rb/adc_dma/main.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, Zühlke Engineering (Austria) GmbH
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// This Example uses adc to sample s channels 50 times every 0.5s and store the value
+// in a buffer via dma. The adc is set to be triggered by the Timer1 compare event and then to
+// sample both channels using scan mode. The compare event is triggered for a defined number of
+// times by configuring the Timer1 to use one pulse mode with an repetition count. For more
+// information on the timer please refer to the timer register count example. In this configuration,
+// the adc sampling process is started by the cpu but handled completely by peripherals clearing CPU
+// time for other tasks.
+
+#include <modm/architecture/interface/interrupt.hpp>
+#include <modm/board.hpp>
+#include <modm/platform.hpp>
+
+#include "adc_dma.hpp"
+#include "timer_handler.hpp"
+
+using namespace Board;
+using namespace modm::platform;
+using Adc1Dma = AdcDma<Adc1, Dma1::Channel1>;
+
+std::array<uint16_t, 100> adc_results{};
+volatile bool dma_completed = false;
+
+void
+completedCallback()
+{
+	LedD13::toggle();
+	dma_completed = true;
+}
+
+int
+main()
+{
+	Board::initialize();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_INFO << "Start Setup" << modm::endl;
+
+	LedD13::setOutput();
+	LedD13::reset();
+
+	Adc1::connect<GpioInputA0::In0>();
+	Adc1::connect<GpioInputA1::In1>();
+
+	Adc1::setSampleTime(Adc1::SampleTime::Cycles3_5);
+	Adc1::initialize<SystemClock, Adc1::ClockMode::Asynchronous>();
+	modm::delay(500ms);
+	// On STM32G0 Event1 means TIM1's channel 4 capture and compare event.
+	// Each controller has a different trigger mapping, check the reference
+	// manual for more information on the trigger mapping of your controller.
+	Adc1::enableRegularConversionExternalTrigger(Adc1::ExternalTriggerPolarity::RisingEdge,
+												 Adc1::RegularConversionExternalTrigger::Event1);
+
+	Adc1::setChannels(Adc1::channelSequenceFromPins<GpioInputA0, GpioInputA1>());
+	Dma1::enable();
+	Adc1Dma::initialize<SystemClock>(adc_results);
+	Adc1Dma::setCompletedConversionCallback(completedCallback);
+	Adc1Dma::startDma();
+	Adc1::startConversion();
+
+	advancedTimerConfig<Timer1>(adc_results.size() / 2 - 1);
+	timerStart<Timer1>();
+
+	while (true)
+	{
+		modm::delay(0.5s);
+		if (!dma_completed) { continue; }
+		dma_completed = false;
+		MODM_LOG_INFO << "Measurements"
+					  << "\r" << modm::endl;
+		for (uint16_t sample : adc_results) { MODM_LOG_INFO << sample << ", "; }
+		MODM_LOG_INFO << "\r" << modm::endl;
+		adc_results.fill(0);
+		timerStart<Timer1>();
+	}
+	return 0;
+}

--- a/examples/nucleo_g070rb/adc_dma/project.xml
+++ b/examples/nucleo_g070rb/adc_dma/project.xml
@@ -1,0 +1,12 @@
+<library>
+    <extends>modm:nucleo-g070rb</extends>
+    <options>
+        <option name="modm:build:build.path">../../../build/nucleo_g070rb/adc_dma</option>
+    </options>
+    <modules>
+        <module>modm:build:scons</module>
+        <module>modm:platform:timer:1</module>
+        <module>modm:platform:adc</module>
+        <module>modm:platform:dma</module>
+    </modules>
+</library>

--- a/examples/nucleo_g070rb/adc_dma/timer_handler.hpp
+++ b/examples/nucleo_g070rb/adc_dma/timer_handler.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Zühlke Engineering (Austria) GmbH
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef EXAMPLE_TimerHANDLER_HPP
+#define EXAMPLE_TimerHANDLER_HPP
+
+#include <modm/architecture/interface/interrupt.hpp>
+#include <modm/board.hpp>
+#include <modm/platform.hpp>
+
+#include "adc_dma.hpp"
+
+using namespace Board;
+using namespace modm::platform;
+using namespace std::chrono_literals;
+
+template<class Timer>
+void
+advancedTimerConfig(uint8_t repetitionCount)
+{
+	Timer::enable();
+	Timer::setMode(Timer::Mode::UpCounter, Timer::SlaveMode::Disabled,
+				   Timer::SlaveModeTrigger::Internal0, Timer::MasterMode::Update, true);
+	Timer::setPrescaler(84);
+	Timer::setOverflow(9999);
+	Timer::setRepetitionCount(repetitionCount);
+
+	Timer::enableOutput();
+	Timer::configureOutputChannel(4, Timer::OutputCompareMode::Pwm, 999, Timer::PinState::Enable);
+}
+
+template<class Timer>
+static void
+timerStart()
+{
+	Timer::applyAndReset();
+	Timer::start();
+}
+
+#endif  // EXAMPLE_TimerHANDLER_HPP

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -3,6 +3,8 @@
  * Copyright (c) 2018, Álan Crístoffer
  * Copyright (c) 2018, Carl Treudler
  * Copyright (c) 2018-2019, Niklas Hauser
+ * Copyright (c) 2023, Daniel Waldhaeusl (Zuehlke Engineering)
+ * Copyright (c) 2024, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -15,7 +17,10 @@
 #ifndef MODM_STM32{{ target.family | upper }}_ADC{{ id }}_HPP
 #define MODM_STM32{{ target.family | upper }}_ADC{{ id }}_HPP
 
-#include <stdint.h>
+#include <array>
+#include <cstdint>
+#include <span>
+#include <utility>
 #include "../device.hpp"
 #include <modm/architecture/interface/adc.hpp>
 #include <modm/architecture/interface/register.hpp>
@@ -47,6 +52,14 @@ public:
 		{{ name }} = {{ channel }},
 %% endfor
 	};
+
+	enum class ChannelMask : uint32_t
+	{
+%% for channel, name in channels.items() | sort
+		{{ name }} = (1u << {{ channel }}),
+%% endfor
+	};
+	MODM_FLAGS32(ChannelMask);
 
 	enum class ClockMode
 	{
@@ -140,6 +153,41 @@ public:
 	};
 	MODM_FLAGS32(InterruptFlag);
 
+	enum class DmaMode : uint32_t
+	{
+		Disabled = 0,
+		OneShot = ADC_CFGR1_DMAEN,
+		Circular = ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN,
+		Mask = Circular
+	};
+
+	enum class ExternalTriggerPolarity
+	{
+		NoTriggerDetection = 0x0u,
+		RisingEdge = 0x1u,
+		FallingEdge = 0x2u,
+		RisingAndFallingEdge = 0x3u,
+	};
+
+	/**
+	 * Regular conversion external trigger sources
+	 *
+	 * The source mapped to each event varies per controller family,
+	 * refer to the ADC external trigger section in the reference manual
+	 * of your controller for more information
+	 */
+	enum class RegularConversionExternalTrigger
+	{
+		Event0 = 0x0u,
+		Event1 = 0x1u,
+		Event2 = 0x2u,
+		Event3 = 0x3u,
+		Event4 = 0x4u,
+		Event5 = 0x5u,
+		Event6 = 0x6u,
+		Event7 = 0x7u,
+	};
+
 public:
 	// start inherited documentation
 	template< class... Signals >
@@ -170,6 +218,9 @@ public:
 	initialize();
 
 	static inline void
+	enable();
+
+	static inline void
 	disable();
 
 	static inline void
@@ -197,6 +248,9 @@ public:
 
 	static inline void
 	startConversion();
+
+	static inline void
+	stopConversion();
 
 	static inline bool
 	isConversionFinished();
@@ -251,6 +305,37 @@ public:
 	setChannel(Channel channel);
 %% endif
 
+	/**
+	 * Set channel scan sequence mask. All selected channels will be converted
+	 * sequentially starting from the lowest.
+	 *
+	 * @param channels Mask of channels to convert
+	 */
+	static inline void
+	setChannels(ChannelMask_t channels);
+
+	template<typename... Gpios>
+	static consteval ChannelMask_t
+	channelMaskFromPins();
+
+%% if target.family in ["g0"]
+	/**
+	 * Set channel scan sequence to convert up to 8 channels in arbitrary order.
+	 *
+	 * @warning The sequence provided must contain at least one but no more than 8 channels.
+	 * 			Channels above 15 are not supported due to hardware limitations. If channels
+	 * 			16 to 18 should be sampled the in-order conversion sequence must be used instead.
+	 * @param channels Flag mask of channels to convert
+	 * @return true if provided channel sequence is valid, false otherwise.
+	 */
+	static inline bool
+	setChannels(std::span<const Channel> channels);
+
+	template<typename... Gpios>
+	static consteval std::array<Channel, sizeof...(Gpios)>
+	channelSequenceFromPins();
+%% endif
+
 	static inline void
 	clearChannel(Channel channel);
 
@@ -287,6 +372,9 @@ public:
 %% if target.family in ["g0"]
 	static inline void
 	setSampleTime(SampleTime sampleTime, SampleTimeGroup group = SampleTimeGroup::Group1);
+
+	static inline void
+	setSampleTimeGroup(Channel channel, SampleTimeGroup group = SampleTimeGroup::Group1);
 %% else
 	static inline void
 	setSampleTime(SampleTime sampleTime);
@@ -313,6 +401,47 @@ public:
 
 	static inline void
 	acknowledgeInterruptFlags(InterruptFlag_t flags);
+
+	static inline uintptr_t
+	getDataRegisterAddress();
+
+	static inline void
+	enableRegularConversionExternalTrigger(
+		ExternalTriggerPolarity externalTriggerPolarity,
+		RegularConversionExternalTrigger regularConversionExternalTrigger);
+
+	/**
+	 * Configure DMA mode (disabled, one-shot or circular)
+	 *
+	 * In one-shot mode DMA requests are disabled at the end of the DMA transfer.
+	 * If circular mode is selected request are being generated as long as
+	 * conversions are performed.
+	 *
+	 * @warning May only be called while no conversion is ongoing
+	 */
+	static inline void
+	setDmaMode(DmaMode mode);
+
+	static inline bool
+	getAdcEnabled();
+
+	static inline void
+	enableInternalChannel(Channel channel);
+
+private:
+%% if target.family in ["g0"]
+	static inline void
+	waitChannelConfigReady();
+
+	static inline void
+	resetChannelConfigReady();
+
+	static inline void
+	enableOrderedSequenceMode();
+
+	static inline void
+	disableOrderedSequenceMode();
+%% endif
 
 public:
 	static constexpr uint8_t TS_CAL1_TEMP{30};

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -3,6 +3,8 @@
  * Copyright (c) 2018, Álan Crístoffer
  * Copyright (c) 2018, Carl Treudler
  * Copyright (c) 2019, Niklas Hauser
+ * Copyright (c) 2023, Daniel Waldhaeusl (Zuehlke Engineering)
+ * Copyright (c) 2024, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -19,7 +21,8 @@
 #include <modm/platform/clock/rcc.hpp>
 #include <modm/architecture/interface/delay.hpp>
 #include <modm/math/algorithm/prescaler.hpp>
-
+#include <modm/math/algorithm/enumerate.hpp>
+#include <algorithm>
 
 template< class SystemClock, modm::platform::Adc{{ id }}::ClockMode mode,
 		  modm::frequency_t frequency, modm::percent_t tolerance >
@@ -68,12 +71,15 @@ modm::platform::Adc{{ id }}::initialize()
 }
 
 void
+modm::platform::Adc{{ id }}::enable()
+{
+	ADC1->CR |= ADC_CR_ADEN;  // switch on ADC
+}
+
+void
 modm::platform::Adc{{ id }}::disable()
 {
-	if (ADC1->CR & ADC_CR_ADSTART) {
-		ADC1->CR |= ADC_CR_ADSTP;
-		while (ADC1->CR & ADC_CR_ADSTP) ;
-	}
+	stopConversion();
 
 	ADC1->CR |= ADC_CR_ADDIS;
 	while (ADC1->CR & ADC_CR_ADEN) ;
@@ -132,6 +138,91 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel, const SampleTimeG
 	if(uint32_t(channel) > {{channels | max}})
 		return false;
 
+%% if target.family in ["g0"]
+	disableOrderedSequenceMode();
+	resetChannelConfigReady();
+%% endif
+
+	enableInternalChannel(channel);
+%% if target.family in ["g0"]
+	setSampleTimeGroup(channel, group);
+	// clear Channel Configuration Ready flag
+	resetChannelConfigReady();
+	ADC1->CHSELR = 1 << uint32_t(channel);
+	waitChannelConfigReady();
+%% else
+	ADC1->CHSELR = 1 << uint32_t(channel);
+%% endif
+
+	return true;
+}
+
+void
+modm::platform::Adc{{ id }}::setChannels(ChannelMask_t channels)
+{
+%% if target.family in ["g0"]
+	disableOrderedSequenceMode();
+	resetChannelConfigReady();
+%% endif
+	ADC1->CHSELR = channels.value;
+%% if target.family in ["g0"]
+	waitChannelConfigReady();
+%% endif
+}
+
+template<typename... Gpios>
+consteval auto
+modm::platform::Adc{{ id }}::channelMaskFromPins() -> ChannelMask_t
+{
+	return (static_cast<ChannelMask>(1u << std::to_underlying(getPinChannel<Gpios>())) | ...);
+}
+
+%% if target.family in ["g0"]
+bool
+modm::platform::Adc{{ id }}::setChannels(std::span<const Channel> channels)
+{
+	if (channels.size() < 1 || channels.size() > 8)
+		return false;
+
+	const bool invalid = std::ranges::any_of(channels, [](Channel c) {
+		return std::to_underlying(c) > 15;
+	});
+	if (invalid)
+		return false;
+
+	enableOrderedSequenceMode();
+	resetChannelConfigReady();
+
+	uint32_t config = 0xFFFF'FFFF;
+	for (const auto [i, ch] : modm::enumerate(channels)) {
+		enableInternalChannel(ch);
+		config = (config & ~((0xF) << i)) | (std::to_underlying(ch) << i);
+	}
+	ADC1->CHSELR = config;
+	waitChannelConfigReady();
+	return true;
+}
+
+template<typename... Gpios>
+consteval auto
+modm::platform::Adc{{ id }}::channelSequenceFromPins() -> std::array<Channel, sizeof...(Gpios)>
+{
+	const auto length = sizeof...(Gpios);
+	static_assert(length > 0 && length <= 8, "Invalid channel count");
+	constexpr auto channels = std::array{getPinChannel<Gpios>()...};
+
+	constexpr bool valid = std::ranges::all_of(channels, [](Channel c) {
+		return std::to_underlying(c) <= 15;
+	});
+	static_assert(valid, "Channels 16-18 are not supported, use ordered sequence with mask");
+
+	return channels;
+}
+%% endif
+
+void
+modm::platform::Adc{{ id }}::enableInternalChannel(Channel channel)
+{
 	if (channel == Channel::InternalReference and
 	    not (ADC1_COMMON->CCR & ADC_CCR_VREFEN))
 	{
@@ -152,29 +243,19 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel, const SampleTimeG
 		ADC1_COMMON->CCR |= ADC_CCR_TSEN;
 		modm::delay_us(135);
 	}
+}
 
 %% if target.family in ["g0"]
+void
+modm::platform::Adc{{ id }}::setSampleTimeGroup(Channel channel, SampleTimeGroup group)
+{
 	if (group == SampleTimeGroup::Group1) {
 		ADC1->SMPR &= ~(0x100ul << uint32_t(channel));
 	} else {
 		ADC1->SMPR |=  (0x100ul << uint32_t(channel));
 	}
-%% else
-%% endif
-
-	// clear Channel Configuration Ready flag
-%% if target.family in ["g0"]
-	ADC1->ISR = ADC_ISR_CCRDY;
-	ADC1->CHSELR = 1 << uint32_t(channel);
-	while(not (ADC1->ISR & ADC_ISR_CCRDY)) ;
-%% else
-	ADC1->CHSELR = 1 << uint32_t(channel);
-%% endif
-
-	return true;
 }
 
-%% if target.family in ["g0"]
 void
 modm::platform::Adc{{ id }}::enableOversampling(OversampleRatio ratio, OversampleShift shift)
 {
@@ -294,6 +375,15 @@ modm::platform::Adc{{ id }}::startConversion()
 	ADC1->CR |= ADC_CR_ADSTART;
 }
 
+void
+modm::platform::Adc{{ id }}::stopConversion()
+{
+	if (ADC1->CR & ADC_CR_ADSTART) {
+		ADC1->CR |= ADC_CR_ADSTP;
+		while (ADC1->CR & ADC_CR_ADSTP);
+	}
+}
+
 bool
 modm::platform::Adc{{ id }}::isConversionFinished()
 {
@@ -360,3 +450,69 @@ modm::platform::Adc{{ id }}::setWaitMode(const bool enable)
 		ADC1->CFGR1 &= ~ADC_CFGR1_WAIT;
 	}
 }
+
+uintptr_t
+modm::platform::Adc{{ id }}::getDataRegisterAddress()
+{
+	return (uintptr_t) &(ADC1->DR);
+}
+
+void
+modm::platform::Adc{{ id }}::enableRegularConversionExternalTrigger(
+	ExternalTriggerPolarity externalTriggerPolarity,
+	RegularConversionExternalTrigger regularConversionExternalTrigger)
+{
+	const auto polarity =
+		(static_cast<uint32_t>(externalTriggerPolarity) << ADC_CFGR1_EXTEN_Pos);
+	const auto externalTrigger =
+		(static_cast<uint32_t>(regularConversionExternalTrigger) << ADC_CFGR1_EXTSEL_Pos);
+	const auto mask = ADC_CFGR1_EXTEN_Msk | ADC_CFGR1_EXTSEL_Msk;
+	ADC1->CFGR1 = (ADC1->CFGR1 & ~mask) | polarity | externalTrigger;
+}
+
+void
+modm::platform::Adc{{ id }}::setDmaMode(DmaMode mode)
+{
+	ADC1->CFGR1 = (ADC1->CFGR1 & ~static_cast<uint32_t>(DmaMode::Mask))
+		| static_cast<uint32_t>(mode);
+}
+
+bool
+modm::platform::Adc{{ id }}::getAdcEnabled()
+{
+	return (ADC1->CR & ADC_CR_ADEN);
+}
+
+%% if target.family in ["g0"]
+void
+modm::platform::Adc{{ id }}::waitChannelConfigReady()
+{
+	while (not (ADC1->ISR & ADC_ISR_CCRDY));
+}
+
+void
+modm::platform::Adc{{ id }}::resetChannelConfigReady()
+{
+	ADC1->ISR = ADC_ISR_CCRDY;
+}
+
+void
+modm::platform::Adc{{ id }}::enableOrderedSequenceMode()
+{
+	if ((ADC1->CFGR1 & ADC_CFGR1_CHSELRMOD) == 0u) {
+		resetChannelConfigReady();
+		ADC1->CFGR1 |= ADC_CFGR1_CHSELRMOD;
+		waitChannelConfigReady();
+	}
+}
+
+void
+modm::platform::Adc{{ id }}::disableOrderedSequenceMode()
+{
+	if (ADC1->CFGR1 & ADC_CFGR1_CHSELRMOD) {
+		resetChannelConfigReady();
+		ADC1->CFGR1 &= ~ADC_CFGR1_CHSELRMOD;
+		waitChannelConfigReady();
+	}
+}
+%% endif

--- a/src/modm/platform/adc/stm32f0/adc_interrupt.cpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_interrupt.cpp.in
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2009-2010, Fabian Greif
+ * Copyright (c) 2009-2010, Martin Rosekeit
+ * Copyright (c) 2012, 2014-2015, 2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "adc_interrupt.hpp"
+#include <modm/architecture/interface/interrupt.hpp>
+// ----------------------------------------------------------------------------
+modm::platform::AdcInterrupt{{ id }}::Handler
+modm::platform::AdcInterrupt{{ id }}::handler([](){});
+
+
+MODM_ISR({{ irq }})
+{
+	if (modm::platform::AdcInterrupt{{ id }}::getInterruptFlags()) {
+		modm::platform::AdcInterrupt{{ id }}::handler();
+	}
+}

--- a/src/modm/platform/adc/stm32f0/adc_interrupt.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_interrupt.hpp.in
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2017, Niklas Hauser
+ * Copyright (c) 2017, Fabian Greif
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_ADC_INTERRUPT_{{ id }}_HPP
+#define MODM_STM32_ADC_INTERRUPT_{{ id }}_HPP
+
+#include "adc.hpp"
+#include <modm/architecture/interface/adc_interrupt.hpp>
+
+
+namespace modm::platform
+{
+
+/**
+ * ADC Interrupt module
+ *
+ * This class allows you to attach functions to the ADC Conversion
+ * Complete Interrupt via function pointers.
+ * Be aware however, that this implementation is slower and requires
+ * more resources than writing the function code directly into
+ * the interrupt service routines.
+ *
+ * @see AnalogSensors uses this implemenation.
+ *
+ * @ingroup		modm_platform_adc_{{id}}
+ * @author		Niklas Hauser
+ */
+class AdcInterrupt{{ id }} : public Adc{{ id }}, public modm::AdcInterrupt
+{
+public:
+	static inline void
+	attachInterruptHandler(Handler handler)
+	{
+		AdcInterrupt{{ id }}::handler = handler;
+	}
+
+	static Handler handler;
+};
+
+} // namespace modm::platform
+
+#endif // MODM_STM32_ADC_INTERRUPT_HPP

--- a/src/modm/platform/adc/stm32f0/module.lb
+++ b/src/modm/platform/adc/stm32f0/module.lb
@@ -62,3 +62,5 @@ def build(env):
 
     env.template("adc.hpp.in")
     env.template("adc_impl.hpp.in")
+    env.template("adc_interrupt.hpp.in", "adc_interrupt.hpp")
+    env.template("adc_interrupt.cpp.in", "adc_interrupt.cpp")


### PR DESCRIPTION
1. Adds IRQ and DMA capabilities for the G0 ADC implementation. 
2. Adds Vbat, Vref and temperature channel bits on the ADC.
3. Adds an example to the G0 adc with dma usage. The example is similar to the one present on stm32f401re.   