### PR TITLE
Add STM32F723E-DISCOVERY board

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,74 +672,75 @@ We have out-of-box support for many development boards including documentation.
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-disco-f429zi">DISCO-F429ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-disco-f469ni">DISCO-F469NI</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-disco-f723ie">DISCO-F723IE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-disco-f746ng">DISCO-F746NG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-disco-f769ni">DISCO-F769NI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-disco-f769ni">DISCO-F769NI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-disco-l152rc">DISCO-L152RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-disco-l476vg">DISCO-L476VG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-feather-m0">FEATHER-M0</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-feather-m4">FEATHER-M4</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-feather-m4">FEATHER-M4</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-feather-rp2040">FEATHER-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-mega-2560-pro">MEGA-2560-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-c031c6">NUCLEO-C031C6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f031k6">NUCLEO-F031K6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f031k6">NUCLEO-F031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f042k6">NUCLEO-F042K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f072rb">NUCLEO-F072RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f091rc">NUCLEO-F091RC</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f103rb">NUCLEO-F103RB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f103rb">NUCLEO-F103RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303k8">NUCLEO-F303K8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303re">NUCLEO-F303RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f334r8">NUCLEO-F334R8</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f401re">NUCLEO-F401RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f401re">NUCLEO-F401RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f411re">NUCLEO-F411RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f429zi">NUCLEO-F429ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f439zi">NUCLEO-F439ZI</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446re">NUCLEO-F446RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446re">NUCLEO-F446RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446ze">NUCLEO-F446ZE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f746zg">NUCLEO-F746ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f767zi">NUCLEO-F767ZI</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g070rb">NUCLEO-G070RB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g070rb">NUCLEO-G070RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g071rb">NUCLEO-G071RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431rb">NUCLEO-G431RB</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/black_pill_f411/usbfatfs/main.cpp
+++ b/examples/black_pill_f411/usbfatfs/main.cpp
@@ -139,7 +139,7 @@ int
 main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 	initializeFatFs();
 	tusb_init();
 

