### PR TITLE
Fix Python syntax

### DIFF
--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -43,8 +43,8 @@ def get_irq_list(device):
     irqs = {v["position"]: v["name"] for v in device.get_driver("core")["vector"]}
     irqs = [v for v in irqs.values() if v.startswith("DMA") and v[3].isdigit() and not "DMA2D" in v]
 
-    instance_pattern = re.compile("(DMA\d_(Ch|Channel|Stream)\d(_\d)*)")
-    channel_pattern = re.compile("DMA(?P<instance>\d)_(Ch|Channel|Stream)(?P<channels>(\d(_\d)*))")
+    instance_pattern = re.compile(r"(DMA\d_(Ch|Channel|Stream)\d(_\d)*)")
+    channel_pattern = re.compile(r"DMA(?P<instance>\d)_(Ch|Channel|Stream)(?P<channels>(\d(_\d)*))")
     irq_list = []
     for irq in irqs:
         instances = []

--- a/src/modm/platform/i2c/stm32-extended/module.lb
+++ b/src/modm/platform/i2c/stm32-extended/module.lb
@@ -17,7 +17,7 @@ import re
 global_properties = {}
 
 def get_shared_irqs(device):
-    irq_re = re.compile("I2C\d(_\d)+")
+    irq_re = re.compile(r"I2C\d(_\d)+")
     shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
     shared_irqs = [v for v in shared_irqs if irq_re.fullmatch(v)]
     shared_irq_map = {}

--- a/tools/bitmap/pbm2c.py
+++ b/tools/bitmap/pbm2c.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 		# switch to the next line
 		input = input[input.find("\n") + 1:]
 
-	result = re.match("^(\d+) (\d+)\n", input)
+	result = re.match(r"^(\d+) (\d+)\n", input)
 	if not result:
 		print("bad format!")
 

--- a/tools/font_creator/font_export.py
+++ b/tools/font_creator/font_export.py
@@ -135,7 +135,7 @@ def read_font_file(filename):
 	lines = open(filename).readlines()
 	for line_number, line in enumerate(lines):
 		if char_mode:
-			result = re.match("^\[([ #]+)\]\n", line)
+			result = re.match(r"^\[([ #]+)\]\n", line)
 			if not result:
 				raise ParseException("Illegal Format in: %s" % line[:-1], line_number)
 
@@ -165,7 +165,7 @@ def read_font_file(filename):
 			if char_line_count == 0:
 				char_mode = False
 		elif line[0] == '#':
-			result = re.match("^#(\w+)[ \t]+:[ \t]+(.*)\n", line)
+			result = re.match(r"^#(\w+)[ \t]+:[ \t]+(.*)\n", line)
 			if not result:
 				print("Error in: ", line)
 				exit(1)
@@ -184,7 +184,7 @@ def read_font_file(filename):
 				elif key == "vspace":
 					font.vspace = int(value)
 				elif key == "char":
-					charMatch = re.match("^(\d+)([ \t]*.*)", value)
+					charMatch = re.match(r"^(\d+)([ \t]*.*)", value)
 					if not charMatch:
 						raise ParseException("Illegal Format in: %s" % line[:-1], line_number)
 					number = int(charMatch.group(1))


### PR DESCRIPTION
Since Python 3.6 backslash-character pairs that are not valid escape sequences are [deprecated](https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior) and generate a `SyntaxWarning: invalid escape sequence` warning. This is fixed by using raw string.

The same problem is also fixed in modm-devices submodule, see modm-io/modm-devices#109.