### PR TITLE
Add option to specify which repositories to generate SConscript files for

### DIFF
--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -6,7 +6,6 @@
   </repositories>
   <options>
     <option name="modm:build:scons:include_sconstruct">True</option>
-    <option name="modm:build:scons:include_repos">modm-test</option>
     <option name="modm:build:info.build">True</option>
     <option name="modm:build:info.git">Info+Status</option>
     <option name="modm:build:scons:cache_dir">$cache</option>

--- a/test/config/lbuild.xml
+++ b/test/config/lbuild.xml
@@ -6,6 +6,7 @@
   </repositories>
   <options>
     <option name="modm:build:scons:include_sconstruct">True</option>
+    <option name="modm:build:scons:include_repos">modm-test</option>
     <option name="modm:build:info.build">True</option>
     <option name="modm:build:info.git">Info+Status</option>
     <option name="modm:build:scons:cache_dir">$cache</option>

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -17,6 +17,7 @@ from os.path import join, relpath, isdir, exists
 def init(module):
     module.name = ":build:scons"
     module.description = FileReader("module.md")
+    module.order = 10000 # do project-wide file generation last
 
 
 def prepare(module, options):
@@ -29,10 +30,6 @@ def prepare(module, options):
     module.add_option(
         PathOption(name="path.artifact", default="artifacts", absolute=True,
                    description=descr_path_artifact))
-
-    module.add_option(
-        StringOption(name="include_repos", default="",
-                    description=descr_include_repos))
 
     module.add_collector(
         CallableCollector(name="flag_format",
@@ -154,15 +151,8 @@ def post_build(env):
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["::image.source"])
     has_nanopb = env.has_module(":nanopb")
-
-    repositories = ["modm"]
-    for token in env["include_repos"].split(","):
-        repo = token.strip()
-        if repo in env.buildlog.repositories and isdir(env.real_outpath(repo, basepath=".")):
-            repositories.append(repo)
-        elif repo != "":
-            env.log.error(f"\"{repo}\" is not a valid repository!")
-
+    repositories = [p for p in env.buildlog.repositories if isdir(env.real_outpath(p, basepath="."))]
+    repositories.sort(key=lambda name: "0" if name == "modm" else name)
     generated_paths = [join(env.relcwdoutpath(""), r) for r in repositories]
 
     subs = env.query("::device")
@@ -218,7 +208,14 @@ def post_build(env):
             if nflag: return nflag;
         return '"{}"'.format(flag)
 
-    for repo in repositories:
+    # Generate SConscript files for each repository that doesn't already have one
+    repos_without_sconscript = repositories.copy()
+    for op in env.buildlog.operations:
+        repo, relpath = op.repository, env.relative_outpath(op.filename, op.repository)
+        if relpath == "SConscript" and repo in repos_without_sconscript:
+            repos_without_sconscript.remove(repo)
+
+    for repo in repos_without_sconscript:
         files = []
         repo_filter = lambda scope: scope.repository == repo
         repo_flags = env.query("::collect_flags")(env, repo_filter)
@@ -248,7 +245,6 @@ def post_build(env):
             "is_modm": repo == "modm",
         })
 
-        # Generate library SConscript
         env.outbasepath = repo
         env.template("resources/SConscript.in", "SConscript",
                      filters={"flags_format": flags_format,
@@ -277,13 +273,4 @@ descr_path_artifact = """# Path to Artifact Store
 The artifact folder contains ELF files named by their GNU build id hash. This
 allows identification of firmware on the device via serial output and is useful
 for archiving or post-mortem debugging.
-"""
-
-descr_include_repos = """# Include Additional Repositories
-
-This should be a comma-separated list of repository names for which to generate
-additional SConscript files. Note: `include_sconstruct` should generally be
-disabled when using this option, as you will want to write a custom SConstruct.
-
-!!! warning "This overwrites any existing `../[repo]/SConscript` files!"
 """

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -209,11 +209,9 @@ def post_build(env):
         return '"{}"'.format(flag)
 
     # Generate SConscript files for each repository that doesn't already have one
-    repos_without_sconscript = repositories.copy()
-    for op in env.buildlog.operations:
-        repo, relpath = op.repository, env.relative_outpath(op.filename, op.repository)
-        if relpath == "SConscript" and repo in repos_without_sconscript:
-            repos_without_sconscript.remove(repo)
+    repos_with_sconscript = set(op.repository for op in env.buildlog.operations
+                                if op.filename == f"{op.repository}/SConscript")
+    repos_without_sconscript = set(repositories) - repos_with_sconscript
 
     for repo in repos_without_sconscript:
         files = []

--- a/tools/build_script_generator/scons/module.lb
+++ b/tools/build_script_generator/scons/module.lb
@@ -30,6 +30,10 @@ def prepare(module, options):
         PathOption(name="path.artifact", default="artifacts", absolute=True,
                    description=descr_path_artifact))
 
+    module.add_option(
+        StringOption(name="include_repos", default="",
+                    description=descr_include_repos))
+
     module.add_collector(
         CallableCollector(name="flag_format",
                           description="Formatting compile flags for SCons"))
@@ -150,8 +154,15 @@ def post_build(env):
     has_xpcc_generator = env.has_module(":communication:xpcc:generator")
     has_image_source = len(env["::image.source"])
     has_nanopb = env.has_module(":nanopb")
-    repositories = [p for p in env.buildlog.repositories if isdir(env.real_outpath(p, basepath="."))]
-    repositories.sort(key=lambda name: "0" if name == "modm" else name)
+
+    repositories = ["modm"]
+    for token in env["include_repos"].split(","):
+        repo = token.strip()
+        if repo in env.buildlog.repositories and isdir(env.real_outpath(repo, basepath=".")):
+            repositories.append(repo)
+        elif repo != "":
+            env.log.error(f"\"{repo}\" is not a valid repository!")
+
     generated_paths = [join(env.relcwdoutpath(""), r) for r in repositories]
 
     subs = env.query("::device")
@@ -266,4 +277,13 @@ descr_path_artifact = """# Path to Artifact Store
 The artifact folder contains ELF files named by their GNU build id hash. This
 allows identification of firmware on the device via serial output and is useful
 for archiving or post-mortem debugging.
+"""
+
+descr_include_repos = """# Include Additional Repositories
+
+This should be a comma-separated list of repository names for which to generate
+additional SConscript files. Note: `include_sconstruct` should generally be
+disabled when using this option, as you will want to write a custom SConstruct.
+
+!!! warning "This overwrites any existing `../[repo]/SConscript` files!"
 """


### PR DESCRIPTION
Currently, the `modm:scons:build` module will generate an SConscript for itself and every other repository included in the build process. This causes issues if another repository has its own method of generating an SConscript, since modm will overwrite it.

This PR changes the behaviour to only generate SConscript files for modm and any additional repos specified in `modm:scons:build:include_repos` (comma-separated list of repository names).

Note: this is a minor breaking change since *no additional repositories* will be included by default, whereas previously they would have been.