### PR TITLE
Fix python syntax in modm_tools

### DIFF
--- a/tools/modm_tools/avrdude.py
+++ b/tools/modm_tools/avrdude.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### AvrDude
 
 This tool simply wraps the `avrdude` command to provide two features:

--- a/tools/modm_tools/bmp.py
+++ b/tools/modm_tools/bmp.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### Black Magic Probe
 
 This tool wraps GDB to program an ELF file onto a target connected to a BMP.

--- a/tools/modm_tools/bossac.py
+++ b/tools/modm_tools/bossac.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### BOSSA
 
 This tool simply wraps the `bossac` command line tool to guess the serial port.

--- a/tools/modm_tools/build_id.py
+++ b/tools/modm_tools/build_id.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### GNU Build-ID
 
 To extract the build ID from an ELF file:

--- a/tools/modm_tools/elf2uf2.py
+++ b/tools/modm_tools/elf2uf2.py
@@ -11,7 +11,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### UF2 Converter
 
 UF2 is a [Microsoft file format](https://github.com/microsoft/uf2) to pass

--- a/tools/modm_tools/itm.py
+++ b/tools/modm_tools/itm.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### Logging via Single-Wire Output (SWO)
 
 Logging using the SWO protocol is supported by the `modm:platform:itm` module.

--- a/tools/modm_tools/jlink.py
+++ b/tools/modm_tools/jlink.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### JLink
 
 Simply wraps JLinkGDBServer and issues the right command to program the target.

--- a/tools/modm_tools/openocd.py
+++ b/tools/modm_tools/openocd.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### OpenOCD
 
 Simply wraps OpenOCD and issues the right command to program the target.

--- a/tools/modm_tools/rtt.py
+++ b/tools/modm_tools/rtt.py
@@ -10,7 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # -----------------------------------------------------------------------------
 
-"""
+r"""
 ### Logging via Real-Time Transport (RTT)
 
 Logging using the RTT protocol is supported by the `modm:platform:rtt` module.

--- a/tools/modm_tools/size.py
+++ b/tools/modm_tools/size.py
@@ -9,7 +9,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""
+r"""
 ### Size Report
 
 Inspects the ELF file and generates a size report of the static usage of the


### PR DESCRIPTION
With recent python versions there are a lot of warnings (`DeprecationWarning` until python 3.11, `SyntaxWarning` from version 3.12 onwards) generated from the modm_tools python code:
```bash
$ scons
scons: Reading SConscript files ...
/...blink/modm/modm_tools/bmp.py:13: SyntaxWarning: invalid escape sequence '\*'
  """
/.../blink/modm/modm_tools/build_id.py:13: SyntaxWarning: invalid escape sequence '\*'
[...]
```

Is it necessary to adapt the way this doc strings are extracted form the python files, @salkinium? I don't know where exactly that happens...