### PR TITLE
Add STM32C0x

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -109,6 +109,32 @@ jobs:
           name: samx7-compile-all
           path: test/all/log
 
+  stm32c0-compile-all:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2023-03-12
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager modm
+      - name: Compile HAL for all STM32C0
+        run: |
+          (cd test/all && python3 run_all.py stm32c0 --quick-remaining)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stm32c0-compile-all
+          path: test/all/log
+
   stm32f0-compile-all:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-22.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -135,6 +135,10 @@ jobs:
       - name: Update lbuild
         run: |
           pip3 install --upgrade --upgrade-strategy=eager modm
+      - name: Examples STM32C0 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_c031c6)
       - name: Examples STM32F0 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -658,59 +658,60 @@ We have out-of-box support for many development boards including documentation.
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-feather-rp2040">FEATHER-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-mega-2560-pro">MEGA-2560-PRO</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-c031c6">NUCLEO-C031C6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f031k6">NUCLEO-F031K6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f042k6">NUCLEO-F042K6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f042k6">NUCLEO-F042K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f072rb">NUCLEO-F072RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f091rc">NUCLEO-F091RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f103rb">NUCLEO-F103RB</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303k8">NUCLEO-F303K8</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303k8">NUCLEO-F303K8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303re">NUCLEO-F303RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f334r8">NUCLEO-F334R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f401re">NUCLEO-F401RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f411re">NUCLEO-F411RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f411re">NUCLEO-F411RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f429zi">NUCLEO-F429ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f439zi">NUCLEO-F439ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446re">NUCLEO-F446RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446ze">NUCLEO-F446ZE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446ze">NUCLEO-F446ZE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f746zg">NUCLEO-F746ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g070rb">NUCLEO-G070RB</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g071rb">NUCLEO-G071RB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g071rb">NUCLEO-G071RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431rb">NUCLEO-G431RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3779<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3839<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->2974<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->3034<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->416<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 - Raspberry Pi: <!--rpicount-->1<!--/rpicount--> device.
@@ -104,12 +104,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <table>
 <tr>
 <th align="center"></th>
-<th align="center" colspan="14">STM32</th>
+<th align="center" colspan="15">STM32</th>
 <th align="center" colspan="4">SAM</th>
 <th align="center" colspan="1">RP</th>
 <th align="center" colspan="3">AT</th>
 </tr><tr>
 <th align="left">Peripheral</th>
+<th align="center">C0</th>
 <th align="center">F0</th>
 <th align="center">F1</th>
 <th align="center">F2</th>
@@ -143,6 +144,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -158,6 +160,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 </tr><tr>
 <td align="left">CAN</td>
+<td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -182,6 +185,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Comparator</td>
+<td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -206,6 +210,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 </tr><tr>
 <td align="left">DAC</td>
+<td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -243,6 +248,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -254,6 +260,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Ethernet</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -293,6 +300,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -303,10 +311,11 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 </tr><tr>
 <td align="left">External Memory</td>
 <td align="center">✕</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -320,12 +329,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✕</td>
-<td align="center">○</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">GPIO</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -364,6 +374,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
@@ -374,6 +385,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 </tr><tr>
 <td align="left">Internal Flash</td>
+<td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
@@ -412,6 +424,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -422,6 +435,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Random Generator</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
@@ -446,6 +460,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">SPI</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -489,11 +504,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">Timer</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -539,9 +556,11 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 </tr><tr>
 <td align="left">Unique ID</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -566,6 +585,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">USB</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/examples/nucleo_c031c6/adc/main.cpp
+++ b/examples/nucleo_c031c6/adc/main.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Jörg Ebeling
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+/*
+ * This example demonstrates the usage of the ADC peripheral.
+ * Connect two potentiometers to A0 and A1 to get reasonable readings or just
+ * touch the two pins with your fingers to get ... interesting readings.
+ * Make sure you're not too charged up with static electricity!
+ */
+
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+
+	Adc1::connect<GpioA0::In0, GpioA1::In1>();
+	Adc1::initialize<Board::SystemClock, Adc1::ClockMode::Asynchronous,
+					 24_MHz>();  // 24MHz/160.5 sample time=6.6us (fulfill Ts_temp of 5us)
+
+	Adc1::setResolution(Adc1::Resolution::Bits12);
+	Adc1::setSampleTime(Adc1::SampleTime::Cycles160_5);
+	Adc1::setRightAdjustResult();
+	Adc1::enableOversampling(Adc1::OversampleRatio::x16, Adc1::OversampleShift::Div16);
+
+	while (true)
+	{
+		Board::LedD13::toggle();
+		modm::delay(500ms);
+
+		const uint16_t vref = Adc1::readInternalVoltageReference();
+		MODM_LOG_INFO.printf("Vref=%4humV T=%2hu°C A0=%4humV A1=%4humV\n",
+							 vref, Adc1::readTemperature(vref),
+							 (vref * Adc1::readChannel(Adc1::Channel::In0) / 0xFFF),
+							 (vref * Adc1::readChannel(Adc1::Channel::In1) / 0xFFF));
+	}
+}

