### PR TITLE
[stm32] add missing HSI48-related functionality

### DIFF
--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -69,15 +69,16 @@ def build(env):
     properties["pllprediv2"] = False    # FIXME: not sure what value this should have
     properties["pll_hse_prediv2"] = target["family"] == "f1" and target["name"] in ["01", "02", "03"]
     properties["hsi48"] = \
+        (target["family"] in ["g4", "h5", "h7", "l5", "u0", "u5"]) or \
         (target["family"] == "f0" and target["name"] in ["42", "48", "71", "72", "78", "91", "98"]) or \
-        (target["family"] == "l4" and target["name"][0] not in ["7", "8"]) or \
-        (target["family"] == "l5") or \
-        (target["family"] == "u5")
-    if target["family"] in ["l4", "l5"]:
+        (target["family"] == "g0" and target["name"] in ["b1", "c1"]) or \
+        (target["family"] == "l0" and target["name"][1] == "2") or \
+        (target["family"] == "l4" and target["name"][0] not in ["7", "8"])
+    if target["family"] in ["g4", "l0", "l4", "l5", "u0"]:
         properties["hsi48_cr"] = "CRRCR"
-    elif target["family"] in ["c0", "u5"]:
+    elif target["family"] in ["g0", "h5", "h7", "u5"]:
         properties["hsi48_cr"] = "CR"
-    else:
+    elif target["family"] in ["f0"]:
         properties["hsi48_cr"] = "CR2"
     properties["pll_p"] = ((target["family"] == "l4" and target["name"] not in ["12", "22"]) or target["family"] == "g4")
     properties["overdrive"] = (target["family"] == "f7") or \

--- a/src/modm/platform/clock/stm32/rcc.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc.hpp.in
@@ -116,7 +116,7 @@ public:
 		Hsi16 = 0b10,
 		Hse = 0b11,
 %% endif
-%% if hsi48 and target.family not in ["l4", "l5", "u5"]
+%% if hsi48 and target.family in ["f0"]
 		/// High speed internal clock (48 MHz)
 		Hsi48 = RCC_CFGR_PLLSRC_HSI48_PREDIV,
 		InternalClockMHz48 = Hsi48,
@@ -171,7 +171,7 @@ public:
 		Hsi16 = Hsi,
 %% endif
 		Hse = RCC_CFGR_SW_HSE,
-%% if hsi48 and target.family != "l4"
+%% if hsi48 and target.family in ["f0"]
 		Hsi48 = RCC_CFGR_SW_HSI48,
 		InternalClockMHz48 = Hsi48,
 %% endif
@@ -383,6 +383,12 @@ public:
 		Pll1Q = 0b10 << RCC_CCIPR1_ICLKSEL_Pos,
 		Msik  = 0b11 << RCC_CCIPR1_ICLKSEL_Pos,
 	};
+%% elif hsi48 and target.family in ["l0"]
+	enum class Clock48Source
+	{
+		PllQ = 0,
+		Hsi48 = RCC_CCIPR_HSI48SEL,
+	};
 %% endif
 
 %% if target.family in ["f2", "f4", "f7"]
@@ -456,7 +462,7 @@ public:
 		MultiSpeedInternalClockK = (0b1001 << RCC_{{cfgr_mco}}_MCOSEL_Pos), // MSIK
 	%% endif
 	};
-%% else
+%% elif target.family in ["f0", "f1", "f3"]
 	enum class
 	ClockOutputSource : uint32_t
 	{
@@ -814,6 +820,12 @@ public:
 	{
 		RCC->CCIPR1 = (RCC->CCIPR1 & ~RCC_CCIPR1_ICLKSEL_Msk) | uint32_t(source);
 	}
+%% elif hsi48 and target.family in ["l0"]
+	static inline void
+	setClock48Source(Clock48Source source)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_HSI48SEL_Msk) | uint32_t(source);
+	}
 %% endif
 
 %% if target.family == "h7"
@@ -829,6 +841,31 @@ public:
 	enableUsbClockSource(UsbClockSource source)
 	{
 		RCC->{{d2}}CCIP2R = (RCC->{{d2}}CCIP2R & ~RCC_{{d2}}CCIP2R_USBSEL_Msk) | uint32_t(source);
+	}
+%% elif hsi48 and target.family in ["f0"] and (target.name in ["42", "48", "72", "78"])
+	enum class
+	UsbClockSource : uint32_t
+	{
+		Hsi48 = 0,
+		Pll = RCC_CFGR3_USBSW_PLLCLK,
+	};
+	static inline void
+	enableUsbClockSource(UsbClockSource source)
+	{
+		RCC->CFGR3 = (RCC->CFGR3 & ~RCC_CFGR3_USBSW_Msk) | uint32_t(source);
+	}
+%% elif hsi48 and target.family in ["g0"]
+	enum class
+	UsbClockSource : uint32_t
+	{
+		Hsi48 = 0,
+		Hse = RCC_CCIPR2_USBSEL_0,
+		Pll = RCC_CCIPR2_USBSEL_1,
+	};
+	static inline void
+	enableUsbClockSource(UsbClockSource source)
+	{
+		RCC->CCIPR2 = (RCC->CCIPR2 & ~RCC_CCIPR2_USBSEL_Msk) | uint32_t(source);
 	}
 %% endif
 


### PR DESCRIPTION
Fixes #1250

- add `Rcc::enableInternalClockMHz48` function for stm32 g0 g4 l0 h7 (h5 u0)
- make changes to `PllSource`, `SystemClockSource`, `Clock48Source` and `UsbClockSource`

| family | hsi48_cr |
|:-------|:---------|
| F0 (42, 48, 71,72,78, 91, 98) | CR2 |
| G0 (B1 C1) | CR |
| G4 | CRRCR |
| L0 (x2) | CRRCR |
| L4 (`target["name"][0] not in ["7", "8"]`) | CRRCR |
| U0 | CRRCR |
| L5 | CRRCR |
| U5 | CR |
| H5 | CR |
| H7 | CR |

