### PR TITLE
STM32H5 support

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -712,6 +712,58 @@ jobs:
           name: stm32g4-compile-all-2
           path: test/all/log
 
+  stm32h5-compile-all-1:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
+      - name: Compile HAL for all STM32H5 Part 1
+        run: |
+          (cd test/all && python3 run_all.py stm32h5 --quick-remaining --split 2 --part 0)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stm32h5-compile-all-1
+          path: test/all/log
+
+  stm32h5-compile-all-2:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
+      - name: Compile HAL for all STM32H5 Part 2
+        run: |
+          (cd test/all && python3 run_all.py stm32h5 --quick-remaining --split 2 --part 1)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stm32h5-compile-all-2
+          path: test/all/log
+
   stm32h7-compile-all-1:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -187,6 +187,10 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py nucleo_g474re nucleo_g431rb nucleo_g431kb)
+      - name: Examples STM32H5 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_h503rb weact_h503cb weact_h562rg)
       - name: Examples STM32H7 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -735,39 +735,43 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431rb">NUCLEO-G431RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h503rb">NUCLEO-H503RB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/bsptable-->

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3809<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3888<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->3065<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->3144<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->355<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 - Raspberry Pi: <!--rpicount-->1<!--/rpicount--> device.
@@ -104,7 +104,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <table>
 <tr>
 <th align="center"></th>
-<th align="center" colspan="15">STM32</th>
+<th align="center" colspan="16">STM32</th>
 <th align="center" colspan="4">SAM</th>
 <th align="center" colspan="1">RP</th>
 <th align="center" colspan="3">AT</th>
@@ -119,6 +119,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center">F7</th>
 <th align="center">G0</th>
 <th align="center">G4</th>
+<th align="center">H5</th>
 <th align="center">H7</th>
 <th align="center">L0</th>
 <th align="center">L1</th>
@@ -144,6 +145,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✅</td>
@@ -160,6 +162,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 </tr><tr>
 <td align="left">CAN</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -197,6 +200,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -211,6 +215,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 </tr><tr>
 <td align="left">DAC</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -244,6 +249,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -267,6 +273,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -301,6 +308,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -318,6 +326,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✕</td>
+<td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✕</td>
@@ -358,8 +367,10 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 </tr><tr>
 <td align="left">I<sup>2</sup>C</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -404,12 +415,14 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">IWDG</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -446,6 +459,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -463,6 +477,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -494,6 +509,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -530,11 +546,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
+<td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 </tr><tr>
 <td align="left">Timer</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -582,9 +600,11 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 </tr><tr>
 <td align="left">Unique ID</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -610,6 +630,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">USB</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/examples/generic/blinky/project.xml
+++ b/examples/generic/blinky/project.xml
@@ -9,5 +9,6 @@
   </modules>
   <collectors>
     <!-- <collect name="modm:build:openocd.source">interface/stlink.cfg</collect> -->
+    <!-- <collect name="modm:build:openocd.source">interface/stlink-dap.cfg</collect> -->
   </collectors>
 </library>

--- a/examples/generic/usb/project.xml
+++ b/examples/generic/usb/project.xml
@@ -19,9 +19,14 @@
   <!-- <extends>modm:samd21-mini</extends> -->
   <!-- <extends>modm:weact-g0b1cb</extends> -->
   <!-- <extends>modm:weact-u585ci</extends> -->
+  <!-- <extends>modm:nucleo-h503rb</extends> -->
+  <!-- <extends>modm:weact-h503cb</extends> -->
+  <!-- <extends>modm:weact-h562rg</extends> -->
   <options>
     <option name="modm:build:build.path">../../../build/generic/usb</option>
     <option name="modm:tinyusb:config">device.cdc,device.msc</option>
+    <!-- <option name="modm:board:weact-h562rg:logger">RTT</option> -->
+    <!-- <option name="modm:board:weact-h503cb:with_rtt">yes</option> -->
     <!-- <option name="modm:tinyusb:config">device.cdc,device.midi</option> -->
 
     <!-- Required for modm:disco-f429zi -->
@@ -38,6 +43,7 @@
   </modules>
   <collectors>
     <!-- <collect name="modm:build:cppdefines">CFG_TUSB_DEBUG=3</collect> -->
-    <collect name="modm:build:openocd.source">interface/stlink.cfg</collect>
+    <!-- <collect name="modm:build:openocd.source">interface/stlink.cfg</collect> -->
+    <!-- <collect name="modm:build:openocd.source">interface/stlink-dap.cfg</collect> -->
   </collectors>
 </library>

