### PR TITLE
[ext] Use CPU properties from modm-devices

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -556,7 +556,7 @@ jobs:
           name: stm32l5-compile-all
           path: test/all/log
 
-  stm32u5-compile-all:
+  stm32u5-compile-all-1:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
@@ -572,14 +572,40 @@ jobs:
       - name: Update lbuild
         run: |
           pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
-      - name: Compile HAL for all STM32U5
+      - name: Compile HAL for all STM32U5 Part 1
         run: |
-          (cd test/all && python3 run_all.py stm32u5 --quick-remaining)
+          (cd test/all && python3 run_all.py stm32u5 --quick-remaining --split 2 --part 0)
       - name: Upload log artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: stm32u5-compile-all
+          name: stm32u5-compile-all-1
+          path: test/all/log
+
+  stm32u5-compile-all-2:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
+      - name: Compile HAL for all STM32U5 Part 2
+        run: |
+          (cd test/all && python3 run_all.py stm32u5 --quick-remaining --split 2 --part 1)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stm32u5-compile-all-2
           path: test/all/log
 
   stm32g0-compile-all-1:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Examples STM32F7 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py stm32f746g_discovery stm32f769i_discovery nucleo_f746zg nucleo_f767zi)
+          (cd examples && ../tools/scripts/examples_compile.py stm32f746g_discovery stm32f769i_discovery nucleo_f746zg nucleo_f767zi nucleo_f722ze)
       - name: Examples STM32G0 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -703,47 +703,49 @@ We have out-of-box support for many development boards including documentation.
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446re">NUCLEO-F446RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446ze">NUCLEO-F446ZE</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f722ze">NUCLEO-F722ZE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f746zg">NUCLEO-F746ZG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g070rb">NUCLEO-G070RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g071rb">NUCLEO-G071RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g0b1re">NUCLEO-G0B1RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431rb">NUCLEO-G431RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/bsptable-->

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3826<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3809<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->3082<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->3065<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->355<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 - Raspberry Pi: <!--rpicount-->1<!--/rpicount--> device.

--- a/examples/nucleo_f722ze/blink/main.cpp
+++ b/examples/nucleo_f722ze/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Leds::write(1 << (counter % (Leds::width+1) ));
+		modm::delay(Button::read() ? 100ms : 500ms);
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_f722ze/blink/project.xml
+++ b/examples/nucleo_f722ze/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nucleo-f722ze</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_f722ze/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/arm/core.lb
+++ b/ext/arm/core.lb
@@ -19,8 +19,7 @@ def prepare(module, options):
     return options[":target"].has_driver("core:cortex-m*")
 
 def build(env):
-    core = env[":target"].get_driver("core")["type"]
-    core = core.replace("cortex-m", "").replace("+", "plus").replace("f", "").replace("d", "")
+    core = env[":target"].get_driver("core")["type"][8:]
 
     env.outbasepath = "modm/ext/cmsis/core"
     env.copy("cmsis/CMSIS/Core/Include/core_cm{}.h".format(core), "core_cm{}.h".format(core))

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -125,8 +125,7 @@ def build(env):
     env.copy("cmsis-dsp/CMSIS-DSP/Include/dsp/utils.h", "dsp/utils.h")
     env.copy("cmsis-dsp/CMSIS-DSP/Include/dsp/debug.h", "dsp/debug.h")
 
-    core = env[":target"].get_driver("core")["type"][8:]
-    core = core.replace("+", "PLUS").replace("f", "").replace("d", "")
+    core = env[":target"].get_driver("core")["type"][8:].upper()
     global includes
     env.substitutions = {
         "core": core,

--- a/ext/aws/module.lb
+++ b/ext/aws/module.lb
@@ -98,9 +98,8 @@ def build(env):
         "with_heap": env.has_module(":platform:heap"),
         "with_fpu": env.get(":platform:cortex-m:float-abi", "soft") != "soft",
     }
-    path = core.replace("cortex-m", "ARM_CM").replace("+", "").replace("fd", "f").upper()
-    path = path.replace("CM7F", "CM7/r0p1") # use subfolder for M7
-    path = path.replace("CM33F", "CM33") # common port for FPU/non-FPU version
+    path = core.replace("cortex-m", "ARM_CM").replace("plus", "").upper()
+    path = path.replace("CM4", "CM4F").replace("CM7", "CM7/r0p1") # use subfolder for M7
     path = path.replace("CM33", "CM33_NTZ/non_secure") # no trustzone supported, use non_secure subfolder
     path = "freertos/FreeRTOS/Source/portable/GCC/{}".format(path)
 

--- a/ext/st/module.lb
+++ b/ext/st/module.lb
@@ -15,52 +15,6 @@ import re
 from pathlib import Path
 from collections import defaultdict
 
