### PR TITLE
Adding Eigen Linear Algebra support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "ext/vl53/vl53"]
 	path = ext/vl53/vl53
 	url = https://github.com/modm-ext/vl53-partial.git
+[submodule "ext/libeigen/eigen"]
+	path = ext/libeigen/eigen
+	url = https://github.com/modm-ext/eigen-partial.git

--- a/examples/nucleo_g474re/eigen/main.cpp
+++ b/examples/nucleo_g474re/eigen/main.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <modm/board.hpp>
+#include <Eigen/Eigen>
+
+using namespace Board;
+
+Eigen::IOFormat squarebrackets(5, 0, ", ", "\n", "[", "]");
+
+int
+main()
+{
+	Board::initialize();
+	LedD13::setOutput();
+
+	while (1)
+	{
+		Eigen::Matrix2f mat{{1.111f, 2.2222f}, {3.333f, 4.4f}};
+		Eigen::Vector2f u{-1.1f, 1.5f}, v{2.2f, 0.5f};
+		MODM_LOG_INFO.width(2);
+		MODM_LOG_INFO.precision(0);
+		MODM_LOG_INFO << "Here is mat*mat:\n" << mat * mat << modm::endl;
+		MODM_LOG_INFO.width(5);
+		MODM_LOG_INFO.precision(1);
+		MODM_LOG_INFO << "Here is mat*u:\n" << mat * u << modm::endl;
+		MODM_LOG_INFO.width(8);
+		MODM_LOG_INFO.precision(3);
+		MODM_LOG_INFO << "Here is u^T*mat:\n" << u.transpose() * mat << modm::endl;
+		MODM_LOG_INFO.width(10);
+		MODM_LOG_INFO.precision(5);
+		MODM_LOG_INFO << "Here is u^T*v:\n" << u.transpose() * v << modm::endl;
+		MODM_LOG_INFO.width(15);
+		MODM_LOG_INFO.precision(7);
+		MODM_LOG_INFO << "Here is u*v^T:\n" << u * v.transpose() << modm::endl;
+		MODM_LOG_INFO << "Let's multiply mat by itself" << modm::endl;
+		mat = mat * mat;
+		MODM_LOG_INFO << "Now mat is mat:\n" << mat.format(squarebrackets) << modm::endl;
+
+		modm::delay(1s);
+	}
+
+	return 0;
+}

--- a/examples/nucleo_g474re/eigen/project.xml
+++ b/examples/nucleo_g474re/eigen/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-g474re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_g474re/eigen</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:heap</module>
+    <module>modm:eigen</module>
+  </modules>
+</library>

--- a/ext/gcc/assert.cpp.in
+++ b/ext/gcc/assert.cpp.in
@@ -11,7 +11,6 @@
 
 #include <cstdint>
 #include <bits/functexcept.h>
-#include <modm/math/utils/bit_constants.hpp>
 
 %% if options["assert_on_exception"]
 #include <modm/architecture/interface/assert.hpp>

