### PR TITLE
[ci] Upgrade to GCC14

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-avr:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -221,7 +221,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -273,7 +273,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -299,7 +299,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -325,7 +325,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -351,7 +351,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -377,7 +377,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -403,7 +403,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -430,7 +430,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -456,7 +456,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -482,7 +482,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -508,7 +508,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -534,7 +534,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -560,7 +560,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -586,7 +586,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -612,7 +612,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -638,7 +638,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -664,7 +664,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -690,7 +690,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -716,7 +716,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
   build-upload-docs:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-base:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-base:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
   unittests-linux-generic:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
 
     steps:
       - name: Check out repository
@@ -127,7 +127,7 @@ jobs:
   stm32-examples:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
   stm32f4-examples-1:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -215,7 +215,7 @@ jobs:
   stm32f4-examples-2:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -238,7 +238,7 @@ jobs:
   avr-examples:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-avr:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -267,7 +267,10 @@ jobs:
         if: always()
         run: |
           (cd test && make compile-arduino-uno)
-          (cd test && make compile-arduino-nano_A compile-arduino-nano_B compile-arduino-nano_C compile-arduino-nano_D compile-arduino-nano_E compile-arduino-nano_F compile-arduino-nano_G)
+          # D, G, and I overflow FLASH
+          (cd test && make \
+              compile-arduino-nano_A compile-arduino-nano_B compile-arduino-nano_C \
+              compile-arduino-nano_E compile-arduino-nano_F compile-arduino-nano_H)
       - name: Compile AVR Unittests ATmega
         if: always()
         run: |
@@ -286,7 +289,7 @@ jobs:
   hal-compile-quick-1:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -311,7 +314,7 @@ jobs:
   hal-compile-quick-2:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -336,7 +339,7 @@ jobs:
   hal-compile-quick-3:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -361,7 +364,7 @@ jobs:
   hal-compile-quick-4:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2024-12-01
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,8 +25,8 @@ jobs:
           export HOMEBREW_NO_INSTALL_CLEANUP=1 # saves time
           brew update
           # brew unlink gcc
-          brew install doxygen boost gcc@13 avr-gcc@13 arm-gcc-bin@13 cmake || true
-          brew link --force avr-gcc@13 arm-gcc-bin@13
+          brew install doxygen boost gcc@14 avr-gcc@14 arm-gcc-bin@14 cmake || true
+          brew link --force avr-gcc@14 arm-gcc-bin@14
           # brew upgrade boost gcc git || true
 
       - name: Setup environment - Python pip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,41 +40,48 @@ jobs:
       #   Unzip -zipfile "gcc-arm-none-eabi-win64.zip" -outdir "C:\"
       # is not faster than
       #   Expand-Archive -Path gcc-arm-none-eabi-win64.zip -DestinationPath C:\ -Force