--- a/examples/nucleo_c031c6/adc/project.xml
+++ b/examples/nucleo_c031c6/adc/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-c031c6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_c031c6/adc</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:adc</module>
+  </modules>
+</library>

--- a/examples/nucleo_c031c6/adc_sequence/main.cpp
+++ b/examples/nucleo_c031c6/adc_sequence/main.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Jörg Ebeling
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <array>
+
+using namespace Board;
+
+/*
+ * This example demonstrates the usage of the ADC peripheral.
+ * Connect two potentiometers to A0 and A1 to get reasonable readings or just
+ * touch the two pins with your fingers to get ... interesting readings.
+ * Make sure you're not too charged up with static electricity!
+ *
+ * NOTE: the readings are raw ADC values and need to be converted to voltage!
+ */
+
+std::array<uint16_t, 4> adc_data_buf;
+
+static void
+adc_handler()
+{
+	static uint8_t adc_data_idx = 0;
+
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfConversion)
+	{
+		Adc1::acknowledgeInterruptFlags(Adc1::InterruptFlag::EndOfConversion);
+		adc_data_buf.at(adc_data_idx) = Adc1::getValue();
+		adc_data_idx++;
+	}
+	if (Adc1::getInterruptFlags() & Adc1::InterruptFlag::EndOfSequence)
+	{
+		Adc1::acknowledgeInterruptFlags(Adc1::InterruptFlag::EndOfSequence);
+		adc_data_idx = 0;
+	}
+}
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+	MODM_LOG_INFO << "Board initialized" << modm::endl;
+
+	Adc1::connect<GpioA0::In0, GpioA1::In1>();
+	Adc1::initialize<Board::SystemClock, Adc1::ClockMode::Asynchronous,
+					 24_MHz>();  // 24MHz/160.5 sample time=6.6us (fulfill Ts_temp of 5us)
+	Adc1::setResolution(Adc1::Resolution::Bits12);
+	Adc1::setRightAdjustResult();
+	Adc1::setSampleTime(Adc1::SampleTime::Cycles160_5);
+
+	const Adc1::Channel sequence[4] = {Adc1::Channel::InternalReference, Adc1::Channel::In0,
+									   Adc1::Channel::In1, Adc1::Channel::Temperature};
+	Adc1::setChannels(sequence);
+
+	Adc1::enableInterruptVector(15);
+	Adc1::enableInterrupt(Adc1::Interrupt::EndOfConversion | Adc1::Interrupt::EndOfSequence);
+	AdcInterrupt1::attachInterruptHandler(adc_handler);
+	Adc1::enableFreeRunningMode();
+	Adc1::startConversion();
+
+	while (true)
+	{
+		Board::LedD13::toggle();
+		modm::delay(500ms);
+
+		MODM_LOG_INFO << "ADC: ";
+		for (size_t i = 0; auto value : adc_data_buf)
+		{
+			MODM_LOG_INFO << i++ << "=" << value << " ";
+		}
+		MODM_LOG_INFO << modm::endl;
+	}
+	return 0;
+}

--- a/examples/nucleo_c031c6/adc_sequence/project.xml
+++ b/examples/nucleo_c031c6/adc_sequence/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nucleo-c031c6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_c031c6/adc_sequence</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:adc</module>
+  </modules>
+</library>

--- a/examples/nucleo_c031c6/blink/main.cpp
+++ b/examples/nucleo_c031c6/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		LedD13::toggle();
+		modm::delay(Button::read() ? 100ms : 500ms);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_c031c6/blink/project.xml
+++ b/examples/nucleo_c031c6/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-c031c6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_c031c6/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_c031c6/timer/main.cpp
+++ b/examples/nucleo_c031c6/timer/main.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Jörg Ebeling
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+MODM_ISR(TIM14)
+{
+	Timer14::acknowledgeInterruptFlags(Timer14::InterruptFlag::Update);
+	MODM_LOG_DEBUG << "Set LED" << modm::endl;
+	Board::LedD13::set();
+}
+
+MODM_ISR(TIM16)
+{
+	Timer16::acknowledgeInterruptFlags(Timer16::InterruptFlag::Update);
+	MODM_LOG_DEBUG << "Reset LED" << modm::endl;
+	Board::LedD13::reset();
+}
+
+int
+main()
+{
+	Board::initialize();
+	Board::LedD13::setOutput();
+
+	MODM_LOG_INFO << "Board & Logger initialized" << modm::endl;
+
+	Timer14::enable();
+	Timer14::setMode(Timer14::Mode::UpCounter);
+	Timer14::setPeriod<Board::SystemClock>(1000ms);
+	Timer14::applyAndReset();
+	Timer14::enableInterrupt(Timer14::Interrupt::Update);
+	Timer14::enableInterruptVector(true, 5);
+
+	Timer16::enable();
+	Timer16::setMode(Timer16::Mode::UpCounter);
+	Timer16::setPeriod<Board::SystemClock>(909ms);
+	Timer16::applyAndReset();
+	Timer16::enableInterrupt(Timer16::Interrupt::Update);
+	Timer16::enableInterruptVector(true, 5);
+
+	Timer14::start();
+	Timer16::start();
+
+	while (true) ;
+}