--- a/examples/nucleo_h503rb/blink/main.cpp
+++ b/examples/nucleo_h503rb/blink/main.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	for (const auto [traits, start, end, size] : modm::platform::HeapTable())
+	{
+		MODM_LOG_INFO.printf("Memory section %#x @[0x%p,0x%p](%u)\n",
+							 traits.value, start, end, size);
+	}
+
+	uint32_t counter(0);
+	modm::ShortTimeout tmr;
+
+	while (true)
+	{
+		Leds::write(1 << (counter % (Leds::width+1) ));
+		// modm::delay(Button::read() ? 100ms : 500ms);
+		tmr.restart(Button::read() ? 100ms : 500ms);
+		while(not tmr.execute()) ;
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_h503rb/blink/project.xml
+++ b/examples/nucleo_h503rb/blink/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-h503rb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_h503rb/blink</option>
+  </options>
+  <modules>
+    <module>modm:architecture:memory</module>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/examples/weact_h503cb/blink/main.cpp
+++ b/examples/weact_h503cb/blink/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <modm/board.hpp>
+
+int main()
+{
+	Board::initialize();
+	Board::Leds::setOutput();
+
+	while (true)
+	{
+		Board::Leds::toggle();
+		modm::delay(Board::Button::read() ? 250ms : 500ms);
+		static uint32_t counter(0);
+		MODM_LOG_INFO << "Loop counter: " << (counter++) << modm::endl;
+	}
+	return 0;
+}

--- a/examples/weact_h503cb/blink/project.xml
+++ b/examples/weact_h503cb/blink/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <extends>modm:weact-h503cb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/weact_h503cb/blink</option>
+    <option name="modm:board:weact-h503cb:with_rtt">yes</option>
+  </options>
+  <modules>
+    <module>modm:architecture:delay</module>
+    <module>modm:build:scons</module>
+  </modules>
+  <collectors>
+    <collect name="modm:build:openocd.source">interface/stlink-dap.cfg</collect>
+  </collectors>
+</library>

--- a/examples/weact_h562rg/blink/main.cpp
+++ b/examples/weact_h562rg/blink/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <modm/board.hpp>
+
+int main()
+{
+	Board::initialize();
+	Board::Leds::setOutput();
+
+	while (true)
+	{
+		Board::Leds::toggle();
+		modm::delay(Board::Button::read() ? 250ms : 500ms);
+		static uint32_t counter(0);
+		MODM_LOG_INFO << "Loop counter: " << (counter++) << modm::endl;
+	}
+	return 0;
+}

--- a/examples/weact_h562rg/blink/project.xml
+++ b/examples/weact_h562rg/blink/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <extends>modm:weact-h562rg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/weact_h562rg/blink</option>
+    <option name="modm:board:weact-h562rg:logger">RTT</option>
+  </options>
+  <modules>
+    <module>modm:architecture:delay</module>
+    <module>modm:build:scons</module>
+  </modules>
+  <collectors>
+    <collect name="modm:build:openocd.source">interface/stlink-dap.cfg</collect>
+  </collectors>
+</library>

--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -103,7 +103,7 @@ def build(env):
     if target.platform == "stm32":
         tusb_config["CFG_TUSB_MCU"] = f"OPT_MCU_STM32{target.family.upper()}"
         # TODO: use modm-devices driver type for this
-        fs_dev = (target.family in ["f0", "f3", "l0", "g0", "g4"] or
+        fs_dev = (target.family in ["f0", "f3", "l0", "g0", "g4", "h5"] or
                  (target.family == "f1" and target.name <= "03"))
         if fs_dev:
             # PMA buffer size: 512B or 1024B

--- a/repo.lb
+++ b/repo.lb
@@ -78,7 +78,7 @@ class DevicesCache(dict):
             "stm32c0",
             "stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
             "stm32g0", "stm32g4",
-            "stm32h7",
+            "stm32h5", "stm32h7",
             "stm32l0", "stm32l1", "stm32l4", "stm32l5",
             "stm32u5",
         )

--- a/src/modm/board/nucleo_h503rb/board.hpp
+++ b/src/modm/board/nucleo_h503rb/board.hpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_h503rb
+#define MODM_BOARD_HAS_LOGGER
+
+namespace Board
+{
+/// @ingroup modm_board_nucleo_h503rb
+/// @{
+using namespace modm::literals;
+
+/// STM32H503RB running at 250MHz from PLL clock generated from 24 MHz HSE
+struct SystemClock
+{
+	static constexpr uint32_t Hse = 24_MHz;
+
+	static constexpr Rcc::PllConfig pll1
+	{
+		.range = Rcc::PllInputRange::MHz2_4,
+		.M = 12,  //  24 MHz /  12 =   2 MHz
+		.N = 250, //   2 MHz * 120 = 500 MHz
+		.P = 2,   // 500 MHz /   2 = 250 MHz = F_cpu
+	};
+	static constexpr uint32_t Pll1P = Hse / pll1.M * pll1.N / pll1.P;
+	static_assert(Pll1P == Rcc::MaxFrequency);
+
+	static constexpr Rcc::PllConfig pll2
+	{
+		.range = Rcc::PllInputRange::MHz8_16,
+		.M = 3,  //  24 MHz /  3 =   8 MHz
+		.N = 18, //   8 MHz * 18 = 144 MHz
+		.Q = 3,  // 144 MHz /  3 =  48 MHz = F_usb
+	};
+	static constexpr uint32_t Pll2Q = Hse / pll2.M * pll2.N / pll2.Q;
+
+	static constexpr uint32_t SysClk = Pll1P;
+	static constexpr uint32_t Frequency = SysClk;
+
+	// AHB Bus - Max 250MHz
+	static constexpr uint32_t Hclk = SysClk / 1;
+	static constexpr uint32_t Ahb = Hclk;
+
+	// APB Buses - Max 250MHz
+	static constexpr uint32_t Apb1 = Hclk / 1;
+	static constexpr uint32_t Apb2 = Hclk / 1;
+	static constexpr uint32_t Apb3 = Hclk / 1;
+
+	// Peripherals on AHB2
+	static constexpr uint32_t Adc1 = Hclk;
+	static constexpr uint32_t Dac1 = Hclk;
+
+	// Peripherals on APB2
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+
+	// Peripherals on APB1
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Fdcan1 = Apb1;
+
+	// Peripherals on APB3
+	static constexpr uint32_t LpUart1 = Apb3;
+
+	// Timer Clocks
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+
+	static constexpr uint32_t Timer1 = Apb2Timer;
+	static constexpr uint32_t Timer2 = Apb1Timer;
+	static constexpr uint32_t Timer3 = Apb1Timer;
+	static constexpr uint32_t Timer6 = Apb1Timer;
+	static constexpr uint32_t Timer7 = Apb1Timer;
+
+	static constexpr uint32_t Usb = Pll2Q;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLowSpeedExternalCrystal();
+		Rcc::enableExternalCrystal();
+
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
+		Rcc::setFlashLatency<Frequency>();
+
+		Rcc::enablePll1(Rcc::PllSource::Hse, pll1);
+		Rcc::enablePll2(Rcc::PllSource::Hse, pll2);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb3Prescaler(Rcc::ApbPrescaler::Div1);
+
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
+		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+
+		return true;
+	}
+
+};
+
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA2;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+
+using D0  = GpioB15;
+using D1  = GpioB14;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB10;
+using D7  = GpioA8;
+using D8  = GpioC7;
+using D9  = GpioC6;
+using D10 = GpioC9;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB7;
+using D15 = GpioB6;
+
+using Button = GpioInputC13;
+
+using Led = GpioOutputA5;
+using Leds = SoftwareGpioPort< Led >;
+/// @}
+
+namespace usb
+{
+/// @ingroup modm_board_nucleo_h503rb
+/// @{
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Device = UsbFs;
+/// @}
+}
+
+namespace stlink
+{
+/// @ingroup modm_board_nucleo_h503rb
+/// @{
+using Tx = GpioOutputA4;
+using Rx = GpioInputA3;
+using Uart = BufferedUart<UsartHal3, UartTxBuffer<2048>>;
+/// @}
+}
+
+/// @ingroup modm_board_nucleo_h503rb
+/// @{
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Led::setOutput(modm::Gpio::Low);
+	Button::setInput();
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+/// @}
+
+}

