### PR TITLE
[tools] Font generation with Python 3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           python3 tools/scripts/authors.py --handles --count --shoutout --since 2017-01-01
           python3 tools/xpcc_generator/builder/system_layout.py examples/xpcc/xml/communication.xml -o /tmp
+          python3 tools/font_creator/font_export.py tools/font_creator/fonts/all_caps_3x5.font /tmp/all_caps_converted
 
   stm32-examples:
     runs-on: ubuntu-22.04

--- a/tools/font_creator/font_export.py
+++ b/tools/font_creator/font_export.py
@@ -152,7 +152,7 @@ def read_font_file(filename):
 				if c == " ":
 					pass
 				elif c == "#":
-					y = char_line_index / 8
+					y = int(char_line_index / 8)
 					offset = y * char.width
 					char.data[offset + index] |= 1 << (char_line_index % 8)
 				else:


### PR DESCRIPTION
Script was not working with Python 3

Before
```bash
$ python2 font_export.py fonts/all_caps_3x5.font test
$ python font_export.py fonts/all_caps_3x5.font test
Traceback (most recent call last):
  File "/home/akos/repos/modm/tools/font_creator/font_export.py", line 229, in <module>
    font = read_font_file(filename)
  File "/home/akos/repos/modm/tools/font_creator/font_export.py", line 157, in read_font_file
    char.data[offset + index] |= 1 << (char_line_index % 8)
TypeError: list indices must be integers or slices, not float
```

After 
```bash
$ python2 font_export.py fonts/all_caps_3x5.font test
$ python font_export.py fonts/all_caps_3x5.font test
```