### PR TITLE
Fix GCC13 memcpy warning in CAN modules

### DIFF
--- a/src/modm/platform/can/lpc/c_can.cpp.in
+++ b/src/modm/platform/can/lpc/c_can.cpp.in
@@ -311,7 +311,7 @@ modm::platform::Can::getMessage(can::Message & message)
 		return false;
 	}
 	else {
-		memcpy(&message, &rxQueue.get(), sizeof(message));
+		message = rxQueue.get();
 		rxQueue.pop();
 
 		// Check for other messages in MOBs

--- a/src/modm/platform/can/stm32/can.cpp.in
+++ b/src/modm/platform/can/stm32/can.cpp.in
@@ -391,7 +391,8 @@ modm::platform::Can{{ id }}::getMessage(can::Message& message, uint8_t *filter_i
 	}
 	else {
         auto& rxMessage = rxQueue.get();
-		memcpy(&message, &rxMessage.message, sizeof(message));
+		message = rxMessage.message;
+
         if(filter_id != nullptr) (*filter_id) = rxMessage.filter_id;
 		rxQueue.pop();
 		return true;


### PR DESCRIPTION
Resolves #1180.

Tested with an STM32F407; untested with LPC.