+      # GCC 12 comes with the Windows image now
+      #   Start-Job {
+      #     Set-Location $using:PWD
+      #     Add-Type -Assembly "System.IO.Compression.Filesystem"
+      #     Invoke-WebRequest -OutFile gcc-win64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r3.zip
+      #     [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-win64.zip", "C:\")
+      #   }
       - name: Download and Unzip GCCs
         shell: powershell
         run: |
           $ProgressPreference = 'SilentlyContinue'
           Start-Job {
             Set-Location $using:PWD
-            Add-Type -Assembly "System.IO.Compression.Filesystem"
-            Invoke-WebRequest -OutFile gcc-win64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-18.1.5-11.0.1-msvcrt-r8/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r8.zip
-            [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-win64.zip", "C:\")
-          }
-          Start-Job {
-            Set-Location $using:PWD
-            Invoke-WebRequest -OutFile gcc-arm-none-eabi-win64.zip https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip
-            Expand-Archive -Path gcc-arm-none-eabi-win64.zip -DestinationPath C:\ -Force
+            Invoke-WebRequest -OutFile gcc-arm-none-eabi-win64-14.zip https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-mingw-w64-x86_64-arm-none-eabi.zip
+            New-Item -Path "C:\" -Name "arm-none-eabi-14" -ItemType "Directory"
+            Expand-Archive -Path gcc-arm-none-eabi-win64-14.zip -DestinationPath C:\arm-none-eabi-14 -Force
+            Remove-Item gcc-arm-none-eabi-win64-14.zip
           }
           Start-Job {
             Set-Location $using:PWD
             Add-Type -Assembly "System.IO.Compression.Filesystem"
-            Invoke-WebRequest -OutFile gcc-avr-win64.zip https://github.com/ZakKemble/avr-gcc-build/releases/download/v13.2.0-1/avr-gcc-13.2.0-x64-windows.zip
+            Invoke-WebRequest -OutFile gcc-avr-win64.zip https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-windows.zip
             [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-avr-win64.zip", "C:\")
+            Remove-Item gcc-avr-win64.zip
           }
           Get-Job | Wait-Job
 
+      # No need for this anymore
+      # dir C:\mingw64
+      # dir C:\mingw64\bin
+      # echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install GCCs
         if: always()
         shell: powershell
         run: |
           dir C:\
-          dir C:\mingw64
-          dir C:\arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi
-          dir C:\avr-gcc-13.2.0-x64-windows
-          echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\avr-gcc-13.2.0-x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          rm gcc-arm-none-eabi-win64.zip
+          dir C:\arm-none-eabi-14\
+          dir C:\arm-none-eabi-14\bin
+          dir C:\avr-gcc-14.1.0-x64-windows
+          dir C:\avr-gcc-14.1.0-x64-windows\bin
+          echo "C:\arm-none-eabi-14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\avr-gcc-14.1.0-x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Python
         if: always()

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -15,8 +15,8 @@ Note that the modm examples use the SCons build system by default, however,
 you are not *required* to use it. See [the reference manual](../../reference/build-systems)
 for additional build system documentation.
 
-!!! info "Use GCC 12 or newer"
-    modm uses C++23, so you need *at least* GCC 12, we recommend GCC 13.
+!!! info "Use GCC 13 or newer"
+    modm uses C++23, so you need *at least* GCC 13, we recommend GCC 14.
 
 !!! warning "Beware of AVRs"
     We **strongly discourage** using AVRs for new designs, due to a significant
@@ -58,7 +58,7 @@ We use [Doxypress][doxypress_binaries] to generate the API documentation:
 
 ```sh
 sudo mkdir /opt/doxypress
-wget -O- https://github.com/copperspice/doxypress/releases/download/dp-1.7.0/doxypress-1.7.0-ubuntu24.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
+wget -O- https://github.com/copperspice/doxypress/releases/download/dp-2.0.0/doxypress-2.0.0-ubuntu24.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
 ```
 
 Add the directory to your `PATH` variable in `~/.bashrc`:
@@ -75,13 +75,13 @@ If your Linux distribution provides up-to-date packages, we recommend using them
 Otherwise, including Ubuntu 24.04, we recommend using the [*xPack GNU Arm Embedded GCC* binary distribution][toolchain-arm-xpack]:
 
 ```sh
-wget -O- https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v13.3.1-1.1/xpack-arm-none-eabi-gcc-13.3.1-1.1-linux-x64.tar.gz | sudo tar xz -C /opt/
+wget -O- https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v14.2.1-1.1/xpack-arm-none-eabi-gcc-14.2.1-1.1-linux-x64.tar.gz | sudo tar xz -C /opt/
 ```
 
 Add it to your `PATH` variable in `~/.bashrc`:
 
 ```sh
-export PATH="/opt/xpack-arm-none-eabi-gcc-13.3.1-1.1/bin:$PATH"
+export PATH="/opt/xpack-arm-none-eabi-gcc-14.2.1-1.1/bin:$PATH"
 ```
 
 Install the OpenOCD tool:
@@ -101,7 +101,7 @@ sudo apt install openocd
 Download and extract the [pre-built AVR toolchain][modm-avr-gcc]:
 
 ```sh
-wget -O- https://github.com/modm-io/avr-gcc/releases/download/v13.2.0/modm-avr-gcc.tar.bz2 | sudo tar xj -C /opt
+wget -O- https://github.com/modm-io/avr-gcc/releases/download/v14.2.0/modm-avr-gcc.tar.bz2 | sudo tar xj -C /opt
 ```
 
 !!! warning "AVR toolchain install directory"
@@ -169,8 +169,8 @@ Install the [pre-built ARM toolchain](https://github.com/osx-cross/homebrew-arm)
 
 ```sh
 brew tap osx-cross/arm
-brew install arm-gcc-bin@13 openocd
-brew link --force arm-gcc-bin@13
+brew install arm-gcc-bin@14 openocd
+brew link --force arm-gcc-bin@14
 ```
 
 To program Microchip SAM devices via the bootloader, install the `bossac` tool:
@@ -186,8 +186,8 @@ Install the [AVR toolchain from source](https://github.com/osx-cross/homebrew-av
 
 ```sh
 brew tap osx-cross/avr
-brew install avr-gcc@13
-brew link --force avr-gcc@13
+brew install avr-gcc@14
+brew link --force avr-gcc@14
 ```
 
 
@@ -196,7 +196,7 @@ brew link --force avr-gcc@13
 To compile modm *for x86_64 macOS* you need to install these tools too:
 
 ```sh
-brew install boost gcc@13
+brew install boost gcc@14
 ```
 
 
@@ -276,7 +276,7 @@ openocd --version
 #### Microchip AVR
 
 Download the [pre-built AVR toolchain][winavr] and unpack the `.zip` file using
-the context menu `7-Zip > Extract to "avr-gcc-13.2.0-..."`
+the context menu `7-Zip > Extract to "avr-gcc-14.2.0-..."`
 Then rename and move the extracted folder to `C:\Program Files\avr-gcc`.
 Open PowerShell to add the `\bin` folder to the `Path`:
 
@@ -404,7 +404,7 @@ picocom --baud 115200 --imap lfcrlf --echo /dev/ttyACM0
 [openocd-install]: https://github.com/rleh/openocd-build
 [udev-rules-openocd]: https://github.com/openocd-org/openocd/blob/master/contrib/60-openocd.rules#L84-L99
 [usbipd]: https://github.com/dorssel/usbipd-win
-[winavr]: https://github.com/ZakKemble/avr-gcc-build/releases/tag/v13.2.0-1
+[winavr]: https://github.com/ZakKemble/avr-gcc-build/releases
 [windows-store-ubuntu-22-04-1-lts]: https://www.microsoft.com/store/productId/9PN20MSR04DW
 [wingit]: https://git-scm.com/download/win
 [winterm]: https://github.com/Microsoft/Terminal

--- a/ext/gcc/atomic.cpp.in
+++ b/ext/gcc/atomic.cpp.in
@@ -16,11 +16,27 @@
  *
  * We ignore the memory order, since the runtime switching takes longer than
  * the DMB instruction.
+ *
+ * These functions cannot be inlined, since the compiler builtins are named the
+ * same. Terrible design really.
  */
 
+// ============================ atomics for bools ============================
+extern "C" bool
+__atomic_test_and_set(volatile void *ptr, int /*memorder*/)
+{
+	bool value{};
+	__modm_atomic_pre_barrier(__ATOMIC_SEQ_CST);
+	{
+		modm::atomic::Lock _;
+		value = *reinterpret_cast<volatile bool*>(ptr);
+		*reinterpret_cast<volatile bool*>(ptr) = true;
+	}
+	__modm_atomic_post_barrier(__ATOMIC_SEQ_CST);
+	return value;
+}
+
 // ============================ atomics for arrays ============================
-// These functions cannot be inlined, since the compiler builtins are named the
-// same. Terrible design really.
 extern "C" void
 __atomic_load(unsigned int size, const volatile void *src, void *dest, int /*memorder*/)
 {

--- a/src/modm/driver/display/ssd1306.hpp
+++ b/src/modm/driver/display/ssd1306.hpp
@@ -135,7 +135,7 @@ public:
 	modm::ResumableResult<bool>
 	setDisplayMode(DisplayMode mode = DisplayMode::Normal)
 	{
-		commandBuffer[0] = mode;
+		commandBuffer[0] = uint8_t(mode);
 		return writeCommands(1);
 	}
 

--- a/src/modm/platform/core/cortex/assert.cpp.in
+++ b/src/modm/platform/core/cortex/assert.cpp.in
@@ -86,11 +86,6 @@ modm_assert_report(_modm_assertion_info *cinfo)
 	}
 }
 
-// Mingw64 :facepalm;
-#if defined(__MINGW64__) && !defined(__clang__)
-#define PRIuPTR "I64u"
-#endif
-
 modm_weak
 void modm_abandon(const modm::AssertionInfo &info)
 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -185,6 +185,10 @@ compile-arduino-nano_H:
 	$(call compile-test,arduino-nano_H,size)
 run-arduino-nano_H:
 	$(call run-test,arduino-nano_H,size)
+compile-arduino-nano_I:
+	$(call compile-test,arduino-nano_I,size)
+run-arduino-nano_I:
+	$(call run-test,arduino-nano_I,size)
 
 
 compile-mega-2560-pro_A:

--- a/test/config/arduino-nano_D.xml
+++ b/test/config/arduino-nano_D.xml
@@ -24,10 +24,11 @@
 
 
     <module>modm-test:test:driver</module>
-    <module>modm-test:test:stdc++</module>
+
+    <!-- <module>modm-test:test:stdc++</module> -->
 
 
-    <!-- <<module>modm-test:test:io</module>
+    <!-- <module>modm-test:test:io</module>
     <module>modm-test:test:platform:**</module> -->
 
 

--- a/test/config/arduino-nano_E.xml
+++ b/test/config/arduino-nano_E.xml
@@ -23,12 +23,13 @@
     <!-- <module>modm-test:test:container</module> -->
 
 
-    <!-- <module>modm-test:test:driver</module>
-    <module>modm-test:test:stdc++</module> -->
+    <!-- <module>modm-test:test:driver</module> -->
+
+    <module>modm-test:test:stdc++</module>
 
 
-    <module>modm-test:test:io</module>
-    <module>modm-test:test:platform:**</module>
+    <!-- <module>modm-test:test:io</module>
+    <module>modm-test:test:platform:**</module> -->
 
 
     <!-- <module>modm-test:test:processing</module> -->

--- a/test/config/arduino-nano_G.xml
+++ b/test/config/arduino-nano_G.xml
@@ -31,10 +31,10 @@
     <module>modm-test:test:platform:**</module> -->
 
 
-    <!-- <module>modm-test:test:processing</module> -->
+    <module>modm-test:test:processing</module>
 
 
-    <module>modm-test:test:ui</module>
+    <!-- <module>modm-test:test:ui</module> -->
     <!-- <module>modm-test:test:math</module> -->
   </modules>
 </library>

--- a/test/config/arduino-nano_H.xml
+++ b/test/config/arduino-nano_H.xml
@@ -34,7 +34,7 @@
     <!-- <module>modm-test:test:processing</module> -->
 
 
-    <!-- <module>modm-test:test:ui</module> -->
-    <module>modm-test:test:math</module>
+    <module>modm-test:test:ui</module>
+    <!-- <module>modm-test:test:math</module> -->
   </modules>
 </library>

--- a/test/config/arduino-nano_I.xml
+++ b/test/config/arduino-nano_I.xml
@@ -2,8 +2,8 @@
 <library>
   <extends>modm:arduino-nano</extends>
   <options>
-    <option name="modm:build:build.path">../../build/generated-unittest/arduino-nano_F/</option>
-    <option name="modm:build:unittest.source">../../build/generated-unittest/arduino-nano_F/modm-test</option>
+    <option name="modm:build:build.path">../../build/generated-unittest/arduino-nano_I/</option>
+    <option name="modm:build:unittest.source">../../build/generated-unittest/arduino-nano_I/modm-test</option>
     <option name="modm:build:info.git">Disabled</option>
     <option name="modm:io:with_float">True</option>
     <option name="modm:io:with_long_long">True</option>
@@ -27,14 +27,14 @@
     <module>modm-test:test:stdc++</module> -->
 
 
-    <module>modm-test:test:io</module>
-    <module>modm-test:test:platform:**</module>
+    <!-- <module>modm-test:test:io</module>
+    <module>modm-test:test:platform:**</module> -->
 
 
     <!-- <module>modm-test:test:processing</module> -->
 
 
-    <!-- <module>modm-test:test:ui</module>
-    <module>modm-test:test:math</module> -->
+    <!-- <module>modm-test:test:ui</module> -->
+    <module>modm-test:test:math</module>
   </modules>
 </library>

--- a/test/config/arduino-uno.xml
+++ b/test/config/arduino-uno.xml
@@ -20,8 +20,8 @@
 
     <!-- <module>modm-test:test:io</module>
     <module>modm-test:test:platform:**</module> -->
-    <module>modm-test:test:processing</module>
-    <!-- <module>modm-test:test:ui</module> -->
+    <!-- <module>modm-test:test:processing</module> -->
+    <module>modm-test:test:ui</module>
 
     <!-- <module>modm-test:test:math</module> -->
   </modules>

--- a/tools/build_script_generator/scons/resources/SConscript.in
+++ b/tools/build_script_generator/scons/resources/SConscript.in
@@ -22,8 +22,8 @@ env["COMPILERPREFIX"] = "avr-"
 env["COMPILERPREFIX"] = "arm-none-eabi-"
 %% endif
 %% if family == "darwin"
-# Using homebrew gcc-13 on macOS instead of clang
-env["COMPILERSUFFIX"] = "-13"
+# Using homebrew gcc-14 on macOS instead of clang
+env["COMPILERSUFFIX"] = "-14"
 %% endif
 %% endif
 


### PR DESCRIPTION
Let's see what breaks…

- [x] avr-gcc 14 now delegates `__atomic_test_and_set` to the library: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118280
- [x] avr-gcc 14 seems to have a size regression and overflows the unittests for the Arduino Uno and Nano. This is not an issue for us, since the unittests still fit in their entirety on the ATMega2560.
- [x] Windows arm-none-eabi-gcc 14 has a different unzip folder structure, it unzips directly into the folder, instead of a subfolder, causing the /bin path not to be correct.