--- a/examples/nucleo_c031c6/timer/project.xml
+++ b/examples/nucleo_c031c6/timer/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-c031c6</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_c031c6/timer</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:timer:14</module>
+    <module>modm:platform:timer:16</module>
+  </modules>
+</library>

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -127,7 +127,7 @@ def common_header_file(env):
     define = None
 
     content = Path(localpath(folder, family_header)).read_text(encoding="utf-8", errors="replace")
-    match = re.findall(r"if defined\((?P<define>STM32[FGHLU][\w\d]+)\)", content)
+    match = re.findall(r"if defined\((?P<define>STM32[CFGHLU][\w\d]+)\)", content)
     define = getDefineForDevice(device.identifier, match)
     if define is None or match is None:
         raise ValidateException("No device define found for '{}'!".format(device.partname))

--- a/repo.lb
+++ b/repo.lb
@@ -83,7 +83,8 @@ class DevicesCache(dict):
         device_file_names += glob.glob(repopath("tools/devices/**/*.xml"))
 
         # roughly filter to supported devices
-        supported = ["stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
+        supported = ["stm32c0",
+                     "stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
                      "stm32g0", "stm32g4",
                      "stm32h7",
                      "stm32l0", "stm32l1", "stm32l4", "stm32l5",

--- a/src/modm/board/nucleo64_arduino_c0.hpp
+++ b/src/modm/board/nucleo64_arduino_c0.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+// Nucleo64 Arduino Header Footprint for STM32C031C6
+// Schematic: https://www.st.com/resource/en/schematic_pack/mb1549-u575ziq-c03_schematic.pdf
+
+#ifndef MODM_STM32_NUCLEO64_ARDUINO_HPP
+#define MODM_STM32_NUCLEO64_ARDUINO_HPP
+
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA4;
+using A3 = GpioB1;
+using A4 = GpioA11;
+using A5 = GpioA12;
+
+using D0  = GpioB7;
+using D1  = GpioB6;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB10;
+using D5  = GpioB4;
+using D6  = GpioB5;
+using D7  = GpioA15;
+using D8  = GpioA9;
+using D9  = GpioC7;
+using D10 = GpioB0;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+
+#endif // MODM_STM32_NUCLEO64_ARDUINO_HPP

--- a/src/modm/board/nucleo_c031c6/board.hpp
+++ b/src/modm/board/nucleo_c031c6/board.hpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016-2018, 2024, Niklas Hauser
+ * Copyright (c) 2017, Nick Sarten
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef MODM_STM32_NUCLEO_C031C6_HPP
+#define MODM_STM32_NUCLEO_C031C6_HPP
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+/// @ingroup modm_board_nucleo_c031c6
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+namespace Board
+{
+/// @ingroup modm_board_nucleo_c031c6
+/// @{
+using namespace modm::literals;
+
+/// STM32C031C6 running at 48MHz generated from the internal clock
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = Rcc::HsiFrequency;
+	static constexpr uint32_t Ahb = Frequency;
+	static constexpr uint32_t Apb = Frequency;
+
+	static constexpr uint32_t Adc1    = Apb;
+
+	static constexpr uint32_t Spi1    = Apb;
+
+	static constexpr uint32_t Usart1  = Apb;
+	static constexpr uint32_t Usart2  = Apb;
+
+	static constexpr uint32_t I2c1    = Apb;
+
+	static constexpr uint32_t Timer1  = Apb;
+	static constexpr uint32_t Timer2  = Apb;
+	static constexpr uint32_t Timer3  = Apb;
+	static constexpr uint32_t Timer14 = Apb;
+	static constexpr uint32_t Timer16 = Apb;
+	static constexpr uint32_t Timer17 = Apb;
+	static constexpr uint32_t Iwdg    = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		// 48MHz generated from internal RC
+		Rcc::enableInternalClock();
+		Rcc::setHsiSysDivider(Rcc::HsiSysDivider::Div1);
+		// set flash latency for 48MHz
+		Rcc::setFlashLatency<Frequency>();
+		// switch system clock to PLL output
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div1);
+		// update frequencies for busy-wait delay functions
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino Footprint
+#include "nucleo64_arduino.hpp"
+
+using Button = GpioInputC13;
+using LedD13 = D13;
+
+using Leds = SoftwareGpioPort< LedD13 >;
+/// @}
+
+namespace stlink
+{
+/// @ingroup modm_board_nucleo_c031c6
+/// @{
+using Rx = GpioInputA3;
+using Tx = GpioOutputA2;
+using Uart = BufferedUart<UsartHal2, UartTxBuffer<64>>;
+/// @}
+}
+
+/// @ingroup modm_board_nucleo_c031c6
+/// @{
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+}
+/// @}
+
+}
+
+#endif	// MODM_STM32_NUCLEO_C031C6_HPP

