### PR TITLE
[ext] Check for device.hpp before including in CMSIS-DSP

### DIFF
--- a/ext/arm/arm_math.h.in
+++ b/ext/arm/arm_math.h.in
@@ -31,7 +31,9 @@ extern "C"
 {
 #endif
 
+#if __has_include(<modm/platform/device.hpp>)
 #include <modm/platform/device.hpp>
+#endif
 
 /* Local configuration file */
 #if __has_include(<arm_math_local.h>)


### PR DESCRIPTION
Checks for the existence of `modm/platform/device.hpp` before including it in `arm_math.h`. This fixes CMSIS-DSP not compiling when running on a hosted platform (#1201).