### PR TITLE
[RTT] printf include path wrong on cmake build

### DIFF
--- a/ext/segger/rtt_modm_port.cpp.in
+++ b/ext/segger/rtt_modm_port.cpp.in
@@ -70,7 +70,7 @@ unsigned SEGGER_RTT_GetBytesInDownBuffer(unsigned BufferIndex) {
 }
 %#
 %% if with_printf
-#include <modm/ext/printf/printf.h>
+#include <printf/printf.h>
 
 static void output_gadget(char c, void* BufferIndex)
 {


### PR DESCRIPTION
Hi All,

my cmake build with rtt failed due to the printf.h included in rtt_modm_port.cpp. The include was given with a full path
`#include <modm/ext/printf/printf.h>`. The cmake file generated from modm does not include the base folder, but the ext folder is included. So i changed the path accordingly. I expect that scons and other builds include the ext folder as well. So it should not be a big deal.