### PR TITLE
[driver] driver for ST vl53l5, vl53l7, vl53l8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "ext/segger/rtt"]
 	path = ext/segger/rtt
 	url = https://github.com/modm-ext/segger-rtt.git
+[submodule "ext/vl53/vl53"]
+	path = ext/vl53/vl53
+	url = https://github.com/modm-ext/vl53-partial.git

--- a/examples/nucleo_h723zg/vl53/vl53l5cx_i2c/main.cpp
+++ b/examples/nucleo_h723zg/vl53/vl53l5cx_i2c/main.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+// Tested with VL53L5CX-SATEL
+extern "C" {
+#include "../../../../ext/vl53/vl53/vl53l5cx/examples/Example_1_ranging_basic.h"
+#include "../../../../ext/vl53/vl53/vl53l5cx/examples/Example_2_get_set_params.h"
+#include "../../../../ext/vl53/vl53/vl53l5cx/examples/Example_3_ranging_modes.h"
+#include "../../../../ext/vl53/vl53/vl53l5cx/examples/Example_5_multiple_targets_per_zone.h"
+}
+
+#include <modm/driver/vl53/vl53_transport.hpp>
+
+using namespace Board;
+
+using I2c = I2cMaster1;
+using Scl = GpioB8;  // D15
+using Sda = GpioB9;  // D14
+
+using Int = GpioB5;
+using Rst = GpioD14;
+using PwrEn = GpioD15;
+using LPn = GpioF3;
+
+modm::Vl53I2cTransport<I2c, LPn> transport{VL53L5CX_DEFAULT_I2C_ADDRESS >> 1};
+
+int
+main()
+{
+	Board::initialize();
+
+	Leds::setOutput();
+
+	PwrEn::setOutput(true);
+
+	LPn::setOutput(false);
+	// Snc::setOutput(false);
+
+	transport.resetSensor();
+
+	I2c::connect<Scl::Scl, Sda::Sda>(I2c::PullUps::External);
+	I2c::initialize<Board::SystemClock, 1_MHz>();
+
+	example1(&transport);
+	example2(&transport);
+	example3(&transport);
+	example5(&transport);
+}

--- a/examples/nucleo_h723zg/vl53/vl53l5cx_i2c/project.xml
+++ b/examples/nucleo_h723zg/vl53/vl53l5cx_i2c/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_h723zg/vl53l5cx_i2c</option>
+    <option name="modm:platform:cortex-m:main_stack_size">8Ki</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:vl53:vl53l5cx</module>
+  </modules>
+</library>

--- a/examples/nucleo_h723zg/vl53/vl53l7_vl53l8_i2c/main.cpp
+++ b/examples/nucleo_h723zg/vl53/vl53l7_vl53l8_i2c/main.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+// Tested with MIKROE LIGHTRANGER 12 CLICK Breakout
+// with VL53L8CH variant, so histogram example 12 is supported
+extern "C" {
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_12_cnh_data.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_1_ranging_basic.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_2_get_set_params.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_3_ranging_modes.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_5_multiple_targets_per_zone.h"
+}
+
+#include <modm/driver/vl53/vl53_transport.hpp>
+
+using namespace Board;
+
+using I2c = I2cMaster1;
+using Scl = GpioB8;  // D15
+using Sda = GpioB9;  // D14
+
+using Rst = GpioD6;
+using Snc = GpioB1;
+using LPn = GpioA3;
+using Int = GpioD7;
+
+modm::Vl53I2cTransport<I2c, LPn> transport{VL53LMZ_DEFAULT_I2C_ADDRESS >> 1};
+
+int
+main()
+{
+	Board::initialize();
+
+	Leds::setOutput();
+
+	LPn::setOutput(false);
+	Snc::setOutput(false);
+
+	transport.resetSensor();
+
+	I2c::connect<Scl::Scl, Sda::Sda>(I2c::PullUps::Internal);
+	I2c::initialize<Board::SystemClock, 1_MHz>();
+
+	example1(&transport);
+	example2(&transport);
+	example3(&transport);
+	example5(&transport);
+	example12(&transport);
+}

