### PR TITLE
[fiber] Improve timing of poll functions

### DIFF
--- a/src/modm/processing/fiber/functions.hpp
+++ b/src/modm/processing/fiber/functions.hpp
@@ -90,12 +90,16 @@ poll_for(std::chrono::duration<Rep, Period> sleep_duration, Function &&condition
 							  std::chrono::duration<Rep, std::milli>>,
 		modm::chrono::milli_clock, modm::chrono::micro_clock>;
 
+	// Ensure the sleep duration is rounded up to the next full clock tick
+	const auto clock_sleep_duration(
+			std::chrono::ceil<typename Clock::duration>(sleep_duration));
+
 	const auto start = Clock::now();
 	do {
 		modm::this_fiber::yield();
 		if (std::forward<Function>(condition)()) return true;
 	}
-	while((Clock::now() - start) <= sleep_duration);
+	while((Clock::now() - start) < clock_sleep_duration);
 	return false;
 }
 
@@ -125,7 +129,7 @@ poll_until(std::chrono::time_point<Clock, Duration> sleep_time, Function &&condi
 		modm::this_fiber::yield();
 		if (std::forward<Function>(condition)()) return true;
 	}
-	while((Clock::now() - start) <= sleep_duration);
+	while((Clock::now() - start) < sleep_duration);
 	return false;
 }
 


### PR DESCRIPTION
There are two problems with the poll functions:

1. Calling `sleep_for` with nanoseconds (or less) durations would be cast to 0us or 0ms. This is now fixed by making the duration at least 1us or 1ms. (cc @TomSaw)
2. The condition was not checked again after a yield, thus can time out if the yield takes longer. The correct behavior should check the function upon entry of the poll for a fast exit and then again after each yield **before** checking the timeout.
3. Fix infinite loop when passing 0s as sleep time, whoops. Now it only yields once.

- [x] Implementation
- [x] Documentation
- [x] Add Unit Tests