### PR TITLE
Fix Dw3110 initialization function failing on STM32 G474

### DIFF
--- a/src/modm/driver/radio/dw3110/dw3110_phy_impl.hpp
+++ b/src/modm/driver/radio/dw3110/dw3110_phy_impl.hpp
@@ -97,7 +97,7 @@ modm::Dw3110Phy<SpiMaster, Cs>::initialize(Dw3110::Channel channel, Dw3110::Prea
 			MODM_LOG_ERROR << "Failed to reach IDLE_PLL State!" << modm::endl;
 			RF_RETURN(false);
 		}
-		fetchSystemStatus();
+		fetchChipState();
 	}
 
 	if (!RF_CALL(calibrate())) { RF_RETURN(false); }


### PR DESCRIPTION
Corrects a bug in the DW3110 driver that causes the initialization function to fail on faster chips. On the F401 it initializes successfully because the device reaches IDLE_PLL in the time it takes to check it once. On G474 it always times out on first power up since the state that is checked against was not updated correctly. 