### PR TITLE
Make dfu-util flash to the offset set by modm:platform:cortex-m:linkerscript.flash_offset

### DIFF
--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -118,6 +118,8 @@ def post_build(env):
     if subs["core"].startswith("cortex-m"):
         # get memory information
         subs["memories"] = env.query("::memories")
+        subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
+        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
     else:
         subs["memories"] = []
     # Set these substitutions for all templates

--- a/tools/build_script_generator/cmake/module.lb
+++ b/tools/build_script_generator/cmake/module.lb
@@ -119,7 +119,7 @@ def post_build(env):
         # get memory information
         subs["memories"] = env.query("::memories")
         subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
-        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
+        subs["flash_address"] = hex(0x08000000 + subs["flash_offset"])
     else:
         subs["memories"] = []
     # Set these substitutions for all templates

--- a/tools/build_script_generator/make/module.lb
+++ b/tools/build_script_generator/make/module.lb
@@ -55,6 +55,8 @@ def post_build(env):
         subs["uf2mem"] = ["{:#x}:{:#x}:{}".format(m["start"], m["start"] + m["size"],
                           "CONTENTS" if "flash" in m["name"] else "NO_CONTENTS")
                           for m in subs["memories"]]
+        subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
+        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
     else:
         subs["memories"] = []
     # Add SCons specific data

--- a/tools/build_script_generator/make/module.lb
+++ b/tools/build_script_generator/make/module.lb
@@ -56,7 +56,7 @@ def post_build(env):
                           "CONTENTS" if "flash" in m["name"] else "NO_CONTENTS")
                           for m in subs["memories"]]
         subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
-        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
+        subs["flash_address"] = hex(0x08000000 + subs["flash_offset"])
     else:
         subs["memories"] = []
     # Add SCons specific data

--- a/tools/build_script_generator/make/resources/Makefile.in
+++ b/tools/build_script_generator/make/resources/Makefile.in
@@ -117,9 +117,10 @@ program-jlink: build
 	@$(PYTHON3) -m modm_tools.jlink -device $(MODM_JLINK_DEVICE) $(ELF_FILE)
 
 delay?=5
+CONFIG_FLASH_ADDRESS?=0x08000000
 .PHONY: program-dfu
 program-dfu: bin
-	@dfu-util -v -E$(delay) -R -i 0 -a 0 -s 0x08000000:leave -D $(BIN_FILE)
+	@dfu-util -v -E$(delay) -R -i 0 -a 0 -s $(CONFIG_FLASH_ADDRESS):leave -D $(BIN_FILE)
 %#
 %% if platform in ["sam"]
 .PHONY: program-bossac

--- a/tools/build_script_generator/make/resources/config.mk.in
+++ b/tools/build_script_generator/make/resources/config.mk.in
@@ -47,6 +47,8 @@ MODM_GDB_COMMANDS = -x $(MODM_PATH)/gdbinit -ex "dir $(GCC_BASE)" -ex "modm_setu
 MODM_GDB_COMMANDS_OPENOCD = -x $(MODM_PATH)/gdbinit_openocd
 MODM_GDB_COMMANDS_JLINK = -x $(MODM_PATH)/gdbinit_jlink
 MODM_GDB_COMMANDS_BMP = -x $(MODM_PATH)/gdbinit_bmp
+CONFIG_FLASH_OFFSET := {{ flash_offset }}
+CONFIG_FLASH_ADDRESS := {{ flash_address }}
 %% if platform == "sam"
 %% if bossac_offset
 MODM_BOSSAC_OFFSET := {{ bossac_offset }}

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -163,6 +163,8 @@ def post_build(env):
     if subs["core"].startswith("cortex-m"):
         # get memory information
         subs["memories"] = env.query("::memories")
+        subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
+        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
     else:
         subs["memories"] = []
     # Add SCons specific data

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -164,7 +164,7 @@ def post_build(env):
         # get memory information
         subs["memories"] = env.query("::memories")
         subs["flash_offset"] = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
-        subs["flash_address"] = hex(0x08000000 + env.get(":platform:cortex-m:linkerscript.flash_offset", 0))
+        subs["flash_address"] = hex(0x08000000 + subs["flash_offset"])
     else:
         subs["memories"] = []
     # Add SCons specific data

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -135,6 +135,12 @@ env.Append(MODM_GDBINIT_OPENOCD = "$BASEPATH/modm/gdbinit_openocd")
 env.Append(MODM_GDBINIT_JLINK = "$BASEPATH/modm/gdbinit_jlink")
 env.Append(MODM_GDBINIT_BMP = "$BASEPATH/modm/gdbinit_bmp")
 env.Append(MODM_GDB_COMMANDS = ["dir $GCC_PATH", "modm_setup_tui"])
+
+%% if core.startswith("cortex-m")
+env["CONFIG_FLASH_OFFSET"] = {{ flash_offset }}
+env["CONFIG_FLASH_ADDRESS"] = {{ flash_address }}
+%% endif
+
 %% if platform == "sam"
 %% if bossac_offset
 env.Append(MODM_BOSSAC_OFFSET = {{ bossac_offset }})

--- a/tools/build_script_generator/scons/site_tools/dfu.py
+++ b/tools/build_script_generator/scons/site_tools/dfu.py
@@ -27,7 +27,8 @@ from SCons.Script import *
 # -----------------------------------------------------------------------------
 def program_dfu(env, source):
 	delay = ARGUMENTS.get("delay", "5")
-	actionString  = 'dfu-util -v -E{} -R -i 0 -a 0 -s 0x08000000:leave -D $SOURCE'.format(delay)
+	flash_address = env.get("CONFIG_FLASH_ADDRESS", 0x08000000)
+	actionString  = 'dfu-util -v -E{} -R -i 0 -a 0 -s {}:leave -D $SOURCE'.format(delay, flash_address)
 	return env.AlwaysBuildAction(actionString, "$PROGRAM_DFU_COMSTR", source)
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Today I started playing around with my Arduino Portenta H7 board. It has a (yet unsupported) dual core STM32H7 and a bootloader. When trying to set the flash offset with `modm:platform:cortex-m:linkerscript.flash_offset` I noted that the dfu scripts always flash to 0x08000000.

This is my proposal to support dfu with flash offsets. I have tested it with the Portenta H7 board using scons and make. CMake currently does not support dfu-util as a programming tool, right?

I have also verified that make and scons still work and dfu-util flashes to 0x08000000 when `modm:platform:cortex-m:linkerscript.flash_offset` is not specified.

I'm looking forward to add support for the STM32H747 soon, at least for the Cortex M7 core.