--- a/src/modm/board/nucleo_h503rb/board.xml
+++ b/src/modm/board/nucleo_h503rb/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h503rbt6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-h503rb</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_h503rb/module.lb
+++ b/src/modm/board/nucleo_h503rb/module.lb
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-h503rb"
+    module.description = """
+# NUCLEO-H503RB
+
+[Nucleo kit for STM32H503RB](https://www.st.com/en/evaluation-tools/nucleo-h503rb.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32h503rbt"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:3",
+        ":platform:usb")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy(".")
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.collect(":build:openocd.source", "board/st_nucleo_h5.cfg")

--- a/src/modm/board/nucleo_u575zi-q/module.lb
+++ b/src/modm/board/nucleo_u575zi-q/module.lb
@@ -44,6 +44,6 @@ def build(env):
     env.copy("../nucleo144_arduino_u5.hpp", "nucleo144_arduino_u5.hpp")
 
     env.outbasepath = "modm/openocd/modm/board/"
-    env.template(repopath("tools/openocd/modm/st_nucleo_dap.cfg.in"), "board.cfg",
+    env.template(repopath("tools/openocd/modm/st_nucleo_swd.cfg.in"), "board.cfg",
                  substitutions={"target": "stm32u5x"})
     env.collect(":build:openocd.source", "modm/board/board.cfg")

--- a/src/modm/board/weact_h503cb/board.hpp.in
+++ b/src/modm/board/weact_h503cb/board.hpp.in
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+%#
+%% if with_logger
+/// @ingroup modm_board_weact_h503cb
+#define MODM_BOARD_HAS_LOGGER
+%#
+%% endif
+namespace Board
+{
+/// @ingroup modm_board_weact_h503cb
+/// @{
+using namespace modm::literals;
+
+/// STM32H503CB running at 250MHz from PLL clock generated from 8 MHz HSE
+struct SystemClock
+{
+	static constexpr uint32_t Hse = 8_MHz;
+
+	static constexpr Rcc::PllConfig pll1
+	{
+		.range = Rcc::PllInputRange::MHz2_4,
+		.M = 4,   //   8 MHz /   4 =   2 MHz
+		.N = 250, //   2 MHz * 120 = 500 MHz
+		.P = 2,   // 500 MHz /   2 = 250 MHz = F_cpu
+	};
+	static constexpr uint32_t Pll1P = Hse / pll1.M * pll1.N / pll1.P;
+	static_assert(Pll1P == Rcc::MaxFrequency);
+
+	static constexpr Rcc::PllConfig pll2
+	{
+		.range = Rcc::PllInputRange::MHz8_16,
+		.M = 1,  //   8 MHz /  1 =   8 MHz
+		.N = 18, //   8 MHz * 18 = 144 MHz
+		.Q = 3,  // 144 MHz /  3 =  48 MHz = F_usb
+	};
+	static constexpr uint32_t Pll2Q = Hse / pll2.M * pll2.N / pll2.Q;
+
+	static constexpr uint32_t SysClk = Pll1P;
+	static constexpr uint32_t Frequency = SysClk;
+
+	// AHB Bus - Max 250MHz
+	static constexpr uint32_t Hclk = SysClk / 1;
+	static constexpr uint32_t Ahb = Hclk;
+
+	// APB Buses - Max 250MHz
+	static constexpr uint32_t Apb1 = Hclk / 1;
+	static constexpr uint32_t Apb2 = Hclk / 1;
+	static constexpr uint32_t Apb3 = Hclk / 1;
+
+	// Peripherals on AHB2
+	static constexpr uint32_t Adc1 = Hclk;
+	static constexpr uint32_t Dac1 = Hclk;
+
+	// Peripherals on APB2
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+
+	// Peripherals on APB1
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Fdcan1 = Apb1;
+
+	// Peripherals on APB3
+	static constexpr uint32_t LpUart1 = Apb3;
+
+	// Timer Clocks
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+
+	static constexpr uint32_t Timer1 = Apb2Timer;
+	static constexpr uint32_t Timer2 = Apb1Timer;
+	static constexpr uint32_t Timer3 = Apb1Timer;
+	static constexpr uint32_t Timer6 = Apb1Timer;
+	static constexpr uint32_t Timer7 = Apb1Timer;
+
+	static constexpr uint32_t Usb = Pll2Q;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLowSpeedExternalCrystal();
+		Rcc::enableExternalCrystal();
+
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
+		Rcc::setFlashLatency<Frequency>();
+
+		Rcc::enablePll1(Rcc::PllSource::Hse, pll1);
+		Rcc::enablePll2(Rcc::PllSource::Hse, pll2);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb3Prescaler(Rcc::ApbPrescaler::Div1);
+
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
+		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+
+		return true;
+	}
+
+};
+
+using Button = GpioInverted<GpioInputA0>;
+
+using Led = GpioInverted<GpioOutputC13>;
+using Leds = SoftwareGpioPort< Led >;
+/// @}
+
+namespace usb
+{
+/// @ingroup modm_board_weact_h503cb
+/// @{
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Device = UsbFs;
+/// @}
+}
+
+/// @ingroup modm_board_weact_h503cb
+/// @{
+%% if with_logger
+using LoggerDevice = modm::IODeviceWrapper< Rtt<0>, modm::IOBuffer::DiscardIfFull >;
+%#
+%% endif
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	Led::setOutput(modm::Gpio::Low);
+	Button::setInput(Gpio::InputType::PullUp);
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+/// @}
+
+}
+

--- a/src/modm/board/weact_h503cb/board.xml
+++ b/src/modm/board/weact_h503cb/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h503cbt6</option>
+  </options>
+  <modules>
+    <module>modm:board:weact-h503cb</module>
+  </modules>
+</library>

--- a/src/modm/board/weact_h503cb/module.lb
+++ b/src/modm/board/weact_h503cb/module.lb
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:weact-h503cb"
+    module.description = """
+# WeAct Studio STM32H503CB Core Board
+
+[Documentation](https://github.com/WeActStudio/WeActStudio.STM32H503CoreBoard)
+
+Cheap and bread-board-friendly board for the STM32H503 series.
+
+
+## Programming
+
+Since the board has no St-Link programmer on the board,
+you must use DFU (Device Firmware Update (via USB)) to program the board.
+A DFU command is integrated into the `modm:build:scons` tool:
+
+```
+scons program-dfu
+```
+
+Note that you need to manually reset the board due to a bug in the DFU
+implementation.
+
+
+## Logging
+
+To log via RTT attach a debugger to the SWD port and select the RTT option:
+
+```xml
+<option name="modm:board:weact-h503cb:with_rtt">yes</option>
+```
+
+Then log using:
+
+```sh
+scons log-rtt
+```
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32h503cbt"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:usb")
+
+    module.add_option(
+            BooleanOption(name="with_rtt", description="Log using RTT", default=False,
+                          dependencies=lambda v: ":platform:rtt" if v else None))
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": env["with_rtt"],
+        "with_assert": env.has_module(":architecture:assert"),
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.template("board.hpp.in")
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.template(repopath("tools/openocd/modm/stm32_swd.cfg.in"), "board.cfg",
+                 substitutions={"target": "stm32h5x"})
+    env.collect(":build:openocd.source", "modm/board/board.cfg")

--- a/src/modm/board/weact_h562rg/board.hpp.in
+++ b/src/modm/board/weact_h562rg/board.hpp.in
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+%#
+%% if with_logger
+/// @ingroup modm_board_weact_h562rg
+#define MODM_BOARD_HAS_LOGGER
+%#
+%% endif
+namespace Board
+{
+/// @ingroup modm_board_weact_h562rg
+/// @{
+using namespace modm::literals;
+
+/// STM32H562RG running at 250MHz from PLL clock generated from 8 MHz HSE
+struct SystemClock
+{
+	static constexpr uint32_t Hse = 8_MHz;
+
+	static constexpr Rcc::PllConfig pll1
+	{
+		.range = Rcc::PllInputRange::MHz2_4,
+		.M = 4,   //   8 MHz /   4 =   2 MHz
+		.N = 250, //   2 MHz * 120 = 500 MHz
+		.P = 2,   // 500 MHz /   2 = 250 MHz = F_cpu
+	};
+	static constexpr uint32_t Pll1P = Hse / pll1.M * pll1.N / pll1.P;
+	static_assert(Pll1P == Rcc::MaxFrequency);
+
+	static constexpr Rcc::PllConfig pll3
+	{
+		.range = Rcc::PllInputRange::MHz8_16,
+		.M = 1,  //   8 MHz /  1 =   8 MHz
+		.N = 18, //   8 MHz * 18 = 144 MHz
+		.Q = 3,  // 144 MHz /  3 =  48 MHz = F_usb
+	};
+	static constexpr uint32_t Pll3Q = Hse / pll3.M * pll3.N / pll3.Q;
+
+	static constexpr uint32_t SysClk = Pll1P;
+	static constexpr uint32_t Frequency = SysClk;
+
+	// AHB Buses - Max 250MHz
+	static constexpr uint32_t Hclk = SysClk / 1;
+	static constexpr uint32_t Ahb1 = Hclk;
+	static constexpr uint32_t Ahb2 = Hclk;
+	static constexpr uint32_t Ahb3 = Hclk;
+	static constexpr uint32_t Ahb4 = Hclk;
+
+	// APB Buses - Max 250MHz
+	static constexpr uint32_t Apb1 = Hclk / 1;
+	static constexpr uint32_t Apb2 = Hclk / 1;
+	static constexpr uint32_t Apb3 = Hclk / 1;
+
+	// Peripherals on AHB2
+	static constexpr uint32_t Adc1 = Ahb2;
+	static constexpr uint32_t Adc2 = Ahb2;
+	static constexpr uint32_t Dac1 = Ahb2;
+
+	// Peripherals on AHB4
+	static constexpr uint32_t Sdmmc1 = Ahb4;
+	static constexpr uint32_t Fmc    = Ahb4;
+	static constexpr uint32_t OctoSpi1 = Ahb4;
+
+	// Peripherals on APB2
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi4 = Apb2;
+	static constexpr uint32_t Spi6 = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Sai1 = Apb2;
+	static constexpr uint32_t Sai2 = Apb2;
+
+	// Peripherals on APB1
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4 = Apb1;
+	static constexpr uint32_t Uart5 = Apb1;
+	static constexpr uint32_t Usart6 = Apb1;
+	static constexpr uint32_t Uart7 = Apb1;
+	static constexpr uint32_t Uart8 = Apb1;
+	static constexpr uint32_t Uart9 = Apb1;
+	static constexpr uint32_t Usart10 = Apb1;
+	static constexpr uint32_t Usart11 = Apb1;
+	static constexpr uint32_t Uart12 = Apb1;
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t Fdcan1 = Hse;
+
+	// Peripherals on APB3
+	static constexpr uint32_t Spi5 = Apb3;
+	static constexpr uint32_t LpUart1 = Apb3;
+	static constexpr uint32_t I2c3 = Apb3;
+	static constexpr uint32_t I2c4 = Apb3;
+
+	// Timer Clocks
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+
+	// APB1 Timers
+	static constexpr uint32_t Timer2 = Apb1Timer;
+	static constexpr uint32_t Timer3 = Apb1Timer;
+	static constexpr uint32_t Timer4 = Apb1Timer;
+	static constexpr uint32_t Timer5 = Apb1Timer;
+	static constexpr uint32_t Timer6 = Apb1Timer;
+	static constexpr uint32_t Timer7 = Apb1Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+
+	// APB2 Timers
+	static constexpr uint32_t Timer1 = Apb2Timer;
+	static constexpr uint32_t Timer8 = Apb2Timer;
+	static constexpr uint32_t Timer15 = Apb2Timer;
+	static constexpr uint32_t Timer16 = Apb2Timer;
+	static constexpr uint32_t Timer17 = Apb2Timer;
+
+	static constexpr uint32_t Usb = Pll3Q;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLowSpeedExternalCrystal();
+		Rcc::enableExternalCrystal();
+
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
+		Rcc::setFlashLatency<Frequency>();
+
+		Rcc::enablePll1(Rcc::PllSource::Hse, pll1);
+		Rcc::enablePll3(Rcc::PllSource::Hse, pll3);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb3Prescaler(Rcc::ApbPrescaler::Div1);
+
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
+		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll3Q);
+
+		return true;
+	}
+
+};
+
+using Button = GpioInputC13;
+
+using Led = GpioOutputB2;
+using Leds = SoftwareGpioPort< Led >;
+/// @}
+
+namespace sdmmc
+{
+/// @ingroup modm_board_weact_h562rg
+/// @{
+using Conn = GpioA8;
+using Cmd = GpioD2;
+
+using Dat0 = GpioC8;
+using Dat1 = GpioC9;
+using Dat2 = GpioC10;
+using Dat3 = GpioC11;
+using Clk = GpioC12;
+/// @}
+}
+
+namespace usb
+{
+/// @ingroup modm_board_weact_h562rg
+/// @{
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Device = UsbFs;
+/// @}
+}
+
+namespace uart
+{
+/// @ingroup modm_board_weact_h562rg
+/// @{
+using Tx = GpioOutputA9;
+using Rx = GpioInputA10;
+%% if with_logger == "UART"
+using Uart = BufferedUart<UsartHal1, UartTxBuffer<2048>>;
+%% endif
+/// @}
+}
+
+/// @ingroup modm_board_weact_h562rg
+/// @{
+%% if with_logger == "UART"
+using LoggerDevice = modm::IODeviceWrapper< uart::Uart, modm::IOBuffer::BlockIfFull >;
+%#
+%% elif with_logger == "RTT"
+using LoggerDevice = modm::IODeviceWrapper< Rtt<0>, modm::IOBuffer::DiscardIfFull >;
+%#
+%% endif
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+%% if with_logger == "UART"
+%#
+	uart::Uart::connect<uart::Tx::Tx, uart::Rx::Rx>(Gpio::InputType::PullUp);
+	uart::Uart::initialize<SystemClock, 115200_Bd>();
+%% endif
+%#
+	Led::setOutput(modm::Gpio::Low);
+	Button::setInput(Gpio::InputType::PullDown);
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+/// @}
+
+}
+

