### PR TITLE
FreeRTOS queues for the uart module

### DIFF
--- a/examples/black_pill_f401/uart_freertos/main.cpp
+++ b/examples/black_pill_f401/uart_freertos/main.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, Sascha Schade
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2019, Raphael Lehmann
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+/*
+ * A single FreeRTOS task which reads symbols from Usart1
+ * and sends them back, toggling the LED for every symbol
+ */
+
+using namespace Board;
+
+using Uart = Usart1;
+TaskHandle_t h_mainTask;
+
+void
+taskMain(void *)
+{
+    Uart::connect<GpioOutputB6::Tx, GpioInputB7::Rx>();
+	Uart::initialize<SystemClock, 115200_Bd>();
+    Led::set();
+
+    uint8_t chr;
+    while (true)
+    {
+        Uart::read( chr, portMAX_DELAY );
+        Uart::write( chr );
+        Led::toggle();
+    }
+}
+
+constexpr int stack_size = 200;
+StackType_t stack[stack_size];
+StaticTask_t taskBuffer;
+
+int
+main()
+{
+	Board::initialize();
+
+    h_mainTask = xTaskCreateStatic(taskMain, "Main",  stack_size, NULL, 2, stack, &taskBuffer);
+    configASSERT( h_mainTask != NULL );
+    vTaskStartScheduler();
+	return 0;
+}

--- a/examples/black_pill_f401/uart_freertos/project.xml
+++ b/examples/black_pill_f401/uart_freertos/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:black-pill-f401</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/black_pill_f401/uart_freertos</option>
+    <option name="modm:platform:uart:1:buffer.tx">2Ki</option>
+    <option name="modm:platform:uart:1:buffer.rx">2Ki</option>
+    <option name="modm:platform:uart:1:queue_type">freertos</option>
+  </options>
+  <modules>
+    <module>modm:build:make</module>
+    <module>modm:platform:uart:1</module>
+  </modules>
+</library>

--- a/src/modm/platform/uart/stm32/module.lb
+++ b/src/modm/platform/uart/stm32/module.lb
@@ -41,6 +41,14 @@ class Instance(Module):
                 description="",
                 minimum=0, maximum="64Ki-2",
                 default=0))
+        module.add_option(
+            EnumerationOption(
+                name="queue_type",
+                description="Type of the queue used for the buffering",
+                enumeration=["modm", "freertos"],
+                default="modm",
+                dependencies=lambda v: {"modm": None,
+                                        "freertos": ":freertos"}[v]))
 
         return True
 
@@ -54,6 +62,7 @@ class Instance(Module):
         props["name"] = self.driver["name"].capitalize() + str(self.instance)
         props["hal"] = self.driver["name"].capitalize() + "Hal" + str(self.instance)
         props["buffered"] = env["buffer.tx"] or env["buffer.rx"]
+        props["has_freertos_queue"] = env["queue_type"] == "freertos"
 
         env.substitutions = props
         env.outbasepath = "modm/src/modm/platform/uart"

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -340,7 +340,7 @@ MODM_ISR({{ name | upper }})
 %% if has_freertos_queue
             xQueueReceiveFromISR( txQueue, &data, &xHigherPriorityTaskWoken );
 %% else
-			data = txBuffer.get());
+			data = txBuffer.get();
 			txBuffer.pop();
 %% endif
             {{ hal }}::write(data);

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -206,7 +206,7 @@ bool
 %% endif
 }
 
-    
+
 std::size_t
 {{ name }}::read(uint8_t *data, std::size_t length
 %% if has_freertos_queue

--- a/src/modm/platform/uart/stm32/uart.cpp.in
+++ b/src/modm/platform/uart/stm32/uart.cpp.in
@@ -25,15 +25,29 @@
 
 %% if buffered
 #include <modm/architecture/interface/atomic_lock.hpp>
+%% if not has_freertos_queue
 #include <modm/architecture/driver/atomic/queue.hpp>
+%% endif
 
 namespace
 {
 %% if options["buffer.rx"]
+%% if has_freertos_queue
+    static StaticQueue_t rxQueueStructure;
+    static uint8_t rxStorage[ {{ options["buffer.rx"] }} ];
+    static QueueHandle_t rxQueue = xQueueCreateStatic(sizeof(rxStorage), 1, rxStorage, &rxQueueStructure);
+%% else
 	static modm::atomic::Queue<uint8_t, {{ options["buffer.rx"] }}> rxBuffer;
 %% endif
+%% endif
 %% if options["buffer.tx"]
+%% if has_freertos_queue
+    static StaticQueue_t txQueueStructure;
+    static uint8_t txStorage[ {{ options["buffer.rx"] }} ];
+    static QueueHandle_t txQueue = xQueueCreateStatic(sizeof(txStorage), 1, txStorage, &txQueueStructure);
+%% else
 	static modm::atomic::Queue<uint8_t, {{ options["buffer.tx"] }}> txBuffer;
+%% endif
 %% endif
 }
 %% endif
@@ -67,13 +81,21 @@ void
 }
 
 bool
