### PR TITLE
Fix cmake cmp0175 warnings on cmake 3.31 and higher

### DIFF
--- a/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
+++ b/tools/build_script_generator/cmake/resources/ModmConfiguration.cmake.in
@@ -175,132 +175,140 @@ function(modm_targets_create project_name)
 %% if core.startswith("cortex-m")
   add_custom_command(TARGET ${project_name}
     POST_BUILD
-    COMMAND cmake -E env PYTHONPATH=${PROJECT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.size ${project_name}.elf \"{{ memories }}\")
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.size ${project_name}.elf \"{{ memories }}\")
 %% endif
 
-  add_custom_target(size DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET size
+  add_custom_target(TARGET size ALL DEPENDS size.stamp)
+  add_custom_command(OUTPUT size.stamp
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.size ${PROJECT_BINARY_DIR}/${project_name}.elf \"{{ memories }}\"
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.size ${PROJECT_BINARY_DIR}/${project_name}.elf \"{{ memories }}\"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(program DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET program
+
+  add_custom_target(program DEPENDS program.done)
+  add_custom_command(OUTPUT program.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.openocd -f modm/openocd.cfg
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.openocd -f modm/openocd.cfg
         ${PROJECT_BINARY_DIR}/${project_name}.elf
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(program-bmp DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET program-bmp
+
+  add_custom_target(program-bmp DEPENDS program-bmp.done)
+  add_custom_command(OUTPUT program-bmp.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.bmp -p ${MODM_BMP_PORT}
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.bmp -p ${MODM_BMP_PORT}
         ${PROJECT_BINARY_DIR}/${project_name}.elf
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(program-jlink DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET program-jlink
+  add_custom_target(program-jlink DEPENDS program-jlink.done)
+  add_custom_command(OUTPUT program-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.jlink -device {{ jlink_partname }}
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.jlink -device {{ jlink_partname }}
         ${PROJECT_BINARY_DIR}/${project_name}.elf
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(debug DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET debug
+  add_custom_target(debug DEPENDS debug.done)
+  add_custom_command(OUTPUT debug.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_gdbinit
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_gdbinit
         --elf ${PROJECT_BINARY_DIR}/${project_name}.elf --ui=${MODM_DBG_UI}
         openocd -f modm/openocd.cfg
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(debug-bmp DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET debug-bmp
+  add_custom_target(debug-bmp DEPENDS debug-bmp.done)
+  add_custom_command(OUTPUT debug-bmp.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_bmp
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_bmp
         --elf ${PROJECT_BINARY_DIR}/${project_name}.elf --ui=${MODM_DBG_UI}
         bmp -p ${MODM_BMP_PORT}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(debug-jlink DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET debug-jlink
+  add_custom_target(debug-jlink DEPENDS debug-jlink.done)
+  add_custom_command(OUTPUT debug-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_jlink
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit -x modm/openocd_jlink
         --elf ${PROJECT_BINARY_DIR}/${project_name}.elf --ui=${MODM_DBG_UI}
         jlink -device {{ jlink_partname }}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(debug-coredump DEPENDS ${project_name}.elf)
-  add_custom_command(TARGET debug-coredump
+  add_custom_target(debug-coredump DEPENDS debug-coredump.done)
+  add_custom_command(OUTPUT debug-coredump
     USES_TERMINAL
-    COMMAND cmake -E env	PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
+    COMMAND cmake -E env	PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
         --elf ${PROJECT_BINARY_DIR}/${project_name}.elf --ui=${MODM_DBG_UI}
         crashdebug
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${PROJECT_BINARY_DIR}/${project_name}.elf)
 
-  add_custom_target(coredump)
-  add_custom_command(TARGET coredump
+  add_custom_target(coredump DEPENDS coredump.done)
+  add_custom_command(OUTPUT coredump.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
         -ex "modm_coredump" -ex "modm_build_id" -ex "quit"
         openocd -f modm/openocd.cfg
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(coredump-bmp)
-  add_custom_command(TARGET coredump-bmp
+  add_custom_target(coredump-bmp DEPENDS coredump-bmp.done)
+  add_custom_command(OUTPUT coredump-bmp.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
         -ex "modm_coredump" -ex "modm_build_id" -ex "quit"
         bmp -p ${MODM_BMP_PORT}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(coredump-jlink)
-  add_custom_command(TARGET coredump-jlink
+  add_custom_target(coredump-jlink DEPENDS coredump-jlink.done)
+  add_custom_command(OUTPUT coredump-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.gdb -x modm/gdbinit
         -ex "modm_coredump" -ex "modm_build_id" -ex "quit"
         jlink -device {{ jlink_partname }}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(reset)
-  add_custom_command(TARGET reset
+  add_custom_target(reset DEPENDS reset.done)
+  add_custom_command(OUTPUT reset.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.openocd -f modm/openocd.cfg --reset
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.openocd -f modm/openocd.cfg --reset
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(reset-bmp)
-  add_custom_command(TARGET reset-bmp
+  add_custom_target(reset-bmp DEPENDS reset-bmp.done)
+  add_custom_command(OUTPUT reset-bmp.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.bmp -p ${MODM_BMP_PORT} --reset
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.bmp -p ${MODM_BMP_PORT} --reset
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(reset-jlink)
-  add_custom_command(TARGET reset-jlink
+  add_custom_target(reset-jlink DEPENDS reset-jlink.done)
+  add_custom_command(OUTPUT reset-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.jlink -device {{ jlink_partname }} --reset
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.jlink -device {{ jlink_partname }} --reset
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(log-itm)
-  add_custom_command(TARGET log-itm
+  add_custom_target(log-itm DEPENDS log-itm.done)
+  add_custom_command(OUTPUT log-itm.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.itm openocd -f modm/openocd.cfg --fcpu ${MODM_ITM_FCPU}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.itm openocd -f modm/openocd.cfg --fcpu ${MODM_ITM_FCPU}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(log-itm-jlink)
-  add_custom_command(TARGET log-itm-jlink
+  add_custom_target(log-itm-jlink DEPENDS log-itm-jlink.done)
+  add_custom_command(OUTPUT log-itm-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.itm jlink -device {{ jlink_partname }}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.itm jlink -device {{ jlink_partname }}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(log-rtt)
-  add_custom_command(TARGET log-rtt
+  add_custom_target(log-rtt DEPENDS log-rtt.done)
+  add_custom_command(OUTPUT log-rtt.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.rtt --channel ${MODM_RTT_CHANNEL} openocd -f modm/openocd.cfg
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.rtt --channel ${MODM_RTT_CHANNEL} openocd -f modm/openocd.cfg
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-  add_custom_target(log-rtt-jlink)
-  add_custom_command(TARGET log-rtt-jlink
+  add_custom_target(log-rtt-jlink DEPENDS log-rtt-jlink.done)
+  add_custom_command(OUTPUT log-rtt-jlink.done
     USES_TERMINAL
-    COMMAND cmake -E env PYTHONPATH=modm ${Python3_EXECUTABLE} -m modm_tools.rtt --channel ${MODM_RTT_CHANNEL} jlink -device {{ jlink_partname }}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+    COMMAND cmake -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/modm ${Python3_EXECUTABLE} -m modm_tools.rtt --channel ${MODM_RTT_CHANNEL} jlink -device {{ jlink_partname }}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endfunction()
 


### PR DESCRIPTION
I use cmake 4.0 and gcc 14.2 on my project. the hole cmake build is based on the cmake example project.

What does thid fix?:
1. [CMake starting from 3.31](https://cmake.org/cmake/help/latest/policy/CMP0175.html) have the cmp0175 policy which deprecateds the USE_TERMINAL flag for custom output commands. To fix that i changed the Comands generated in ModmConfiguration.cmake to the approach cmake suggests. currently it works for the build but i have done very little testing on the commands if everything works as expected. 
2. My CMake root and the modm root are differnent folders. To make that possible i needed to change how project_source_dir is filled and that it is used for the linker script as well. Also the python path needed to change to the "CMAKE_CURRENT_SOURCE_DIR" because thats inside the generated modm folder.