--- a/examples/feather_m4/usbserial/main.cpp
+++ b/examples/feather_m4/usbserial/main.cpp
@@ -23,7 +23,7 @@ int
 main()
 {
 	initialize();
-	initializeUsbFs();
+	initializeUsb();
 
 	tusb_init();
 

--- a/examples/generic/delay/main.cpp
+++ b/examples/generic/delay/main.cpp
@@ -151,7 +151,7 @@ int main()
 int main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 	counter.initialize(true);
 	tusb_init();
 

--- a/examples/generic/usb/main.cpp
+++ b/examples/generic/usb/main.cpp
@@ -38,9 +38,7 @@ void midi_task();
 int main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
-	// DISCO-F746NG also has a HS port:
-	// Board::initializeUsbHs();
+	Board::initializeUsb();
 	tusb_init();
 
 	while (true)

--- a/examples/generic/usb/project.xml
+++ b/examples/generic/usb/project.xml
@@ -8,6 +8,7 @@
   <!-- <extends>modm:disco-f411ve</extends> -->
   <!-- <extends>modm:disco-f429zi</extends> -->
   <!-- <extends>modm:disco-f469ni</extends> -->
+  <!-- <extends>modm:disco-f723ie</extends> -->
   <!-- <extends>modm:disco-f746ng</extends> -->
   <!-- <extends>modm:disco-l476vg</extends> -->
   <!-- <extends>modm:feather-m0</extends> -->

--- a/examples/nucleo_f429zi/usb_freertos/main.cpp
+++ b/examples/nucleo_f429zi/usb_freertos/main.cpp
@@ -50,8 +50,8 @@ public:
 	void
 	run()
 	{
-		MODM_LOG_INFO << "USBTask: Calling Board::initializeUsbFs() ..." << modm::endl;
-		Board::initializeUsbFs(4);
+		MODM_LOG_INFO << "USBTask: Calling Board::initializeUsb() ..." << modm::endl;
+		Board::initializeUsb(4);
 		MODM_LOG_INFO << "USBTask: Calling tusb_init() ..." << modm::endl;
 		tusb_init();
 		MODM_LOG_INFO << "... done!" << modm::endl;

--- a/examples/nucleo_f429zi/usbfatfs/main.cpp
+++ b/examples/nucleo_f429zi/usbfatfs/main.cpp
@@ -141,7 +141,7 @@ int
 main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 	initializeFatFs();
 	tusb_init();
 

--- a/examples/nucleo_f446ze/usbserial/main.cpp
+++ b/examples/nucleo_f446ze/usbserial/main.cpp
@@ -36,7 +36,7 @@ void tud_resume_cb() { tmr.restart(1s); }
 int main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 
 	tusb_init();
 

--- a/examples/rp_pico/spi_dma/main.cpp
+++ b/examples/rp_pico/spi_dma/main.cpp
@@ -29,7 +29,7 @@ using Spi = SpiMaster0_Dma<DmaRx, DmaTx>;
 int main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 	tusb_init();
 
 	Spi::connect<Mosi::Tx, Miso::Rx, Sck::Sclk>();

--- a/examples/samd/usbserial/main.cpp
+++ b/examples/samd/usbserial/main.cpp
@@ -55,7 +55,7 @@ void tud_resume_cb() { tmr.restart(1s); }
 int main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 
 	// Output 500hz PWM on D12 so we can validate the GCLK0 clock speed.
 	PM->APBCMASK.reg |= PM_APBCMASK_TCC0;

--- a/examples/samd21_xplained_pro/usbserial/main.cpp
+++ b/examples/samd21_xplained_pro/usbserial/main.cpp
@@ -22,7 +22,7 @@ int
 main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 
 	tusb_init();
 

--- a/examples/same54_xplained_pro/usbserial/main.cpp
+++ b/examples/same54_xplained_pro/usbserial/main.cpp
@@ -22,7 +22,7 @@ int
 main()
 {
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 
 	tusb_init();
 

--- a/examples/samg55_xplained_pro/usbserial/main.cpp
+++ b/examples/samg55_xplained_pro/usbserial/main.cpp
@@ -12,7 +12,7 @@ int main() {
 	modm::delay_ms(5);
 	GpioA22::setInput();
 
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 
 	tusb_init();
 

--- a/examples/stm32f3_discovery/usb_dfu/main.cpp
+++ b/examples/stm32f3_discovery/usb_dfu/main.cpp
@@ -57,7 +57,7 @@ int main()
 		);
 	}
 	Board::initialize();
-	Board::initializeUsbFs();
+	Board::initializeUsb();
 	tusb_init();
 
 	while (true)

--- a/src/modm/board/black_pill_f103/board.hpp
+++ b/src/modm/board/black_pill_f103/board.hpp
@@ -125,11 +125,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/black_pill_f411/board.hpp
+++ b/src/modm/board/black_pill_f411/board.hpp
@@ -125,7 +125,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -136,6 +136,12 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBUSBSEN;
 	USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBUSASEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/blue_pill_f103/board.hpp
+++ b/src/modm/board/blue_pill_f103/board.hpp
@@ -125,11 +125,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/disco_f072rb/board.hpp
+++ b/src/modm/board/disco_f072rb/board.hpp
@@ -149,11 +149,17 @@ initializeL3g()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // namespace Board

--- a/src/modm/board/disco_f303vc/board.hpp
+++ b/src/modm/board/disco_f303vc/board.hpp
@@ -211,11 +211,17 @@ initializeLsm3()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f401vc/board.hpp
+++ b/src/modm/board/disco_f401vc/board.hpp
@@ -218,21 +218,6 @@ initializeLsm3()
 	lsm3::I2cMaster::initialize<SystemClock, 400_kHz>();
 }
 
-/// not supported yet, due to missing I2S driver
-inline void
-initializeCs43()
-{
-//	cs43::Lrck::connect(cs43::I2sMaster::Ws);
-//	cs43::Mclk::connect(cs43::I2sMaster::Mck);
-//	cs43::Sclk::connect(cs43::I2sMaster::Ck);
-//	cs43::Sdin::connect(cs43::I2sMaster::Sd);
-
-	cs43::Reset::setOutput(modm::Gpio::High);
-
-	cs43::I2cMaster::connect<cs43::Scl::Scl, cs43::Sda::Sda>();
-	cs43::I2cMaster::initialize<SystemClock, 100_kHz>();
-}
-
 inline void
 initializeL3g()
 {
@@ -245,16 +230,8 @@ initializeL3g()
 	l3g::SpiMaster::setDataMode(l3g::SpiMaster::DataMode::Mode3);
 }
 
-/// not supported yet, due to missing I2S driver
 inline void
-initializeMp45()
-{
-//	mp45::Clk::connect(mp45::I2sMaster::Ck);
-//	mp45::Dout::connect(mp45::I2sMaster::Sd);
-}
-
-inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -266,6 +243,11 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
 
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f407vg/board.hpp
+++ b/src/modm/board/disco_f407vg/board.hpp
@@ -210,31 +210,8 @@ initializeLis3()
 	lis3::SpiMaster::setDataMode(lis3::SpiMaster::DataMode::Mode3);
 }
 
