### PR TITLE
[driver] Add AS5600 driver + generalize data-type for external encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,104 +722,106 @@ your specific needs.
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ams5915">AMS5915</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-apa102">APA102</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-as5047">AS5047</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-at24mac402">AT24MAC402</a></td>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-as5600">AS5600</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-at24mac402">AT24MAC402</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-block-device-spi-flash">SPI Flash</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bme280">BME280</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bmi088">BMI088</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bmp085">BMP085</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-bno055">BNO055</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-cat24aa">CAT24AA</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-cat24aa">CAT24AA</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-cycle_counter">CYCLE-COUNTER</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-drv832x_spi">DRV832X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1302">DS1302</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds1631">DS1631</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ds18b20">DS18B20</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-ea_dog">EA-DOG</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-ea_dog">EA-DOG</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input">Encoder Input</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_input-bitbang">Encoder Input BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-encoder_output-bitbang">Encoder Output BitBang</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ft245">FT245</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ft6x06">FT6x06</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-gpio_sampler">Gpio Sampler</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-gpio_sampler">Gpio Sampler</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hclax">HCLAx</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hd44780">HD44780</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc58x">HMC58x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hmc6343">HMC6343</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-hx711">HX711</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-i2c-eeprom">I2C-EEPROM</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-i2c-eeprom">I2C-EEPROM</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ili9341">ILI9341</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-is31fl3733">IS31FL3733</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-itg3200">ITG3200</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ixm42xxx">IXM42XXX</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-l3gd20">L3GD20</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lan8720a">LAN8720A</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lan8720a">LAN8720A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lawicel">LAWICEL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis302dl">LIS302DL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3dsh">LIS3DSH</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lis3mdl">LIS3MDL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lm75">LM75</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-lp503x">LP503x</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-lp503x">LP503x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm303a">LSM303A</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6ds33">LSM6DS33</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-lsm6dso">LSM6DSO</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ltc2984">LTC2984</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max31855">MAX31855</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-max31865">MAX31865</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-max31865">MAX31865</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max6966">MAX6966</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-max7219">MAX7219</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp23x17">MCP23x17</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp2515">MCP2515</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp3008">MCP3008</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp7941x">MCP7941x</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp7941x">MCP7941x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mcp990x">MCP990X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-mmc5603">MMC5603</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5611">MS5611</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ms5837">MS5837</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-nokia5110">NOKIA5110</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-nrf24">NRF24</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-nrf24">NRF24</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-parallel_tft_display">TFT-DISPLAY</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pat9125el">PAT9125EL</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca8574">PCA8574</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9535">PCA9535</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9548a">PCA9548A</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9685">PCA9685</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-pca9685">PCA9685</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-qmc5883l">QMC5883L</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sh1106">SH1106</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s65">SIEMENS-S65</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-siemens_s75">SIEMENS-S75</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sk6812">SK6812</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sk9822">SK9822</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ssd1306">SSD1306</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-st7586s">ST7586S</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-st7789">ST7789</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stts22h">STTS22H</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-stusb4500">STUSB4500</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-sx1276">SX1276</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-sx128x">SX128X</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3414">TCS3414</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tcs3472">TCS3472</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tlc594x">TLC594x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp102">TMP102</a></td>
-<td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp12x">TMP12x</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp12x">TMP12x</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-tmp175">TMP175</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-touch2046">TOUCH2046</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl53l0">VL53L0</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-vl6180">VL6180</a></td>
 <td align="center"><a href="https://modm.io/reference/module/modm-driver-ws2812">WS2812</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/drivertable-->

