### PR TITLE
[stm32/sam_x7x] Allow I2C interrupt priority to be set

### DIFF
--- a/src/modm/platform/i2c/sam_x7x/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/sam_x7x/i2c_master.cpp.in
@@ -289,7 +289,7 @@ MODM_ISR(TWIHS{{ id }})
 // ----------------------------------------------------------------------------
 
 void
-modm::platform::I2cMaster{{ id }}::initializeWithClockConfig(uint32_t cwgrRegister)
+modm::platform::I2cMaster{{ id }}::initializeWithClockConfig(uint32_t cwgrRegister, uint8_t isrPriority)
 {
 	ClockGen::enable<ClockPeripheral::I2c{{ id }}>();
 
@@ -307,9 +307,7 @@ modm::platform::I2cMaster{{ id }}::initializeWithClockConfig(uint32_t cwgrRegist
 	// Enable arbitration lost interrupt
 	TWIHS{{ id }}->TWIHS_IER = TWIHS_IER_ARBLST;
 
-	// TODO: make priority configurable?
-	// 10 is also used in the STM32 extended driver
-	NVIC_SetPriority(TWIHS{{ id }}_IRQn, 10);
+	NVIC_SetPriority(TWIHS{{ id }}_IRQn, isrPriority);
 	NVIC_EnableIRQ(TWIHS{{ id }}_IRQn);
 }
 

--- a/src/modm/platform/i2c/sam_x7x/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/sam_x7x/i2c_master.hpp.in
@@ -146,14 +146,14 @@ public:
 	 */
 	template<class SystemClock, baudrate_t baudrate=kBd(100), percent_t tolerance=pct(5)>
 	static void
-	initialize()
+	initialize(uint8_t isrPriority = 10u)
 	{
 		static_assert(baudrate <= 400'000, "Baudrate must not exceed 400 kHz for I2C fast mode");
 		constexpr std::optional<uint32_t> registerValue = calculateTimings<SystemClock, baudrate, tolerance>();
 		static_assert(bool(registerValue), "Could not find a valid clock configuration for the requested"
 			" baudrate and tolerance");
 
-		initializeWithClockConfig(registerValue.value());
+		initializeWithClockConfig(registerValue.value(), isrPriority);
 	}
 
 	static bool
@@ -167,7 +167,7 @@ public:
 
 private:
 	static void
-	initializeWithClockConfig(uint32_t cwgrRegister);
+	initializeWithClockConfig(uint32_t cwgrRegister, uint8_t isrPriority);
 };
 
 

--- a/src/modm/platform/i2c/stm32/i2c_master.cpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.cpp.in
@@ -588,7 +588,7 @@ MODM_ISR(I2C{{ id }}_ER)
 // ----------------------------------------------------------------------------
 
 void
-modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint8_t peripheralFrequency, uint8_t riseTime, uint16_t prescaler)
+modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint8_t peripheralFrequency, uint8_t riseTime, uint16_t prescaler, uint8_t isrPriority)
 {
 	// no reset, since we want to keep the transaction attached!
 
@@ -597,9 +597,9 @@ modm::platform::I2cMaster{{ id }}::initializeWithPrescaler(uint8_t peripheralFre
 	I2C{{ id }}->CR1 = I2C_CR1_SWRST; 		// reset module
 	I2C{{ id }}->CR1 = 0;
 
-	NVIC_SetPriority(I2C{{ id }}_ER_IRQn, 10);
+	NVIC_SetPriority(I2C{{ id }}_ER_IRQn, isrPriority);
 	NVIC_EnableIRQ(I2C{{ id }}_ER_IRQn);
-	NVIC_SetPriority(I2C{{ id }}_EV_IRQn, 10);
+	NVIC_SetPriority(I2C{{ id }}_EV_IRQn, isrPriority);
 	NVIC_EnableIRQ(I2C{{ id }}_EV_IRQn);
 
 	I2C{{ id }}->CR2 = peripheralFrequency;

--- a/src/modm/platform/i2c/stm32/i2c_master.hpp.in
+++ b/src/modm/platform/i2c/stm32/i2c_master.hpp.in
@@ -70,7 +70,7 @@ public:
 	 */
 	template<class SystemClock, baudrate_t baudrate=kBd(100), percent_t tolerance=pct(5)>
 	static void
-	initialize()
+	initialize(uint8_t isrPriority = 10u)
 	{
 		// calculate the expected clock ratio
 		constexpr uint8_t scalar = (baudrate <= 100'000) ? 2 : ((baudrate <= 300'000) ? 3 : 25);
@@ -96,7 +96,7 @@ public:
 		constexpr float trise_raw = max_rise_time < 0 ? 0 : std::floor(max_rise_time / (1'000.f / freq));
 		constexpr uint8_t trise = trise_raw > 62 ? 63 : (trise_raw + 1);
 
-		initializeWithPrescaler(freq, trise, prescaler);
+		initializeWithPrescaler(freq, trise, prescaler, isrPriority);
 	}
 
 	static bool
@@ -110,7 +110,7 @@ public:
 
 private:
 	static void
-	initializeWithPrescaler(uint8_t peripheralFrequency, uint8_t riseTime, uint16_t prescaler);
+	initializeWithPrescaler(uint8_t peripheralFrequency, uint8_t riseTime, uint16_t prescaler, uint8_t isrPriority);
 };
 
 } // namespace platform


### PR DESCRIPTION
Allow the I2C interrupt priority to be set, for the other I2C driver not taken care of in #1143.
I just noticed it and wanted to prevent the interfaces from diverging.

cc @victorandrehc