-/// not supported yet, due to missing I2S driver
 inline void
-initializeCs43()
-{
-//	cs43::Lrck::connect(cs43::I2sMaster::Ws);
-//	cs43::Mclk::connect(cs43::I2sMaster::Mck);
-//	cs43::Sclk::connect(cs43::I2sMaster::Ck);
-//	cs43::Sdin::connect(cs43::I2sMaster::Sd);
-
-	cs43::Reset::setOutput(modm::Gpio::High);
-
-	cs43::I2cMaster::connect<cs43::Scl::Scl, cs43::Sda::Sda>();
-	cs43::I2cMaster::initialize<SystemClock, 100_kHz>();
-}
-
-/// not supported yet, due to missing I2S driver
-inline void
-initializeMp45()
-{
-//	mp45::Clk::connect(mp45::I2sMaster::Ck);
-//	mp45::Dout::connect(mp45::I2sMaster::Sd);
-}
-
-inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -245,6 +222,12 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f411ve/board.hpp
+++ b/src/modm/board/disco_f411ve/board.hpp
@@ -198,31 +198,8 @@ initializeLis3()
 	lis3::SpiMaster::setDataMode(lis3::SpiMaster::DataMode::Mode3);
 }
 
-/// not supported yet, due to missing I2S driver
 inline void
-initializeCs43()
-{
-	//	cs43::Lrck::connect(cs43::I2sMaster::Ws);
-	//	cs43::Mclk::connect(cs43::I2sMaster::Mck);
-	//	cs43::Sclk::connect(cs43::I2sMaster::Ck);
-	//	cs43::Sdin::connect(cs43::I2sMaster::Sd);
-
-	cs43::Reset::setOutput(modm::Gpio::High);
-
-	cs43::I2cMaster::connect<cs43::Scl::Scl, cs43::Sda::Sda>();
-	cs43::I2cMaster::initialize<SystemClock, 100_kHz>();
-}
-
-/// not supported yet, due to missing I2S driver
-inline void
-initializeMp45()
-{
-	//	mp45::Clk::connect(mp45::I2sMaster::Ck);
-	//	mp45::Dout::connect(mp45::I2sMaster::Sd);
-}
-
-inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -233,5 +210,11 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 }

--- a/src/modm/board/disco_f429zi/board.hpp
+++ b/src/modm/board/disco_f429zi/board.hpp
@@ -284,7 +284,7 @@ initializeL3g()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	Rcc::enable<Peripheral::Usbotgfs>();
 	usb::Device::initialize<SystemClock>(priority);
@@ -296,6 +296,12 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_HS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
 	USB_OTG_HS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f469ni/board.hpp.in