--- a/src/modm/board/weact_h562rg/board.xml
+++ b/src/modm/board/weact_h562rg/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h562rgt6</option>
+  </options>
+  <modules>
+    <module>modm:board:weact-h562rg</module>
+  </modules>
+</library>

--- a/src/modm/board/weact_h562rg/module.lb
+++ b/src/modm/board/weact_h562rg/module.lb
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:weact-h562rg"
+    module.description = """
+# WeAct Studio STM32H562RG Core Board
+
+[Documentation](https://github.com/WeActStudio/WeActStudio.STM32H5_64Pin_CoreBoard)
+
+Cheap and bread-board-friendly board for the STM32H562 series.
+
+
+## Programming
+
+Since the board has no programmer on the board, you must use DFU(Device Firmware
+Update (via USB)) to program the board. A DFU command is integrated into the
+`modm:build:scons` tool:
+
+```
+scons program-dfu
+```
+
+Note that you need to manually reset the board due to a bug in the DFU
+implementation.
+
+
+## Logging
+
+To log via RTT attach a debugger to the SWD port and select the RTT option:
+
+```xml
+<option name="modm:board:weact-h562rg:logger">RTT</option>
+```
+
+Then log using:
+
+```sh
+scons log-rtt
+```
+
+To log via UART, attach a serial adapter to the log pins and select the UART option:
+
+```xml
+<option name="modm:board:weact-h562rg:logger">UART</option>
+```
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32h562rgt"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:usb")
+
+    values = {"Disabled": None, "RTT": ":platform:rtt", "UART": ":platform:uart:1"}
+    module.add_option(
+            EnumerationOption(name="logger", description="Logging mechanism",
+                              enumeration=list(values.keys()), default="Disabled",
+                              dependencies=lambda v: values[v]))
+
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": False if env["logger"] == "Disabled" else env["logger"],
+        "with_assert": env.has_module(":architecture:assert"),
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.template("board.hpp.in")
+
+    env.outbasepath = "modm/openocd/modm/board/"
+    env.template(repopath("tools/openocd/modm/stm32_swd.cfg.in"), "board.cfg",
+                 substitutions={"target": "stm32h5x"})
+    env.collect(":build:openocd.source", "modm/board/board.cfg")

--- a/src/modm/platform/adc/stm32/module.lb
+++ b/src/modm/platform/adc/stm32/module.lb
@@ -79,9 +79,6 @@ def prepare(module, options):
     if target["family"] in ["f2", "f4", "f7"]:
         props["shared_irqs"] = {"ADC": listify([int(i) for i in device.get_driver("adc")["instance"]])}
         props["shared_irq_ids"] = props["shared_irqs"]["ADC"]
-    elif target["family"] in ["u5"]:
-        # STM32U5 is not yet supported with any ADC implementation im modm
-        return False
     else:
         shared_irqs = [v["name"] for v in device.get_driver("core")["vector"]]
         shared_irqs = [v for v in shared_irqs if v.startswith("ADC") and "_" in v]

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -31,6 +31,7 @@ def build(env):
     p["target"] = t = device.identifier
     p["partname"] = device.partname
     p["core"] = device.get_driver("core")["type"]
+    p["max_frequency"] = int(device.get_driver("rcc")["max-frequency"][0])
 
     if t.family in ["c0"]:
         p["hsi_frequency"] = 48_000_000

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -41,7 +41,7 @@ def build(env):
         p["hsi_frequency"] = 8_000_000
         p["lsi_frequency"] = 40_000
         p["boot_frequency"] = p["hsi_frequency"]
-    elif t.family in ["h7"]:
+    elif t.family in ["h5", "h7"]:
         p["hsi_frequency"] = 64_000_000
         p["lsi_frequency"] = 32_000
         p["boot_frequency"] = p["hsi_frequency"]
@@ -142,8 +142,18 @@ def build(env):
     env.substitutions = p
     env.outbasepath = "modm/src/modm/platform/clock"
 
-    env.template("rcc.cpp.in")
-    env.template("rcc.hpp.in")
+    if t.family in ["h5"]:
+        uart_ids = device.get_driver("usart")["instance"]
+        if device.has_driver("uart"):
+            uart_ids += device.get_driver("uart")["instance"]
+        p["uart_ids"] = list(map(int, uart_ids))
+        p["spi_ids"] = list(map(int, device.get_driver("spi")["instance"]))
+        p["i2c_ids"] = list(map(int, device.get_driver("i2c")["instance"]))
+        env.template("rcc_h5.hpp.in", "rcc.hpp")
+    else:
+        env.template("rcc.hpp.in")
+        env.template("rcc.cpp.in")
+    env.copy("rcc_defs.cpp")
 
     all_peripherals = env.query(":cmsis:device:peripherals")
     rcc_map = env.query(":cmsis:device:rcc-map")

--- a/src/modm/platform/clock/stm32/rcc.cpp.in
+++ b/src/modm/platform/clock/stm32/rcc.cpp.in
@@ -17,14 +17,8 @@
 
 #include "rcc.hpp"
 
-// CMSIS Core compliance
-constinit uint32_t modm_fastdata SystemCoreClock(modm::platform::Rcc::BootFrequency);
-modm_weak void SystemCoreClockUpdate() { /* Nothing to update */ }
-
 namespace modm::platform
 {
-constinit uint16_t modm_fastdata delay_fcpu_MHz(computeDelayMhz(Rcc::BootFrequency));
-constinit uint16_t modm_fastdata delay_ns_per_loop(computeDelayNsPerLoop(Rcc::BootFrequency));
 
 // ----------------------------------------------------------------------------
 %% if target.family == "f0"

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -42,6 +42,7 @@ public:
 	static constexpr uint32_t LsiFrequency = {{ lsi_frequency | modm.digsep }};
 	static constexpr uint32_t HsiFrequency = {{ hsi_frequency | modm.digsep }};
 	static constexpr uint32_t BootFrequency = {{ boot_frequency | modm.digsep }};
+	static constexpr uint32_t MaxFrequency = {{ max_frequency | modm.digsep }};
 
 %% if target.family == "c0"
 	enum class

--- a/src/modm/platform/clock/stm32/rcc_defs.cpp
+++ b/src/modm/platform/clock/stm32/rcc_defs.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2012, 2014-2019, 2021, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "rcc.hpp"
+
+// CMSIS Core compliance
+constinit uint32_t modm_fastdata SystemCoreClock(modm::platform::Rcc::BootFrequency);
+modm_weak void SystemCoreClockUpdate() { /* Nothing to update */ }
+
+namespace modm::platform
+{
+constinit uint16_t modm_fastdata delay_fcpu_MHz(computeDelayMhz(Rcc::BootFrequency));
+constinit uint16_t modm_fastdata delay_ns_per_loop(computeDelayNsPerLoop(Rcc::BootFrequency));
+
+}

--- a/src/modm/platform/clock/stm32/rcc_h5.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_h5.hpp.in
@@ -1,0 +1,618 @@
+/*
+ * Copyright (c) 2012, 2016, Sascha Schade
+ * Copyright (c) 2012, 2017, Fabian Greif
+ * Copyright (c) 2012, 2014-2017, 2025, Niklas Hauser
+ * Copyright (c) 2013-2014, Kevin Läufer
+ * Copyright (c) 2018, 2021-2022, Christopher Durand
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_STM32_RCC_HPP
+#define MODM_STM32_RCC_HPP
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/architecture/interface/delay.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Reset and Clock Control for STM32 devices.
+ *
+ * This class abstracts access to clock settings on the STM32.
+ * You need to use this class to enable internal and external clock
+ * sources & outputs, set PLL parameters and AHB & APB prescalers.
+ * Don't forget to set the flash latencies.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_rcc
+ */
+class Rcc
+{
+public:
+	static constexpr uint32_t CsiFrequency = 4'000'000;
+	static constexpr uint32_t LsiFrequency = {{ lsi_frequency | modm.digsep }};
+	static constexpr uint32_t HsiFrequency = {{ hsi_frequency | modm.digsep }};
+	static constexpr uint32_t BootFrequency = {{ boot_frequency | modm.digsep }};
+	static constexpr uint32_t MaxFrequency = {{ max_frequency | modm.digsep }};
+
+	/// Connect GPIO signals like MCO to the clock tree
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Rcc, Signals...>;
+		Connector::connect();
+	}
+
+	/// Enable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	enable();
+
+	/// Check if a peripheral clock is enabled
+	template< Peripheral peripheral >
+	static bool
+	isEnabled();
+
+	/// Disable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	disable();
+
+
+public:
+	/** Set flash latency for CPU frequency and voltage.
+	 * Does nothing if CPU frequency is too high for the available
+	 * voltage.
+	 *
+	 * @returns maximum CPU frequency for voltage.
+	 * @retval	<=CPU_Frequency flash latency has been set correctly.
+	 * @retval	>CPU_Frequency requested frequency too high for voltage.
+	 */
+	template< uint32_t Core_Hz, uint16_t Core_mV = 3300>
+	static uint32_t
+	setFlashLatency();
+
+	/// Update the SystemCoreClock and delay variables.
+	template< uint32_t Core_Hz >
+	static void
+	updateCoreFrequency();
+
+
+public:
+	// clock sources
+	static inline bool
+	enableInternalClock(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->CR |= RCC_CR_HSION;
+		while (not (retval = (RCC->CR & RCC_CR_HSIRDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static inline bool
+	enableInternalClockMHz4(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->CR |= RCC_CR_CSION;
+		while (not (retval = (RCC->CR & RCC_CR_CSIRDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static inline bool
+	enableInternalClockMHz48(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->CR |= RCC_CR_HSI48ON;
+		while (not (retval = (RCC->CR & RCC_CR_HSI48RDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static inline bool
+	enableExternalClock(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
+		while (not (retval = (RCC->CR & RCC_CR_HSERDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static inline bool
+	enableExternalCrystal(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
+		while (not (retval = (RCC->CR & RCC_CR_HSERDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static inline bool
+	enableLowSpeedInternalClock(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->BDCR |= RCC_BDCR_LSION;
+		while (not (retval = (RCC->BDCR & RCC_BDCR_LSIRDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	static bool
+	enableLowSpeedExternalClock(uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
+		while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	enum class
+	LseDrive : uint32_t
+	{
+		Low        = 0b00 << RCC_BDCR_LSEDRV_Pos,
+		MediumLow  = 0b01 << RCC_BDCR_LSEDRV_Pos,
+		MediumHigh = 0b10 << RCC_BDCR_LSEDRV_Pos,
+		High       = 0b11 << RCC_BDCR_LSEDRV_Pos,
+	};
+	static bool
+	enableLowSpeedExternalCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
+	{
+		bool retval;
+		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) | uint32_t(drive);
+		RCC->BDCR |= RCC_BDCR_LSEON;
+		while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
+			;
+		return retval;
+	}
+
+	// clock modifiers
+	enum class
+	PllSource : uint8_t
+	{
+		None = 0b00,
+		Hsi = 0b01,
+		Csi = 0b10,
+		Hse = 0b11,
+	};
+	enum class
+	PllInputRange : uint8_t
+	{
+		MHz1_2 = 0,
+		MHz2_4 = 1,
+		MHz4_8 = 2,
+		MHz8_16 = 3,
+	};
+	enum class
+	PllVcoRange : uint8_t
+	{
+		Wide = 0,   ///< 128 to 560 MHz
+		Medium = 1, ///< 150 to 420 MHz
+	};
+	struct PllConfig
+	{
+		PllInputRange range;
+		uint8_t M;
+		uint16_t N;
+		uint8_t P = 0xff;
+		uint8_t Q = 0xff;
+		uint8_t R = 0xff;
+		uint8_t Frac = 0;
+		PllVcoRange vcoRange = PllVcoRange::Wide;
+	};
+
+%% set pll_ids = ([1,2] if target.name == "03" else [1,2,3])
+%% for id in pll_ids
+	/// Configure and enable PLL{{id}}
+	static inline bool
+	enablePll{{id}}(PllSource source, const PllConfig& cfg, uint32_t waitCycles = 0x10000)
+	{
+	%% if id == 1
+		// PLLxP divider must be even!
+		if (cfg.P & 1 or cfg.N < 4) return false;
+	%% else
+		if (cfg.N < 4) return false;
+	%% endif
+
+		// Select clock source
+		uint32_t cfgr{uint32_t(source) & RCC_PLL{{id}}CFGR_PLL{{id}}SRC};
+		// Set PLL M divider
+		cfgr |= ((uint32_t(cfg.M) << RCC_PLL{{id}}CFGR_PLL{{id}}M_Pos) & RCC_PLL{{id}}CFGR_PLL{{id}}M);
+		// PLL input range
+		cfgr |= (uint32_t(cfg.range) << RCC_PLL{{id}}CFGR_PLL{{id}}RGE_Pos);
+		// VCO range
+		cfgr |= (uint32_t(cfg.vcoRange) << RCC_PLL{{id}}CFGR_PLL{{id}}VCOSEL_Pos);
+		// Set PLL fractional value
+		if (cfg.Frac != 0)
+		{
+			RCC->PLL{{id}}FRACR = uint32_t(cfg.Frac) << RCC_PLL{{id}}FRACR_PLL{{id}}FRACN_Pos;
+			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}FRACEN;
+		}
+
+		// Set all dividers
+		uint32_t divr{(uint32_t(cfg.N - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}N_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}N};
+		if (cfg.R != 0xff)
+		{
+			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}REN;
+			divr |= ((uint32_t(cfg.R - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}R_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}R);
+		}
+		if (cfg.Q != 0xff)
+		{
+			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}QEN;
+			divr |= ((uint32_t(cfg.Q - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}Q_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}Q);
+		}
+		if (cfg.P != 0xff)
+		{
+			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}PEN;
+			divr |= ((uint32_t(cfg.P - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}P_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}P);
+		}
+
+		// enable pll
+		RCC->PLL{{id}}CFGR = cfgr;
+		RCC->PLL{{id}}DIVR = divr;
+		RCC->CR |= RCC_CR_PLL{{id}}ON;
+
+		uint32_t tmp;
+		while (not (tmp = (RCC->CR & RCC_CR_PLL{{id}}RDY)) and --waitCycles)
+			;
+
+		return tmp;
+	}
+
+	/// Disable PLL{{id}}.
+	static inline bool
+	disablePll{{id}}(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CR &= ~RCC_CR_PLL{{id}}ON;
+		while ((RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles)
+			;
+		RCC->PLL{{id}}CFGR = 0;
+		RCC->PLL{{id}}DIVR = 0;
+		return waitCycles > 0;
+	}
+
+%% endfor
+%#
+	enum class
+	AhbPrescaler : uint8_t
+	{
+		Div1   = 0b0000,
+		Div2   = 0b1000,
+		Div4   = 0b1001,
+		Div8   = 0b1010,
+		Div16  = 0b1011,
+		Div64  = 0b1100,
+		Div128 = 0b1101,
+		Div256 = 0b1110,
+		Div512 = 0b1111,
+	};
+	static inline bool
+	setAhbPrescaler(AhbPrescaler prescaler)
+	{
+		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_HPRE) |
+					 (uint32_t(prescaler) << RCC_CFGR2_HPRE_Pos);
+		return true;
+	}
+
+	enum class
+	ApbPrescaler : uint8_t
+	{
+		Div1   = 0b000,
+		Div2   = 0b100,
+		Div4   = 0b101,
+		Div8   = 0b110,
+		Div16  = 0b111
+	};
+%% for id in [1,2,3]
+	static inline bool
+	setApb{{id}}Prescaler(ApbPrescaler prescaler)
+	{
+		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_PPRE{{id}}) |
+					 (uint32_t(prescaler) << RCC_CFGR2_PPRE{{id}}_Pos);
+		return true;
+	}
+%% endfor
+%#
+	// clock sinks
+	enum class
+	SystemClockSource : uint32_t
+	{
+		Hsi = 0b00,
+		Csi = 0b01,
+		Hse = 0b10,
+		Pll1P = 0b11,
+
+		InternalClock = Hsi,
+		ExternalClock = Hse,
+		ExternalCrystal = Hse,
+	};
+	static inline bool
+	enableSystemClock(SystemClockSource src, uint32_t waitCycles = 0x10000)
+	{
+		RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW) | uint32_t(src);
+
+		// Wait till the main PLL is used as system clock source
+		while ((RCC->CFGR1 & RCC_CFGR1_SWS) != (uint32_t(src) << RCC_CFGR1_SWS_Pos))
+			if (not --waitCycles) return false;
+
+		return true;
+	}
+
+	enum class
+	RealTimeClockSource : uint32_t
+	{
+		Disabled = 0,
+		Lse = 0b01 << RCC_BDCR_RTCSEL_Pos,
+		Lsi = 0b10 << RCC_BDCR_RTCSEL_Pos,
+		Hse = 0b11 << RCC_BDCR_RTCSEL_Pos,
+
+		ExternalClock = Hse,
+		ExternalCrystal = Hse,
+		LowSpeedInternalClock = Lsi,
+		LowSpeedExternalClock = Lse,
+		LowSpeedExternalCrystal = Lse
+	};
+	static inline bool
+	enableRealTimeClock(RealTimeClockSource src, uint8_t hseDiv = 0xff)
+	{
+		RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_RTCPRE) | ((uint8_t(hseDiv) << RCC_CFGR1_RTCPRE_Pos) & RCC_CFGR1_RTCPRE);
+		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
+		return true;
+	}
+
+	enum class
+	WatchdogClockSource : uint32_t
+	{
+		LowSpeedInternalClock = 0
+	};
+	static inline bool
+	enableWatchdogClock(WatchdogClockSource /*src*/ = WatchdogClockSource::LowSpeedInternalClock)
+	{ return true; }
+
+	// CCIPR1
+	enum class
+	UartClockSource : uint8_t
+	{
+		Bus   = 0b000,
+		Pll2Q = 0b001,
+%% if 3 in pll_ids
+		Pll3Q = 0b010,
+%% endif
+		Hsi   = 0b011,
+		Csi   = 0b100,
+		Lse   = 0b101
+	};
+%% for id in uart_ids | sort
+	%% set s = "s" if id in [1,2,3,6,10,11] else ""
+	%% set c = 2 if id in [11,12] else 1
+	static inline void
+	enableU{{s}}art{{id}}ClockSource(UartClockSource src)
+	{
+		RCC->CCIPR{{c}} = (RCC->CCIPR{{c}} & ~RCC_CCIPR{{c}}_U{{s|upper}}ART{{id}}SEL) |
+					  (uint32_t(src) << RCC_CCIPR{{c}}_U{{s|upper}}ART{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	// CCIPR3
+	enum class
+	LpUartClockSource : uint8_t
+	{
+		Bus   = 0b000,
+		Pll2P = 0b001,
+%% if 3 in pll_ids
+		Pll3Q = 0b010,
+%% endif
+		Hsi   = 0b011,
+		Csi   = 0b100,
+		Lse   = 0b101
+	};
+	static inline void
+	enableLpUart1ClockSource(LpUartClockSource src)
+	{
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_LPUART1SEL) |
+					  (uint32_t(src) << RCC_CCIPR3_LPUART1SEL_Pos);
+	}
+
+	enum class
+	Spi123ClockSource : uint8_t
+	{
+		Pll1Q    = 0b000,
+		Pll2P    = 0b001,
+%% if 3 in pll_ids
+		Pll3Q    = 0b010,
+%% endif
+		AudioClk = 0b011,
+		Bus      = 0b100
+	};
+%% for id in spi_ids | sort if id in [1,2,3]
+	static inline void
+	enableSpi{{id}}ClockSource(Spi123ClockSource src)
+	{
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) |
+					  (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
+	}
+%% endfor
+%% if target.name != "03"
+	enum class
+	Spi456ClockSource : uint8_t
+	{
+		Bus   = 0b000,
+		Pll2Q = 0b001,
+		Pll3Q = 0b010,
+		Hsi   = 0b011,
+		Csi   = 0b100,
+		Hse   = 0b101
+	};
+%% for id in spi_ids | sort if id in [1,2,3]
+	static inline void
+	enableSpi{{id}}ClockSource(Spi456ClockSource src)
+	{
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) |
+					  (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
+	}
+%% endfor
+%% endif
+%#
+	// CCIPR4
+	enum class
+	I2cClockSource : uint8_t
+	{
+		Bus   = 0b00,
+		Pll2R = 0b01,
+		Hsi   = 0b10,
+		Csi   = 0b11
+	};
+%% for id in i2c_ids | sort
+	static inline void
+	enableI2c{{id}}ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR4 = (RCC->CCIPR4 & ~RCC_CCIPR4_I2C{{id}}SEL) |
+					  (uint32_t(src) << RCC_CCIPR4_I2C{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	enum class
+	UsbClockSource : uint32_t
+	{
+		Disabled = 0,
+		Pll1Q = 0b01 << RCC_CCIPR4_USBSEL_Pos,
+		Pll{{pll_ids[-1]}}Q = 0b10 << RCC_CCIPR4_USBSEL_Pos,
+		Hsi48 = 0b11 << RCC_CCIPR4_USBSEL_Pos,
+	};
+	static inline void
+	enableUsbClockSource(UsbClockSource src)
+	{
+		RCC->CCIPR4 = (RCC->CCIPR4 & ~RCC_CCIPR4_USBSEL) | uint32_t(src);
+	}
+
+	// CCIPR5
+	enum class
+	CanClockSource : uint32_t
+	{
+		Hse = 0,
+		Pll1Q = 0b01 << RCC_CCIPR5_FDCANSEL_Pos,
+		Pll2Q = 0b10 << RCC_CCIPR5_FDCANSEL_Pos,
+		Disabled = 0b11 << RCC_CCIPR5_FDCANSEL_Pos,
+	};
+	static void
+	setCanClockSource(CanClockSource src)
+	{
+		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_FDCANSEL) | uint32_t(src);
+	}
+
+	enum class
+	RngClockSource : uint32_t
+	{
+		Hsi48 = 0,
+		Pll1Q = 0b01 << RCC_CCIPR5_RNGSEL_Pos,
+		Lse   = 0b10 << RCC_CCIPR5_RNGSEL_Pos,
+		Lsi   = 0b11 << RCC_CCIPR5_RNGSEL_Pos,
+	};
+	static void
+	setCanClockSource(RngClockSource src)
+	{
+		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_RNGSEL) | uint32_t(src);
+	}
+
+	enum class
+	AdcDacClockSource : uint32_t
+	{
+		Hclk = 0,
+		SysClk = 0b001 << RCC_CCIPR5_ADCDACSEL_Pos,
+		Pll2R  = 0b010 << RCC_CCIPR5_ADCDACSEL_Pos,
+		Hse    = 0b011 << RCC_CCIPR5_ADCDACSEL_Pos,
+		Hsi    = 0b100 << RCC_CCIPR5_ADCDACSEL_Pos,
+		Csi    = 0b101 << RCC_CCIPR5_ADCDACSEL_Pos,
+	};
+	static void
+	setAdcDacClockSource(AdcDacClockSource src)
+	{
+		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_ADCDACSEL) | uint32_t(src);
+	}
+
+public:
+	// outputs
+	enum class
+	ClockOutput1Source : uint32_t
+	{
+		Hsi = 0,
+		Lse = RCC_CFGR1_MCO1SEL_0,
+		Hse = RCC_CFGR1_MCO1SEL_1,
+		Pll1Q = RCC_CFGR1_MCO1SEL_1 | RCC_CFGR1_MCO1SEL_0,
+		Hsi48 = RCC_CFGR1_MCO1SEL_2
+	};
+	enum class
+	ClockOutput2Source : uint32_t
+	{
+		SystemClock = 0,
+		Pll2P = RCC_CFGR1_MCO2SEL_0,
+		Hse = RCC_CFGR1_MCO2SEL_1,
+		Pll1P = RCC_CFGR1_MCO2SEL_1 | RCC_CFGR1_MCO2SEL_0,
+		Csi = RCC_CFGR1_MCO2SEL_2,
+		Lsi = RCC_CFGR1_MCO2SEL_2 | RCC_CFGR1_MCO2SEL_0
+	};
+%% for id in [1,2]
+	static inline bool
+	enableClockOutput{{id}}(ClockOutput{{id}}Source src, uint8_t div)
+	{
+		RCC->CFGR1 = (RCC->CFGR1 & ~(RCC_CFGR1_MCO{{id}}SEL | RCC_CFGR1_MCO{{id}}PRE)) |
+					 uint32_t(src) | ((div << RCC_CFGR1_MCO{{id}}PRE_Pos) & RCC_CFGR1_MCO{{id}}PRE);
+		return true;
+	}
+%% endfor
+
+
+public:
+	// TODO: move to Pwr module
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Scale0 = 0b11 << PWR_VOSCR_VOS_Pos,
+		Scale1 = 0b10 << PWR_VOSCR_VOS_Pos,
+		Scale2 = 0b01 << PWR_VOSCR_VOS_Pos,
+		Scale3 = 0b00,
+	};
+	static inline bool
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 0x10000)
+	{
+		const auto currentSetting = PWR->VOSCR & PWR_VOSCR_VOS;
+		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
+
+		PWR->VOSCR = (PWR->VOSCR & ~PWR_VOSCR_VOS) | uint32_t(voltage);
+
+		while (PWR->VOSSR & PWR_VOSSR_VOSRDY)
+			if (--waitCycles == 0) return false;
+		return true;
+	}
+
+
+private:
+	struct flash_latency
+	{
+		uint32_t latency;
+		uint32_t max_frequency;
+	};
+	static constexpr flash_latency
+	computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV);
+};
+
+} // namespace modm::platform
+
+
+#include "rcc_impl.hpp"
+
+#endif	//  MODM_STM32_RCC_HPP

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -60,27 +60,27 @@ Rcc::setFlashLatency()
 	uint32_t acr = FLASH->ACR & ~FLASH_ACR_LATENCY;
 	// set flash latency
 	acr |= fl.latency;
-%% if target["family"] in ["f2", "f4", "l4", "g4"]
+%% if target.family in ["f2", "f4", "l4", "g4"]
 	// enable flash prefetch and data and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
-%% elif target["family"] in ["c0", "g0"]
+%% elif target.family in ["c0", "g0"]
 	// enable flash prefetch and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ICEN;
-%% elif target["family"] == "f7"
+%% elif target.family == "f7"
 	// enable flash prefetch and flash accelerator
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ARTEN;
-%% elif target["family"] in ["l1"]
+%% elif target.family in ["l1"]
 	// enable 64-bit access, must be enabled *before* prefetch and latency!
 	FLASH->ACR |= FLASH_ACR_ACC64;
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTEN;
-%% elif target["family"] == "l0"
+%% elif target.family == "l0"
 	// enable flash prefetch and pre-read
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_PRE_READ;
-%% elif target["family"] in ["u5"]
+%% elif target.family in ["u5"]
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTEN;
-%% elif target["family"] not in ["h7", "l5"]
+%% elif target.family not in ["h7", "l5", "h5"]
 	// enable flash prefetch
 	acr |= FLASH_ACR_PRFTBE;
 %% endif

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -39,6 +39,19 @@ def prepare(module, options):
                 default="sram")
             )
 
+    if options[":target"].has_driver("icache"):
+        module.add_option(
+            BooleanOption(
+                name="enable_icache",
+                description="Enable Instruction-Cache",
+                default=True))
+    if options[":target"].has_driver("dcache"):
+        module.add_option(
+            BooleanOption(
+                name="enable_dcache",
+                description="Enable Data-Cache",
+                default=False))
+
     module.depends(":platform:cortex-m")
     return True
 
@@ -47,7 +60,9 @@ def build(env):
     target = env[":target"].identifier
     env.substitutions = {
         "target": target,
-        "vector_table_location": env.get(":platform:core:vector_table_location", "rom")
+        "vector_table_location": env.get(":platform:core:vector_table_location", "rom"),
+        "enable_icache": env.get("enable_icache", False),
+        "enable_dcache": env.get("enable_dcache", False),
     }
     env.outbasepath = "modm/src/modm/platform/core"
     # startup helper code
@@ -61,6 +76,7 @@ def build(env):
         "l0": (3,  4), # CM0+ tested on L031 in RAM
         "g0": (3,  4), # CM0+ tested on G072 in RAM
         "f7": (4,  4), # CM7  tested on F767 in ITCM
+        "h5": (4,  4), # CM7  tested on H503 in ITCM
         "h7": (4,  4), # CM7  tested on H743 in ITCM
         "l4": (3,  4), # CM4  tested on L476 in SRAM2
         "l5": (3,  4), # CM33 tested on L552 in RAM

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -39,7 +39,7 @@ __modm_initialize_platform(void)
 	RCC->APB4ENR |= RCC_APB4ENR_SYSCFGEN; __DSB();
 %% elif target.family == "u5"
 	RCC->APB3ENR |= RCC_APB3ENR_SYSCFGEN; __DSB();
-%% else
+%% elif target.family not in ["h5"]
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN; __DSB();
 %% endif
 
@@ -95,11 +95,41 @@ __modm_initialize_platform(void)
 	PWR->SVMCR |= PWR_SVMCR_ASV | PWR_SVMCR_IO2SV | PWR_SVMCR_USV;
 	// Enable Backup SRAM (BKPSRAM)
 	RCC->AHB1ENR |= RCC_AHB1ENR_BKPSRAMEN;
+%% elif target.family == "h5"
+	// Enable the IO compensation cells
+	RCC->APB3ENR |= RCC_APB3ENR_SBSEN;
+	__DSB();
+	SBS->CCCSR |= SBS_CCCSR_EN1 | SBS_CCCSR_EN2;
+	// Enable Backup SRAM (BKPSRAM)
+	RCC->AHB1ENR |= RCC_AHB1ENR_BKPRAMEN;
 %% endif
 
 %% if vector_table_location == "ram"
 	__DSB();
 	// Remap SRAM to 0x0 for vector table relocation without VTOR register
 	SYSCFG->CFGR1 |= SYSCFG_CFGR1_MEM_MODE;
+%% endif
+
+%% if enable_icache
+	// We need to define the OTP as non-cachable otherwise the ICACHE access will cause a Hardfault
+	// 1. Define Attribute 0 as Non-Cacheable (0x44)
+	MPU->MAIR[1] = (0x44UL << 24);
+	// Use last region to keep 0-3 aliases free
+	MPU->RNR = 7;
+	// 2. Configure Region 0: Base Address + Read-Only (0x2 << 1) + Execute-Never (1)
+	MPU->RBAR = 0x08FFF000UL | (0x2UL << 1) | 1UL;
+	// 3. Configure Region 0: Limit Address + Enable (1) + Attribute Index 0 (0 << 1)
+	MPU->RLAR = 0x08FFFFFFUL | (7UL << 1) | 1UL;
+	// 4. Enable MPU with Background Map (to keep the rest of Flash/RAM working)
+	MPU->CTRL = MPU_CTRL_PRIVDEFENA_Msk | MPU_CTRL_ENABLE_Msk;
+	__DMB();
+	// Enable the Instruction Cache
+	ICACHE->CR |= ICACHE_CR_EN;
+	__DMB();
+%% endif
+%% if enable_dcache
+	// Enable the Data Cache
+	DCACHE1->CR |= DCACHE_CR_EN;
+	__DMB();
 %% endif
 }

--- a/src/modm/platform/extint/stm32/module.lb
+++ b/src/modm/platform/extint/stm32/module.lb
@@ -47,12 +47,12 @@ def validate(env):
 def build(env):
     target = env[":target"].identifier
 
-    separate_flags = target.family in ["c0", "g0", "l5", "u5"]
+    separate_flags = target.family in ["c0", "g0", "l5", "u5", "h5"]
     extended = target.family in ["l4", "l5", "g4", "h7"]
     if separate_flags: extended = target.name in ["b1", "c1"]
 
     exti_reg = "SYSCFG"
-    if target.family in ["c0", "g0", "l5", "u5"]: exti_reg = "EXTI"
+    if target.family in ["c0", "g0", "l5", "u5", "h5"]: exti_reg = "EXTI"
     if target.family in ["f1"]: exti_reg = "AFIO"
 
     global extimap

--- a/src/modm/platform/gpio/stm32/data.hpp.in
+++ b/src/modm/platform/gpio/stm32/data.hpp.in
@@ -17,7 +17,7 @@
 namespace modm::platform::detail
 {
 
-%% if target.family in ["h7"]
+%% if target.family in ["h5", "h7"]
 enum class
 AdcPolarity
 {
@@ -26,7 +26,7 @@ AdcPolarity
 };
 %% endif
 template<class Signal, Peripheral p> struct SignalConnection;
-template<class Data, Peripheral p{% if target.family in ["h7"] %}, AdcPolarity ap{% endif %}> static constexpr int8_t AdcChannel = -1;
+template<class Data, Peripheral p{% if target.family in ["h5", "h7"] %}, AdcPolarity ap{% endif %}> static constexpr int8_t AdcChannel = -1;
 template<class Data, Peripheral p> static constexpr int8_t DacChannel = -1;
 
 struct DataUnused {};

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -26,7 +26,7 @@ modm_gpio_enable(void)
 %% elif target.family in ["f1"]
 %%	set clock_tree = "APB2"
 %%	set prefix = "IOP"
-%% elif target.family in ["l4", "l5", "g4", "u5"]
+%% elif target.family in ["l4", "l5", "g4", "h5", "u5"]
 %%  set clock_tree = 'AHB2'
 %% elif target.family in ["c0", "g0", "l0"]
 %%  set clock_tree = 'IOP'

--- a/src/modm/platform/usb/stm32/usb.hpp.in
+++ b/src/modm/platform/usb/stm32/usb.hpp.in
@@ -33,10 +33,8 @@ public:
 #ifdef PWR_CR2_USV
 		PWR->CR2 |= PWR_CR2_USV;
 #endif
-%% elif target.family in ["h5"]
-#ifdef PWR_USBSCR_USB33DEN
-		PWR->USBSCR |= PWR_USBSCR_USB33DEN;
-#endif
+%% elif target.family == "h5" and target.name != "03"
+		PWR->USBSCR |= PWR_USBSCR_USB33DEN | PWR_USBSCR_USB33SV;
 %% elif target.family in ["h7"]
 #ifdef PWR_CR3_USB33DEN
 		PWR->CR3 |= PWR_CR3_USB33DEN;

--- a/tools/openocd/modm/st_nucleo_dap.cfg.in
+++ b/tools/openocd/modm/st_nucleo_dap.cfg.in
@@ -1,4 +1,0 @@
-source [find interface/stlink-dap.cfg]
-transport select dapdirect_swd
-source [find target/{{target}}.cfg]
-reset_config srst_only srst_nogate

--- a/tools/openocd/modm/st_nucleo_swd.cfg.in
+++ b/tools/openocd/modm/st_nucleo_swd.cfg.in
@@ -1,4 +1,10 @@
-source [find interface/stlink.cfg]
-transport select swd
+if { [catch {source [find interface/stlink-dap.cfg]}] } {
+	source [find interface/stlink.cfg]
+}
+if { [catch {transport select dapdirect_swd}] } {
+	if { [catch {transport select swd}] } {
+		transport select hla_swd
+	}
+}
 source [find target/{{target}}.cfg]
 reset_config srst_only srst_nogate

--- a/tools/openocd/modm/stm32_swd.cfg.in
+++ b/tools/openocd/modm/stm32_swd.cfg.in
@@ -1,3 +1,7 @@
-transport select swd
+if { [catch {transport select dapdirect_swd}] } {
+	if { [catch {transport select swd}] } {
+		transport select hla_swd
+	}
+}
 source [find target/{{target}}.cfg]
 reset_config none


### PR DESCRIPTION
- [x] Fix modm-devices https://github.com/modm-io/modm-devices/pull/114
- [x] Port STM32H5 family
  - [x] RCC
  - [x] GPIO
  - [x] Core incl ICACHE/DCACHE
  - [x] USB and TinyUSB
  - [x] EXTI
- [x] Add NUCLEO-H503RB board
- [x] Add WEACT-H503CB board
- [x] Add WEACT-H562RG board
- [x] Tested in hardware on all added BSPs with Blinky and TinyUSB
- [x] Compile all job passed previously