--- a/ext/libeigen/Version.in
+++ b/ext/libeigen/Version.in
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, Henrik Hose
+ * Copyright (c) 2025, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#if __has_include(<modm_conf_eigen.h>)
+#  include <modm_conf_eigen.h>
+#endif
+%% if with_io
+#include <modm/io.hpp>
+%#
+%% else
+%#
+#define EIGEN_NO_IO
+%% endif
+#define EIGEN_DONT_VECTORIZE
+#define EIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT
+#define EIGEN_DONT_PARALLELIZE
+
+#define EIGEN_MALLOC_ALREADY_ALIGNED 1
+#ifndef EIGEN_MAX_ALIGN_BYTES
+#define EIGEN_MAX_ALIGN_BYTES 0
+#endif
+#ifndef EIGEN_MAX_STATIC_ALIGN_BYTES
+#define EIGEN_MAX_STATIC_ALIGN_BYTES 4
+#endif
+%#
+%% if not with_heap
+#define EIGEN_NO_MALLOC
+%% endif
+#ifndef EIGEN_STACK_ALLOCATION_LIMIT
+#define EIGEN_STACK_ALLOCATION_LIMIT 1024
+#endif
+
+#ifndef MODM_DEBUG_BUILD
+#define EIGEN_NO_DEBUG
+#endif
+
+#include <modm/architecture/interface/assert.hpp>
+
+#define eigen_assert(cond) \
+    modm_assert(cond, "eigen", __FILE__ ":" MODM_STRINGIFY(__LINE__) " -> \"" #cond "\"")
+
+#include "Version_orig"

--- a/ext/libeigen/module.lb
+++ b/ext/libeigen/module.lb
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Henrik Hose
+# Copyright (c) 2025, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":eigen"
+    module.description = FileReader("module.md")
+
+
+def prepare(module, options):
+    module.depends(":architecture:assert")
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/ext/eigen"
+    env.collect(":build:path.include", "modm/ext/eigen")
+
+    env.substitutions = {
+        "with_heap": env.has_module(":platform:heap"),
+        "with_io": env.has_module(":io") and env.has_module(":platform:heap"),
+    }
+    env.copy("eigen/Eigen", "Eigen", ignore=env.ignore_files("Version"))
+    env.copy("eigen/Eigen/Version", "Eigen/Version_orig")
+    env.template("Version.in", "Eigen/Version")

--- a/ext/libeigen/module.md
+++ b/ext/libeigen/module.md
@@ -1,0 +1,16 @@
+# Eigen Linear Algebra Library
+
+Eigen is a C++ template library for linear algebra: matrices, vectors, numerical
+solvers, and related algorithms. It is widely used in scientific computing,
+computer graphics, machine learning, and robotics due to its efficiency and
+ease of use.
+
+https://libeigen.gitlab.io
+
+This modules provides a configuration to use Eigen with or without heap, io, and
+debug functionality.
+
+To print any Eigen values, you need to include the `modm:io` module *and* the
+`modm:platform:heap` module. Unfortunately Eigen's printing functionality relies
+on dynamic memory allocation.
+

--- a/src/modm/architecture/interface/assert.hpp.in
+++ b/src/modm/architecture/interface/assert.hpp.in
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "assert.h"
-#include <modm/architecture/interface/register.hpp>
 %% if core.startswith("avr")
 #include <modm/architecture/interface/accessor_flash.hpp>
 %% endif
@@ -27,13 +26,13 @@ namespace modm
 enum class
 Abandonment : uint8_t
 {
-	DontCare = Bit0,	///< Do not care about failure.
-	Ignore = Bit1,		///< Ignore this failure.
-	Fail = Bit2,		///< This failure is reason for abandonment.
-	Debug = Bit7		///< Only set for a debug-only failure.
+	DontCare = 0b001,	///< Do not care about failure.
+	Ignore = 0b010,		///< Ignore this failure.
+	Fail = 0b100,		///< This failure is reason for abandonment.
+	Debug = 0x80,		///< Only set for a debug-only failure.
 };
-using AbandonmentBehavior = Flags8<Abandonment>;
-MODM_TYPE_FLAGS(AbandonmentBehavior);
+/// Contains the superset of Abandonment behavior
+using AbandonmentBehavior = Abandonment;
 
 /// Contains information about the failed assertion.
 struct modm_packed

--- a/src/modm/architecture/module.lb
+++ b/src/modm/architecture/module.lb
@@ -53,7 +53,6 @@ class Assert(Module):
                               default="release" if platform == "hosted" else "debug",
                               enumeration=["off", "debug", "release"]))
 
-        module.depends(":architecture:register")
         if platform == "avr":
             module.depends(":architecture:accessor")
         return True

--- a/src/modm/driver/color/tcs3472.hpp
+++ b/src/modm/driver/color/tcs3472.hpp
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <modm/architecture/interface/i2c_device.hpp>
+#include <modm/architecture/interface/register.hpp>
 #include <modm/math/utils.hpp>
 #include <modm/ui/color.hpp>
 

--- a/src/modm/driver/color/tcs3472.lb
+++ b/src/modm/driver/color/tcs3472.lb
@@ -19,6 +19,7 @@ def init(module):
 def prepare(module, options):
     module.depends(
         ":architecture:i2c.device",
+        ":architecture:register",
         ":ui:color",
         ":math:utils")
     return True

--- a/src/modm/driver/display/st7586s.lb
+++ b/src/modm/driver/display/st7586s.lb
@@ -18,6 +18,7 @@ def init(module):
 def prepare(module, options):
     module.depends(
         ":architecture:fiber",
+        ":architecture:register",
         ":ui:display")
     return True
 

--- a/src/modm/driver/display/st7586s_protocol.hpp
+++ b/src/modm/driver/display/st7586s_protocol.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <modm/architecture/interface/register.hpp>
 #include <modm/math/utils/endianness.hpp>
 
 /// @cond