--- a/examples/nucleo_h723zg/vl53/vl53l7_vl53l8_i2c/project.xml
+++ b/examples/nucleo_h723zg/vl53/vl53l7_vl53l8_i2c/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_h723zg/vl53l8_vl53l8_i2c</option>
+    <option name="modm:platform:cortex-m:main_stack_size">12Ki</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:i2c:1</module>
+    <module>modm:vl53:vl53lmz</module>
+  </modules>
+</library>

--- a/examples/nucleo_h723zg/vl53/vl53l8_spi/main.cpp
+++ b/examples/nucleo_h723zg/vl53/vl53l8_spi/main.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+// Tested with MIKROE LIGHTRANGER 12 CLICK Breakout
+// with VL53L8CH variant, so histogram example 12 is supported
+extern "C" {
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_12_cnh_data.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_1_ranging_basic.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_2_get_set_params.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_3_ranging_modes.h"
+#include "../../../../ext/vl53/vl53/vl53lmz/examples/Example_5_multiple_targets_per_zone.h"
+}
+
+#include <modm/driver/vl53/vl53_transport.hpp>
+
+using namespace Board;
+
+using SpiMaster = SpiMaster2_Dma<Dma1::Channel0, Dma1::Channel1>;
+using Cs = GpioC0;
+using Mosi = GpioB15;
+using Miso = GpioC2;
+using Sck = GpioD3;
+
+using Rst = GpioD6;
+using Snc = GpioB1;
+using LPn = GpioA3;
+using Int = GpioD7;
+
+modm::Vl53SpiTransport<SpiMaster, Cs, LPn> transport;
+
+int
+main()
+{
+	Board::initialize();
+
+	Dma1::enable();
+	Leds::setOutput();
+
+	LPn::setOutput(false);
+	Snc::setOutput(false);
+	Cs::setOutput(true);
+
+	transport.resetSensor();
+
+	SpiMaster::connect<Sck::Sck, Mosi::Mosi, Miso::Miso>();
+	SpiMaster::initialize<Board::SystemClock, 2.2_MHz>();
+
+	example1(&transport);
+	example2(&transport);
+	example3(&transport);
+	example5(&transport);
+	example12(&transport);
+}

--- a/examples/nucleo_h723zg/vl53/vl53l8_spi/project.xml
+++ b/examples/nucleo_h723zg/vl53/vl53l8_spi/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../../build/nucleo_h723zg/vl53l8_spi</option>
+    <option name="modm:platform:cortex-m:main_stack_size">12Ki</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:dma</module>
+    <module>modm:platform:spi:2</module>
+    <module>modm:vl53:vl53lmz</module>
+  </modules>
+</library>

--- a/ext/vl53/vl53.cpp
+++ b/ext/vl53/vl53.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "vl53_transport.hpp"
+
+extern "C" {
+#include "vl53_platform.h"
+
+uint8_t
+VL53_RdByte(VL53_Platform *p_platform, uint16_t RegisterAddress, uint8_t *p_value)
+{
+	auto *iface = static_cast<modm::Vl53TransportBase *>(p_platform->transport);
+	return iface->readByte(RegisterAddress, p_value);
+}
+
+uint8_t
+VL53_WrByte(VL53_Platform *p_platform, uint16_t RegisterAddress, uint8_t value)
+{
+	auto *iface = static_cast<modm::Vl53TransportBase *>(p_platform->transport);
+	return iface->writeByte(RegisterAddress, value);
+}
+
+uint8_t
+VL53_WrMulti(VL53_Platform *p_platform, uint16_t RegisterAddress, uint8_t *p_values, uint32_t size)
+{
+	auto *iface = static_cast<modm::Vl53TransportBase *>(p_platform->transport);
+	return iface->writeMulti(RegisterAddress, p_values, size);
+}
+
+uint8_t
+VL53_RdMulti(VL53_Platform *p_platform, uint16_t RegisterAddress, uint8_t *p_values, uint32_t size)
+{
+	auto *iface = static_cast<modm::Vl53TransportBase *>(p_platform->transport);
+	return iface->readMulti(RegisterAddress, p_values, size);
+}
+
+void
+VL53_SwapBuffer(uint8_t *buffer, uint16_t size)
+{
+	uint32_t i, tmp;
+
+	for (i = 0; i < size; i = i + 4)
+	{
+		tmp = (buffer[i] << 24) | (buffer[i + 1] << 16) | (buffer[i + 2] << 8) | (buffer[i + 3]);
+		memcpy(&(buffer[i]), &tmp, 4);
+	}
+}
+
+uint8_t
+VL53_WaitMs(VL53_Platform*, uint32_t TimeMs)
+{
+	modm::this_fiber::sleep_for(std::chrono::milliseconds(TimeMs));
+	return 0;
+}
+
+uint8_t
+VL53_Reset_Sensor(VL53_Platform *p_platform)
+{
+	auto *iface = static_cast<modm::Vl53TransportBase *>(p_platform->transport);
+	return iface->resetSensor();
+}
+}