+++ b/src/modm/board/disco_f469ni/board.hpp.in
@@ -248,7 +248,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -258,6 +258,12 @@ initializeUsbFs(uint8_t priority=3)
 	// Enable VBUS sense (B device) via pin PA9
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f723ie/board.hpp
+++ b/src/modm/board/disco_f723ie/board.hpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2015-2018, Niklas Hauser
+ * Copyright (c) 2016, Fabian Greif
+ * Copyright (c) 2016-2017, Sascha Schade
+ * Copyright (c) 2018, Antal Szabó
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture/interface/clock.hpp>
+#include <modm/debug/logger.hpp>
+
+/// @ingroup modm_board_disco_f723ie
+#define MODM_BOARD_HAS_LOGGER
+
+using namespace modm::platform;
+
+namespace Board
+{
+/// @ingroup modm_board_disco_f723ie
+/// @{
+using namespace modm::literals;
+
+/// STM32F7 running at 216MHz from the external 25MHz clock
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 216_MHz;
+	static constexpr uint32_t Apb1 = Frequency / 4;
+	static constexpr uint32_t Apb2 = Frequency / 2;
+
+	static constexpr uint32_t Adc1 = Apb2;
+	static constexpr uint32_t Adc2 = Apb2;
+	static constexpr uint32_t Adc3 = Apb2;
+
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Spi4 = Apb2;
+
+	static constexpr uint32_t Usart1 = Apb2;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Uart4  = Apb1;
+	static constexpr uint32_t Uart5  = Apb1;
+	static constexpr uint32_t Usart6 = Apb2;
+	static constexpr uint32_t Uart7  = Apb1;
+	static constexpr uint32_t Uart8  = Apb1;
+
+	static constexpr uint32_t Can1 = Apb1;
+	static constexpr uint32_t Can2 = Apb1;
+
+	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c2 = Apb1;
+	static constexpr uint32_t I2c3 = Apb1;
+	static constexpr uint32_t I2c4 = Apb1;
+
+	static constexpr uint32_t Apb1Timer = Apb1 * 2;
+	static constexpr uint32_t Apb2Timer = Apb2 * 2;
+	static constexpr uint32_t Timer1  = Apb2Timer;
+	static constexpr uint32_t Timer2  = Apb1Timer;
+	static constexpr uint32_t Timer3  = Apb1Timer;
+	static constexpr uint32_t Timer4  = Apb1Timer;
+	static constexpr uint32_t Timer5  = Apb1Timer;
+	static constexpr uint32_t Timer6  = Apb1Timer;
+	static constexpr uint32_t Timer7  = Apb1Timer;
+	static constexpr uint32_t Timer8  = Apb2Timer;
+	static constexpr uint32_t Timer10 = Apb2Timer;
+	static constexpr uint32_t Timer11 = Apb2Timer;
+	static constexpr uint32_t Timer12 = Apb1Timer;
+	static constexpr uint32_t Timer13 = Apb1Timer;
+	static constexpr uint32_t Timer14 = Apb1Timer;
+
+	static constexpr uint32_t Usb = 48_MHz;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+	static constexpr uint32_t Rtc = 32.768_kHz;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLowSpeedExternalCrystal();
+		Rcc::enableRealTimeClock(Rcc::RealTimeClockSource::LowSpeedExternalCrystal);
+
+		Rcc::enableExternalClock(); // 25 MHz
+		const Rcc::PllFactors pllFactors{
+			.pllM = 25,		// 25MHz / M=25 -> 1MHz
+			.pllN = 432,	// 1MHz * N=432 -> 432MHz
+			.pllP = 2,		// 432MHz / P=2 -> 216MHz = F_cpu
+			.pllQ = 9		// 432MHz / Q=9 -> 48MHz = F_usb
+		};
+		Rcc::enablePll(Rcc::PllSource::ExternalClock, pllFactors);
+		// Required for 216 MHz clock
+		Rcc::enableOverdriveMode();
+
+		Rcc::setFlashLatency<Frequency>();
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+		// APB1 is running at 54MHz
+		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div4);
+		// APB2 is running at 108MHz
+		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div2);
+		Rcc::updateCoreFrequency<Frequency>();
+
+		return true;
+	}
+};
+
+// Arduino footprint
+using A0 = GpioA6;
+using A1 = GpioA4;
+using A2 = GpioC4;
+using A3 = GpioF10;
+using A4 = GpioC0;
+using A5 = GpioC1;
+
+using D0  = GpioA3;
+using D1  = GpioA2;
+using D2  = GpioC5;
+using D3  = GpioE5;
+using D4  = GpioH3;
+using D5  = GpioB0;
+using D6  = GpioE6;
+using D7  = GpioE3;
+using D8  = GpioE4;
+using D9  = GpioH6;
+using D10 = GpioA1;
+using D11 = GpioB5;
+using D12 = GpioB4;
+using D13 = GpioOutputA5;
+using D14 = GpioH5;
+using D15 = GpioH4;
+
+using Button = GpioInputA0;		// User Button
+using LedRed = GpioOutputA7;	// User Red LED
+using LedGreen = GpioOutputB1;	// User Green LED
+using LedD13 = D13;				// User Blue LED (Arduino D13)
+
+using Leds = SoftwareGpioPort< LedD13, LedGreen, LedRed >;
+/// @}
+
+namespace usb_fs
+{
+/// @ingroup modm_board_disco_f723ie
+/// @{
+using Vbus = GpioA9;
+using Id = GpioA10;
+using Dm = GpioA11;
+using Dp = GpioA12;
+using Overcurrent = GpioB10;
+using Power = GpioG8;
+
+using Device = UsbFs;
+/// @}
+}
+
+namespace usb_hs
+{
+/// @ingroup modm_board_disco_f723ie
+/// @{
+
+using Vbus = GpioB13;
+using Id = GpioB12;
+using Dm = GpioB14;
+using Dp = GpioB15;
+using Overcurrent = GpioH10;
+using Power = GpioH12;
+
+using Device = UsbHs;
+/// @}
+}
+
+namespace stlink
+{
+/// @ingroup modm_board_disco_f723ie
+/// @{
+using Tx = GpioOutputC6;
+using Rx = GpioInputC7;
+using Uart = BufferedUart<UsartHal6, UartTxBuffer<2048>>;
+/// @}
+}
+
+/// @ingroup modm_board_disco_f723ie
+/// @{
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Button::setInput();
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	// Full-speed USB port
+	usb_fs::Device::initialize<SystemClock>(priority);
+	usb_fs::Device::connect<usb_fs::Dm::Dm, usb_fs::Dp::Dp, usb_fs::Id::Id>();
+	usb_fs::Overcurrent::setInput();
+
+	// Enable VBUS Sensing B
+	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
+
+	// High-speed USB port
+	usb_hs::Device::initialize<SystemClock>(priority);
+	usb_hs::Device::connect<usb_hs::Dm::Dm, usb_hs::Dp::Dp, usb_hs::Id::Id>();
+	usb_hs::Overcurrent::setInput();
+
+	// Enable VBUS Sensing B
+	USB_OTG_HS->GCCFG |= USB_OTG_GCCFG_VBDEN;
+}
+/// @}
+
+}

