### PR TITLE
[amnb] Adapt for using Resumbles in fiber mode

### DIFF
--- a/examples/nucleo_g071rb/amnb/main.cpp
+++ b/examples/nucleo_g071rb/amnb/main.cpp
@@ -137,9 +137,12 @@ main()
 
 	while (true)
 	{
-		node1.update();
-		node2.update();
-		node3.update();
+		node1.update_transmit();
+		node1.update_receive();
+		node2.update_transmit();
+		node2.update_receive();
+		node3.update_transmit();
+		node3.update_receive();
 		thread.update();
 	}
 

--- a/examples/nucleo_g071rb/amnb_fiber/main.cpp
+++ b/examples/nucleo_g071rb/amnb_fiber/main.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <modm/communication/amnb.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+using namespace std::chrono_literals;
+using namespace modm::amnb;
+using Usart1 = BufferedUart<UsartHal1, UartRxBuffer<32>>;
+using Usart3 = BufferedUart<UsartHal3, UartRxBuffer<16>>;
+using Usart4 = BufferedUart<UsartHal4>;
+// ----------------------------------------------------------------------------
+
+Listener listeners[] =
+{
+	{1, [](uint8_t sender, const uint32_t& data)
+		{
+			MODM_LOG_INFO << "Node2 and Node3 received Broadcast 1 from '" << sender;
+			MODM_LOG_INFO << "': " << data << modm::endl;
+		}
+	},
+	{2, [](uint8_t sender)
+		{
+			MODM_LOG_INFO << "Node2 and Node3 received Broadcast 2 from '" << sender << "'" << modm::endl;
+		}
+	},
+};
+Action actions[] =
+{
+	{1, []() -> Response
+		{
+			static uint8_t counter{0};
+			MODM_LOG_INFO << "Node1 or Node3 received Action 1" << modm::endl;
+			return counter++;
+		}
+	},
+	{2, [](const uint32_t& data) -> Response
+		{
+			static uint8_t counter{0};
+			MODM_LOG_INFO << "Node1 or Node3 received Action 2 with argument: " << data << modm::endl;
+			return ErrorResponse(counter++);
+		}
+	},
+};
+
+// Two nodes on the same device on different UARTs of course!
+DeviceWrapper<Usart1> device1;
+DeviceWrapper<Usart3> device2;
+DeviceWrapper<Usart4> device3;
+Node node1(device1, 1, actions);
+Node node2(device2, 2, listeners);
+Node node3(device3, 3, actions, listeners);
+
+modm::Fiber fiberNode1t([]{ node1.update_transmit(); });
+modm::Fiber fiberNode1r([]{ node1.update_receive(); });
+modm::Fiber fiberNode2t([]{ node2.update_transmit(); });
+modm::Fiber fiberNode2r([]{ node2.update_receive(); });
+modm::Fiber fiberNode3t([]{ node3.update_transmit(); });
+modm::Fiber fiberNode3r([]{ node3.update_receive(); });
+
+// You need to connect D1 with D15 and with A0
+using PinNode1 = GpioC4; // D1
+using PinNode2 = GpioB8; // D15
+using PinNode3 = GpioA0; // A0
+
+class Thread : public modm::pt::Protothread
+{
+	modm::ShortPeriodicTimer tmr{1s};
+	uint32_t counter{0};
+	Result<uint8_t> res1;
+	Result<uint8_t, uint8_t> res2;
+
+public:
+	bool inline
+	update()
+	{
+		PT_BEGIN();
+
+		while(true)
+		{
+			PT_WAIT_UNTIL(tmr.execute());
+
+			node1.broadcast(1, counter++);
+			node3.broadcast(2);
+
+			res1 = PT_CALL(node2.request<uint8_t>(1, 1));
+			MODM_LOG_INFO << "Node1 responded with: " << res1.error();
+			if (res1) { MODM_LOG_INFO << " " << *res1 << modm::endl; }
+
+			res2 = PT_CALL(node1.request<uint8_t, uint8_t>(3, 2, counter));
+			MODM_LOG_INFO << "Node3 responded with: " << res2.error();
+			if (res2.hasUserError()) {
+				MODM_LOG_INFO << " " << *res2.userError() << modm::endl;
+			}
+
+			if (counter % 10 == 0)
+			{
+				MODM_LOG_INFO << "Node1t stack=" << fiberNode1t.stack_usage() << "\nNode1r stack=" << fiberNode1r.stack_usage() << modm::endl;
+				MODM_LOG_INFO << "Node2t stack=" << fiberNode2t.stack_usage() << "\nNode2r stack=" << fiberNode2r.stack_usage() << modm::endl;
+				MODM_LOG_INFO << "Node3t stack=" << fiberNode3t.stack_usage() << "\nNode3r stack=" << fiberNode3r.stack_usage() << modm::endl;
+				MODM_LOG_INFO << "Thread stack=" << this->stack_usage() << modm::endl;
+			}
+		}
+
+		PT_END();
+	}
+}
+thread;
+
+
+
+// ----------------------------------------------------------------------------
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	Usart1::connect<PinNode1::Tx>();
+	Usart1::initialize<SystemClock, 115200>(Usart1::Parity::Even, Usart1::WordLength::Bit9);
+	// Use Single-Wire Half-Duplex Mode
+	PinNode1::configure(Gpio::OutputType::OpenDrain);
+	PinNode1::configure(Gpio::InputType::PullUp);
+	USART1->CR1 &= ~USART_CR1_UE;
+	USART1->CR3 = USART_CR3_HDSEL;
+	USART1->CR1 |= USART_CR1_UE;
+
+	Usart3::connect<PinNode2::Tx>();
+	Usart3::initialize<SystemClock, 115200>(Usart1::Parity::Even, Usart1::WordLength::Bit9);
+	// Use Single-Wire Half-Duplex Mode
+	PinNode2::configure(Gpio::OutputType::OpenDrain);
+	PinNode2::configure(Gpio::InputType::PullUp);
+	USART3->CR1 &= ~USART_CR1_UE;
+	USART3->CR3 = USART_CR3_HDSEL;
+	USART3->CR1 |= USART_CR1_UE;
+
+	Usart4::connect<PinNode3::Tx>();
+	Usart4::initialize<SystemClock, 115200>(Usart1::Parity::Even, Usart1::WordLength::Bit9);
+	// Use Single-Wire Half-Duplex Mode
+	PinNode3::configure(Gpio::OutputType::OpenDrain);
+	PinNode3::configure(Gpio::InputType::PullUp);
+	USART4->CR1 &= ~USART_CR1_UE;
+	USART4->CR3 = USART_CR3_HDSEL;
+	USART4->CR1 |= USART_CR1_UE;
+
+	fiberNode1t.watermark_stack();
+	fiberNode1r.watermark_stack();
+	fiberNode2t.watermark_stack();
+	fiberNode2r.watermark_stack();
+	fiberNode3t.watermark_stack();
+	fiberNode3r.watermark_stack();
+	thread.watermark_stack();
+
+	modm::fiber::Scheduler::run();
+
+	return 0;
+}