--- a/ext/vl53/vl53.lb
+++ b/ext/vl53/vl53.lb
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Henrik Hose
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+class Vl53l5cx(Module):
+    def init(self, module):
+        module.name = "vl53l5cx"
+        module.description = "Driver for ST VL53L5CX Multi-Zone Time-of-Flight Sensor"
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        env.outbasepath = "modm/ext"
+        env.copy("vl53/vl53l5cx/src")
+        env.copy("vl53/vl53l5cx/inc")
+        env.copy("vl53/vl53l5cx/LICENSE.txt")
+        env.collect(":build:path.include", "modm/ext/vl53/vl53l5cx/inc")
+
+class Vl53lmz(Module):
+    def init(self, module):
+        module.name = "vl53lmz"
+        module.description = "Driver for ST VL53L7 and VL53L8 Multi-Zone Time-of-Flight Sensors"
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        env.outbasepath = "modm/ext"
+        env.copy("vl53/vl53lmz/src")
+        env.copy("vl53/vl53lmz/inc")
+        env.copy("vl53/vl53lmz/LICENSE.txt")
+        env.collect(":build:path.include", "modm/ext/vl53/vl53lmz/inc")
+
+def init(module):
+    module.name = ":vl53"
+    module.description = """\
+# ST's VL53 Time-of-Flight ULD Drivers
+
+Currently supported sensors:
+ - With VL53LMZ driver: VL53L7CX, VL53L7CH, VL53L8CX, VL53L8CH
+ - VL53L5CX driver
+
+"""
+
+def prepare(module, options):
+    module.add_submodule(Vl53l5cx())
+    module.add_submodule(Vl53lmz())
+    module.depends(
+        ":architecture:spi.device",
+        ":architecture:i2c.device",
+        ":architecture:fiber",
+        ":driver:i2c.eeprom")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/driver/vl53"
+    env.copy("vl53.cpp")
+    env.copy("vl53_transport.hpp")
+    env.copy("vl53_transport_impl.hpp")
+
+    env.outbasepath = "modm/ext/vl53"
+    env.collect(":build:path.include", "modm/ext/vl53")
+    env.copy("vl53_platform.h")

