### PR TITLE
Also adjust SpiMaster clock of F411-Disco in Board::initializeLis3(...)

### DIFF
--- a/src/modm/board/disco_f411ve/board.hpp
+++ b/src/modm/board/disco_f411ve/board.hpp
@@ -188,7 +188,7 @@ initializeLis3()
 	lis3::Cs::setOutput(modm::Gpio::High);
 
 	lis3::SpiMaster::connect<lis3::Sck::Sck, lis3::Mosi::Mosi, lis3::Miso::Miso>();
-	lis3::SpiMaster::initialize<SystemClock, 5.25_MHz>();
+	lis3::SpiMaster::initialize<SystemClock, 6_MHz>();
 	lis3::SpiMaster::setDataMode(lis3::SpiMaster::DataMode::Mode3);
 }
 


### PR DESCRIPTION
In PR `009bb0` the SystemClock::Frequency has been adjusted from 84 to 96 MHz without also adjusting the SpiMaster clock in `Board::initializeLis3(...)` from 5.25 to 6 MHz which leads to a failing static_assert.