### PR TITLE
[iwdg] Enable IWDG on STM32H7 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/src/modm/platform/iwdg/stm32/iwdg.hpp.in
+++ b/src/modm/platform/iwdg/stm32/iwdg.hpp.in
@@ -50,8 +50,8 @@ public:
 	initialize(Prescaler prescaler, uint16_t reload)
 	{
 		writeKey(writeCommand);
-		IWDG->PR = uint32_t(prescaler);
-		IWDG->RLR = reload;
+		IWDG{{core}}->PR = uint32_t(prescaler);
+		IWDG{{core}}->RLR = reload;
 		writeKey(0); // disable access to PR and RLR registers
 	}
 
@@ -82,14 +82,14 @@ public:
 	static inline Status
 	getStatus()
 	{
-		return Status(IWDG->SR);
+		return Status(IWDG{{core}}->SR);
 	}
 
 private:
 	static inline void
 	writeKey(uint16_t key)
 	{
-		IWDG->KR = key;
+		IWDG{{core}}->KR = key;
 	}
 
 	static constexpr uint16_t reloadCommand = 0xAAAA;

--- a/src/modm/platform/iwdg/stm32/module.lb
+++ b/src/modm/platform/iwdg/stm32/module.lb
@@ -17,9 +17,6 @@ def init(module):
 
 def prepare(module, options):
     device = options[":target"]
-    # STM32H7 is not yet supported with any IWDG implementation
-    if device.identifier.family in ["h7"]:
-        return False
 
     module.depends(":cmsis:device", ":math:algorithm")
     return device.has_driver("iwdg:stm32")
@@ -27,4 +24,6 @@ def prepare(module, options):
 
 def build(env):
     env.outbasepath = "modm/src/modm/platform/iwdg"
-    env.copy("iwdg.hpp")
+    # FIXME: Use IWDG2 for second core on STM32H7x5
+    env.substitutions = {"core": 1 if env[":target"].identifier.family in ["h7"] else ""}
+    env.template("iwdg.hpp.in")


### PR DESCRIPTION
The STM32H7 has dual-core devices, each core has their own IWDG named IWDG1 and IWDG2. On single core devices only IWDG1 is available. This patch only fixes the name of the macro.

- [x] Tested in hardware on a STM32H743II.