--- a/src/modm/board/disco_f723ie/board.xml
+++ b/src/modm/board/disco_f723ie/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f723iek6</option>
+  </options>
+  <modules>
+    <module>modm:board:disco-f723ie</module>
+  </modules>
+</library>

--- a/src/modm/board/disco_f723ie/module.lb
+++ b/src/modm/board/disco_f723ie/module.lb
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:disco-f723ie"
+    module.description = """\
+# STM32F723E DISCOVERY
+
+[Discovery kit for STM32F723E](https://www.st.com/en/evaluation-tools/32f723ediscovery.html)
+
+## TinyUSB
+
+This board has two USB ports: one with Full Speed support and another with true
+High Speed support. By default, TinyUSB runs the device classes on the FS port,
+however, you can reassign it to HS via this option:
+
+```xml
+<options>
+  <option name="modm:tinyusb:config">device.cdc,device.msc</option>
+  <option name="modm:tinyusb:device:port">hs</option>
+</options>
+```
+
+Note that can use TinyUSB with both the device and host classes at the same time
+if you assign them to different ports:
+
+```xml
+```xml
+<options>
+  <option name="modm:tinyusb:config">device.cdc,device.msc</option>
+  <option name="modm:tinyusb:device:port">fs</option>
+  <option name="modm:tinyusb:host:port">hs</option>
+</options>
+```
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f723iek"):
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":debug",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:uart:6",
+        ":platform:usb:fs",
+        ":platform:usb:hs")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.collect(":build:openocd.source", "board/stm32f7discovery.cfg")
+    # Required for TinyUSB to enable the internal HS PHY
+    env.collect(":build:cppdefines", "HSE_VALUE=25000000")
+

--- a/src/modm/board/disco_f746ng/board.hpp
+++ b/src/modm/board/disco_f746ng/board.hpp
@@ -211,8 +211,9 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
+	// Full-speed USB port
 	usb_fs::Device::initialize<SystemClock>(priority);
 	usb_fs::Device::connect<usb_fs::Dm::Dm, usb_fs::Dp::Dp, usb_fs::Id::Id>();
 
@@ -225,11 +226,8 @@ initializeUsbFs(uint8_t priority=3)
 	// B-peripheral session valid override enable
 	USB_OTG_FS->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
 	USB_OTG_FS->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
-}
 
-inline void
-initializeUsbHs(uint8_t priority=3)
-{
+	// High-speed USB port
 	usb_hs::Device::initialize<SystemClock>(priority);
 	usb_hs::Device::connect<
 		usb_hs::Ck::Ulpick,	usb_hs::Stp::Ulpistp,
@@ -251,6 +249,18 @@ initializeUsbHs(uint8_t priority=3)
 	USB_OTG_HS->GUSBCFG &= ~USB_OTG_GUSBCFG_FHMOD;
 	USB_OTG_HS->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbHs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/disco_f746ng/module.lb
+++ b/src/modm/board/disco_f746ng/module.lb
@@ -31,31 +31,15 @@ however, you can reassign it to HS via this option:
 </options>
 ```
 
-Remember to initialize the HS instead of the FS port via the BSP:
-
-```cpp
-Board::initialize();
-Board::initializeUsbHs();
-```
-
 Note that can use TinyUSB with both the device and host classes at the same time
 if you assign them to different ports:
 
-```xml
 ```xml
 <options>
   <option name="modm:tinyusb:config">device.cdc,device.msc</option>
   <option name="modm:tinyusb:device:port">fs</option>
   <option name="modm:tinyusb:host:port">hs</option>
 </options>
-```
-
-You must initialize both ports via the BSP:
-
-```cpp
-Board::initialize();
-Board::initializeUsbFs();
-Board::initializeUsbHs();
 ```
 """
 