-{{ name }}::write(uint8_t data)
+{{ name }}::write(uint8_t data
+%% if has_freertos_queue
+                 , TickType_t timeout
+%% endif
+    )
 {
 %% if options["buffer.tx"]
-	if(txBuffer.isEmpty() && {{ hal }}::isTransmitRegisterEmpty()) {
+	if(transmitBufferSize() == 0 && {{ hal }}::isTransmitRegisterEmpty()) {
 		{{ hal }}::write(data);
 	} else {
+%% if has_freertos_queue
+        if (xQueueSend( txQueue, &data, timeout ) != pdTRUE)
+%% else
 		if (!txBuffer.push(data))
+%% endif
 			return false;
 		// Disable interrupts while enabling the transmit interrupt
 		atomic::Lock lock;
@@ -92,12 +114,20 @@ bool
 }
 
 std::size_t
-{{ name }}::write(const uint8_t *data, std::size_t length)
+{{ name }}::write(const uint8_t *data, std::size_t length
+%% if has_freertos_queue
+                 , TickType_t timeout
+%% endif
+    )
 {
 	uint32_t i = 0;
 	for (; i < length; ++i)
 	{
-		if (!write(*data++)) {
+		if (!write(*data++
+%% if has_freertos_queue
+                   , timeout
+%% endif
+                )) {
 			return i;
 		}
 	}
@@ -108,7 +138,7 @@ bool
 {{ name }}::isWriteFinished()
 {
 %% if options["buffer.tx"]
-	return txBuffer.isEmpty() && {{ hal }}::isTransmitRegisterEmpty();
+	return transmitBufferSize() == 0 && {{ hal }}::isTransmitRegisterEmpty();
 %% else
 	return {{ hal }}::isTransmitRegisterEmpty();
 %% endif
@@ -118,7 +148,11 @@ std::size_t
 {{ name }}::transmitBufferSize()
 {
 %% if options["buffer.tx"]
+%% if has_freertos_queue
+    return uxQueueMessagesWaiting( txQueue );
+%% else
 	return txBuffer.getSize();
+%% endif
 %% else
 	return {{ hal }}::isTransmitRegisterEmpty() ? 0 : 1;
 %% endif
@@ -128,13 +162,15 @@ std::size_t
 {{ name }}::discardTransmitBuffer()
 {
 %% if options["buffer.tx"]
-	std::size_t count = 0;
 	// disable interrupt since buffer will be cleared
 	{{ hal }}::disableInterrupt({{ hal }}::Interrupt::TxEmpty);
-	while(!txBuffer.isEmpty()) {
-		++count;
+	std::size_t count = transmitBufferSize();
+%% if has_freertos_queue
+    xQueueReset( txQueue );
+%% else
+	while(!txBuffer.isEmpty())
 		txBuffer.pop();
-	}
+%% endif
 	return count;
 %% else
 	return 0;
@@ -142,9 +178,16 @@ std::size_t
 }
 
 bool
-{{ name }}::read(uint8_t &data)
+{{ name }}::read(uint8_t &data
+%% if has_freertos_queue
+                 , TickType_t timeout
+%% endif
+    )
 {
 %% if options["buffer.rx"]
+%% if has_freertos_queue
+    return ( xQueueReceive(rxQueue, &data, timeout) == pdTRUE );
+%% else
 	if (rxBuffer.isEmpty()) {
 		return false;
 	} else {
@@ -152,6 +195,7 @@ bool
 		rxBuffer.pop();
 		return true;
 	}
+%% endif
 %% else
 	if({{ hal }}::isReceiveRegisterNotEmpty()) {
 		{{ hal }}::read(data);
@@ -162,12 +206,21 @@ bool
 %% endif
 }
 
+    
 std::size_t
-{{ name }}::read(uint8_t *data, std::size_t length)
+{{ name }}::read(uint8_t *data, std::size_t length
+%% if has_freertos_queue
+                , TickType_t timeout
+%% endif
+    )
 {
 %% if options["buffer.rx"]
 	uint32_t i = 0;
 	for (; i < length; ++i)
+%% if has_freertos_queue
+        if( xQueueReceive(rxQueue, data++, timeout) != pdTRUE )
+            return i;
+%% else
 	{
 		if (rxBuffer.isEmpty()) {
 			return i;
@@ -176,6 +229,7 @@ std::size_t
 			rxBuffer.pop();
 		}
 	}
+%% endif
 	return i;
 %% else
 	(void)length; // avoid compiler warning
@@ -191,7 +245,11 @@ std::size_t
 {{ name }}::receiveBufferSize()
 {
 %% if options["buffer.rx"]
+%% if has_freertos_queue
+    return uxQueueMessagesWaiting( rxQueue );
+%% else
 	return rxBuffer.getSize();
+%% endif
 %% else
 	return {{ hal }}::isReceiveRegisterNotEmpty() ? 1 : 0;
 %% endif
@@ -202,10 +260,18 @@ std::size_t
 {
 %% if options["buffer.rx"]
 	std::size_t count = 0;
+%% if has_freertos_queue
+    uint8_t data;
+    while( uxQueueMessagesWaiting( rxQueue ) > 0 ) {
+        ++count;
+        xQueueReceive( rxQueue, &data, 0 );
+    }
+%% else
 	while(!rxBuffer.isEmpty()) {
 		++count;
 		rxBuffer.pop();
 	}
+%% endif
 	return count;
 %% else
 	return 0;
@@ -243,27 +309,47 @@ modm::platform::{{ name }}::irq()
 MODM_ISR({{ name | upper }})
 %% endif
 {
+%% if has_freertos_queue
+    BaseType_t xHigherPriorityTaskWoken;
+%% endif
 	using namespace modm::platform;
 %% if options["buffer.rx"]
 	if ({{ hal }}::isReceiveRegisterNotEmpty()) {
 		// TODO: save the errors
 		uint8_t data;
 		{{ hal }}::read(data);
+%% if has_freertos_queue
+        xQueueSendFromISR( rxQueue, &data, &xHigherPriorityTaskWoken );
+%% else
 		rxBuffer.push(data);
+%% endif
 	}
 %% endif
 %% if options["buffer.tx"]
 	if ({{ hal }}::isTransmitRegisterEmpty()) {
+%% if has_freertos_queue
+        if( xQueueIsQueueEmptyFromISR( txQueue ) == pdTRUE ) {
+%% else
 		if (txBuffer.isEmpty()) {
+%% endif
 			// transmission finished, disable TxEmpty interrupt
 			{{ hal }}::disableInterrupt({{ hal }}::Interrupt::TxEmpty);
 		}
 		else {
-			{{ hal }}::write(txBuffer.get());
+            uint8_t data;
+%% if has_freertos_queue
+            xQueueReceiveFromISR( txQueue, &data, &xHigherPriorityTaskWoken );
+%% else
+			data = txBuffer.get());
 			txBuffer.pop();
+%% endif
+            {{ hal }}::write(data);
 		}
 	}
 %% endif
 	{{ hal }}::acknowledgeInterruptFlags({{ hal }}::InterruptFlag::OverrunError);
+%% if has_freertos_queue
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+%% endif
 }
 %% endif

--- a/src/modm/platform/uart/stm32/uart.hpp.in
+++ b/src/modm/platform/uart/stm32/uart.hpp.in
@@ -32,6 +32,11 @@
 #include "uart_hal_{{ id }}.hpp"
 %%endif
 
+%% if has_freertos_queue
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+%% endif
+
 namespace modm::platform
 {
 
@@ -96,10 +101,18 @@ public:
 	flushWriteBuffer();
 
 	static bool
-	write(uint8_t data);
+	write(uint8_t data
+%% if has_freertos_queue
+                 , TickType_t timeout=0
+%% endif
+        );
 
 	static std::size_t
-	write(const uint8_t *data, std::size_t length);
+	write(const uint8_t *data, std::size_t length
+%% if has_freertos_queue
+                 , TickType_t timeout=0
+%% endif
+        );
 
 	static bool
 	isWriteFinished();
@@ -111,10 +124,18 @@ public:
 	discardTransmitBuffer();
 
 	static bool
-	read(uint8_t &data);
+	read(uint8_t &data
+%% if has_freertos_queue
+                 , TickType_t timeout=0
+%% endif
+        );
 
 	static std::size_t
-	read(uint8_t *buffer, std::size_t length);
+	read(uint8_t *buffer, std::size_t length
+%% if has_freertos_queue
+                 , TickType_t timeout=0
+%% endif
+        );
 
 	static std::size_t
 	receiveBufferSize();


### PR DESCRIPTION
I suggest a small improvement for the uart module. For projects which are using both FreeRTOS and buffered uart, waiting could be done much more efficiently - instead of a busy loop a task could just sleep. Also, with this change it's now possible to call read and write functions with a timeout.

If you agree with this approach it can be extended to other peripherals (SPI, I2C, etc)