### PR TITLE
[stm32] Disable MASRX in STM32H7 SPI

### DIFF
--- a/src/modm/platform/spi/stm32h7/spi_hal_impl.hpp.in
+++ b/src/modm/platform/spi/stm32h7/spi_hal_impl.hpp.in
@@ -56,8 +56,7 @@ SpiHal{{ id }}::initialize(Prescaler prescaler,
 	// initialize with unlimited transfer size
 	setTransferSize(0);
 
-	// Pause master transfer if RX FIFO is full
-	SPI{{ id }}->CR1 = SPI_CR1_MASRX;
+	SPI{{ id }}->CR1 = 0;
 
 	SPI{{ id }}->CFG2 = static_cast<uint32_t>(dataMode)
 		| static_cast<uint32_t>(dataOrder)


### PR DESCRIPTION
Follow-up to 678fd9a0e0cdd342b2c2d8e9627ec3331f66bf9c and #1223.

The previous PR fixed the core bug but I still see conditions under which the peripheral enters "suspended" state and doesn't recover. I added some in-memory logging to trace execution of the function and I can see the following:
1. TX FIFO is filled (16 bytes), all status flags report as expected. Peripheral is popping bytes and pushing received data essentially as fast as it can be enqueued.
2. All 16 bytes are cleared from the RX FIFO. Status flags are as expected. Both FIFOs indicate empty.
3. Fiber yield (takes a few us)
4. When fiber yield completes, status flags are unchanged.
5. TX loop pushes one byte. Immediately after the push, the peripheral enters SUSP state and doesn't recover.

It seems that once the RX FIFO has been cleared and emptied, the next transmitted byte always enters SUSP mode. It is unclear why this happens. This seems like a peripheral bug to me. There isn't any mention of this behavior in the errata.

I found that either limiting the FIFO usage to only 15 bytes or disabling MASRX is sufficient to fix the issue. When MASRX is not set, neither SUSP nor OVR are seen for the same transmit sequence. In other words, the SUSP state clearly isn't just triggered by the overrun state (it is attempting to suspend before it overruns) and it seems the suspend logic is buggy, or at least, doesn't work how I'd expect.

Since we don't use the suspend state, I disabled it.