--- a/examples/nucleo_g474re/as5047/main.cpp
+++ b/examples/nucleo_g474re/as5047/main.cpp
@@ -35,14 +35,14 @@ public:
 
 		while (true)
 		{
-			PT_CALL(encoder.readout());
+			PT_CALL(encoder.read());
 
 			MODM_LOG_INFO << "\nNew readout:" << modm::endl;
-			MODM_LOG_INFO << "  angle degree: " << data.getAngleDeg() << " degrees" << modm::endl;
-			MODM_LOG_INFO << "     angle rad: " << data.getAngleRad() << " radians" << modm::endl;
-			MODM_LOG_INFO << "     angle raw: " << data.getAngleRaw() << modm::endl;
+			MODM_LOG_INFO << "  angle degree: " << data.toDegree() << " degrees" << modm::endl;
+			MODM_LOG_INFO << "     angle rad: " << data.toRadian() << " radians" << modm::endl;
+			MODM_LOG_INFO << "     angle raw: " << data.data << modm::endl;
 
-			timeout.restart(std::chrono::milliseconds(500));
+			timeout.restart(500ms);
 			PT_WAIT_UNTIL(timeout.isExpired());
 		}
 
@@ -50,7 +50,7 @@ public:
 	}
 
 private:
-	modm::as5047::Data data;
+	modm::as5047::Data data{0};
 	modm::As5047<SpiMaster, Cs> encoder;
 
 	modm::ShortTimeout timeout;

--- a/src/modm/driver/encoder/as5047.hpp
+++ b/src/modm/driver/encoder/as5047.hpp
@@ -11,15 +11,15 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_AS5047_HPP
-#define MODM_AS5047_HPP
+#pragma once
 
 #include <array>
+#include <numbers>
 #include <modm/architecture/interface/register.hpp>
 #include <modm/architecture/interface/spi_device.hpp>
 #include <modm/processing/resumable.hpp>
 #include <modm/processing/timer.hpp>
-#include <numbers>
+#include <modm/math/geometry/angle_int.hpp>
 
 namespace modm
 {
@@ -81,34 +81,7 @@ struct as5047
 
 	};
 
-	struct modm_packed Data
-	{
-		/// @return
-		constexpr float
-		getAngleRad() const
-		{
-			const uint16_t angle = data & 0x3fff;
-			return static_cast<float>(angle) / 16383.f * 2.f * std::numbers::pi_v<float>;
-		}
-
-		/// @return
-		constexpr float
-		getAngleDeg() const
-		{
-			const uint16_t angle = data & 0x3fff;
-			return static_cast<float>(angle) / 16383.f * 360.f;
-		}
-
-		/// @return
-		constexpr uint16_t
-		getAngleRaw() const
-		{
-			const uint16_t angle = data & 0x3fff;
-			return angle;
-		}
-
-		uint16_t data;
-	};
+	using Data = modm::IntegerAngle<14>;
 };  // struct as5047
 
 /**
@@ -129,13 +102,9 @@ public:
 	 */
 	As5047(Data &data);
 
-	/// Call this function once before using the device
-	modm::ResumableResult<void>
-	initialize();
-
 	/// Read the raw data from the sensor
 	modm::ResumableResult<void>
-	readout();
+	read();
 
 	/// Get the data object for this sensor
 	inline Data &
@@ -153,5 +122,3 @@ private:
 }  // namespace modm
 
 #include "as5047_impl.hpp"
-
-#endif  // MODM_AS5047_HPP

--- a/src/modm/driver/encoder/as5047.lb
+++ b/src/modm/driver/encoder/as5047.lb
@@ -22,7 +22,8 @@ def prepare(module, options):
 	module.depends(
 		":architecture:gpio",
 		":architecture:spi.device",
-		":processing:resumable"
+		":processing:resumable",
+		":math:geometry"
     )
 	return True
 