--- a/src/modm/board/nucleo_c031c6/board.xml
+++ b/src/modm/board/nucleo_c031c6/board.xml
@@ -1,0 +1,15 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32c031c6t6</option>
+    <option name="modm:platform:cortex-m:main_stack_size">1Ki</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-c031c6</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_c031c6/module.lb
+++ b/src/modm/board/nucleo_c031c6/module.lb
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-c031c6"
+    module.description = """\
+# NUCLEO-C031C6
+
+[Nucleo kit for STM32C031C6](https://www.st.com/en/evaluation-tools/nucleo-c031c6.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32c031c6t"):
+        return False
+
+    module.depends(":platform:core", ":platform:gpio", ":platform:clock", ":platform:uart:2",
+                   ":debug", ":architecture:clock", ":architecture:clock")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert"),
+        "has_gpio_c14_c15": False
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.copy("../nucleo64_arduino_c0.hpp", "nucleo64_arduino.hpp")
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.copy(repopath("tools/openocd/modm/st_nucleo_c0.cfg"), "st_nucleo_c0.cfg")
+    env.collect(":build:openocd.source", "modm/board/st_nucleo_c0.cfg")

--- a/src/modm/platform/adc/stm32f0/adc.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc.hpp.in
@@ -89,7 +89,7 @@ public:
 %% endif
 	};
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	enum class SampleTimeGroup
 	{
 		Group1,
@@ -229,7 +229,7 @@ public:
 	static inline void
 	setWaitMode(bool enable);
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	static inline void
 	enableOversampling(OversampleRatio ratio, OversampleShift shift = OversampleShift::Div1);
 
@@ -299,7 +299,7 @@ public:
 	 * 		initialize()
 	 */
 	static inline bool
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	setChannel(Channel channel, SampleTimeGroup group = SampleTimeGroup::Group1);
 %% else
 	setChannel(Channel channel);
@@ -318,7 +318,7 @@ public:
 	static consteval ChannelMask_t
 	channelMaskFromPins();
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	/**
 	 * Set channel scan sequence to convert up to 8 channels in arbitrary order.
 	 *
@@ -342,7 +342,7 @@ public:
 	/// Setting the channel for a Pin
 	template< class Gpio >
 	static inline bool
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	setPinChannel(SampleTimeGroup group = SampleTimeGroup::Group1)
 	{
 		return setChannel(getPinChannel<Gpio>(), group);
@@ -369,7 +369,7 @@ public:
 		return readChannel(getPinChannel<Gpio>());
 	}
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	static inline void
 	setSampleTime(SampleTime sampleTime, SampleTimeGroup group = SampleTimeGroup::Group1);
 
@@ -429,7 +429,7 @@ public:
 	enableInternalChannel(Channel channel);
 
 private:
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	static inline void
 	waitChannelConfigReady();
 
@@ -445,7 +445,12 @@ private:
 
 public:
 	static constexpr uint8_t TS_CAL1_TEMP{30};
-%% if target.family in ["f0"]
+%% if target.family in ["c0"]
+	static constexpr uint16_t VDDA_CAL{3000};
+	static inline volatile uint16_t *const VREFINT_CAL{(volatile uint16_t *)0x1FFF756A};
+	static inline volatile uint16_t *const TS_CAL1{(volatile uint16_t *)0x1FFF7568};
+	static constexpr uint16_t TS_AVG_SLOPE{3454}; // Typ. 2.53mV/°C => 2530uV * 4096 / 3000
+%% elif target.family in ["f0"]
 	static constexpr uint16_t VDDA_CAL{3300};
 	static inline volatile uint16_t *const VREFINT_CAL{(volatile uint16_t *)0x1FFF'F7BA};
 	static inline volatile uint16_t *const TS_CAL1{(volatile uint16_t *)0x1FFF'F7B8};

--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -31,8 +31,8 @@ modm::platform::Adc{{ id }}::initialize()
 {
 	Rcc::enable<Peripheral::Adc{{ id }}>();
 
-%% if target.family in ["g0"]
-	ADC1->CR |= ADC_CR_ADVREGEN;
+%% if target.family in ["c0", "g0"]
+	ADC1->CR |= ADC_CR_ADVREGEN; // Enable internal ADC VREG
 	modm::delay_us(20);
 %% endif
 
@@ -48,7 +48,7 @@ modm::platform::Adc{{ id }}::initialize()
 		ADC1->CFGR2 = (ADC1->CFGR2 & ~ADC_CFGR2_CKMODE) | prescaler;
 	}
 	else {
-		ADC1->CFGR2 &= ~ADC_CFGR2_CKMODE;
+		ADC1->CFGR2 &= ~ADC_CFGR2_CKMODE; // Switch to async clock mode
 %% if target.family in ["f0"]
 		Rcc::enableInternalClockMHz14();
 		// There are no prescalers for the asynchronous clock
@@ -138,13 +138,13 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel, const SampleTimeG
 	if(uint32_t(channel) > {{channels | max}})
 		return false;
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	disableOrderedSequenceMode();
 	resetChannelConfigReady();
 %% endif
 
 	enableInternalChannel(channel);
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	setSampleTimeGroup(channel, group);
 	// clear Channel Configuration Ready flag
 	resetChannelConfigReady();
@@ -160,12 +160,12 @@ modm::platform::Adc{{ id }}::setChannel(const Channel channel, const SampleTimeG
 void
 modm::platform::Adc{{ id }}::setChannels(ChannelMask_t channels)
 {
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	disableOrderedSequenceMode();
 	resetChannelConfigReady();
 %% endif
 	ADC1->CHSELR = channels.value;
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	waitChannelConfigReady();
 %% endif
 }
@@ -177,7 +177,7 @@ modm::platform::Adc{{ id }}::channelMaskFromPins() -> ChannelMask_t
 	return (static_cast<ChannelMask>(1u << std::to_underlying(getPinChannel<Gpios>())) | ...);
 }
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 bool
 modm::platform::Adc{{ id }}::setChannels(std::span<const Channel> channels)
 {
@@ -226,7 +226,7 @@ modm::platform::Adc{{ id }}::enableInternalChannel(Channel channel)
 	if (channel == Channel::InternalReference and
 	    not (ADC1_COMMON->CCR & ADC_CCR_VREFEN))
 	{
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 		ADC1->CR |= ADC_CR_ADVREGEN;
 		modm::delay_us(30);
 %% endif
@@ -245,7 +245,7 @@ modm::platform::Adc{{ id }}::enableInternalChannel(Channel channel)
 	}
 }
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 void
 modm::platform::Adc{{ id }}::setSampleTimeGroup(Channel channel, SampleTimeGroup group)
 {
@@ -274,7 +274,7 @@ modm::platform::Adc{{ id }}::disableOversampling()
 
 
 void
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 modm::platform::Adc{{ id }}::setSampleTime(const SampleTime sampleTime, const SampleTimeGroup group)
 {
 	if (group == SampleTimeGroup::Group1) {
@@ -295,7 +295,7 @@ modm::platform::Adc{{ id }}::clearChannel(const Channel channel)
 	if(uint32_t(channel) > {{channels | max}})
 		return;
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 	ADC1->ISR = ADC_ISR_CCRDY;
 	ADC1->CHSELR = 0;
 	while(not (ADC1->ISR & ADC_ISR_CCRDY)) ;
@@ -304,7 +304,7 @@ modm::platform::Adc{{ id }}::clearChannel(const Channel channel)
 %% endif
 
 	if (channel == Channel::InternalReference) {
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 		ADC1->CR &= ~ADC_CR_ADVREGEN;
 %% endif
 		ADC1_COMMON->CCR &= ~ADC_CCR_VREFEN;
@@ -334,6 +334,9 @@ modm::platform::Adc{{ id }}::readTemperature(uint16_t Vref)
 %% if target.family == "f0" and target.name in ["30", "70"]
 	const int32_t value = (int32_t(*TS_CAL1) - (TS_DATA * Vref / VDDA_CAL)) * 1000;
 	return value / TS_AVG_SLOPE + TS_CAL1_TEMP;
+%% elif target.family == "c0"
+	const int32_t value = ((TS_DATA * Vref / VDDA_CAL) - int32_t(*TS_CAL1)) * 1000;
+	return (value / TS_AVG_SLOPE) + TS_CAL1_TEMP;
 %% else
 	const int32_t value = int32_t(TS_CAL2_TEMP - TS_CAL1_TEMP) * (TS_DATA * Vref / VDDA_CAL - *TS_CAL1);
 	return value / (*TS_CAL2 - *TS_CAL1) + TS_CAL1_TEMP;
@@ -483,7 +486,7 @@ modm::platform::Adc{{ id }}::getAdcEnabled()
 	return (ADC1->CR & ADC_CR_ADEN);
 }
 
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 void
 modm::platform::Adc{{ id }}::waitChannelConfigReady()
 {

--- a/src/modm/platform/adc/stm32f0/module.lb
+++ b/src/modm/platform/adc/stm32f0/module.lb
@@ -18,7 +18,8 @@ def init(module):
 
 def prepare(module, options):
     device = options[":target"]
-    if not (device.has_driver("adc:stm32-f0") or
+    if not (device.has_driver("adc:stm32-c0") or
+            device.has_driver("adc:stm32-f0") or
             device.has_driver("adc:stm32-g0")):
         return False
     module.depends(
@@ -40,7 +41,10 @@ def build(env):
     properties["id"] = driver.get("instance", [""])[0]
 
     channels = {i:"In{}".format(i) for i in reversed(range(0,19))}
-    if target.family in ["g0"]:
+    if target.family in ["c0"]:
+        channels[9] = "Temperature"
+        channels[10] = "InternalReference"
+    elif target.family in ["g0"]:
         channels[12] = "Temperature"
         channels[13] = "InternalReference"
         channels[14] = "Battery"

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -35,7 +35,11 @@ def build(env):
     properties["partname"] = device.partname
     properties["core"] = core = device.get_driver("core")["type"]
 
-    if target["family"] in ["f1", "f3"]:
+    if target["family"] in ["c0"]:
+        properties["hsi_frequency"] = 48_000_000
+        properties["lsi_frequency"] = 32_000
+        properties["boot_frequency"] = 12_000_000
+    elif target["family"] in ["f1", "f3"]:
         properties["hsi_frequency"] = 8_000_000
         properties["lsi_frequency"] = 40_000
         properties["boot_frequency"] = properties["hsi_frequency"]
@@ -71,7 +75,7 @@ def build(env):
         (target["family"] == "u5")
     if target["family"] in ["l4", "l5"]:
         properties["hsi48_cr"] = "CRRCR"
-    elif target["family"] in ["u5"]:
+    elif target["family"] in ["c0", "u5"]:
         properties["hsi48_cr"] = "CR"
     else:
         properties["hsi48_cr"] = "CR2"
@@ -111,8 +115,8 @@ def build(env):
                         if target.family == "h7" else ""
     properties["cfgr3"] = ("SRDCFGR" if target.name in ["a0", "a3", "b0", "b3"] else "D3CFGR")
     properties["d3"] = ("SRD" if target.name in ["a0", "a3", "b0", "b3"] else "D3")
-    properties["bdcr"] = "CSR" if target.family in ["l0", "l1"] else "BDCR"
-    properties["pll_ids"] = ["1", "2", "3"] if target.family in ["h7", "u5"] else [""]
+    properties["bdcr"] = "CSR1" if target.family in ["c0"] else "CSR" if target.family in ["l0", "l1"] else "BDCR"
+    properties["pll_ids"] = ["1", "2", "3"] if target.family in ["h7", "u5"] else [] if target.family in ["c0"] else [""]
     properties["has_smps"] = target["family"] == "h7" and (target["name"] in ["25", "35", "45", "47", "55", "57"] or \
         (target["name"] in ["30", "a3", "b0", "b3"] and target["variant"] == "q"))
     properties["ccipr1"] = "CCIPR1" if target.family in ["l5", "u5"] else "CCIPR"

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -125,7 +125,7 @@ Rcc::enableExternalCrystal(uint32_t waitCycles)
 }
 
 
-%% set lsi_cr="BDCR" if target.family in ["u5"] else "CSR"
+%% set lsi_cr="CSR2" if target.family in ["c0"] else "BDCR" if target.family in ["u5"] else "CSR"
 bool
 Rcc::enableLowSpeedInternalClock(uint32_t waitCycles)
 {
@@ -576,7 +576,6 @@ Rcc::setHsiPredivider4Enabled(bool divideBy4, uint32_t waitCycles)
 }
 %% endif
 
-
 %% set sysclksrcf_cfgr="CFGR1" if target.family in ["u5"] else "CFGR"
 bool
 Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
@@ -590,7 +589,6 @@ Rcc::enableSystemClock(SystemClockSource src, uint32_t waitCycles)
 
 	return true;
 }
-
 
 %% if target.family in ["g4", "l5"]
 bool

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -43,6 +43,20 @@ public:
 	static constexpr uint32_t HsiFrequency = {{ hsi_frequency | modm.digsep }};
 	static constexpr uint32_t BootFrequency = {{ boot_frequency | modm.digsep }};
 
+%% if target.family == "c0"
+	enum class
+	HsiSysDivider : uint32_t
+	{
+		Div1   = 0,
+		Div2   = RCC_CR_HSIDIV_0,
+		Div4   = RCC_CR_HSIDIV_1,
+		Div8   = RCC_CR_HSIDIV_1 | RCC_CR_HSIDIV_0,
+		Div16  = RCC_CR_HSIDIV_2,
+		Div64  = RCC_CR_HSIDIV_2 | RCC_CR_HSIDIV_1,
+		Div128 = RCC_CR_HSIDIV_2 | RCC_CR_HSIDIV_1 | RCC_CR_HSIDIV_0,
+	};
+
+%% else
 	enum class
 	PllSource : uint32_t
 	{
@@ -114,6 +128,7 @@ public:
 		ExternalClock = Hse,
 		ExternalCrystal = Hse,
 	};
+%% endif
 
 %% if target.family in ["l0", "l1"]
 	enum class
@@ -134,7 +149,12 @@ public:
 	enum class
 	SystemClockSource : uint32_t
 	{
-%% if target.family == "l5"
+%% if target.family == "c0"
+		Hsi = RCC_CFGR_SWS_HSI,
+		Hse = RCC_CFGR_SWS_HSE,
+		Lsi = RCC_CFGR_SWS_LSI,
+		Lse = RCC_CFGR_SWS_LSE,
+%% elif target.family == "l5"
 		Msi = 0,
 		Hsi = RCC_CFGR_SW_0,
 		Hsi16 = Hsi,
@@ -194,7 +214,7 @@ public:
 	enum class
 	AhbPrescaler : uint32_t
 	{
-%% if target.family in ["l5", "u5"]
+%% if target.family in ["c0", "l5", "u5"]
 		Div1   = 0b0000 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
 		Div2   = 0b1000 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
 		Div4   = 0b1001 << RCC_{{cfgr_prescaler}}_HPRE_Pos,
@@ -217,7 +237,17 @@ public:
 %% endif
 	};
 
-%% if target.family in ["f0", "g0"]
+%% if target.family in ["c0"]
+	enum class
+	ApbPrescaler : uint32_t
+	{
+		Div1   = RCC_CFGR_PPRE_0,
+		Div2   = RCC_CFGR_PPRE_2,
+		Div4   = RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_0,
+		Div8   = RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_1,
+		Div16  = RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_1 | RCC_CFGR_PPRE_0
+	};
+%% elif target.family in ["f0", "g0"]
 	enum class
 	ApbPrescaler : uint32_t
 	{
@@ -396,7 +426,7 @@ public:
 		Csi = RCC_CFGR_MCO2_2,
 		Lsi = RCC_CFGR_MCO2_2 | RCC_CFGR_MCO2_0
 	};
-%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5", "c0"]
 %% set cfgr_mco="CFGR1" if target.family in ["u5"] else "CFGR"
 	enum class
 	ClockOutputSource : uint32_t
@@ -615,6 +645,7 @@ public:
 	};
 %% endif
 
+%% if target.family != "c0"
 	struct PllFactors
 	{
 %% if target.family in ["h7"]
@@ -667,6 +698,7 @@ public:
 	%% endif
 %% endif
 	};
+%% endif
 
 %% if pllsai_p_usb
 	struct PllSaiFactors
@@ -835,7 +867,7 @@ public:
 		RCC->CFGR = tmp | uint32_t(src);
 		return true;
 	}
-%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5"]
+%% elif target.family in ["l0", "l1", "l4", "l5", "g0", "g4", "u5", "c0"]
 	enum class
 	ClockOutputPrescaler : uint32_t
 	{
@@ -844,7 +876,7 @@ public:
 		Div4 = (2 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 		Div8 = (3 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 		Div16 = (4 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
-%% if target.family in ["g0"]
+%% if target.family in ["c0", "g0"]
 		Div32 = (5 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 		Div64 = (6 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
 		Div128 = (7 << RCC_{{cfgr_mco}}_MCOPRE_Pos),
@@ -867,6 +899,15 @@ public:
 %% endif
 
 public:
+%% if target.family in ["c0"]
+	static inline bool
+	setHsiSysDivider(HsiSysDivider hsisysdivider)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_HSIDIV_Msk) | uint32_t(hsisysdivider);
+		return true;
+	}
+
+%% endif
 	static inline bool
 	setAhbPrescaler(AhbPrescaler prescaler)
 	{
@@ -874,7 +915,7 @@ public:
 		return true;
 	}
 
-%% if target.family in ["f0", "g0"]
+%% if target.family in ["c0", "f0", "g0"]
 	static inline bool
 	setApbPrescaler(ApbPrescaler prescaler)
 	{

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -63,7 +63,7 @@ Rcc::setFlashLatency()
 %% if target["family"] in ["f2", "f4", "l4", "g4"]
 	// enable flash prefetch and data and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
-%% elif target["family"] in ["g0"]
+%% elif target["family"] in ["c0", "g0"]
 	// enable flash prefetch and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ICEN;
 %% elif target["family"] == "f7"

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -57,6 +57,7 @@ def build(env):
     # (cycles per loop, setup cost in loops)
     tuning = {
         "g4": (3,  4), # CM4  tested on G476 in RAM
+        "c0": (3,  4), # CM0+ tested on C031 in RAM
         "l0": (3,  4), # CM0+ tested on L031 in RAM
         "g0": (3,  4), # CM0+ tested on G072 in RAM
         "f7": (4,  4), # CM7  tested on F767 in ITCM

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -29,7 +29,7 @@ void
 __modm_initialize_platform(void)
 {
 	// Enable SYSCFG
-%% if target.family == "g0"
+%% if target.family in ["c0", "g0"]
 	RCC->APBENR2 |= RCC_APBENR2_SYSCFGEN;
 %% elif target.family == "f1"
 	RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;

--- a/src/modm/platform/dma/stm32/dma.hpp.in
+++ b/src/modm/platform/dma/stm32/dma.hpp.in
@@ -73,7 +73,7 @@ public:
 %% endif
 		}
 %% endif
-%% if dmaType in ["stm32-mux"] and target.family != "g0":
+%% if dmaType in ["stm32-mux"] and target.family not in ["c0", "g0"]:
 		Rcc::enable<Peripheral::Dmamux1>();
 %% endif
 	}

--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -41,10 +41,10 @@ def prepare(module, options):
 
 def get_irq_list(device):
     irqs = {v["position"]: v["name"] for v in device.get_driver("core")["vector"]}
-    irqs = [v for v in irqs.values() if v.startswith("DMA") and v[3].isdigit() and not "DMA2D" in v]
+    irqs = [v for v in irqs.values() if re.match(r"(?:\w+_)?DMA\d_", v)]
 
-    instance_pattern = re.compile(r"(DMA\d_(Ch|Channel|Stream)\d(_\d)*)")
-    channel_pattern = re.compile(r"DMA(?P<instance>\d)_(Ch|Channel|Stream)(?P<channels>(\d(_\d)*))")
+    instance_pattern = re.compile(r"(DMA\d_(Ch|CH|Channel|Stream)\d(_\d)*)")
+    channel_pattern = re.compile(r"DMA(?P<instance>\d)_(Ch|CH|Channel|Stream)(?P<channels>(\d(_\d)*))")
     irq_list = []
     for irq in irqs:
         instances = []

--- a/src/modm/platform/extint/stm32/module.lb
+++ b/src/modm/platform/extint/stm32/module.lb
@@ -47,12 +47,12 @@ def validate(env):
 def build(env):
     target = env[":target"].identifier
 
-    separate_flags = target.family in ["g0", "l5", "u5"]
+    separate_flags = target.family in ["c0", "g0", "l5", "u5"]
     extended = target.family in ["l4", "l5", "g4", "h7"]
     if separate_flags: extended = target.name in ["b1", "c1"]
 
     exti_reg = "SYSCFG"
-    if target.family in ["g0", "l5", "u5"]: exti_reg = "EXTI"
+    if target.family in ["c0", "g0", "l5", "u5"]: exti_reg = "EXTI"
     if target.family in ["f1"]: exti_reg = "AFIO"
 
     global extimap

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -28,7 +28,7 @@ modm_gpio_enable(void)
 %%	set prefix = "IOP"
 %% elif target.family in ["l4", "l5", "g4", "u5"]
 %%  set clock_tree = 'AHB2'
-%% elif target.family in ["g0", "l0"]
+%% elif target.family in ["c0", "g0", "l0"]
 %%  set clock_tree = 'IOP'
 %% endif
 

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -125,6 +125,10 @@ def validate_alternate_functions(driver, env):
 def get_remap_command(family, key):
     reg = 'SYSCFG->CFGR1'
     mask = {
+        ('c0', 'a9') : 'SYSCFG_CFGR1_PA11_RMP',
+        ('c0', 'a10'): 'SYSCFG_CFGR1_PA12_RMP',
+        ('c0', 'a11'): 'SYSCFG_CFGR1_PA11_RMP',
+        ('c0', 'a12'): 'SYSCFG_CFGR1_PA12_RMP',
         ('f0', 'a9') : 'SYSCFG_CFGR1_PA11_PA12_RMP',
         ('f0', 'a10'): 'SYSCFG_CFGR1_PA11_PA12_RMP',
         ('f0', 'a11'): 'SYSCFG_CFGR1_PA11_PA12_RMP',

--- a/tools/build_script_generator/module.lb
+++ b/tools/build_script_generator/module.lb
@@ -248,7 +248,7 @@ def post_build(env):
         env.substitutions["openocd_sources"] = env.collector_values("openocd.source")
 
         linkerscript = env.query(":platform:cortex-m:linkerscript", {})
-        all_rams = [m for m in linkerscript.get("memories") if "w" in m["access"]]
+        all_rams = [m for m in linkerscript.get("memories", []) if "w" in m["access"]]
         env.substitutions["all_rams"] = all_rams
         vector_table = env.query(":platform:cortex-m:vector_table", {"vector_table_size": 16*4})
         env.substitutions["vector_table_size"] = vector_table["vector_table_size"]

--- a/tools/openocd/modm/st_nucleo_c0.cfg
+++ b/tools/openocd/modm/st_nucleo_c0.cfg
@@ -1,0 +1,11 @@
+# Should work with all STM32C0 Nucleo Dev Boards.
+# http://www.st.com/en/evaluation-tools/stm32-mcu-nucleo.html
+
+source [find interface/stlink.cfg]
+
+transport select hla_swd
+
+source [find target/stm32c0x.cfg]
+
+# use hardware reset
+reset_config srst_only srst_nogate


### PR DESCRIPTION
Add STM32C0x Summary:

- [x] RCC
- [x] Timer
- [x] ADC
- [x] Device driver https://github.com/modm-io/modm-devices/pull/112
- [x] USART
- [x] Examples

---

In relation to #1187, I tried to add STM32C011F6P6 support for a custom PCB.

Well, somehow hard for an ungifted to jump into the internals, who's intention was to use modm for his project ;-)
However, can't become more dumb by trying :-)

Unfortunately I got stuck after a couple of lines and don't know if I missed something to hack in modm or if I made something wrong with my minimal blink example :-/
If I chose a supported MCU it compiles well, but all supported MCU's I found, do also have a board, so... 

This is what I get now:
```
jebeling@lt-je:~/Development/OpenMowerProject/xESC_YF_rev4-adapter/firmware/ext/modm/examples/stm32c0x1/blink$ lbuild build
>> modm: Recomputing device cache...

ERROR: In 'modm:build':

Traceback (most recent call last):
  File "/home/jebeling/Development/OpenMowerProject/xESC_YF_rev4-adapter/firmware/ext/modm/tools/build_script_generator/module.lb", line 251, in post_build
    all_rams = [m for m in linkerscript.get("memories") if "w" in m["access"]]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

Any hints are welcome ;-)