-def getDefineForDevice(device_id, familyDefines):
-    """
-    Returns the STM32 specific define from an identifier
-    """
-    # get all defines for this device name
-    devName = "STM32{}{}".format(device_id.family.upper(), device_id.name.upper())
-
-    # Map STM32F7x8 -> STM32F7x7
-    if device_id.family == "f7" and devName[8] == "8":
-        devName = devName[:8] + "7"
-
-    deviceDefines = sorted([define for define in familyDefines if define.startswith(devName)])
-    # if there is only one define thats the one
-    if len(deviceDefines) == 1:
-        return deviceDefines[0]
-
-    # sort with respecting variants
-    minlen = min(len(d) for d in deviceDefines)
-    deviceDefines.sort(key=lambda d: (d[:minlen], d[minlen:]))
-
-    # now we match for the size-id (and variant-id if applicable).
-    if device_id.family == "h7":
-        devNameMatch = devName + "xx"
-    else:
-        devNameMatch = devName + "x{}".format(device_id.size.upper())
-    if device_id.family == "l1":
-        # Map STM32L1xxQC and STM32L1xxZC -> STM32L162QCxA variants
-        if device_id.pin in ["q", "z"] and device_id.size == "c":
-            devNameMatch += "A"
-        else:
-            devNameMatch += device_id.variant.upper()
-    elif device_id.family == "h7":
-        if device_id.variant:
-            devNameMatch += device_id.variant.upper()
-    for define in deviceDefines:
-        if devNameMatch <= define:
-            return define
-
-    # now we match for the pin-id.
-    devNameMatch = devName + "{}x".format(device_id.pin.upper())
-    for define in deviceDefines:
-        if devNameMatch <= define:
-            return define
-
-    return None
-
 bprops = {}
 def common_rcc_map(env):
     """
@@ -117,23 +71,16 @@ def common_header_file(env):
     """
     device = env[":target"]
 
-    core = device.get_driver("core")["type"]
-    core = core.replace("cortex-m", "").replace("+", "plus").replace("f", "").replace("d", "")
-    core_header = "core_cm{}.h".format(core)
+    core = device.get_driver("core")
+    core_header = "core_cm{}.h".format(core["type"][8:])
 
-    if device.identifier.string[5:8] in ["h7r", "h7s"]:
-        folder = "stm32h7rsxx"
-    else:
-        folder = "stm32{}xx".format(device.identifier.family)
+    folder = core["cmsis-header"]
+    define = core["cmsis-define"]
+
     family_header = folder + ".h"
+    if "xx" not in folder: folder += "x"
     folder = "stm32/{}/Include".format(folder)
-    define = None
 
-    content = Path(localpath(folder, family_header)).read_text(encoding="utf-8", errors="replace")
-    match = re.findall(r"if defined\((?P<define>STM32[CFGHLU][\w\d]+)\)", content)
-    define = getDefineForDevice(device.identifier, match)
-    if define is None or match is None:
-        raise ValidateException("No device define found for '{}'!".format(device.partname))
     device_header = define.lower() + ".h"
     family_define = "STM32{}".format(device.identifier.family.upper())
 

--- a/repo.lb
+++ b/repo.lb
@@ -14,6 +14,7 @@
 import re
 import sys
 import glob
+import json
 import hashlib
 import platform
 
@@ -58,114 +59,53 @@ except ModuleNotFoundError:
 
 # =============================================================================
 class DevicesCache(dict):
-    """
-    Building the device enumeration from modm-device is quite expensive,
-    so we cache the results in `ext/modm-devices.cache`
-    The text file contains two maps:
-
-      1. partname -> file-name.xml
-         We use this to populate the `:target` option, but we only
-         actually parse the device file and build the device on the first
-         access of the value.
-
-      2. file-name.xml -> MD5 hash
-         This is used to check if any files have changed their contents.
-         No additional checks are done, if files have moved, this may fail.
-    """
-
+    """Loads and filters the available devices from modm-devices and tools/devices."""
     def __init__(self):
         dict.__init__(self)
-        self.device_to_file = {}
+        modm_devices = Path(repopath("ext/modm-devices/devices"))
+        tools_devices = Path(repopath("tools/devices"))
+        ignored_devices = Path(repopath("test/all/ignored.txt"))
 
-    def parse_all(self):
-        mapping = {}
-        device_file_names  = glob.glob(repopath("ext/modm-devices/devices/**/*.xml"))
-        device_file_names += glob.glob(repopath("tools/devices/**/*.xml"))
+        # Ignored partnames
+        ignored = [d for d in ignored_devices.read_text().strip().splitlines() if "#" not in d]
+        # Supported device families
+        supported = (
+            "at90", "attiny", "atmega",
+            "rp",
+            "samd21",
+            "samd51", "same51", "same53", "same54", "samg55",
+            "same70", "sams70", "samv70", "samv71",
+            "stm32c0",
+            "stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
+            "stm32g0", "stm32g4",
+            "stm32h7",
+            "stm32l0", "stm32l1", "stm32l4", "stm32l5",
+            "stm32u5",
+        )
+        # Load and filter the device prefixes
+        modm_db = json.loads((modm_devices / "db.json").read_text())
+        modm_db = {name: modm_devices / path
+                   for prefix, values in modm_db.items()
+                     for name, path in values.items()
+                       if prefix in supported and not
+                         any(name.startswith(i) for i in ignored)}
 