--- a/src/modm/board/disco_l476vg/board.hpp
+++ b/src/modm/board/disco_l476vg/board.hpp
@@ -139,7 +139,7 @@ initialize()
 
 /// You must take out the LCD screen and close SB24 and SB25 for USB to work
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -150,6 +150,12 @@ initializeUsbFs(uint8_t priority=3)
 	// Enable VBUS sense (B device) via pin PA9
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/feather_m0/board.hpp
+++ b/src/modm/board/feather_m0/board.hpp
@@ -113,11 +113,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	modm::platform::Usb::initialize<Board::SystemClock>(priority);
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }  // namespace Board

--- a/src/modm/board/feather_m4/board.hpp
+++ b/src/modm/board/feather_m4/board.hpp
@@ -175,12 +175,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsb()
 {
 	modm::platform::Usb::initialize<SystemClock>();
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
 
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs()
+{ initializeUsb(); }
 /// @}
 
 }  // namespace Board

--- a/src/modm/board/feather_rp2040/board.hpp
+++ b/src/modm/board/feather_rp2040/board.hpp
@@ -98,11 +98,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }  // namespace Board

--- a/src/modm/board/nucleo_f429zi/board.hpp
+++ b/src/modm/board/nucleo_f429zi/board.hpp
@@ -164,7 +164,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -175,6 +175,12 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/nucleo_f446ze/board.hpp
+++ b/src/modm/board/nucleo_f446ze/board.hpp
@@ -169,7 +169,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -182,6 +182,12 @@ initializeUsbFs(uint8_t priority=3)
 	// Enable VBUS sense (B device) via pin PA9
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/nucleo_h723zg/board.hpp
+++ b/src/modm/board/nucleo_h723zg/board.hpp
@@ -232,7 +232,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -242,6 +242,12 @@ initializeUsbFs(uint8_t priority=3)
 	// Enable VBUS sense (B device) via pin PA9
 	USB_OTG_HS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }

--- a/src/modm/board/nucleo_h743zi/board.hpp
+++ b/src/modm/board/nucleo_h743zi/board.hpp
@@ -217,9 +217,8 @@ initialize()
 
 	Button::setInput();
 }
-
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -230,6 +229,13 @@ initializeUsbFs(uint8_t priority=3)
 	USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
 }
 
-}
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
+
+}
+
 

--- a/src/modm/board/nucleo_l496zg-p/board.hpp
+++ b/src/modm/board/nucleo_l496zg-p/board.hpp
@@ -172,7 +172,7 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp, usb::Id::Id>();
@@ -180,6 +180,12 @@ initializeUsbFs(uint8_t priority=3)
 	usb::Overcurrent::setInput();
 	usb::Vbus::setInput();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/nucleo_l552ze-q/board.hpp
+++ b/src/modm/board/nucleo_l552ze-q/board.hpp
@@ -174,11 +174,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/nucleo_u575zi-q/board.hpp
+++ b/src/modm/board/nucleo_u575zi-q/board.hpp
@@ -182,11 +182,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/rp_pico/board.hpp
+++ b/src/modm/board/rp_pico/board.hpp
@@ -95,11 +95,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }  // namespace Board

--- a/src/modm/board/samd21_mini/board.hpp
+++ b/src/modm/board/samd21_mini/board.hpp
@@ -95,11 +95,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority = 3)
+initializeUsb(uint8_t priority=3)
 {
 	modm::platform::Usb::initialize<Board::SystemClock>(priority);
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 } // Board namespace

--- a/src/modm/board/samd21_xplained_pro/board.hpp
+++ b/src/modm/board/samd21_xplained_pro/board.hpp
@@ -88,11 +88,18 @@ initialize()
 	Button::setInput(Button::InputType::PullUp);
 }
 
-inline void initializeUsbFs()
+inline void
+initializeUsb()
 {
 	modm::platform::Usb::initialize<Board::SystemClock>();
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs()
+{ initializeUsb(); }
 /// @}
 
 } // namespace Board

--- a/src/modm/board/same54_xplained_pro/board.hpp
+++ b/src/modm/board/same54_xplained_pro/board.hpp
@@ -94,11 +94,18 @@ initialize()
 	Button::setInput(InputType::PullUp);
 }
 
-inline void initializeUsbFs()
+inline void
+initializeUsb()
 {
 	modm::platform::Usb::initialize<Board::SystemClock>();
 	modm::platform::Usb::connect<GpioA24::Dm, GpioA25::Dp>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs()
+{ initializeUsb(); }
 /// @}
 
 } // namespace Board

--- a/src/modm/board/same70_xplained/board.hpp
+++ b/src/modm/board/same70_xplained/board.hpp
@@ -82,15 +82,6 @@ initialize()
 	Leds::setOutput();
 	ButtonSW0::setInput(InputType::PullUp);
 }
-
-/*
-// TODO: usb
-inline void initializeUsbFs()
-{
-	//SystemClock::enableUsb();
-	//modm::platform::Usb::initialize<Board::SystemClock>();
-}
-*/
 /// @}
 
 } // namespace Board

--- a/src/modm/board/samg55_xplained_pro/board.hpp
+++ b/src/modm/board/samg55_xplained_pro/board.hpp
@@ -86,11 +86,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs()
+initializeUsb()
 {
 	SystemClock::enableUsb();
 	Usb::initialize<Board::SystemClock>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs()
+{ initializeUsb(); }
 /// @}
 
 } // namespace Board

--- a/src/modm/board/samv71_xplained_ultra/board.hpp
+++ b/src/modm/board/samv71_xplained_ultra/board.hpp
@@ -115,15 +115,6 @@ initialize()
 
 	Can::Can::connect<Can::Rx::Rx, Can::Tx::Tx>(InputType::PullUp);
 }
-
-/*
-// TODO: usb
-inline void initializeUsbFs()
-{
-	//SystemClock::enableUsb();
-	//modm::platform::Usb::initialize<Board::SystemClock>();
-}
-*/
 /// @}
 
 } // namespace Board