--- a/ext/vl53/vl53_platform.h
+++ b/ext/vl53/vl53_platform.h
@@ -1,0 +1,223 @@
+/**
+ *
+ * Copyright (c) 2021 STMicroelectronics.
+ * All rights reserved.
+ *
+ *
+ * This software component is provided to you as part of a software package and
+ * applicable license terms are in the  Package_license file. If you received this
+ * software component outside of a package or without applicable license terms,
+ * the terms of the BSD-3-Clause license shall apply.
+ * You may obtain a copy of the BSD-3-Clause at:
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
+
+#ifndef VL53_PLATFORM_H_
+#define VL53_PLATFORM_H_
+#pragma once
+
+#if __has_include("modm_config_vl53.h")
+#include "modm_config_vl53.h"
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * @brief The macro below is used to define the number of target per zone sent
+ * through I2C. This value can be changed by user, in order to tune I2C
+ * transaction, and also the total memory size (a lower number of target per
+ * zone means a lower RAM). The value must be between 1 and 4.
+ */
+
+#define VL53L5CX_NB_TARGET_PER_ZONE 1U
+
+/*
+ * @brief The macro below can be used to avoid data conversion into the driver.
+ * By default there is a conversion between firmware and user data. Using this macro
+ * allows to use the firmware format instead of user format. The firmware format allows
+ * an increased precision.
+ */
+
+// #define 	VL53L5CX_USE_RAW_FORMAT
+
+/*
+ * @brief All macro below are used to configure the sensor output. User can
+ * define some macros if he wants to disable selected output, in order to reduce
+ * I2C access.
+ */
+
+// #define VL53L5CX_DISABLE_AMBIENT_PER_SPAD
+// #define VL53L5CX_DISABLE_NB_SPADS_ENABLED
+// #define VL53L5CX_DISABLE_NB_TARGET_DETECTED
+// #define VL53L5CX_DISABLE_SIGNAL_PER_SPAD
+// #define VL53L5CX_DISABLE_RANGE_SIGMA_MM
+// #define VL53L5CX_DISABLE_DISTANCE_MM
+// #define VL53L5CX_DISABLE_REFLECTANCE_PERCENT
+// #define VL53L5CX_DISABLE_TARGET_STATUS
+// #define VL53L5CX_DISABLE_MOTION_INDICATOR
+
+/*
+ * @brief The macro below is used to define the number of target per zone sent
+ * through I2C. This value can be changed by user, in order to tune I2C
+ * transaction, and also the total memory size (a lower number of target per
+ * zone means a lower RAM usage).
+ */
+
+#define VL53LMZ_NB_TARGET_PER_ZONE 1
+
+/*
+ * @brief All macro below are used to configure the sensor output. User can
+ * define some macros if he wants to disable selected output, in order to reduce
+ * I2C access.
+ */
+
+// #define VL53LMZ_DISABLE_AMBIENT_PER_SPAD
+// #define VL53LMZ_DISABLE_NB_SPADS_ENABLED
+// #define VL53LMZ_DISABLE_NB_TARGET_DETECTED
+// #define VL53LMZ_DISABLE_SIGNAL_PER_SPAD
+// #define VL53LMZ_DISABLE_RANGE_SIGMA_MM
+// #define VL53LMZ_DISABLE_DISTANCE_MM
+// #define VL53LMZ_DISABLE_REFLECTANCE_PERCENT
+// #define VL53LMZ_DISABLE_TARGET_STATUS
+// #define VL53LMZ_DISABLE_SCI
+
+/**
+ * @brief Structure VL53_Platform needs to be filled by the customer,
+ * depending on his platform. At least, it contains the VL53 I2C address.
+ * Some additional fields can be added, as descriptors, or platform
+ * dependencies. Anything added into this structure is visible into the platform
+ * layer.
+ */
+
+typedef struct
+{
+	/* To be filled with customer's platform. At least an I2C address/descriptor
+	 * needs to be added */
+	/* Example for most standard platform : I2C address of sensor */
+	uint16_t address;
+
+	void *transport;
+
+} VL53_Platform;
+
+/*
+ * @brief The macro below is used to define the number of target per zone sent
+ * through I2C. This value can be changed by user, in order to tune I2C
+ * transaction, and also the total memory size (a lower number of target per
+ * zone means a lower RAM). The value must be between 1 and 4.
+ */
+
+#define VL53_NB_TARGET_PER_ZONE 1U
+
+/*
+ * @brief The macro below can be used to avoid data conversion into the driver.
+ * By default there is a conversion between firmware and user data. Using this macro
+ * allows to use the firmware format instead of user format. The firmware format allows
+ * an increased precision.
+ */
+
+// #define 	VL53_USE_RAW_FORMAT
+
+/*
+ * @brief All macro below are used to configure the sensor output. User can
+ * define some macros if he wants to disable selected output, in order to reduce
+ * I2C access.
+ */
+
+// #define VL53_DISABLE_AMBIENT_PER_SPAD
+// #define VL53_DISABLE_NB_SPADS_ENABLED
+// #define VL53_DISABLE_NB_TARGET_DETECTED
+// #define VL53_DISABLE_SIGNAL_PER_SPAD
+// #define VL53_DISABLE_RANGE_SIGMA_MM
+// #define VL53_DISABLE_DISTANCE_MM
+// #define VL53_DISABLE_REFLECTANCE_PERCENT
+// #define VL53_DISABLE_TARGET_STATUS
+// #define VL53_DISABLE_MOTION_INDICATOR
+
+/**
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @param (uint16_t) Address : I2C location of value to read.
+ * @param (uint8_t) *p_values : Pointer of value to read.
+ * @return (uint8_t) status : 0 if OK
+ */
+
+uint8_t
+VL53_RdByte(VL53_Platform *p_platform, uint16_t RegisterAdress, uint8_t *p_value);
+
+/**
+ * @brief Mandatory function used to write one single byte.
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @param (uint16_t) Address : I2C location of value to read.
+ * @param (uint8_t) value : Pointer of value to write.
+ * @return (uint8_t) status : 0 if OK
+ */
+
+uint8_t
+VL53_WrByte(VL53_Platform *p_platform, uint16_t RegisterAdress, uint8_t value);
+
+/**
+ * @brief Mandatory function used to read multiples bytes.
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @param (uint16_t) Address : I2C location of values to read.
+ * @param (uint8_t) *p_values : Buffer of bytes to read.
+ * @param (uint32_t) size : Size of *p_values buffer.
+ * @return (uint8_t) status : 0 if OK
+ */
+
+uint8_t
+VL53_RdMulti(VL53_Platform *p_platform, uint16_t RegisterAdress, uint8_t *p_values, uint32_t size);
+
+/**
+ * @brief Mandatory function used to write multiples bytes.
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @param (uint16_t) Address : I2C location of values to write.
+ * @param (uint8_t) *p_values : Buffer of bytes to write.
+ * @param (uint32_t) size : Size of *p_values buffer.
+ * @return (uint8_t) status : 0 if OK
+ */
+
+uint8_t
+VL53_WrMulti(VL53_Platform *p_platform, uint16_t RegisterAdress, uint8_t *p_values, uint32_t size);
+
+/**
+ * @brief Optional function, only used to perform an hardware reset of the
+ * sensor. This function is not used in the API, but it can be used by the host.
+ * This function is not mandatory to fill if user don't want to reset the
+ * sensor.
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @return (uint8_t) status : 0 if OK
+ */
+
+uint8_t
+VL53_Reset_Sensor(VL53_Platform *p_platform);
+
+/**
+ * @brief Mandatory function, used to swap a buffer. The buffer size is always a
+ * multiple of 4 (4, 8, 12, 16, ...).
+ * @param (uint8_t*) buffer : Buffer to swap, generally uint32_t
+ * @param (uint16_t) size : Buffer size to swap
+ */
+
+void
+VL53_SwapBuffer(uint8_t *buffer, uint16_t size);
+/**
+ * @brief Mandatory function, used to wait during an amount of time. It must be
+ * filled as it's used into the API.
+ * @param (VL53_Platform*) p_platform : Pointer of VL53 platform
+ * structure.
+ * @param (uint32_t) TimeMs : Time to wait in ms.
+ * @return (uint8_t) status : 0 if wait is finished.
+ */
+
+uint8_t
+VL53_WaitMs(VL53_Platform *p_platform, uint32_t TimeMs);
+
+#endif  // _PLATFORM_H_