--- a/src/modm/driver/encoder/as5047_impl.hpp
+++ b/src/modm/driver/encoder/as5047_impl.hpp
@@ -11,10 +11,6 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_AS5047_HPP
-#error "Don't include this file directly, use 'as5047.hpp' instead!"
-#endif
-
 namespace modm
 {
 
@@ -27,7 +23,7 @@ As5047<SpiMaster, Cs>::As5047(Data &data) : data(data)
 
 template<typename SpiMaster, typename Cs>
 modm::ResumableResult<void>
-As5047<SpiMaster, Cs>::readout()
+As5047<SpiMaster, Cs>::read()
 {
 	RF_BEGIN();
 
@@ -39,7 +35,7 @@ As5047<SpiMaster, Cs>::readout()
 	RF_CALL(SpiMaster::transfer(outBuffer, inBuffer, 2));
 	Cs::set();
 
-	modm::delay_us(1);
+	modm::delay(1us);
 
 	Cs::reset();
 	outBuffer[1] = 0;

--- a/src/modm/driver/encoder/as5600.hpp
+++ b/src/modm/driver/encoder/as5600.hpp
@@ -1,0 +1,332 @@
+
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/*
+ * Copyright (c) 2024, Thomas Sommer
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/architecture/interface/register.hpp>
+#include <modm/math/geometry/angle_int.hpp>
+
+namespace modm
+{
+
+/// @ingroup modm_driver_as5600
+struct as5600
+{
+
+	// @see datasheet page 19
+	enum Register : uint8_t
+	{
+		ZMCO = 0x00,
+		ZPOS = 0x01,       // two bytes
+		MPOS = 0x03,       // two bytes
+		MANG = 0x05,       // two bytes
+		CONF = 0x07,       // two bytes
+		ANGLE_RAW = 0x0C,  // two bytes
+		ANGLE = 0x0E,      // two bytes
+		STATUS = 0x0B,
+		AGC = 0x1A,
+		MAGNITUDE = 0x1B,  // two bytes
+		BURN = 0xFF,
+
+		// Only AS5600L supports changing the I2c address
+		I2C_ADDR = 0x20,
+		I2C_UPDT = 0x21,
+	};
+
+	// @see datasheet page 20
+	enum class Config : uint16_t
+	{
+		PM0 = Bit0,  // Power Mode
+		PM1 = Bit1,
+
+		HYST0 = Bit2,  // Hysteresis
+		HYST1 = Bit3,
+
+		OUTS0 = Bit4,  // Output Stage
+		OUTS1 = Bit5,
+
+		PWM0 = Bit6,  // PWM Frequency
+		PWM1 = Bit7,
+
+		SF0 = Bit8,  // Slow Filter
+		SF1 = Bit9,
+
+		FTH0 = Bit10,  // Fast Filter Threshold
+		FTH1 = Bit11,
+		FTH2 = Bit12,
+
+		WD = Bit13  // Watchdog    0: Off, 1: On
+	};
+	MODM_FLAGS16(Config);
+
+	enum class PowerMode : uint16_t
+	{
+		NOM = 0,
+		LPM1 = 1,
+		LPM2 = 2,
+		LPM3 = 3,
+	};
+	using PowerMode_t = Configuration<Config_t, PowerMode, 0b11, 0>;
+
+	enum class Hysteresis : uint16_t
+	{
+		OFF = 0,
+		LSB = 1,
+		LSB2 = 2,
+		LSB3 = 3
+	};
+	using Hysteresis_t = Configuration<Config_t, Hysteresis, 0b11, 2>;
+
+	enum class OutputStage : uint16_t
+	{
+		ANALOG = 0,
+		ANALOG_REDUCED = 1,
+		PWM = 2
+	};
+	using OutputStage_t = Configuration<Config_t, OutputStage, 0b11, 4>;
+
+	enum class PWMFrequency : uint16_t
+	{
+		Hz115 = 0,
+		Hz230 = 1,
+		Hz460 = 2,
+		Hz920 = 3
+	};
+	using PWMFrequency_t = Configuration<Config_t, PWMFrequency, 0b11, 6>;
+
+	enum class SlowFilter : uint16_t
+	{
+		x16 = 0,
+		x8 = 1,
+		x4 = 2,
+		x2 = 3
+	};
+	using SlowFilter_t = Configuration<Config_t, SlowFilter, 0b11, 8>;
+
+	enum class FastFilterThreshold : uint16_t
+	{
+		LSB6 = 0,
+		LSB7 = 1,
+		LSB9 = 2,
+		LSB18 = 3,
+		LSB21 = 4,
+		LSB24 = 5,
+		LSB10 = 6
+	};
+	using FastFilterThreshold_t = Configuration<Config_t, FastFilterThreshold, 0b11, 10>;
+
+	enum class Burn : uint8_t
+	{
+		ANGLE = Bit3,  // Burn Angle data
+		CONFIG = Bit2  // Burn Config data
+	};
+
+	// @see datasheet page 21
+	enum class Status : uint8_t
+	{
+		MagnetTooStrong = Bit3,
+		MagnetTooWeak = Bit4,
+		MagnetDetected = Bit5
+	};
+	MODM_FLAGS8(Status);
+
+	using Data = modm::IntegerAngle<12>;
+};
+
+/// @ingroup modm_driver_as5600
+template<class I2cMaster>
+class As5600 : public as5600, public modm::I2cDevice<I2cMaster, 2>
+{
+public:
+	/** AS5600 has hardwired address 0x36
+	 * AS4500L has default address 0x40 but supports programming a different one
+	 */
+	As5600(Data &data, uint8_t address = 0x36) : I2cDevice<I2cMaster, 2>(address), data(data) {}
+
+	/** Reset to Power up state.
+	 * Useful for developement, not required in production.
+	 */
+	modm::ResumableResult<bool>
+	reset()
+	{
+		RF_BEGIN();
+
+		bool success = true;
+
+		/// The config registers span from 0x00 to 0x08
+		for (uint8_t reg = 0x00; reg < 0x08; reg += 2)
+		{
+			buffer[0] = reg;
+			buffer[1] = 0;
+			buffer[2] = 0;
+
+			this->transaction.configureWrite(buffer, 3);
+
+			RF_CALL(this->runTransaction());
+			success &= this->wasTransactionSuccessful();
+		}
+
+		RF_END_RETURN(success);
+	}
+
+	modm::ResumableResult<bool>
+	configure(Config_t config)
+	{
+		return write(Register::CONF, config.value);
+	}
+
+	modm::ResumableResult<bool>
+	setI2cAddress(uint8_t address)
+	{
+		return write(Register::I2C_ADDR, address);
+	}
+
+  /// Wait 1ms after setting the lower limit
+	modm::ResumableResult<bool>
+	setLowerLimit(Data data)
+	{
+		return write(Register::ZPOS, data.data);
+	}
+
+  /// Wait 1ms after setting the upper limit
+	modm::ResumableResult<bool>
+	setUpperLimit(Data data)
+	{
+		return write(Register::MPOS, data.data);
+	}
+
+	modm::ResumableResult<bool>
+	setMaxAngle(Data data)
+	{
+		return write(Register::MANG, data.data);
+	}
+
+  /// Permanently burn configurations
+	/// @warning As5600 can be burned only 3 times!
+	modm::ResumableResult<bool>
+	burn(Burn flags)
+	{
+		buffer[0] = static_cast<uint8_t>(flags);
+		return write(Register::BURN, buffer, 1);
+	}
+
+	modm::ResumableResult<Data>
+	getRawValue()
+	{
+		RF_BEGIN();
+
+		const uint16_t result = RF_CALL(read<uint16_t>(Register::ANGLE_RAW));
+
+		// Raw value requires masking
+		RF_END_RETURN(Data(result & Data::max));
+	}
+
+	modm::ResumableResult<Status>
+	getStatus()
+	{
+		return static_cast<Status>(read<uint8_t>(Register::STATUS));
+	}
+
+	modm::ResumableResult<uint16_t>
+	getMagnitude()
+	{
+		return read<uint16_t>(Register::MAGNITUDE);
+	}
+
+	/** Automated Gain Control
+	 *
+	 * The AS5600 uses Automatic Gain Control in a closed loop to compensate
+	 * for variations of the magnetic field strength due to changes of temperature,
+	 * airgap between IC and magnet, and magnet degradation.
+	 *
+	 * For the most robust performance, the gain value should be in the center of its range.
+	 * The airgap of the physical system can be adjusted to achieve this value.
+	 *
+	 * In 5V operation, range is 0-255
+	 * In 3.3V operation, range is reduced to 0-128
+	 */
+	modm::ResumableResult<uint8_t>
+	getAgcValue()
+	{
+		return read<uint8_t>(Register::AGC);
+	}
+
+	modm::ResumableResult<bool>
+	read()
+	{
+		RF_BEGIN();
+
+		data.data = RF_CALL(read<uint16_t>(Register::ANGLE));
+
+		RF_END_RETURN(this->wasTransactionSuccessful());
+	}
+
+	inline Data &
+	getData()
+	{
+		return data;
+	}
+
+private:
+	template<std::unsigned_integral T>
+	modm::ResumableResult<bool>
+	write(Register reg, T value)
+	{
+		RF_BEGIN();
+
+		buffer[0] = reg;
+
+		if constexpr (std::is_same_v<T, uint8_t>)
+		{
+			buffer[1] = value;
+		} else
+		{
+			buffer[1] = value >> 8;
+			buffer[2] = value;
+		}
+
+		this->transaction.configureWrite(buffer, 1 + sizeof(T));
+
+		RF_END_RETURN_CALL(this->runTransaction());
+	}
+
+	template<std::unsigned_integral T>
+	modm::ResumableResult<T>
+	read(Register reg)
+	{
+		RF_BEGIN();
+
+		buffer[0] = reg;
+		this->transaction.configureWriteRead(buffer, 1, buffer + 1, sizeof(T));
+
+		RF_CALL(this->runTransaction());
+
+		T result;
+
+		if constexpr (std::is_same_v<T, uint8_t>)
+		{
+			result = buffer[1];
+		} else
+		{
+			result = buffer[1] << 8 | buffer[2];
+		}
+
+		RF_END_RETURN(result);
+	}
+
+	Data &data;
+	uint8_t buffer[3];
+};
+}  // namespace modm