-        # roughly filter to supported devices
-        supported = ["stm32c0",
-                     "stm32f0", "stm32f1", "stm32f2", "stm32f3", "stm32f4", "stm32f7",
-                     "stm32g0", "stm32g4",
-                     "stm32h7",
-                     "stm32l0", "stm32l1", "stm32l4", "stm32l5",
-                     "stm32u5",
-                     "at90", "attiny", "atmega",
-                     "samd21", "samg55",
-                     "same70", "sams70", "samv70", "samv71",
-                     "samd51", "same51", "same53", "same54",
-                     "rp2040",
-                     "hosted"]
-        device_file_names = [dfn for dfn in device_file_names if any(s in dfn for s in supported)]
-        # These files are ignored due to various issues
-        ignored = [d for d in Path(repopath("test/all/ignored.txt")).read_text().strip().splitlines() if "#" not in d]
+        # Add all the tools devices
+        tools_db = json.loads((tools_devices / "db.json").read_text())
+        tools_db = {name: tools_devices / path for name, path in tools_db.items()}
 
-        # Parse the files and build the :target enumeration
-        parser = modm_devices.parser.DeviceParser()
-        for device_file_name in device_file_names:
-            device_file = parser.parse(device_file_name)
-            for device in device_file.get_devices():
-                if not any(device.partname.startswith(i) for i in ignored):
-                    self[device.partname] = device
-                    mapping[device.partname] = device_file_name
-
-        return mapping
-
-    def build(self):
-        cache = Path(repopath("ext/modm-devices.cache"))
-        repos = {p:None for p in [".", "ext/modm-devices"]}
-        recompute_required = not cache.exists()
-
-        if cache.exists():
-            # Read cache file and populate :target
-            for line in cache.read_text().splitlines():
-                line = line.split(" ")
-                if line[0].startswith("/"):
-                    file = line[0][1:]
-
-                    # Store repo shas
-                    if file in repos.keys():
-                        repos[file] = line[1]
-                        continue
-
-                    # Check normal files
-                    file = Path(repopath(file))
-                    if not file.exists() or (line[1] != hashlib.md5(file.read_bytes()).hexdigest()):
-                        recompute_required = True
-                        break
-                else:
-                    # Store None as device file value
-                    self.device_to_file[line[0]] = line[1]
-                    self[line[0]] = None
-
-        try:
-            # Check with real repository shas
-            real_repos = {path:Repo(repopath(path)).commit().hexsha for path in repos}
-            if any(real_repos[path] != sha for path, sha in repos.items()):
-                recompute_required = True
-            repos = real_repos
-        except:
-            recompute_required = True
-
-        if recompute_required:
-            check_submodules()
-            print(">> modm: Recomputing device cache...")
-            content = self.parse_all()
-            # prefix the files with a / so we can distinguish them from partnames
-            files = ["/{} {}".format(Path(f).relative_to(repopath(".")),
-                                    hashlib.md5(Path(f).read_bytes()).hexdigest())
-                     for f in set(content.values())]
-            content = ["{} {}".format(d, Path(f).relative_to(repopath(".")))
-                       for (d, f) in content.items()]
-            repos = ["/{} {}".format(path, sha) for path, sha in repos.items()]
-            content = sorted(content) + sorted(files + repos)
-            cache.write_text("\n".join(content))
+        self.mapping = modm_db
+        self.mapping.update(tools_db)
+        # Initialize the dictionary to None
+        for name in self.mapping.keys():
+            self[name] = None
 
     def __getitem__(self, item):
         value = dict.__getitem__(self, item)
         if value is None:
             # Parse the device file and build its devices
             parser = modm_devices.parser.DeviceParser()
-            device_file = parser.parse(repopath(self.device_to_file[item]))
+            device_file = parser.parse(self.mapping[item])
             for device in device_file.get_devices():
                 self[device.partname] = device
             return self[item]
@@ -262,18 +202,11 @@ def init(repo):
     repo.add_filter("modm.chr", lambda num: chr(num + ord("A")))
     repo.add_filter("modm.digsep", lambda num: f"{num:,}".replace(",", "'"))
 
-    # Compute the available data from modm-devices
-    devices = DevicesCache()
-    try:
-        devices.build()
-    except (modm_devices.ParserException) as e:
-        print(e)
-        exit(1)
-
+    # Add the target option with all available devices
     repo.add_option(
         TargetOption(name="target",
                      description=descr_target,
-                     enumeration=devices))
+                     enumeration=DevicesCache()))
 
 def prepare(repo, options):
     repo.add_modules_recursive("ext", modulefile="*.lb")