--- a/ext/vl53/vl53_transport.hpp
+++ b/ext/vl53/vl53_transport.hpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_VL53_TRANSPORT_HPP
+#define MODM_VL53_TRANSPORT_HPP
+
+#include <cstdint>
+#include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/architecture/interface/spi_device.hpp>
+#include <modm/driver/storage/i2c_eeprom.hpp>
+#include <modm/processing/fiber.hpp>
+
+namespace modm
+{
+
+class Vl53TransportBase
+{
+public:
+	virtual ~Vl53TransportBase() = default;
+
+	virtual uint8_t
+	writeMulti(uint16_t reg, const uint8_t *values, uint32_t size) = 0;
+	virtual uint8_t
+	readMulti(uint16_t reg, uint8_t *values, uint32_t size) = 0;
+	virtual uint8_t
+	writeByte(uint16_t reg, uint8_t value) = 0;
+	virtual uint8_t
+	readByte(uint16_t reg, uint8_t *value) = 0;
+	virtual uint8_t
+	resetSensor() = 0;
+};
+
+template<typename SpiMaster, typename Cs, typename Lpn>
+class Vl53SpiTransport : public modm::SpiDevice<SpiMaster>, public Vl53TransportBase
+{
+public:
+	Vl53SpiTransport()
+	{
+		this->attachConfigurationHandler([] {
+			SpiMaster::setDataMode(SpiMaster::DataMode::Mode3);
+			SpiMaster::setDataOrder(SpiMaster::DataOrder::MsbFirst);
+			SpiMaster::setDataSize(SpiMaster::DataSize::Bit8);
+		});
+	};
+
+	Vl53SpiTransport(const Vl53SpiTransport &) = delete;
+
+	Vl53SpiTransport &
+	operator=(const Vl53SpiTransport &) = delete;
+
+	uint8_t
+	writeMulti(uint16_t register_address, const uint8_t *p_values, uint32_t size) override;
+
+	uint8_t
+	readMulti(uint16_t register_address, uint8_t *p_values, uint32_t size) override;
+
+	uint8_t
+	readByte(uint16_t register_address, uint8_t *p_value) override
+	{
+		return this->readMulti(register_address, p_value, 1);
+	}
+
+	uint8_t
+	writeByte(uint16_t register_address, uint8_t value) override
+	{
+		return this->writeMulti(register_address, &value, 1);
+	}
+
+	uint8_t
+	resetSensor() override;
+
+private:
+	uint8_t addr_buffer[2];
+
+	static uint16_t
+	SPI_WRITE_MASK(uint16_t x) noexcept
+	{
+		return static_cast<uint16_t>(x | 0x8000);
+	}
+
+	static uint16_t
+	SPI_READ_MASK(uint16_t x) noexcept
+	{
+		return static_cast<uint16_t>(x & static_cast<uint16_t>(~0x8000));
+	}
+};
+
+template<typename I2cMaster, typename Lpn>
+class Vl53I2cTransport : public I2cEeprom<I2cMaster, 2>, public Vl53TransportBase
+{
+public:
+	Vl53I2cTransport(const uint8_t address) : I2cEeprom<I2cMaster, 2>{address} {};
+
+	Vl53I2cTransport(const Vl53I2cTransport &) = delete;
+
+	Vl53I2cTransport &
+	operator=(const Vl53I2cTransport &) = delete;
+
+	uint8_t
+	writeMulti(uint16_t register_address, const uint8_t *p_values, uint32_t size) override;
+
+	uint8_t
+	readMulti(uint16_t register_address, uint8_t *p_values, uint32_t size) override;
+
+	inline uint8_t
+	readByte(uint16_t register_address, uint8_t *p_value) override;
+
+	inline uint8_t
+	writeByte(uint16_t register_address, uint8_t value) override;
+
+	uint8_t
+	resetSensor() override;
+};
+
+}  // namespace modm
+
+#include "vl53_transport_impl.hpp"
+
+#endif

