### PR TITLE
[utils] Deprecate allocator::Dynamic for std::allocator

### DIFF
--- a/src/modm/communication/rpr/interface.hpp
+++ b/src/modm/communication/rpr/interface.hpp
@@ -18,7 +18,7 @@
 #include <modm/architecture/utils.hpp>
 #include <modm/container/queue.hpp>
 #include <modm/processing/timer.hpp>
-#include <modm/utils/allocator/dynamic.hpp>
+#include <memory>
 
 #include "constants.hpp"
 
@@ -123,7 +123,7 @@ namespace modm
 			static Queue messagesToSend;
 			static Queue receivedMessages;
 
-			static modm::allocator::Dynamic<uint8_t> bufferAllocator;
+			static std::allocator<uint8_t> bufferAllocator;
 
 			static Message receiveBuffer;
 			static uint8_t rx_buffer[N+8];

--- a/src/modm/communication/rpr/interface_impl.hpp
+++ b/src/modm/communication/rpr/interface_impl.hpp
@@ -472,7 +472,7 @@ modm::rpr::Interface<Device, N>::popMessage(Queue &queue)
 		// deallocate the external buffer
 		Message message = queue.get();
 		MODM_RPR_LOG("deallocating");
-		bufferAllocator.deallocate(message.payload);
+		bufferAllocator.deallocate(message.payload, message.length);
 		// then remove the rest
 		queue.pop();
 	}

--- a/src/modm/container/module.lb
+++ b/src/modm/container/module.lb
@@ -20,8 +20,7 @@ def init(module):
 def prepare(module, options):
     module.depends(
         ":architecture",
-        ":io",
-        ":utils")
+        ":io")
     return True
 
 

--- a/src/modm/utils/allocator.hpp
+++ b/src/modm/utils/allocator.hpp
@@ -19,6 +19,7 @@
 namespace modm::allocator
 {
 
+// DEPRECATED: 2025q3
 /**
  * Base class for all allocator types
  *
@@ -66,6 +67,7 @@ protected:
     }
 };
 
+// DEPRECATED: 2025q3
 /**
  * Dynamic memory allocator
  *
@@ -76,7 +78,8 @@ protected:
  * @author  Fabian Greif
  */
 template <typename T>
-class Dynamic : public AllocatorBase<T>
+class [[deprecated("Please use std::allocator<T> instead!")]]
+Dynamic : public AllocatorBase<T>
 {
 public:
     template <typename U>


### PR DESCRIPTION
Let's see what breaks. Maybe something for AVRs?