### PR TITLE
ADC sequence of G0 (and C0) devicec have  wrong channel shift?

### DIFF
--- a/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
+++ b/src/modm/platform/adc/stm32f0/adc_impl.hpp.in
@@ -196,7 +196,7 @@ modm::platform::Adc{{ id }}::setChannels(std::span<const Channel> channels)
 	uint32_t config = 0xFFFF'FFFF;
 	for (const auto [i, ch] : modm::enumerate(channels)) {
 		enableInternalChannel(ch);
-		config = (config & ~((0xF) << i)) | (std::to_underlying(ch) << i);
+		config = (config & ~((0xF) << i*4)) | (std::to_underlying(ch) << i*4);
 	}
 	ADC1->CHSELR = config;
 	waitChannelConfigReady();


### PR DESCRIPTION
While still working on my STM32C0x implementation #1188, I had a head-cruncher by building a ADC-Sequence example.
For me it looks like the implementation is wrong as it shifts the ADC channel only by 1 bit instead of 4.
So in my opinion ADC sequences can't work for ~~F0,~~ G0 as well as C0 devices?!