### PR TITLE
[RTT] clone submodule url issue fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,4 +51,4 @@
 	url = https://github.com/modm-ext/json-partial.git
 [submodule "ext/segger/rtt"]
 	path = ext/segger/rtt
-	url = git@github.com:modm-ext/segger-rtt.git
+	url = https://github.com/modm-ext/segger-rtt.git


### PR DESCRIPTION
Hi All,

when trying to clone modm by` git clone `and then `git submodules update --init`, i get the error below:

`git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:modm-ext/segger-rtt.git' into submodule path 'C:/Projekte/modm/ext/segger/rtt' failed
Failed to clone 'ext/segger/rtt'. Retry scheduled
Cloning into 'C:/Projekte/modm/ext/st/stm32'...
Cloning into 'C:/Projekte/modm/ext/segger/rtt'...`

when changing the url to https it worked for me. as the rtt url was the only one using ssh i changed that in this PR.

BR

Alex