--- a/src/modm/board/stm32_f4ve/board.hpp
+++ b/src/modm/board/stm32_f4ve/board.hpp
@@ -280,16 +280,6 @@ initialize()
 	Usart1::initialize<Board::SystemClock, 115200_Bd>();
 }
 
-/// not supported yet, due to missing USB driver
-inline void
-initializeUsb()
-{
-	usb::Power::setOutput(Gpio::OutputType::PushPull, Gpio::OutputSpeed::MHz2);
-
-	usb::Overcurrent::setInput(Gpio::InputType::Floating);
-	usb::VBus::setInput(Gpio::InputType::Floating);
-}
-
 inline void
 initializeW25q16()
 {

--- a/src/modm/board/thingplus_rp2040/board.hpp
+++ b/src/modm/board/thingplus_rp2040/board.hpp
@@ -92,11 +92,17 @@ initialize()
 }
 
 inline void
-initializeUsbFs(uint8_t priority=3)
+initializeUsb(uint8_t priority=3)
 {
 	usb::Device::initialize<SystemClock>(priority);
 	usb::Device::connect<>();
 }
+
+// DEPRECATE: 2026q2
+[[deprecated("Use initializeUsb() instead!")]]
+inline void
+initializeUsbFs(uint8_t priority=3)
+{ initializeUsb(priority); }
 /// @}
 
 }  // namespace Board

--- a/src/modm/platform/usb/stm32/module.lb
+++ b/src/modm/platform/usb/stm32/module.lb
@@ -67,6 +67,7 @@ def generate_instance(env, port, otg=False):
         "port": port,
         "peripheral": "Usbotg{}".format(port) if otg else "Usb",
         "is_otg": otg,
+        "is_phyc": port == "hs" and not is_ulpi,
         "is_remap": irq_data["is_remap"],
         "irqs": irq_data["port_irqs"][port],
         "target": env[":target"].identifier,

--- a/src/modm/platform/usb/stm32/usb.hpp.in
+++ b/src/modm/platform/usb/stm32/usb.hpp.in
@@ -43,6 +43,14 @@ public:
 #endif
 %% endif
 		Rcc::enable<Peripheral::{{ peripheral }}>();
+%% if is_phyc
+		Rcc::enable<Peripheral::Usbotghsulpi>();
+#ifdef RCC_APB2ENR_OTGPHYCEN
+		RCC->APB2ENR |= RCC_APB2ENR_OTGPHYCEN; __DSB();
+#elif defined RCC_AHB2ENR1_USBPHYCEN
+		RCC->AHB2ENR1 |= RCC_AHB2ENR1_USBPHYCEN; __DSB();
+#endif
+%% endif
 %% if is_remap
 		SYSCFG->CFGR1 |= SYSCFG_CFGR1_USB_IT_RMP;
 %% endif

--- a/tools/scripts/examples_compile.py
+++ b/tools/scripts/examples_compile.py
@@ -69,7 +69,7 @@ def build(project):
     elif ":build:cmake" in project_cfg and not is_running_on_windows:
         build_dir = re.search(r'name=".+?:build:build.path">(.*?)</option>', project_cfg)[1]
         cmd = "cmake -E make_directory {}/cmake-build-release; ".format(build_dir)
-        cmd += '(cd {}/cmake-build-release && cmake -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" {}); '.format(build_dir, path.absolute())
+        cmd += '(cd {}/cmake-build-release && cmake -DCMAKE_BUILD_TYPE=MinSizeRel -G "Unix Makefiles" {}); '.format(build_dir, path.absolute())
         cmd += "cmake --build {}/cmake-build-release".format(build_dir)
         commands.append( (cmd, "CMake") )
 


### PR DESCRIPTION
- [x] Merge `Board::initializeUsbFs()` and `Board::initializeUsbHs()` into just `Board::initializeUsb()`. The naming convention was initially introduced to hint at the fact that modm (and TinyUSB) did not support HS ports yet. But this has not been true for a while now.
- [x] Fix clock enablement for internal HS PHYC on STM32F7.
- [x] Add STM32F723E-DISCO board with functioning HS usb port.