### PR TITLE
Fix minor typo in driver/encoder/as5600.lb

### DIFF
--- a/src/modm/driver/encoder/as5600.lb
+++ b/src/modm/driver/encoder/as5600.lb
@@ -13,7 +13,7 @@
 def init(module):
 	module.name = ":driver:as5600"
 	module.description = """\
-# AS5600 10 bit absolute encoder SPI driver
+# AS5600 10 bit absolute encoder I2C driver
 
 [Datasheet](https://ams.com/documents/20143/36005/AS5600_DS000365_5-00.pdf)
 """


### PR DESCRIPTION
Apologies about the branch name -- it was generated by GitHub.