### PR TITLE
[scons] Fix duplicates in SConscript for external lbuild repos

### DIFF
--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -8,8 +8,7 @@
 
 #!/usr/bin/env python3
 
-from os.path import join, abspath, realpath, dirname
-import shutil
+from os.path import join, abspath
 Import("env")
 
 profile = ARGUMENTS.get("profile", "release")
@@ -28,24 +27,17 @@ env["COMPILERSUFFIX"] = "-12"
 %% endif
 %% endif
 
+%% if toolpaths
 # SCons tools
 env.Append(toolpath=[
 %% for toolpath in toolpaths | sort
     abspath("{{ toolpath | modm.windowsify(escape_level=1) }}"),
 %% endfor
 ])
+%% endif
 %% for tool in tools | sort
 env.Tool("{{tool}}")
 %% endfor
-
-c_compiler_name = env["CC"]
-c_compiler_path = shutil.which(c_compiler_name)
-
-if c_compiler_path is None:
-    print(f'Selected compiler "{c_compiler_name}" not found on PATH. Please add its installation directory to the PATH environment variable.')
-    exit(1)
-
-env["GCC_PATH"] = dirname(dirname(realpath(c_compiler_path)))
 
 %% macro generate_flags_for_profile(name, profile, append=False)
 env{% if append %}.Append({{name | upper}}{% else %}["{{name | upper}}"]{% endif %} = [
@@ -205,6 +197,7 @@ env.AppendUnique(LIBPATH=[
 env.ParseConfig("pkg-config --cflags --libs {{ packages | sort | join(" ") }}")
 %% endif
 
+%% if is_modm
 for flags in ["CCFLAGS", "CFLAGS", "CXXFLAGS", "ASFLAGS", "ARCHFLAGS", "LINKFLAGS"]:
 	flags_str = ARGUMENTS.get(flags)
 	if flags_str is not None:
@@ -220,5 +213,6 @@ for flags in ["CCFLAGS", "CFLAGS", "CXXFLAGS", "ASFLAGS", "ARCHFLAGS", "LINKFLAG
 					exit(1)
 			else:
 				env[flags].append(flag)
+%% endif
 
 Return("library")

--- a/tools/build_script_generator/scons/site_tools/gcc_retarget.py
+++ b/tools/build_script_generator/scons/site_tools/gcc_retarget.py
@@ -13,6 +13,8 @@
 # - 2018, Niklas Hauser
 
 import os
+from os.path import realpath, dirname
+import shutil
 
 from SCons.Script import *
 
@@ -92,7 +94,13 @@ def generate(env, **kw):
     env.AddMethod(strip_binary, 'Strip')
     env.AddMethod(list_symbols, 'Symbols')
 
+    c_compiler_name = env["CC"]
+    assert (c_compiler_path := shutil.which(c_compiler_name)), \
+            f'Selected compiler "{c_compiler_name}" not found on PATH. ' \
+            "Please add its installation directory to the PATH environment variable."
+    env["GCC_PATH"] = dirname(dirname(realpath(c_compiler_path)))
+
 
 def exists(env):
-    return True
+    return env.Detect(env["CC"])
 


### PR DESCRIPTION
SConscript files for external repos should not contain common code that's only necessary in the modm/SConscript repo file.