### PR TITLE
[stm32] Fix flash page size for large F103, F105 and F107 devices

### DIFF
--- a/src/modm/platform/flash/stm32/module.lb
+++ b/src/modm/platform/flash/stm32/module.lb
@@ -37,7 +37,10 @@ def build(env):
         ftype = "sector"
         busy_bit = "FLASH_SR_BSY"
     elif target.family in ["f1"]:
-        block_shift = 10
+        if target.name in  ["05", "07"] or int(flash["size"]) >= 262144:
+            block_shift = 11
+        else:
+            block_shift = 10
         ftype = "page"
         busy_bit = "FLASH_SR_BSY"
     elif target.family in ["g0"]:


### PR DESCRIPTION
Fix page size in flash driver for F103 devices with 256 kB flash or more, F105, and F107.

![flash_f1](https://github.com/modm-io/modm/assets/25187160/a0b25824-ba98-46c6-aa75-91560edb32f5)
