### PR TITLE
[stm32] Prevent SPI RX FIFO overflow in SPI master

### DIFF
--- a/src/modm/platform/spi/stm32h7/spi_master.cpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_master.cpp.in
@@ -71,7 +71,7 @@ SpiMaster{{ id }}::transfer(
 	std::size_t txIndex = 0;
 
 	while (rxIndex < length) {
-		while ((txIndex < length) and !Hal::isTxFifoFull()) {
+		while ((txIndex < length) and !Hal::isTxFifoFull() and (txIndex - rxIndex) < Hal::FifoSize) {
 			Hal::write(tx ? tx[txIndex] : 0);
 			++txIndex;
 		}
@@ -110,7 +110,7 @@ SpiMaster{{ id }}::transfer(
 			while (rxIndex < length) {
 		default:
 		{
-				while ((txIndex < length) and !Hal::isTxFifoFull()) {
+				while ((txIndex < length) and !Hal::isTxFifoFull() and (txIndex - rxIndex) < Hal::FifoSize) {
 					Hal::write(tx ? tx[txIndex] : 0);
 					++txIndex;
 				}


### PR DESCRIPTION
I was doing moderately high bandwidth streaming over SPI on an STM32H7. When I added some UART debug printing elsewhere in my application, it caused an indefinite hang in the SPI transfer() routine in this loop: https://github.com/modm-io/modm/blob/28c87e43136cf6ca422b7c56a68c440a2d580a0a/src/modm/platform/spi/stm32h7/spi_master.cpp.in#L73-L84

I could see txIndex had run far ahead of rxIndex (>30 bytes). The TX loop had all those 30+ bytes in its first execution without the RX loop getting a chance to pop anything. The peripheral had hit an overrun and entered suspended state, meaning the TX FIFO had completely backpressured and the loop was spinning waiting for RX frames which were not forthcoming.

After some investigation I think there are two bugs/oversights in the SpiMaster implementation.

1. I believe the SPI peripheral had popped frames from the SPI TX FIFO before the TX loop had completed, which meant the HAL enqueued more TX frames than would fit in the RX FIFO when the RX data eventually arrived. I think it is a bug to not consider the RX FIFO capacity when pushing into the TX fifo.
2. The HAL sets CR1.MASRX ("master automatic SUSP in receive mode"), which means an RX overflow will cause the PHY to enter "suspended" state until it is cleared by software. But there is no software logic to detect this condition, and the bit will only be cleared on transaction completion. So it isn't clear to me why this bit is set -- the transfer will hang regardless. If the transfer logic is fixed to prevent an RX overflow, this shouldn't matter, but I wanted to call it out in case there was intent to this setting which I don't understand.

I believe the UART byte-by-byte TX interrupts were occurring while in the SPI transmit loop, delaying execution enough for the SPI peripheral to get ahead.

This PR includes a fix for (1) by computing the number of outstanding bytes and bailing out of the TX loop when it hits the RX FIFO capacity. This seems to match the [Cube HAL implementation](https://github.com/STMicroelectronics/stm32h7xx-hal-driver/blob/66b7103d9e146b9e8c5eeab9349855669be40d8a/Src/stm32h7xx_hal_spi.c#L1549).

The non-H7 STM32 driver does a byte-by-byte transfer, which means it shouldn't be affected by this bug. I took a cursory look at the H7 DMA implementation and it isn't obvious to me whether it has a similar failure mode. It seems the operating theory of the DMA implementation is that the RX DMA will clear the FIFO faster than the RX FIFO is populated. I don't see any explicit overflow handling. So it might make sense to detect a suspension and resume the TX DMA once RX is flushed. Or it might be unnecessary if the above assumption holds true. Since TX and RX DMA are happening in parallel, it seems fair to me.

I don't have a great understanding of the STM32 SPI IP so I would appreciate a double-check that my diagnosis and fix are appropriate. I haven't done any testing beyond confirming that my Fiber-based test application no longer hangs and produces the expected result. I would also appreciate any thoughts on (2) above. Also, I would appreciate any suggestions on how to reliably hit this condition in a unit test.