--- a/src/modm/io/iostream.hpp.in
+++ b/src/modm/io/iostream.hpp.in
@@ -318,7 +318,6 @@ private:
 	IOStream(const IOStream&) = delete;
 	IOStream& operator =(const IOStream&) = delete;
 
-private:
 	IODevice* const	device;
 	Mode mode = Mode::Ascii;
 %% if options.with_printf
@@ -330,6 +329,7 @@ private:
 %% endif
 	size_t printf_width{};
 %% endif
+	friend class OSizeStream;
 };
 
 /// @ingroup modm_io
@@ -394,6 +394,57 @@ cyan(IOStream& ios);
 
 IOStream&
 white(IOStream& ios);
+
+
+class OSizeStream : public IOStream
+{
+public:
+	class Buffer : public IODevice
+	{
+		size_t buffer_size{};
+	public:
+		inline constexpr Buffer() = default;
+		using IODevice::write;
+		inline void write(char) override { buffer_size++; }
+		inline void flush() override { buffer_size = 0; }
+		inline bool read(char&) override { return false; }
+
+		inline size_t
+		size() const
+		{
+			return buffer_size;
+		}
+
+		inline size_t
+		length() const
+		{
+			return buffer_size;
+		}
+	};
+
+	inline OSizeStream() : IOStream(buffer) {}
+
+	inline const Buffer&
+	str() const
+	{
+		return buffer;
+	}
+
+	inline void
+	copyfmt(const IOStream& other)
+	{
+		this->mode = other.mode;
+%% if options.with_printf
+%% if options.with_float
+		this->printf_precision = other.printf_precision;
+%% endif
+		this->printf_width = other.printf_width;
+%% endif
+	}
+
+private:
+	Buffer buffer;
+};
 /// @}
 
 }	// namespace modm

--- a/src/modm/io/iostream.hpp.in
+++ b/src/modm/io/iostream.hpp.in
@@ -246,6 +246,29 @@ public:
 	vprintf(const char *fmt, va_list vlist) __attribute__((format(printf, 2, 0)));
 %% endif
 
+%% if options.with_printf
+	inline int width() const { return printf_width; }
+	inline int width(int w) {
+		const size_t old = printf_width;
+		if (w < 0) w = 0;
+		printf_width = w;
+		return old;
+	}
+%% if options.with_float
+	inline int precision() const { return printf_precision; }
+	inline int precision(int p) {
+		const size_t old = printf_precision;
+		if (p < 0) p = 6;
+		printf_precision = p;
+		return old;
+	}
+%% endif
+%% endif
+	inline char fill() const { return ' '; }
+	inline char fill(char) {
+		return ' ';
+	}
+
 
 protected:
 	template< typename T >
@@ -302,6 +325,10 @@ private:
 	static void out_char(char c, void* arg)
 	{ if (c) reinterpret_cast<modm::IOStream*>(arg)->write(c); }
 	printf_output_gadget_t output_gadget{out_char, this, NULL, 0, INT_MAX};
+%% if options.with_float
+	size_t printf_precision{6};
+%% endif
+	size_t printf_width{};
 %% endif
 };
 

--- a/src/modm/io/iostream_printf.cpp.in
+++ b/src/modm/io/iostream_printf.cpp.in
@@ -34,14 +34,17 @@ typedef unsigned long long printf_unsigned_value_t;
 typedef unsigned long printf_unsigned_value_t;
 #endif
 
+#define FLAGS_SPACE		(1U <<  3U)
 #define FLAGS_SHORT		(1U <<  7U)
 #define FLAGS_LONG		(1U <<  9U)
 #define FLAGS_LONG_LONG	(1U << 10U)
