### PR TITLE
[fiber] Add more yields into modm

### DIFF
--- a/src/modm/platform/i2c/bitbang/bitbang_i2c_master_impl.hpp
+++ b/src/modm/platform/i2c/bitbang/bitbang_i2c_master_impl.hpp
@@ -18,6 +18,7 @@
 #ifndef MODM_SOFTWARE_BITBANG_I2C_HPP
 #	error	"Don't include this file directly, use 'bitbang_i2c_master.hpp' instead!"
 #endif
+#include <modm/processing/fiber.hpp>
 
 // debugging for serious dummies
 /*
@@ -314,6 +315,8 @@ template <class Scl, class Sda>
 bool
 modm::platform::BitBangI2cMaster<Scl, Sda>::write(uint8_t data)
 {
+	modm::this_fiber::yield();
+
 	DEBUG_SW_I2C('W');
 	// shift through all 8 bits
 	for(uint_fast8_t i = 0; i < 8; ++i)
@@ -359,6 +362,8 @@ template <class Scl, class Sda>
 bool
 modm::platform::BitBangI2cMaster<Scl, Sda>::read(uint8_t &data, bool ack)
 {
+	modm::this_fiber::yield();
+
 	DEBUG_SW_I2C('R');
 	// release data line
 	SDA::set();

--- a/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
+++ b/src/modm/platform/spi/bitbang/bitbang_spi_master_impl.hpp
@@ -17,6 +17,7 @@
 #ifndef MODM_SOFTWARE_BITBANG_SPI_MASTER_HPP
 #	error	"Don't include this file directly, use 'bitbang_spi_master.hpp' instead!"
 #endif
+#include <modm/processing/fiber.hpp>
 
 template <typename Sck, typename Mosi, typename Miso>
 uint16_t
@@ -84,6 +85,8 @@ template <typename Sck, typename Mosi, typename Miso>
 uint8_t
 modm::platform::BitBangSpiMaster<Sck, Mosi, Miso>::transferBlocking(uint8_t data)
 {
+	modm::this_fiber::yield();
+
 	for (uint_fast8_t ii = 0; ii < 8; ++ii)
 	{
 		// CPHA=1, sample on falling edge


### PR DESCRIPTION
Since https://github.com/modm-io/modm/pull/1172 we have a polyfill for fiber yields that are empty when the fiber module is not enabled. Therefore we can add a whole lot of yields into modm without affecting non-fiber based projects.

- [x] BitBang I2C driver on every byte
- [x] BitBang SPI driver on every byte
- [ ] some more when I have the time