--- a/ext/vl53/vl53_transport_impl.hpp
+++ b/ext/vl53/vl53_transport_impl.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_VL53_TRANSPORT_HPP
+#error "Don't include this file directly, use 'bmi088_transport.hpp' instead!"
+#endif
+
+namespace modm
+{
+
+template<typename SpiMaster, typename Cs, typename Lpn>
+uint8_t
+Vl53SpiTransport<SpiMaster, Cs, Lpn>::writeMulti(uint16_t RegisterAddress, const uint8_t *p_values,
+												 uint32_t size)
+{
+	addr_buffer[0] = SPI_WRITE_MASK(RegisterAddress) >> 8;
+	addr_buffer[1] = SPI_WRITE_MASK(RegisterAddress) & 0xFF;
+
+	modm::this_fiber::poll([&] { return this->acquireMaster(); });
+	Cs::reset();
+	SpiMaster::transfer(addr_buffer, nullptr, sizeof(addr_buffer));
+	SpiMaster::transfer(&p_values[0], nullptr, size);
+
+	if (this->releaseMaster()) { Cs::set(); }
+	return 0;
+}
+
+template<typename SpiMaster, typename Cs, typename Lpn>
+uint8_t
+Vl53SpiTransport<SpiMaster, Cs, Lpn>::readMulti(uint16_t RegisterAddress, uint8_t *p_values,
+												uint32_t size)
+{
+	addr_buffer[0] = SPI_READ_MASK(RegisterAddress) >> 8;
+	addr_buffer[1] = SPI_READ_MASK(RegisterAddress) & 0xFF;
+
+	modm::this_fiber::poll([&] { return this->acquireMaster(); });
+	Cs::reset();
+	SpiMaster::transfer(&addr_buffer[0], nullptr, 2);
+	SpiMaster::transfer(nullptr, p_values, size);
+	if (this->releaseMaster()) { Cs::set(); }
+	return 0;
+}
+
+template<typename SpiMaster, typename Cs, typename Lpn>
+uint8_t
+Vl53SpiTransport<SpiMaster, Cs, Lpn>::resetSensor()
+{
+	Lpn::reset();
+	modm::this_fiber::sleep_for(100ms);
+	Lpn::set();
+	modm::this_fiber::sleep_for(100ms);
+	return 0;
+}
+
+template<typename I2cMaster, typename Lpn>
+uint8_t
+Vl53I2cTransport<I2cMaster, Lpn>::writeMulti(uint16_t RegisterAddress, const uint8_t *p_values,
+											 uint32_t size)
+{
+	const auto status = I2cEeprom<I2cMaster, 2>::write(RegisterAddress, p_values, size);
+	return static_cast<uint8_t>(not status);
+};
+
+template<typename I2cMaster, typename Lpn>
+uint8_t
+Vl53I2cTransport<I2cMaster, Lpn>::readMulti(uint16_t RegisterAddress, uint8_t *p_values,
+											uint32_t size)
+{
+	uint8_t data_write[2];
+	data_write[0] = (RegisterAddress >> 8) & 0xFF;
+	data_write[1] = RegisterAddress & 0xFF;
+
+	const auto status = this->writeRead(&data_write[0], 2, p_values, size);
+	return static_cast<uint8_t>(not status);
+};
+
+template<typename I2cMaster, typename Lpn>
+uint8_t
+Vl53I2cTransport<I2cMaster, Lpn>::readByte(uint16_t RegisterAddress, uint8_t *p_value)
+{
+	uint8_t data_write[2];
+
+	data_write[0] = (RegisterAddress >> 8) & 0xFF;
+	data_write[1] = RegisterAddress & 0xFF;
+
+	const auto status = this->writeRead(&data_write[0], 2, p_value, 1);
+
+	return static_cast<uint8_t>(not status);
+}
+
+template<typename I2cMaster, typename Lpn>
+uint8_t
+Vl53I2cTransport<I2cMaster, Lpn>::writeByte(uint16_t RegisterAddress, uint8_t value)
+{
+	const auto status = I2cEeprom<I2cMaster, 2>::write(RegisterAddress, &value, 1);
+	return static_cast<uint8_t>(not status);
+}
+
+template<typename I2cMaster, typename Lpn>
+uint8_t
+Vl53I2cTransport<I2cMaster, Lpn>::resetSensor()
+{
+	Lpn::reset();
+	modm::this_fiber::sleep_for(100ms);
+	Lpn::set();
+	modm::this_fiber::sleep_for(100ms);
+	return 0;
+}
+
+}  // namespace modm