--- a/examples/nucleo_g071rb/amnb_fiber/project.xml
+++ b/examples/nucleo_g071rb/amnb_fiber/project.xml
@@ -1,0 +1,18 @@
+<library>
+  <extends>modm:nucleo-g071rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g071rb/amnb_fiber</option>
+    <option name="modm:communication:amnb:with_heap">no</option>
+    <option name="modm:processing:protothread:use_fiber">yes</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:communication:amnb</module>
+    <module>modm:platform:uart:1</module>
+    <module>modm:platform:uart:3</module>
+    <module>modm:platform:uart:4</module>
+    <module>modm:build:scons</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:fiber</module>
+  </modules>
+</library>

--- a/src/modm/communication/amnb/module.md
+++ b/src/modm/communication/amnb/module.md
@@ -239,11 +239,16 @@ else if (response.hasUserError())
 else Error error = response.error();
 
 
-/// node.update() must be called as often as possible!
+/// node.update_{transmit, receive}() must be called as often as possible!
 while(true)
 {
-    node.update();
+    node.update_transmit();
+    node.update_receive();
 }
+
+// Alternatively you require one fiber per update function
+modm::Fiber<> fiberNodeTransmit([]{ node.update_transmit(); });
+modm::Fiber<> fiberNodeReceive([]{ node.update_receive(); });
 ```
 
 

--- a/src/modm/processing/fiber/mutex.hpp
+++ b/src/modm/processing/fiber/mutex.hpp
@@ -22,6 +22,14 @@
 #include <atomic>
 #include <mutex>
 
+/// @cond
+namespace modm
+{
+template< uint8_t Functions > class Resumable;
+template< uint8_t Levels > class NestedResumable;
+}
+/// @endcond
+
 namespace modm::fiber
 {
 
@@ -32,6 +40,9 @@ namespace modm::fiber
 /// @see https://en.cppreference.com/w/cpp/thread/mutex
 class mutex
 {
+	template< uint8_t Functions > friend class ::modm::Resumable;
+	template< uint8_t Levels > friend class ::modm::NestedResumable;
+
 	mutex(const mutex&) = delete;
 	mutex& operator=(const mutex&) = delete;
 
@@ -87,6 +98,9 @@ public:
 /// @see https://en.cppreference.com/w/cpp/thread/recursive_mutex
 class recursive_mutex
 {
+	template< uint8_t Functions > friend class ::modm::Resumable;
+	template< uint8_t Levels > friend class ::modm::NestedResumable;
+
 	recursive_mutex(const recursive_mutex&) = delete;
 	recursive_mutex& operator=(const recursive_mutex&) = delete;
 	using count_t = uint16_t;

--- a/src/modm/processing/resumable/macros.hpp
+++ b/src/modm/processing/resumable/macros.hpp
@@ -169,14 +169,14 @@
 	} \
 	static_assert(uint16_t(__COUNTER__) - rfCounter < 256, "You have too many states in this resumable function!")
 
-#define RF_RETURN_1() \
+#define RF_RETURN_0() \
 	do { \
 			this->stopRf(rfIndex); \
 			this->popRf(); \
 			return {modm::rf::Stop}; \
 	} while(0)
 
-#define RF_RETURN_0(result) \
+#define RF_RETURN_1(result) \
 	do { \
 			this->stopRf(rfIndex); \
 			this->popRf(); \
@@ -184,7 +184,7 @@
 	} while(0)
 
 // Beginner structure for nested resumable functions
-#define RF_BEGIN_1() \
+#define RF_BEGIN_0() \
 	constexpr uint16_t rfCounter = __COUNTER__; \
 	this->template checkRfType<true>(); \
 	constexpr uint8_t rfIndex = 0; \
@@ -196,7 +196,7 @@
 			RF_INTERNAL_SET_CASE(__COUNTER__);
 
 // Beginner structure for conventional resumable functions
-#define RF_BEGIN_0(index) \
+#define RF_BEGIN_1(index) \
 	constexpr uint16_t rfCounter = __COUNTER__; \
 	this->template checkRfFunctions<index>(); \
 	this->template checkRfType<false>(); \
@@ -205,41 +205,9 @@
 		case (::modm::rf::Stopped): \
 			RF_INTERNAL_SET_CASE(__COUNTER__);
 
-// the following completely unreadable preprocessor macro magic is based on this
-// https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/
-// http://efesx.com/2010/07/17/variadic-macro-to-count-number-of-arguments/#comment-255
-#define RF_ARG3(_0, _1, _2, ...) _2
-#define RF_HAS_COMMA(...) RF_ARG3(__VA_ARGS__, 1, 0)
-#define RF_TRIGGER_PARENTHESIS_(...) ,
-
-#define RF_ISEMPTY(...) _RF_ISEMPTY( \
-			/* test if there is just one argument, eventually an empty one */ \
-			RF_HAS_COMMA(__VA_ARGS__), \
-			/* test if _TRIGGER_PARENTHESIS_ together with the argument adds a comma */ \
-			RF_HAS_COMMA(RF_TRIGGER_PARENTHESIS_ __VA_ARGS__), \
-			/* test if the argument together with a parenthesis adds a comma */ \
-			RF_HAS_COMMA(__VA_ARGS__ (/*empty*/)), \
-			/* test if placing it between _TRIGGER_PARENTHESIS_ and the parenthesis adds a comma */ \
-			RF_HAS_COMMA(RF_TRIGGER_PARENTHESIS_ __VA_ARGS__ (/*empty*/)) \
-			)
-
-#define RF_PASTE5(_0, _1, _2, _3, _4) _0 ## _1 ## _2 ## _3 ## _4
-#define _RF_ISEMPTY(_0, _1, _2, _3) RF_HAS_COMMA(RF_PASTE5(RF_IS_EMPTY_CASE_, _0, _1, _2, _3))
-#define RF_IS_EMPTY_CASE_0001 ,
-
-// all we wanted is to call RF_BEGIN_0 for 1 argument
-// and call RF_BEGIN_1 for 0 arguments. Makes total sense.
-#define RF_GET_BEGIN_MACRO3(n) RF_BEGIN_ ## n
-#define RF_GET_BEGIN_MACRO2(n) RF_GET_BEGIN_MACRO3(n)
-#define RF_GET_BEGIN_MACRO(...) RF_GET_BEGIN_MACRO2(RF_ISEMPTY(__VA_ARGS__))
-#define RF_BEGIN(...) RF_GET_BEGIN_MACRO(__VA_ARGS__)(__VA_ARGS__)
-
-// all we wanted is to call RF_RETURN_0 for 1 argument
-// and call RF_RETURN_1 for 0 arguments. Makes total sense.
-#define RF_GET_RETURN_MACRO3(n) RF_RETURN_ ## n
-#define RF_GET_RETURN_MACRO2(n) RF_GET_RETURN_MACRO3(n)
-#define RF_GET_RETURN_MACRO(...) RF_GET_RETURN_MACRO2(RF_ISEMPTY(__VA_ARGS__))
-#define RF_RETURN(...) RF_GET_RETURN_MACRO(__VA_ARGS__)(__VA_ARGS__)
+#define MODM_RF_GET_MACRO(_0, _1, NAME, ...) NAME
+#define RF_BEGIN(...) MODM_RF_GET_MACRO(_0 __VA_OPT__(,) __VA_ARGS__, RF_BEGIN_1, RF_BEGIN_0)(__VA_ARGS__)
+#define RF_RETURN(...) MODM_RF_GET_MACRO(_0 __VA_OPT__(,) __VA_ARGS__, RF_RETURN_1, RF_RETURN_0)(__VA_ARGS__)
 
 #endif
 

--- a/src/modm/processing/resumable/macros_fiber.hpp
+++ b/src/modm/processing/resumable/macros_fiber.hpp
@@ -13,13 +13,24 @@
 #define MODM_RF_MACROS_FIBER_HPP
 
 #include <modm/processing/fiber.hpp>
+#include <modm/processing/fiber/mutex.hpp>
 
 /// @ingroup modm_processing_resumable
 /// @{
 
+#ifdef __DOXYGEN__
 /// Declare start of resumable function with index.
 /// @warning Use at start of the `resumable()` implementation!
-#define RF_BEGIN(...)
+#define RF_BEGIN(index)
+
+/**
+ * Declare start of a nested resumable function.
+ * This will immediately return if the nesting is too deep.
+ *
+ * @warning Use at start of the `resumable()` implementation!
+ */
+#define RF_BEGIN()
+#endif
 
 
 /**
@@ -93,5 +104,21 @@
 	return __VA_ARGS__
 
 /// @}
+
+#ifndef __DOXYGEN__
+
+#define RF_BEGIN_0() \
+	this->template checkRfType<true>(); \
+	modm::fiber::lock_guard rfLockGuardState{this->rfState};
+
+#define RF_BEGIN_1(index) \
+	this->template checkRfType<false>(); \
+	this->template checkRfFunctions<index>(); \
+	modm::fiber::lock_guard rfLockGuardState{this->rfStateArray[index]};
+
+#define MODM_RF_GET_MACRO(_0, _1, NAME, ...) NAME
+#define RF_BEGIN(...) MODM_RF_GET_MACRO(_0 __VA_OPT__(,) __VA_ARGS__, RF_BEGIN_1, RF_BEGIN_0)(__VA_ARGS__)
+
+#endif
 
 #endif // MODM_RF_MACROS_FIBER_HPP

--- a/src/modm/processing/resumable/resumable_fiber.hpp
+++ b/src/modm/processing/resumable/resumable_fiber.hpp
@@ -12,6 +12,8 @@
 #pragma once
 
 #include "macros.hpp"
+#include <modm/processing/fiber.hpp>
+#include <modm/processing/fiber/mutex.hpp>
 #include <stdint.h>
 
 #define MODM_RESUMABLE_IS_FIBER
@@ -27,27 +29,84 @@ template < typename T >
 using ResumableResult = T;
 
 /// Resumable functions implemented via fibers are normal functions
-template< uint8_t Functions = 0 >
-struct Resumable
+template< uint8_t Functions = 1 >
+class Resumable
 {
+public:
+    bool isResumableRunning(uint8_t id) const
+    {
+        return id < Functions and rfStateArray[id].locked;
+    }
+    bool areAnyResumablesRunning() const
+    {
+        for (const auto &state : rfStateArray) if (state.locked) return true;
+        return false;
+    }
+    bool areAnyResumablesRunning(std::initializer_list<uint8_t> ids) const
+    {
+        for (uint8_t id : ids) if (isResumableRunning(id)) return true;
+        return false;
+    }
+    bool areAllResumablesRunning(std::initializer_list<uint8_t> ids) const
+    {
+        for (uint8_t id : ids) if (not isResumableRunning(id)) return false;
+        return true;
+    }
+    bool joinResumables(std::initializer_list<uint8_t> ids) const
+    {
+        modm::this_fiber::poll([&]{ return not areAnyResumablesRunning(ids); });
+        return true;
+    }
     // unimplementable with fibers, but may be stubbed by user application
     void stopAllResumables();
     bool stopResumable(uint8_t id);
-    bool isResumableRunning(uint8_t id) const;
-    bool areAnyResumablesRunning() const;
-    bool areAnyResumablesRunning(std::initializer_list<uint8_t> ids) const;
-    bool areAllResumablesRunning(std::initializer_list<uint8_t> ids) const;
-    bool joinResumables(std::initializer_list<uint8_t> ids) const;
+
+protected:
+    /// @cond
+    template<uint8_t index>
+    static void
+    checkRfFunctions()
+    {
+        static_assert(index < Functions,
+                "Index out of bounds! Increase the `Functions` template argument of your Resumable class.");
+    }
+    template<bool isNested>
+    static void
+    checkRfType()
+    {
+        static_assert(isNested == false, "You must declare an index for this resumable function!");
+    }
+    modm::fiber::mutex rfStateArray[Functions];
+    /// @endcond
 };
 
 /// Resumable functions implemented via fibers are normal functions
-template< uint8_t Levels = 0 >
-struct NestedResumable
+template< uint8_t Levels = 1 >
+class NestedResumable
 {
+public:
+    bool isResumableRunning() const
+    {
+        return rfState.owner != rfState.NoOwner;
+    }
+    int8_t getResumableDepth() const
+    {
+        return isResumableRunning() ? rfState.count - 1 : -1;
+    }
     // unimplementable with fibers, but may be stubbed by user application
     void stopResumable();
-    bool isResumableRunning() const;
-    int8_t getResumableDepth() const;
+
+protected:
+    /// @cond
+    template<bool isNested>
+    static void
+    checkRfType()
+    {
+        static_assert(isNested == true, "You cannot declare an index for a _nested_ resumable function!");
+    }
+
+    modm::fiber::recursive_mutex rfState;
+    /// @endcond
 };
 
 /// @}

--- a/test/modm/communication/amnb/node_test.cpp
+++ b/test/modm/communication/amnb/node_test.cpp
@@ -36,7 +36,7 @@ AmnbNodeTest::testBroadcast()
 	{
 		node.broadcast(0x10);
 		node.broadcast(0x20, uint32_t(0x03020100));
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		const uint8_t raw[] = {0x7E, 0x7E, 84, 0x08, 0x10, 0, 0x7E, 0x7E, 58, 0x08, 0x20, 4, 0, 1, 2, 3};
 		TEST_ASSERT_EQUALS(SharedMedium::raw_transmitted.size(), sizeof(raw));
 		TEST_ASSERT_EQUALS_ARRAY(SharedMedium::transmitted, raw, sizeof(raw));
@@ -46,7 +46,7 @@ AmnbNodeTest::testBroadcast()
 	SharedMedium::fail_tx_index = 2;
 	{
 		node.broadcast(0x70);
-		for(uint32_t ii=0; ii < 20000; ii += 10) { node.update(); micro_clock::setTime(ii); }
+		for(uint32_t ii=0; ii < 20000; ii += 10) { node.update_transmit(); node.update_receive(); micro_clock::setTime(ii); }
 		// first transmission attempt fails
 		const uint8_t raw[] = {0x7E, 0x7E, 110, 0x7E, 0x7E, 110, 0x08, 0x70, 0};
 		TEST_ASSERT_EQUALS(SharedMedium::raw_transmitted.size(), sizeof(raw));
@@ -65,7 +65,7 @@ AmnbNodeTest::testRequest()
 		micro_clock::setTime(0); milli_clock::setTime(0);
 		modm::ResumableResult< Result<> > res{0};
 		for(uint32_t ii=0; (res = node.request(0x10, 0x80)).getState() == modm::rf::Running; ii += 10)
-		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update(); }
+		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update_transmit(); node.update_receive(); }
 
 		TEST_ASSERT_EQUALS(res.getResult().error(), Error::RequestTimeout);
 		TEST_ASSERT_FALSE(bool(res.getResult()));
@@ -79,7 +79,7 @@ AmnbNodeTest::testRequest()
 		micro_clock::setTime(0); milli_clock::setTime(0);
 		modm::ResumableResult< Result<> > res{0};
 		for(uint32_t ii=0; (res = node.request(0x10, 0x80)).getState() == modm::rf::Running; ii += 10)
-		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update(); }
+		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update_transmit(); node.update_receive(); }
 
 		TEST_ASSERT_EQUALS(res.getResult().error(), Error::ResponseAllocationFailed);
 		TEST_ASSERT_FALSE(bool(res.getResult()));
@@ -94,7 +94,7 @@ AmnbNodeTest::testRequest()
 		micro_clock::setTime(0); milli_clock::setTime(0);
 		modm::ResumableResult< Result<uint8_t, uint8_t> > res{0};
 		for(uint32_t ii=0; (res = node.request<uint8_t, uint8_t>(0x10, 0x80, uint8_t(0x10))).getState() == modm::rf::Running; ii += 10)
-		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update(); }
+		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update_transmit(); node.update_receive(); }
 
 		TEST_ASSERT_EQUALS(res.getResult().error(), Error::UserError);
 		TEST_ASSERT_FALSE(bool(res.getResult()));
@@ -116,7 +116,7 @@ AmnbNodeTest::testRequest()
 		for(uint32_t ii=0;
 		    (res = node.request<uint32_t>(0x10, 0x80, uint32_t(0x03020100))).getState() == modm::rf::Running;
 		    ii += 10)
-		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update(); }
+		{ micro_clock::setTime(ii); milli_clock::setTime(ii/1000); node.update_transmit(); node.update_receive(); }
 
 		TEST_ASSERT_EQUALS(res.getResult().error(), Error::Ok);
 		TEST_ASSERT_TRUE(bool(res.getResult()));
@@ -177,7 +177,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 104, 8, 1, 68, 0, 1, 2, 3});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 0);
 		const uint8_t raw[] = {0x7E, 0x7E, 237, 8, 1, 97, 2};
 		TEST_ASSERT_EQUALS(SharedMedium::transmitted.size(), sizeof(raw));
@@ -188,7 +188,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 163, 8, 10, 64});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 0);
 		const uint8_t raw[] = {0x7E, 0x7E, 76, 8, 10, 129, 3};
 		TEST_ASSERT_EQUALS(SharedMedium::transmitted.size(), sizeof(raw));
@@ -200,7 +200,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 227, 8, 1, 64});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 1);
 		TEST_ASSERT_EQUALS(count, 11);
 		const uint8_t raw[] = {0x7E, 0x7E, 42, 8, 1, 96};
@@ -212,7 +212,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 141, 8, 2, 68, 0, 1, 2, 3});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 2);
 		TEST_ASSERT_EQUALS(count, 11+21);
 		const uint8_t raw[] = {0x7E, 0x7E, 209, 8, 2, 96};
@@ -224,7 +224,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 46, 8, 3, 68, 0, 1, 2, 3});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 4);
 		const uint8_t raw[] = {0x7E, 0x7E, 84, 8, 3, 100, 4, 5, 6, 7};
 		TEST_ASSERT_EQUALS(SharedMedium::transmitted.size(), sizeof(raw));
@@ -235,7 +235,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 233, 8, 4, 64});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 8);
 		const uint8_t raw[] = {0x7E, 0x7E, 94, 8, 4, 161, 3};
 		TEST_ASSERT_EQUALS(SharedMedium::transmitted.size(), sizeof(raw));
@@ -246,7 +246,7 @@ AmnbNodeTest::testAction()
 	SharedMedium::reset();
 	SharedMedium::add_rx({0x7E, 0x7E, 227, 8, 5, 68, 0, 1, 2, 3});
 	{
-		node.update(); node.update();
+		node.update_transmit(); node.update_receive(); node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 16);
 		const uint8_t raw[] = {0x7E, 0x7E, 133, 8, 5, 164, 0xde, 0xc0, 0xad, 0xba};
 		TEST_ASSERT_EQUALS(SharedMedium::transmitted.size(), sizeof(raw));
@@ -291,20 +291,20 @@ AmnbNodeTest::testListener()
 	trig = 0;
 	SharedMedium::add_rx({0x7E, 0x7E, 4, 32, 1, 0});
 	{
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 1);
 		TEST_ASSERT_EQUALS(count, 11);
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 1);
 		TEST_ASSERT_EQUALS(count, 11);
 	}
 	trig = 0;
 	SharedMedium::add_rx({0x7E, 0x7E, 102, 16, 2, 4, 0, 1, 2, 3});
 	{
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 6);
 		TEST_ASSERT_EQUALS(count, 11+21);
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 6);
 		TEST_ASSERT_EQUALS(count, 11+21);
 	}
@@ -312,10 +312,10 @@ AmnbNodeTest::testListener()
 	SharedMedium::add_rx({0x7E, 0x7E, 4, 32, 1, 0});
 	SharedMedium::add_rx({0x7E, 0x7E, 102, 16, 2, 4, 0, 1, 2, 3});
 	{
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 1);
 		TEST_ASSERT_EQUALS(count, 11+21+12);
-		node.update();
+		node.update_transmit(); node.update_receive();
 		TEST_ASSERT_EQUALS(trig, 7);
 		TEST_ASSERT_EQUALS(count, 11+21+12+22);
 	}


### PR DESCRIPTION
- [x] Implement proper mutex protection in Resumable interface with fiber mutexes.
- [x] Split `update()` method of AMNB into `update_transmit()/update_receive()`.
- [x] Add fiber example of AMNB