--- a/src/modm/driver/encoder/as5600.lb
+++ b/src/modm/driver/encoder/as5600.lb
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2024, Thomas Sommer
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+	module.name = ":driver:as5600"
+	module.description = """\
+# AS5600 10 bit absolute encoder SPI driver
+
+[Datasheet](https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf)
+"""
+
+def prepare(module, options):
+	module.depends(
+		":architecture:gpio",
+		":architecture:i2c.device",
+		":processing:resumable",
+		":math:geometry"
+    )
+	return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/encoder"
+    env.copy("as5600.hpp")

--- a/src/modm/math/geometry/angle_int.hpp
+++ b/src/modm/math/geometry/angle_int.hpp
@@ -1,0 +1,65 @@
+// coding: utf-8
+// ----------------------------------------------------------------------------
+/*
+ * Copyright (c) 2024, Thomas Sommer
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cmath>
+#include <modm/math/utils/integer_traits.hpp>
+#include <numbers>
+
+namespace modm
+{
+
+/// @brief Represents an absolute angle in a full circle
+/// @group modm_math_geometry
+template<int Bits>
+struct modm_packed IntegerAngle
+{
+	using T = modm::least_uint<Bits>;
+	using DeltaType = std::make_signed_t<modm::least_uint<Bits + 1>>;
+
+	T data;
+	static constexpr T max = std::pow(2, Bits) - 1;
+
+	constexpr DeltaType
+	getDelta()
+	{
+		static DeltaType previous{static_cast<DeltaType>(data)};
+		DeltaType delta = DeltaType(data) - previous;
+
+		if (delta < -(max / 2))
+		{
+			delta += max;
+		} else if (delta > (max / 2))
+		{
+			delta -= max;
+		}
+
+		previous = data;
+
+		return delta;
+	}
+
+	constexpr float
+	toDegree() const
+	{
+		return float(data) * 360 / max;
+	}
+
+	constexpr float
+	toRadian() const
+	{
+		return float(data) * 2 * std::numbers::pi_v<float> / max;
+	}
+};
+}  // namespace modm


### PR DESCRIPTION
Driver for a small and cheap magnetic encoder.

First, i've generalized the angle data type of existing magnetic encoder driver as5047.
👉 A consequent follow up would be to integrate `driver/encoder/angle.hpp` with `math/geometry/angle.hpp`. F.e. by adding conversion constructors to `math/geometry/angle.hpp` and drop the redundant methods ::toRadian() and ::toDegree() in `driver/encoder/angle.hpp`. But we might also just keep it as it is.

What do you think?