--- a/src/modm/board/nucleo_f722ze/board.xml
+++ b/src/modm/board/nucleo_f722ze/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32f722zet6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-f722ze</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_f722ze/module.lb
+++ b/src/modm/board/nucleo_f722ze/module.lb
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-f722ze"
+    module.description = """\
+# NUCLEO-F722ZE
+
+[Nucleo kit for STM32F722ZE](https://www.st.com/en/evaluation-tools/nucleo-f722ze.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32f722ze"):
+        return False
+
+    module.depends(
+        ":architecture:clock",
+        ":debug",
+        ":platform:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:uart:3")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy("../nucleo_f746zg/board.hpp", "board.hpp")
+    env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_f7.cfg");

--- a/src/modm/board/nucleo_f746zg/board.hpp
+++ b/src/modm/board/nucleo_f746zg/board.hpp
@@ -11,20 +11,19 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_STM32_NUCLEO_F746ZG_HPP
-#define MODM_STM32_NUCLEO_F746ZG_HPP
+#pragma once
 
 #include <modm/platform.hpp>
 #include <modm/architecture/interface/clock.hpp>
 #include <modm/debug/logger.hpp>
-/// @ingroup modm_board_nucleo_f746zg
+/// @ingroup modm_board_nucleo_f746zg modm_board_nucleo_f722ze
 #define MODM_BOARD_HAS_LOGGER
 
 using namespace modm::platform;
 
 namespace Board
 {
-/// @ingroup modm_board_nucleo_f746zg
+/// @ingroup modm_board_nucleo_f746zg modm_board_nucleo_f722ze
 /// @{
 using namespace modm::literals;
 
@@ -127,7 +126,7 @@ using Leds = SoftwareGpioPort< LedRed, LedBlue, LedGreen >;
 
 namespace stlink
 {
-/// @ingroup modm_board_nucleo_f746zg
+/// @ingroup modm_board_nucleo_f746zg modm_board_nucleo_f722ze
 /// @{
 using Tx = GpioOutputD8;
 using Rx = GpioInputD9;
@@ -135,27 +134,25 @@ using Uart = BufferedUart<UsartHal3, UartTxBuffer<2048>>;
 /// @}
 }
 
-/// @ingroup modm_board_nucleo_f746zg
+/// @ingroup modm_board_nucleo_f746zg modm_board_nucleo_f722ze
 /// @{
 using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
 
 inline void
 initialize()
 {
-    SystemClock::enable();
-    SysTickTimer::initialize<SystemClock>();
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
 
-    stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
-    stlink::Uart::initialize<SystemClock, 115200_Bd>();
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
 
-    LedGreen::setOutput(modm::Gpio::Low);
-    LedBlue::setOutput(modm::Gpio::Low);
-    LedRed::setOutput(modm::Gpio::Low);
+	LedGreen::setOutput(modm::Gpio::Low);
+	LedBlue::setOutput(modm::Gpio::Low);
+	LedRed::setOutput(modm::Gpio::Low);
 
-    Button::setInput();
+	Button::setInput();
 }
 /// @}
 
 }
-
-#endif  // MODM_STM32_NUCLEO_F746ZG_HPP

--- a/src/modm/board/nucleo_h743zi/board.hpp
+++ b/src/modm/board/nucleo_h743zi/board.hpp
@@ -132,16 +132,6 @@ struct SystemClock
 		Rcc::enablePll2(Rcc::PllSource::ExternalClock, pllFactors2);
 		Rcc::setCanClockSource(Rcc::CanClockSource::Pll2Q);
 
-		// Use PLL3 for USB 48MHz
-		const Rcc::PllFactors pllFactors3{
-			.range = Rcc::PllInputRange::MHz4_8,
-			.pllM = 2,		//   8MHz / M=   4MHz
-			.pllN = 60,		//   4MHz * N= 240MHz
-			.pllP = 5,		// 240MHz / P=  48MHz
-			.pllQ = 5,		// 240MHz / Q=  48MHz = F_usb
-			.pllR = 5,		// 240MHz / R=  48MHz
-		};
-		Rcc::enablePll3(Rcc::PllSource::ExternalClock, pllFactors3);
 		Rcc::setFlashLatency<Ahb>();
 		// max 240MHz on AHB
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div2);
@@ -152,9 +142,20 @@ struct SystemClock
 		Rcc::setApb4Prescaler(Rcc::Apb4Prescaler::Div2);
 		// update clock frequencies
 		Rcc::updateCoreFrequency<Hclk>();
-		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll3Q);
 		// Switch the main clock source to PLL
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
+
+		// Use PLL3 for USB 48MHz
+		const Rcc::PllFactors pllFactors3{
+			.range = Rcc::PllInputRange::MHz1_2,
+			.pllM = 4,		//   8MHz / M=   2MHz
+			.pllN = 120,	//   2MHz * N= 240MHz
+			.pllP = 5,		// 240MHz / P=  48MHz
+			.pllQ = 5,		// 240MHz / Q=  48MHz = F_usb
+			.pllR = 5,		// 240MHz / R=  48MHz
+		};
+		Rcc::enablePll3(Rcc::PllSource::ExternalClock, pllFactors3);
+		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll3Q);
 
 		return true;
 	}

--- a/src/modm/platform/core/cortex/linker.macros
+++ b/src/modm/platform/core/cortex/linker.macros
@@ -25,7 +25,7 @@ MEMORY
 	%% for memory in memories
 	{{ memory.name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
 	%% endfor
-	%% for memory in cont_ram_regions
+	%% for memory in (cont_flash_regions + cont_ram_regions)
 	%% if memory.cont_name != memory.name
 	{{ memory.cont_name | upper }} ({{ memory.access }}) : ORIGIN = {{ "0x%08X" % memory.start }}, LENGTH = {{ memory.size }}
 	%% endif
@@ -178,13 +178,13 @@ EXCEPTION_FRAME_SIZE = {{ exception_frame_size }};
 %% endmacro
 
 
-%% macro all_heap_sections(table_copy, table_zero, table_heap, props={})
+%% macro all_heap_sections(memory, table_copy, table_zero, table_heap, props={})
 	%% set ram_first_index = cont_ram["contains"][0]["index"]
 	%% for cont_region in cont_ram_regions
 		%% for region in cont_region.contains
 	/* Sections in {{ region.name|upper }} */
 			%% if region.index != ram_first_index
-{{ section_load(cont_region.cont_name|upper + " AT >FLASH", table_copy, sections=["data_"+region.name]) }}
+{{ section_load(cont_region.cont_name|upper + " AT >" + memory, table_copy, sections=["data_"+region.name]) }}
 				%% do table_zero.append("bss_"+region.name)
 			%% endif
 {{ section_heap(region.name|upper, "heap_"+region.name, cont_region.cont_name|upper,

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -97,43 +97,60 @@ def common_memories(env):
     flash_offset = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
     flash_reserved = env.get(":platform:cortex-m:linkerscript.flash_reserved", 0)
     for m in memories:
-        if m["name"] == "flash":
+        if m["name"] in ["flash", "flash1"]:
             m["start"] = int(m["start"], 0) + flash_offset
-            m["size"] = int(m["size"], 0) - flash_offset - flash_reserved
+            m["size"] = int(m["size"], 0) - flash_offset
+        elif m["name"] in ["flash2", "flash"]:
+            m["start"] = int(m["start"], 0)
+            m["size"] = int(m["size"], 0) - flash_reserved
         else:
             m["start"] = int(m["start"], 0)
             m["size"] = int(m["size"], 0)
+
+    memories.sort(key=lambda m: m["start"])
+    # Find all continuous memory sections
+    cont = []
+    index = 0
+    for m in memories:
+        if cont and (cont[-1]["start"] + cont[-1]["size"] == m["start"]):
+            cont[-1]["size"] += m["size"]
+            cont[-1]["contains"].append({**m, "index": index})
+            if not cont[-1]["cont_name"].startswith("cont_"):
+                cont[-1]["cont_name"] = "cont_" + cont[-1]["cont_name"]
+        else:
+            cont.append(dict(m))
+            cont[-1]["contains"] = [{**m, "index": index}]
+            cont[-1]["cont_name"] = cont[-1]["name"]
+        index += 1
+
+    cont_flash_regions = list(c for c in cont if "flash" in c["name"])
+    cont_flash = sorted(cont_flash_regions, key=lambda m: -m["size"])[0]
+    cont_flash_name = cont_flash["cont_name"] if len(cont_flash["contains"]) > 1 else cont_flash["name"]
+
+    ram_regions = list(sorted(m["name"] for m in memories if "ram" in m["name"]))
+    cont_ram_regions = list(c for c in cont if "ram" in c["name"] or "dtcm" in c["name"])
+    cont_ram = sorted(cont_ram_regions, key=lambda m: -m["size"])[0]
+    cont_ram_name = cont_ram["cont_name"] if len(cont_ram["contains"]) > 1 else cont_ram["name"]
 
     # Add reserved FLASH section to memories
     if flash_reserved:
         memories.append({
             "name": "flash_reserved",
             "access": "rx",
-            "start": next(m["start"] + m["size"] for m in memories if m["name"] == "flash"),
+            "start": next(m["start"] + m["size"] for m in memories if m["name"] in ["flash2", "flash1", "flash"]),
             "size": flash_reserved})
-
-    # Find all continuous internal SRAM sections
-    cont = []
-    index = 0
-    for m in memories:
-        if "ram" in m["name"] or "dtcm" in m["name"]:
-            if cont and (cont[-1]["start"] + cont[-1]["size"] == m["start"]):
-                cont[-1]["size"] += m["size"]
-                cont[-1]["contains"].append({**m, "index": index})
-                if not cont[-1]["cont_name"].startswith("cont_"):
-                    cont[-1]["cont_name"] = "cont_" + cont[-1]["cont_name"]
-            else:
-                cont.append(dict(m))
-                cont[-1]["contains"] = [{**m, "index": index}]
-                cont[-1]["cont_name"] = cont[-1]["name"]
-            index += 1
+        memories.sort(key=lambda m: m["start"])
 
     properties = {
         "memories": memories,
         "regions": [m["name"] for m in memories],
-        "ram_regions": list(sorted(m["name"] for m in memories if "ram" in m["name"])),
-        "cont_ram_regions": cont,
-        "cont_ram": sorted(cont, key=lambda m: -m["size"])[0],
+        "ram_regions": ram_regions,
+        "cont_flash_regions": cont_flash_regions,
+        "cont_flash": cont_flash,
+        "cont_flash_name": cont_flash_name.upper(),
+        "cont_ram_regions": cont_ram_regions,
+        "cont_ram": cont_ram,
+        "cont_ram_name": cont_ram_name.upper(),
     }
     return properties
 
@@ -304,6 +321,8 @@ def prepare(module, options):
 
     module.add_query(
         EnvironmentQuery(name="vector_table", factory=common_vector_table))
+    module.add_query(
+        EnvironmentQuery(name="memories", factory=common_memories))
     module.add_query(
         EnvironmentQuery(name="linkerscript", factory=common_linkerscript))
 

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -112,6 +112,7 @@ def common_memories(env):
     cont = []
     index = 0
     for m in memories:
+        if "alias" in m: continue
         if cont and (cont[-1]["start"] + cont[-1]["size"] == m["start"]):
             cont[-1]["size"] += m["size"]
             cont[-1]["contains"].append({**m, "index": index})
@@ -236,8 +237,8 @@ def prepare(module, options):
             maximum="64Ki",
             default="3Ki"))
 
-    core = options[":target"].get_driver("core")["type"]
-    if "m7" in core:
+    core = options[":target"].get_driver("core")
+    if "m7" in core["type"]:
         module.add_option(
             BooleanOption(
                 name="enable_icache",
@@ -249,7 +250,7 @@ def prepare(module, options):
                 description="Enable Data-Cache",
                 default=True))
 
-    if "f" in core:
+    if core.get("fpu"):
         module.add_option(
             EnumerationOption(
                 name="float-abi",
@@ -257,10 +258,10 @@ def prepare(module, options):
                 enumeration=["soft", "softfp", "hard"],
                 default="hard"))
 
-    memories = listify(options[":target"].get_driver("core")["memory"])
+    memories = listify(core["memory"])
 
     # Cortex-M0 does not have remappable vector table, so it will remain in Flash
-    if options[":target"].get_driver("core")["type"] != "cortex-m0":
+    if core["type"] != "cortex-m0":
         default_location = "rom"
         if any((m["name"] == "ccm" and "x" in m["access"]) or m["name"] == "dtcm" for m in memories):
             default_location = "ram"
@@ -447,20 +448,12 @@ def build(env):
             linkerscript if linkerscript else "modm/link/linkerscript.ld")))
 
     # Compilation for FPU
-    core = env[":target"].get_driver("core")["type"]
-    cpu = core.replace("fd", "").replace("f", "").replace("+", "plus")
-    env.collect(":build:archflags", "-mcpu={}".format(cpu), "-mthumb")
+    core = env[":target"].get_driver("core")
+    env.collect(":build:archflags", "-mcpu=" + core["type"], "-mthumb")
 
     single_precision = True
-    fpu = core.replace("cortex-m", "").replace("+", "")
-    if "f" in fpu:
-        fpu_spec = {
-            "4f": "-mfpu=fpv4-sp-d16",
-            "33f": "-mfpu=fpv4-sp-d16",
-            "7f": "-mfpu=fpv5-sp-d16",
-            "7fd": "-mfpu=fpv5-d16",
-        }[fpu]
-        env.collect(":build:archflags", "-mfloat-abi={}".format(env["float-abi"]), fpu_spec)
+    if (fpu_spec := core.get("fpu")):
+        env.collect(":build:archflags", "-mfloat-abi=" + env["float-abi"], "-mfpu=" + fpu_spec)
         single_precision = ("-sp-" in fpu_spec)
     if single_precision:
         env.collect(":build:ccflags", "-Wdouble-promotion")

--- a/src/modm/platform/core/cortex/module.md
+++ b/src/modm/platform/core/cortex/module.md
@@ -162,10 +162,11 @@ The following macros are available:
   `__{name}_end` will be the maximum of the location counter and the `memory`
   section end address, so that previous sections will push this section back.
 
-- `all_heap_sections(table_copy, table_zero, table_heap, props={})`: places the
-  heap sections as described by `cont_ram_regions` of the `linkerscript` query.
-  This also adds bss and noinit sections into each region. The `props` key can
-  be used to override the default `0x001f` memory properties.
+- `all_heap_sections(memory, table_copy, table_zero, table_heap, props={})`:
+  places the heap sections as described by `cont_ram_regions` of the
+  `linkerscript` query. This also adds bss and noinit sections into each
+  region. The `props` key can be used to override the default `0x001f` memory
+  properties.
 
 - `section_rom(memory)`: place all read-only sections (`.text`, `.rodata` etc)
   into `memory`.

--- a/src/modm/platform/core/cortex/ram.ld.in
+++ b/src/modm/platform/core/cortex/ram.ld.in
@@ -14,24 +14,24 @@ __stack_offset = ALIGN(MAIN_STACK_SIZE, (1 << LOG2CEIL({{ highest_irq + 16 }})) 
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
-{{ linker.section_vector_rom("FLASH") }}
+{{ linker.section_vector_rom(cont_flash_name) }}
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
-{{ linker.section_stack(cont_ram.cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
+{{ linker.section_stack(cont_ram_name, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram_name, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["fastdata", "fastcode", "data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap) }}
 
 %% if with_crashcatcher
     %#
@@ -45,9 +45,9 @@ SECTIONS
     %#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/core/rp/flash.ld.in
+++ b/src/modm/platform/core/rp/flash.ld.in
@@ -8,7 +8,7 @@
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
 	.boot2 :
 	{
@@ -27,19 +27,19 @@ SECTIONS
 		__vector_table_rom_end = .;
 	} > FLASH
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
 
 %% if vector_table_location == "ram"
 {{ linker.section_vector_ram("RAM", table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram_regions[0].cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
 					  sections_data=["fastdata", "fastcode", "data_" + cont_ram_regions[0].contains[0].name],
 					  sections_bss=["bss_" + cont_ram_regions[0].contains[0].name],
 					  sections_noinit=["faststack"]) }}
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap) }}
 
 %% if with_crashcatcher
 	%#
@@ -94,9 +94,9 @@ SECTIONS
 	%#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/core/stm32/dccm.ld.in
+++ b/src/modm/platform/core/stm32/dccm.ld.in
@@ -14,28 +14,28 @@ __stack_offset = ALIGN(MAIN_STACK_SIZE, (1 << LOG2CEIL({{ highest_irq + 16 }})) 
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
-{{ linker.section_vector_rom("FLASH") }}
+{{ linker.section_vector_rom(cont_flash_name) }}
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
-{{ linker.section_stack(cont_ram.cont_name|upper, "__stack_offset" if vector_table_location == "ram" else None) }}
+{{ linker.section_stack(cont_ram_name, "__stack_offset" if vector_table_location == "ram" else None) }}
 
 %% if vector_table_location == "ram"
-{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram_name, table_copy) }}
 %% endif
 
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["fastcode", "data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap) }}
 
 %% if "backup" in regions
 	/* Sections in memory region BACKUP */
-{{ linker.section_load("BACKUP AT >FLASH", table_copy, sections=["data_backup"]) }}
+{{ linker.section_load("BACKUP AT >" + cont_flash_name, table_copy, sections=["data_backup"]) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
@@ -43,7 +43,7 @@ SECTIONS
 %% endif
 
 	/* Sections in memory region CCM */
-{{ linker.section_load("CCM AT >FLASH", table_copy, sections=["fastdata", "data_ccm"]) }}
+{{ linker.section_load("CCM AT >" + cont_flash_name, table_copy, sections=["fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 	%% do table_heap.append({"name": "heap_ccm", "prop": "0x2002"})
@@ -60,9 +60,9 @@ SECTIONS
 	%#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/core/stm32/iccm.ld.in
+++ b/src/modm/platform/core/stm32/iccm.ld.in
@@ -9,20 +9,20 @@
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
-{{ linker.section_vector_rom("FLASH") }}
+{{ linker.section_vector_rom(cont_flash_name) }}
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
-{{ linker.section_stack(cont_ram.cont_name|upper) }}
+{{ linker.section_stack(cont_ram_name) }}
 
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap) }}
 %% if with_crashcatcher
 	%#
 	/* Bottom of crash stack for `modm:platform:fault` */
@@ -35,7 +35,7 @@ SECTIONS
 %% endif
 
 	/* Sections in memory region CCM */
-{{ linker.section_load("CCM AT >FLASH", table_copy, sections=["fastcode", "fastdata", "data_ccm"]) }}
+{{ linker.section_load("CCM AT >" + cont_flash_name, table_copy, sections=["fastcode", "fastdata", "data_ccm"]) }}
 
 {{ linker.section_heap("CCM", "heap_ccm", sections=["bss_ccm", "noinit_ccm"]) }}
 %% do table_heap.append({"name": "heap_ccm", "prop": "0x2006"})
@@ -46,9 +46,9 @@ SECTIONS
 	%#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/core/stm32/idtcm.ld.in
+++ b/src/modm/platform/core/stm32/idtcm.ld.in
@@ -9,24 +9,24 @@
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
-{{ linker.section_vector_rom("FLASH") }}
+{{ linker.section_vector_rom(cont_flash_name) }}
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
 %% if vector_table_location == "ram"
 {{ linker.section_vector_ram("ITCM", table_copy) }}
 %% endif
 
 	/* Sections in memory region ITCM */
-{{ linker.section_load("ITCM AT >FLASH", table_copy, sections=["fastcode", "data_itcm"]) }}
+{{ linker.section_load("ITCM AT >" + cont_flash_name, table_copy, sections=["fastcode", "data_itcm"]) }}
 
 {{ linker.section_heap("ITCM", "heap_itcm", sections=["noinit_itcm"]) }}
 %% do table_heap.append({"name": "heap_itcm", "prop": "0x2005"})
 
-%% if cont_ram_regions[0].cont_name == "cont_dtcm"
-%% set dtcm_section = "CONT_DTCM"
+%% if "DTCM" in cont_ram_name
+%% set dtcm_section = cont_ram_name
 %% else
 %% set dtcm_section = "DTCM"
 %% endif
@@ -34,23 +34,23 @@ SECTIONS
 %% if stack_in_dtcm
 {{ linker.section_stack(dtcm_section) }}
 %% else
-{{ linker.section_stack(cont_ram.cont_name|upper) }}
+{{ linker.section_stack(cont_ram_name) }}
 %% endif
 
 %% if "dtcm" in cont_ram.cont_name
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["fastdata", "data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 %% else
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
-{{ linker.section_load(dtcm_section + " AT >FLASH", table_copy, sections=["fastdata"]) }}
+{{ linker.section_load(dtcm_section + " AT >" + cont_flash_name, table_copy, sections=["fastdata"]) }}
 %% endif
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap, props={"dtcm": "0x2023" if target.family == "h7" else "0x202b"}) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap, props={"dtcm": "0x2023" if target.family == "h7" else "0x202b"}) }}
 %% if with_crashcatcher
 	%#
 	/* Bottom of crash stack for `modm:platform:fault` */
@@ -60,7 +60,7 @@ SECTIONS
 
 %% if "backup" in regions
 	/* Sections in memory region BACKUP */
-{{ linker.section_load("BACKUP AT >FLASH", table_copy, sections=["data_backup"]) }}
+{{ linker.section_load("BACKUP AT >" + cont_flash_name, table_copy, sections=["data_backup"]) }}
 
 {{ linker.section_heap("BACKUP", "heap_backup", sections=["bss_backup", "noinit_backup"]) }}
 	%% do table_heap.append({"name": "heap_backup", "prop": "0x4009"})
@@ -72,9 +72,9 @@ SECTIONS
 	%#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/core/stm32/ram_remap_vector_table.ld.in
+++ b/src/modm/platform/core/stm32/ram_remap_vector_table.ld.in
@@ -8,22 +8,22 @@
 
 SECTIONS
 {
-{{ linker.section_rom_start("FLASH") }}
+{{ linker.section_rom_start(cont_flash_name) }}
 
-{{ linker.section_vector_rom("FLASH") }}
+{{ linker.section_vector_rom(cont_flash_name) }}
 
-{{ linker.section_rom("FLASH") }}
+{{ linker.section_rom(cont_flash_name) }}
 
-{{ linker.section_vector_ram(cont_ram.cont_name|upper, table_copy) }}
+{{ linker.section_vector_ram(cont_ram_name, table_copy) }}
 
-{{ linker.section_stack(cont_ram.cont_name|upper) }}
+{{ linker.section_stack(cont_ram_name) }}
 
-{{ linker.section_ram(cont_ram.cont_name|upper, "FLASH", table_copy, table_zero,
+{{ linker.section_ram(cont_ram_name, cont_flash_name, table_copy, table_zero,
                       sections_data=["fastdata", "fastcode", "data_" + cont_ram.contains[0].name],
                       sections_bss=["bss_" + cont_ram.contains[0].name],
                       sections_noinit=["faststack"]) }}
 
-{{ linker.all_heap_sections(table_copy, table_zero, table_heap) }}
+{{ linker.all_heap_sections(cont_flash_name, table_copy, table_zero, table_heap) }}
 
 %% if with_crashcatcher
     %#
@@ -37,9 +37,9 @@ SECTIONS
     %#
 %% endif
 
-{{ linker.section_tables("FLASH", table_copy, table_zero, table_heap) }}
+{{ linker.section_tables(cont_flash_name, table_copy, table_zero, table_heap) }}
 
-{{ linker.section_rom_end("FLASH") }}
+{{ linker.section_rom_end(cont_flash_name) }}
 
 {{ linker.section_debug() }}
 }

--- a/src/modm/platform/flash/stm32/module.lb
+++ b/src/modm/platform/flash/stm32/module.lb
@@ -28,8 +28,7 @@ def prepare(module, options):
 
 def build(env):
     target = env[":target"].identifier
-    memories = listify(env[":target"].get_driver("core")["memory"])
-    flash = next(filter(lambda m: m["name"] == "flash", memories))
+    flash = env.query(":platform:cortex-m:memories")["cont_flash"]
 
     dual_bank = False
     family = target.family
@@ -56,8 +55,8 @@ def build(env):
             block_shift = "(FLASH->OPTR & FLASH_OPTR_DBANK ? 11 : 12)"
 
     env.substitutions = {
-        "start": int(flash["start"], 16),
-        "size": int(flash["size"]),
+        "start": flash["start"],
+        "size": flash["size"],
         "type": ftype,
         "shift": block_shift,
         "has_sectors": ftype == "sector",

--- a/test/all/ignored.txt
+++ b/test/all/ignored.txt
@@ -114,3 +114,8 @@ stm32h757
 # These are incompatible with the previous H7 series
 stm32h7r
 stm32h7s
+# Undocumented and inconsistent header and device file
+stm32g411
+stm32g414
+# Not implemented
+rp2350

--- a/tools/devices/db.json
+++ b/tools/devices/db.json
@@ -1,0 +1,7 @@
+{
+    "hosted-darwin": "hosted/darwin-x86_64.xml",
+    "hosted-darwin-arm64": "hosted/darwin-arm64.xml",
+    "hosted-linux": "hosted/linux-x86_64.xml",
+    "hosted-linux-arm64": "hosted/linux-arm64.xml",
+    "hosted-windows": "hosted/windows.xml"
+}


### PR DESCRIPTION
Depends on https://github.com/modm-io/modm-devices/pull/124.

- [x] Tested changed linkerscripts in hardware:
  - [x] Dual bank flash targets
  - [x] Check that STM32F7 ITCM_FLASH alias vs FLASH is still working correctly.
- [x] compile-all passes