### PR DESCRIPTION
## STs Ultra Light Driver for VL53L5 (I2C), VL53L7 (I2C), and VL53L8 (I2C, SPI) 8x8 Pixel Time-of-Flight Sensors

As the interaction with the sensor is pretty complicated (many undocumented registers and huge binary blobs), I use the ultra light drivers (ULD) for the sensors as provided by ST.
If you think this is a good way of integrating support for these sensors, I suggest to add these ULDs as a submodule under ext (see temp commit here for proposed structure). Does this work for y'all?
The VL53L5 driver exists undre STs namespace on github, the VL53LMZ driver for VL53L7 and VL53L8 only on STs website, I thus decided on STs website as datasorce for all drivers; I hope this is fine?
The `update.py` script in the future submodule automatically extracts the files, fixes some typos and bugs in their C-API, prefixes global functions with "VL53_", and unifies the use of the `VL53_Platform` struct among both drivers and their examples.

## modm transport
I added the modm transport SPI and I2C classes in the `ext/vl53` folder, is this the right place or should they go in the `src/modm/driver/position` folder?

## Examples
The VL53L8 sensor supports SPI and I2C, the VL53L7 sensor (same driver as the VL53L8 but wider field of view) supports only I2C, the VL53L5 supports only I2C.
Examples should cover these cases. 

## Todos:
- [x] Test VL53L8 SPI in hardware
- [x]  Test VL53L5 I2C in hardware
- [x] Test VL53L7/VL53L8 I2C in hardware

## Future plans:

Add support for the upcoming [VL53L9](https://www.st.com/en/imaging-and-photonics-solutions/vl53l9cx.html) when its released