+#define FLAGS_PRECISION	(1U << 11U)
+#define FLAGS_ADAPT_EXP	(1U << 12U)
 
 extern
 void print_integer(printf_output_gadget_t* output, printf_unsigned_value_t value,
-				   bool negative, uint8_t base, unsigned int precision,
-				   unsigned int width, unsigned int flags);
+                   bool negative, uint8_t base, unsigned int precision,
+                   unsigned int width, unsigned int flags);
 %% if options.with_float
 extern
 void print_floating_point(printf_output_gadget_t* output, double value,
@@ -78,7 +81,7 @@ IOStream::writeInteger(int16_t value)
 {
 %% if options.with_printf
 	print_integer(&output_gadget, uint16_t(value < 0 ? -value : value),
-	              value < 0, 10, 0, 0, FLAGS_SHORT);
+	              value < 0, 10, 0, printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_SHORT);
 %% else
 	// hard coded for -32'768
 	char str[7 + 1]; // +1 for '\0'
@@ -91,7 +94,8 @@ void
 IOStream::writeInteger(uint16_t value)
 {
 %% if options.with_printf
-	print_integer(&output_gadget, value, false, 10, 0, 0, FLAGS_SHORT);
+	print_integer(&output_gadget, value, false, 10,
+	              0, printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_SHORT);
 %% else
 	// hard coded for 32'768
 	char str[6 + 1]; // +1 for '\0'
@@ -105,7 +109,7 @@ IOStream::writeInteger(int32_t value)
 {
 %% if options.with_printf
 	print_integer(&output_gadget, uint32_t(value < 0 ? -value : value),
-	              value < 0, 10, 0, 0, FLAGS_LONG);
+	              value < 0, 10, 0, printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_LONG);
 %% else
 	// hard coded for -2147483648
 	char str[11 + 1]; // +1 for '\0'
@@ -118,7 +122,8 @@ void
 IOStream::writeInteger(uint32_t value)
 {
 %% if options.with_printf
-	print_integer(&output_gadget, value, false, 10, 0, 0, FLAGS_LONG);
+	print_integer(&output_gadget, value, false, 10, 0,
+	              printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_LONG);
 %% else
 	// hard coded for 4294967295
 	char str[10 + 1]; // +1 for '\0'
@@ -132,13 +137,14 @@ void
 IOStream::writeInteger(int64_t value)
 {
 	print_integer(&output_gadget, uint64_t(value < 0 ? -value : value),
-	              value < 0, 10, 0, 0, FLAGS_LONG_LONG);
+	              value < 0, 10, 0, printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_LONG_LONG);
 }
 
 void
 IOStream::writeInteger(uint64_t value)
 {
-	print_integer(&output_gadget, value, false, 10, 0, 0, FLAGS_LONG_LONG);
+	print_integer(&output_gadget, value, false, 10, 0,
+	              printf_width, (printf_width ? FLAGS_SPACE : 0) | FLAGS_LONG_LONG);
 }
 %% endif
 
@@ -147,7 +153,8 @@ void
 IOStream::writeDouble(const double& value)
 {
 %% if options.with_printf
-	print_floating_point(&output_gadget, value, 0, 0, 0, true);
+	print_floating_point(&output_gadget, value, printf_precision, printf_width,
+	                     (printf_width ? FLAGS_SPACE : 0) | FLAGS_PRECISION | FLAGS_ADAPT_EXP, false);
 %% else
 	if(!std::isfinite(value)) {
 		if(std::isinf(value)) {

--- a/src/modm/platform/adc/at90_tiny_mega/module.lb
+++ b/src/modm/platform/adc/at90_tiny_mega/module.lb
@@ -27,6 +27,7 @@ def prepare(module, options):
 
     module.depends(
         ":architecture:adc",
+        ":architecture:register",
         ":architecture:interrupt",
         ":platform:gpio",
         ":math:algorithm")

--- a/src/modm/platform/can/common/fdcan/module.lb
+++ b/src/modm/platform/can/common/fdcan/module.lb
@@ -21,6 +21,7 @@ def prepare(module, options):
 
     module.depends(
         ":architecture:assert",
+        ":architecture:register",
         ":architecture:can",
         ":architecture:clock")
     return True

--- a/src/modm/platform/core/cortex/assert.cpp.in
+++ b/src/modm/platform/core/cortex/assert.cpp.in
@@ -57,22 +57,22 @@ void
 modm_assert_report(_modm_assertion_info *cinfo)
 {
 	auto info = reinterpret_cast<modm::AssertionInfo *>(cinfo);
-	AbandonmentBehavior behavior(info->behavior);
+	uint8_t behavior(uint8_t(info->behavior));
 
 	for (const AssertionHandler *handler = &__assertion_table_start;
 		 handler < &__assertion_table_end; handler++)
 	{
 %% if core.startswith("avr")
-		behavior |= ((AssertionHandler)pgm_read_ptr(handler))(*info);
+		behavior |= (uint8_t)((AssertionHandler)pgm_read_ptr(handler))(*info);
 %% else
-		behavior |= (*handler)(*info);
+		behavior |= (uint8_t)(*handler)(*info);
 %% endif
 	}
 
-	info->behavior = behavior;
-	behavior.reset(Abandonment::Debug);
-	if ((behavior == Abandonment::DontCare) or
-		(behavior & Abandonment::Fail))
+	info->behavior = AbandonmentBehavior(behavior);
+	behavior &= ~uint8_t(Abandonment::Debug);
+	if ((behavior == uint8_t(Abandonment::DontCare)) or
+		(behavior & uint8_t(Abandonment::Fail)))
 	{
 		modm_abandon(*info);
 %% if core.startswith("cortex-m")

--- a/src/modm/platform/pwm/sam_x7x/module.lb
+++ b/src/modm/platform/pwm/sam_x7x/module.lb
@@ -44,6 +44,7 @@ def prepare(module, options):
         return False
 
     module.depends(
+        ":architecture:register",
         ":cmsis:device",
         ":platform:clock",
         ":platform:gpio")

--- a/src/modm/platform/timer/samg/module.lb
+++ b/src/modm/platform/timer/samg/module.lb
@@ -47,6 +47,7 @@ def prepare(module, options):
         return False
 
     module.depends(
+        ":architecture:register",
         ":cmsis:device",
         ":platform:gpio")
 

--- a/src/modm/platform/timer/samg/timer_channel_base.hpp.in
+++ b/src/modm/platform/timer/samg/timer_channel_base.hpp.in
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "../device.hpp"
+#include <modm/architecture/interface/register.hpp>
 
 namespace modm::platform
 {

--- a/src/modm/platform/uart/sam-sercom/module.lb
+++ b/src/modm/platform/uart/sam-sercom/module.lb
@@ -51,6 +51,7 @@ def prepare(module, options):
     module.depends(
         ":architecture:uart",
         ":architecture:fiber",
+        ":architecture:register",
         ":math:algorithm",
         ":cmsis:device",
         ":platform:gpio",

--- a/test/modm/io/io_stream_test.cpp
+++ b/test/modm/io/io_stream_test.cpp
@@ -216,45 +216,45 @@ IoStreamTest::testStreamInt64()
 void
 IoStreamTest::testFloat()
 {
-	char string[] = "1.23000e+00";
+	char string[] = "1.23";
 
 	(*stream) << 1.23f;
 
-	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 11);
-	TEST_ASSERT_EQUALS(device.bytesWritten, 11U);
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 4);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 4U);
 }
 
 void
 IoStreamTest::testFloat2()
 {
-	char string[] = "4.57000e+02";
+	char string[] = "457";
 
 	(*stream) << 457.0f;
 
-	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 11);
-	TEST_ASSERT_EQUALS(device.bytesWritten, 11U);
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 3);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 3U);
 }
 
 void
 IoStreamTest::testFloat3()
 {
-	char string[] = "-5.12314e+07";
+	char string[] = "-51231400";
 
 	(*stream) << -51231400.0f;
 
-	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 12);
-	TEST_ASSERT_EQUALS(device.bytesWritten, 12U);
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 9);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 9U);
 }
 
 void
 IoStreamTest::testFloat4()
 {
-	char string[] = "-7.23400e-04";
+	char string[] = "-0.000723";
 
 	(*stream) << -0.0007234f;
 
-	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 12);
-	TEST_ASSERT_EQUALS(device.bytesWritten, 12U);
+	TEST_ASSERT_EQUALS_ARRAY(string, device.buffer, 9);
+	TEST_ASSERT_EQUALS(device.bytesWritten, 9U);
 }
 
 void


### PR DESCRIPTION
Simple lbuild include for Eigen and `modm::IOStream` for printing of `Eigen::MatrixBase`

Example tested on Nucleo G474 board.

Niklas modified some things in the integration:
- [x] Eigen doesn't seem to support a config file, so I inject the config into the `Eigen/Version` file, which is included by every file indirectly.
- [x] I moved the iostream support to it's own file and inject it into the `:io` module.
- [x] I made the no malloc macro dependent on whether the `:platform:heap` module is included.
- [x] Redirect `eigen_assert` to `modm_assert` otherwise you won't get any output.
- [x] Add more documentation about eigen
- [x] Somehow use the [built-in Eigen formatting functions](https://libeigen.gitlab.io/eigen/docs-nightly/structEigen_1_1IOFormat.html) instead of rolling our own.
- [x] Fix the compilation regarding `conflicting declaration of C function 'int __cxa_guard_acquire(guard_type*)'`. Was an issue with circular imports due to `assert.hpp` relying on `register.hpp`.