### PR TITLE
Add STM32U0 support

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -556,6 +556,32 @@ jobs:
           name: stm32l5-compile-all
           path: test/all/log
 
+  stm32u0-compile-all:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
+      - name: Compile HAL for all STM32U0
+        run: |
+          (cd test/all && python3 run_all.py stm32u0 --quick-remaining)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stm32u0-compile-all
+          path: test/all/log
+
   stm32u5-compile-all-1:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,6 +179,10 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py nucleo_l552ze-q)
+      - name: Examples STM32U0 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_u083rc)
       - name: Examples STM32U5 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -770,29 +770,30 @@ We have out-of-box support for many development boards including documentation.
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 
 ## Microcontrollers
 
-modm can create a HAL for <!--allcount-->3888<!--/allcount--> devices of these vendors:
+modm can create a HAL for <!--allcount-->3936<!--/allcount--> devices of these vendors:
 
-- STMicroelectronics STM32: <!--stmcount-->3144<!--/stmcount--> devices.
+- STMicroelectronics STM32: <!--stmcount-->3192<!--/stmcount--> devices.
 - Microchip SAM: <!--samcount-->355<!--/samcount--> devices.
 - Microchip AVR: <!--avrcount-->388<!--/avrcount--> devices.
 - Raspberry Pi: <!--rpicount-->1<!--/rpicount--> device.
@@ -104,7 +104,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <table>
 <tr>
 <th align="center"></th>
-<th align="center" colspan="16">STM32</th>
+<th align="center" colspan="17">STM32</th>
 <th align="center" colspan="4">SAM</th>
 <th align="center" colspan="1">RP</th>
 <th align="center" colspan="3">AT</th>
@@ -125,6 +125,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center">L1</th>
 <th align="center">L4</th>
 <th align="center">L5</th>
+<th align="center">U0</th>
 <th align="center">U5</th>
 <th align="center">D1x<br/>D2x<br/>DAx</th>
 <th align="center">D5x<br/>E5x</th>
@@ -154,6 +155,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -177,6 +179,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -207,6 +210,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -215,6 +219,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 </tr><tr>
 <td align="left">DAC</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -258,6 +263,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✅</td>
@@ -283,6 +289,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✕</td>
@@ -292,6 +299,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">External Interrupt</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -333,6 +341,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -344,6 +353,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">GPIO</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -385,6 +395,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -416,12 +427,14 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">IWDG</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -464,6 +477,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -477,6 +491,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -515,6 +530,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -547,11 +563,13 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">○</td>
-<td align="center">○</td>
-<td align="center">○</td>
+<td align="center">✅</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
 </tr><tr>
 <td align="left">Timer</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -601,9 +619,11 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 </tr><tr>
 <td align="left">Unique ID</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -630,6 +650,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">USB</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>

--- a/examples/nucleo_u083rc/blink/main.cpp
+++ b/examples/nucleo_u083rc/blink/main.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	for (const auto [traits, start, end, size] : modm::platform::HeapTable())
+	{
+		MODM_LOG_INFO.printf("Memory section %#x @[0x%p,0x%p](%u)\n",
+							 traits.value, start, end, size);
+	}
+
+	uint32_t counter(0);
+	modm::ShortTimeout tmr;
+
+	while (true)
+	{
+		Leds::write(1 << (counter % (Leds::width+1) ));
+		// modm::delay(Button::read() ? 100ms : 500ms);
+		tmr.restart(Button::read() ? 100ms : 500ms);
+		while(not tmr.execute()) ;
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_u083rc/blink/project.xml
+++ b/examples/nucleo_u083rc/blink/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-u083rc</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_u083rc/blink</option>
+  </options>
+  <modules>
+    <module>modm:architecture:memory</module>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -103,7 +103,7 @@ def build(env):
     if target.platform == "stm32":
         tusb_config["CFG_TUSB_MCU"] = f"OPT_MCU_STM32{target.family.upper()}"
         # TODO: use modm-devices driver type for this
-        fs_dev = (target.family in ["f0", "f3", "l0", "g0", "g4", "h5"] or
+        fs_dev = (target.family in ["f0", "f3", "l0", "g0", "g4", "h5", "u0"] or
                  (target.family == "f1" and target.name <= "03"))
         if fs_dev:
             # PMA buffer size: 512B or 1024B

--- a/repo.lb
+++ b/repo.lb
@@ -80,7 +80,7 @@ class DevicesCache(dict):
             "stm32g0", "stm32g4",
             "stm32h5", "stm32h7",
             "stm32l0", "stm32l1", "stm32l4", "stm32l5",
-            "stm32u5",
+            "stm32u0", "stm32u5",
         )
         # Load and filter the device prefixes
         modm_db = json.loads((modm_devices / "db.json").read_text())

--- a/src/modm/board/nucleo_h503rb/board.hpp
+++ b/src/modm/board/nucleo_h503rb/board.hpp
@@ -96,8 +96,8 @@ struct SystemClock
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableExternalCrystal();
+		Rcc::enableLseCrystal();
+		Rcc::enableHseCrystal();
 
 		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
 		Rcc::setFlashLatency<Frequency>();
@@ -113,11 +113,10 @@ struct SystemClock
 		Rcc::updateCoreFrequency<Frequency>();
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
-		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll2Q);
 
 		return true;
 	}
-
 };
 
 using A0 = GpioA0;

--- a/src/modm/board/nucleo_h503rb/module.lb
+++ b/src/modm/board/nucleo_h503rb/module.lb
@@ -41,5 +41,4 @@ def build(env):
     }
     env.template("../board.cpp.in", "board.cpp")
     env.copy(".")
-    env.outbasepath = "modm/openocd/modm/board/"
     env.collect(":build:openocd.source", "board/st_nucleo_h5.cfg")

--- a/src/modm/board/nucleo_u083rc/board.hpp
+++ b/src/modm/board/nucleo_u083rc/board.hpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_u083rc
+#define MODM_BOARD_HAS_LOGGER
+
+namespace Board
+{
+/// @ingroup modm_board_nucleo_u083rc
+/// @{
+using namespace modm::literals;
+
+/// STM32U083RC running at 56MHz from PLL clock generated from internal HSI
+struct SystemClock
+{
+	static constexpr uint32_t Hsi = Rcc::HsiFrequency;
+
+	static constexpr Rcc::PllConfig pll
+	{
+		.M = 2,  //  16 MHz /  2 =   8 MHz
+		.N = 42, //   8 MHz * 42 = 336 MHz
+		.Q = 7,  // 336 MHz /  7 =  48 MHz = F_usb
+		.R = 6,  // 336 MHz /  6 =  56 MHz = F_cpu
+	};
+	static constexpr uint32_t PllQ = Hsi / pll.M * pll.N / pll.Q;
+	static constexpr uint32_t PllR = Hsi / pll.M * pll.N / pll.R;
+	static_assert(PllR == Rcc::MaxFrequency);
+
+	static constexpr uint32_t SysClk = PllR;
+	static constexpr uint32_t Frequency = SysClk;
+
+	// Max 56MHz
+	static constexpr uint32_t Hclk = SysClk / 1;
+	static constexpr uint32_t Ahb = Hclk;
+	static constexpr uint32_t Apb = Hclk / 1;
+
+	// AHB Peripherals
+	static constexpr uint32_t Dma1 = Ahb;
+	static constexpr uint32_t Dma2 = Ahb;
+	static constexpr uint32_t DmaMux = Ahb;
+	static constexpr uint32_t Exti = Ahb;
+	static constexpr uint32_t Flash = Ahb;
+	static constexpr uint32_t Crc = Ahb;
+	static constexpr uint32_t Tsc = Ahb;
+	static constexpr uint32_t Rng = Ahb;
+	static constexpr uint32_t Aes = Ahb;
+
+	// APB Peripherals
+	static constexpr uint32_t Lcd = Apb;
+	static constexpr uint32_t Wwdg = Apb;
+	static constexpr uint32_t Spi1 = Apb;
+	static constexpr uint32_t Spi2 = Apb;
+	static constexpr uint32_t Spi3 = Apb;
+	static constexpr uint32_t Usart1 = Apb;
+	static constexpr uint32_t Usart2 = Apb;
+	static constexpr uint32_t Usart3 = Apb;
+	static constexpr uint32_t Usart4 = Apb;
+	static constexpr uint32_t I2c1 = Apb;
+	static constexpr uint32_t I2c2 = Apb;
+	static constexpr uint32_t I2c3 = Apb;
+	static constexpr uint32_t I2c4 = Apb;
+	static constexpr uint32_t Dac1 = Apb;
+	static constexpr uint32_t Opamp1 = Apb;
+	static constexpr uint32_t LpTimer1 = Apb;
+	static constexpr uint32_t LpTimer2 = Apb;
+	static constexpr uint32_t LpTimer3 = Apb;
+	static constexpr uint32_t LpUart1 = Apb;
+	static constexpr uint32_t LpUart2 = Apb;
+	static constexpr uint32_t LpUart3 = Apb;
+	static constexpr uint32_t Adc1 = Apb;
+
+	// Timer Clocks
+	static constexpr uint32_t ApbTimer = Apb * 1;
+	static constexpr uint32_t Timer1 = ApbTimer;
+	static constexpr uint32_t Timer2 = ApbTimer;
+	static constexpr uint32_t Timer3 = ApbTimer;
+	static constexpr uint32_t Timer6 = ApbTimer;
+	static constexpr uint32_t Timer7 = ApbTimer;
+	static constexpr uint32_t Timer15 = ApbTimer;
+	static constexpr uint32_t Timer16 = ApbTimer;
+
+	static constexpr uint32_t Usb = PllQ;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLseCrystal();
+		Rcc::enableHsi();
+
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Range1);
+		Rcc::setFlashLatency<Frequency>();
+
+		Rcc::enablePll(Rcc::PllSource::Hsi16, pll);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div1);
+
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::PllR);
+		Rcc::setClock48Source(Rcc::Clock48Source::PllQ);
+
+		return true;
+	}
+};
+
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioA2;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+
+// using D0  = GpioA3; // used for logging
+// using D1  = GpioA2;
+using D2  = GpioA10;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB10;
+using D7  = GpioA8;
+using D8  = GpioA9;
+using D9  = GpioC7;
+using D10 = GpioB6;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB9;
+using D15 = GpioB8;
+
+using Button = GpioInverted<GpioInputC13>;
+
+using Led = GpioOutputA5;
+using Leds = SoftwareGpioPort< Led >;
+/// @}
+
+namespace stlink
+{
+/// @ingroup modm_board_nucleo_u083rc
+/// @{
+using Tx = GpioOutputA2;
+using Rx = GpioInputA3;
+using Uart = BufferedUart<UsartHal2, UartTxBuffer<2048>>;
+/// @}
+}
+
+/// @ingroup modm_board_nucleo_u083rc
+/// @{
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Led::setOutput(modm::Gpio::Low);
+	Button::setInput(Gpio::InputType::PullUp);
+}
+/// @}
+
+}

--- a/src/modm/board/nucleo_u083rc/board.xml
+++ b/src/modm/board/nucleo_u083rc/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32u083rct6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-u083rc</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_u083rc/module.lb
+++ b/src/modm/board/nucleo_u083rc/module.lb
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-u083rc"
+    module.description = """
+# NUCLEO-U083RC
+
+[Nucleo kit for STM32U083RC](https://www.st.com/en/evaluation-tools/nucleo-u083rc.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32u083rct"):
+        return False
+
+    module.depends(
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:2",
+        ":debug")
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy('.')
+    env.collect(":build:openocd.source", "board/st/nucleo-u083rc.cfg")

--- a/src/modm/board/weact_h503cb/board.hpp.in
+++ b/src/modm/board/weact_h503cb/board.hpp.in
@@ -98,8 +98,8 @@ struct SystemClock
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableExternalCrystal();
+		Rcc::enableLseCrystal();
+		Rcc::enableHseCrystal();
 
 		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
 		Rcc::setFlashLatency<Frequency>();
@@ -115,11 +115,10 @@ struct SystemClock
 		Rcc::updateCoreFrequency<Frequency>();
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
-		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll2Q);
 
 		return true;
 	}
-
 };
 
 using Button = GpioInverted<GpioInputA0>;

--- a/src/modm/board/weact_h562rg/board.hpp.in
+++ b/src/modm/board/weact_h562rg/board.hpp.in
@@ -137,8 +137,8 @@ struct SystemClock
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableExternalCrystal();
+		Rcc::enableLseCrystal();
+		Rcc::enableHseCrystal();
 
 		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
 		Rcc::setFlashLatency<Frequency>();
@@ -154,11 +154,10 @@ struct SystemClock
 		Rcc::updateCoreFrequency<Frequency>();
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
-		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll3Q);
+		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll3Q);
 
 		return true;
 	}
-
 };
 
 using Button = GpioInputC13;

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -40,24 +40,21 @@ def build(env):
     elif t.family in ["f0", "f1", "f3"]:
         p["hsi_frequency"] = 8_000_000
         p["lsi_frequency"] = 40_000
-        p["boot_frequency"] = p["hsi_frequency"]
     elif t.family in ["h5", "h7"]:
         p["hsi_frequency"] = 64_000_000
         p["lsi_frequency"] = 32_000
-        p["boot_frequency"] = p["hsi_frequency"]
     elif t.family in ["l0", "l1"]:
         p["hsi_frequency"] = 16_000_000
         p["lsi_frequency"] = 37_000
-        p["msi_frequency"] = 2_097_000
-        p["boot_frequency"] = p["msi_frequency"]
+        p["msi_frequency"] = p["boot_frequency"] = 2_097_000
     elif t.family in ["l5"]:
         p["hsi_frequency"] = 16_000_000
         p["lsi_frequency"] = 32_000
-        p["msi_frequency"] = 4_000_000
-        p["boot_frequency"] = p["msi_frequency"]
+        p["msi_frequency"] = p["boot_frequency"] = 4_000_000
     else:
         p["hsi_frequency"] = 16_000_000
         p["lsi_frequency"] = 32_000
+    if "boot_frequency" not in p:
         p["boot_frequency"] = p["hsi_frequency"]
 
     # TODO: Move this data into the device files
@@ -142,14 +139,21 @@ def build(env):
     env.substitutions = p
     env.outbasepath = "modm/src/modm/platform/clock"
 
-    if t.family in ["h5"]:
-        uart_ids = device.get_driver("usart")["instance"]
-        if device.has_driver("uart"):
-            uart_ids += device.get_driver("uart")["instance"]
-        p["uart_ids"] = list(map(int, uart_ids))
-        p["spi_ids"] = list(map(int, device.get_driver("spi")["instance"]))
-        p["i2c_ids"] = list(map(int, device.get_driver("i2c")["instance"]))
-        env.template("rcc_h5.hpp.in", "rcc.hpp")
+    def instances(*drivers):
+        ids = []
+        for driver in drivers:
+            if device.has_driver(driver):
+                ids += device.get_driver(driver)["instance"]
+        return list(map(int, ids))
+
+    if t.family in ["h5", "u0"]:
+        p["uart_ids"] = instances("usart", "uart")
+        p["lpuart_ids"] = instances("lpuart")
+        p["spi_ids"] = instances("spi")
+        p["i2c_ids"] = instances("i2c")
+        p["tim_ids"] = instances("tim")
+        p["lptim_ids"] = instances("lptim")
+        env.template(f"rcc_{t.family}.hpp.in", "rcc.hpp")
     else:
         env.template("rcc.hpp.in")
         env.template("rcc.cpp.in")

--- a/src/modm/platform/clock/stm32/rcc_h5.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_h5.hpp.in
@@ -1,9 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Sascha Schade
- * Copyright (c) 2012, 2017, Fabian Greif
- * Copyright (c) 2012, 2014-2017, 2025, Niklas Hauser
- * Copyright (c) 2013-2014, Kevin Läufer
- * Copyright (c) 2018, 2021-2022, Christopher Durand
+ * Copyright (c) 2026, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -13,8 +9,7 @@
  */
 // ----------------------------------------------------------------------------
 
-#ifndef MODM_STM32_RCC_HPP
-#define MODM_STM32_RCC_HPP
+#pragma once
 
 #include <cstdint>
 #include "../device.hpp"
@@ -26,7 +21,7 @@ namespace modm::platform
 {
 
 /**
- * Reset and Clock Control for STM32 devices.
+ * Reset and Clock Control for STM32H5 devices.
  *
  * This class abstracts access to clock settings on the STM32.
  * You need to use this class to enable internal and external clock
@@ -40,9 +35,9 @@ class Rcc
 {
 public:
 	static constexpr uint32_t CsiFrequency = 4'000'000;
-	static constexpr uint32_t LsiFrequency = {{ lsi_frequency | modm.digsep }};
-	static constexpr uint32_t HsiFrequency = {{ hsi_frequency | modm.digsep }};
-	static constexpr uint32_t BootFrequency = {{ boot_frequency | modm.digsep }};
+	static constexpr uint32_t LsiFrequency = 32'000;
+	static constexpr uint32_t HsiFrequency = 64'000'000;
+	static constexpr uint32_t BootFrequency = HsiFrequency;
 	static constexpr uint32_t MaxFrequency = {{ max_frequency | modm.digsep }};
 
 	/// Connect GPIO signals like MCO to the clock tree
@@ -92,92 +87,76 @@ public:
 public:
 	// clock sources
 	static inline bool
-	enableInternalClock(uint32_t waitCycles = 0x10000)
+	enableHsi(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->CR |= RCC_CR_HSION;
-		while (not (retval = (RCC->CR & RCC_CR_HSIRDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	static inline bool
-	enableInternalClockMHz4(uint32_t waitCycles = 0x10000)
+	enableCsi(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->CR |= RCC_CR_CSION;
-		while (not (retval = (RCC->CR & RCC_CR_CSIRDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->CR & RCC_CR_CSIRDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	static inline bool
-	enableInternalClockMHz48(uint32_t waitCycles = 0x10000)
+	enableHsi48(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->CR |= RCC_CR_HSI48ON;
-		while (not (retval = (RCC->CR & RCC_CR_HSI48RDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->CR & RCC_CR_HSI48RDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	static inline bool
-	enableExternalClock(uint32_t waitCycles = 0x10000)
+	enableHseClock(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
-		while (not (retval = (RCC->CR & RCC_CR_HSERDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	static inline bool
-	enableExternalCrystal(uint32_t waitCycles = 0x10000)
+	enableHseCrystal(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
-		while (not (retval = (RCC->CR & RCC_CR_HSERDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	static inline bool
-	enableLowSpeedInternalClock(uint32_t waitCycles = 0x10000)
+	enableLsi(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->BDCR |= RCC_BDCR_LSION;
-		while (not (retval = (RCC->BDCR & RCC_BDCR_LSIRDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->BDCR & RCC_BDCR_LSIRDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
-	static bool
-	enableLowSpeedExternalClock(uint32_t waitCycles = 0x10000)
+	static inline bool
+	enableLseClock(uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
 		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
-		while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
-			;
-		return retval;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	enum class
-	LseDrive : uint32_t
+	LseDrive : uint8_t
 	{
-		Low        = 0b00 << RCC_BDCR_LSEDRV_Pos,
-		MediumLow  = 0b01 << RCC_BDCR_LSEDRV_Pos,
-		MediumHigh = 0b10 << RCC_BDCR_LSEDRV_Pos,
-		High       = 0b11 << RCC_BDCR_LSEDRV_Pos,
+		Low        = 0b00,
+		MediumLow  = 0b01,
+		MediumHigh = 0b10,
+		High       = 0b11,
 	};
-	static bool
-	enableLowSpeedExternalCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
+	static inline bool
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
 	{
-		bool retval;
-		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) | uint32_t(drive);
-		RCC->BDCR |= RCC_BDCR_LSEON;
-		while (not (retval = (RCC->BDCR & RCC_BDCR_LSERDY)) and --waitCycles)
-			;
-		return retval;
+		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) |
+					(uint32_t(drive) << RCC_BDCR_LSEDRV_Pos) | RCC_BDCR_LSEON;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	// clock modifiers
@@ -206,15 +185,15 @@ public:
 	struct PllConfig
 	{
 		PllInputRange range;
-		uint8_t M;
-		uint16_t N;
-		uint8_t P = 0xff;
-		uint8_t Q = 0xff;
-		uint8_t R = 0xff;
-		uint8_t Frac = 0;
+		uint8_t M; ///< Div
+		uint16_t N; ///< Mul 4-512
+		uint8_t P = 0; ///< Div 1-128, must be even for PLL1
+		uint8_t Q = 0; ///< Div 1-128
+		uint8_t R = 0; ///< Div 1-128
+		uint16_t Frac = 0; ///< Mul 0 - 8191
 		PllVcoRange vcoRange = PllVcoRange::Wide;
 	};
-
+%#
 %% set pll_ids = ([1,2] if target.name == "03" else [1,2,3])
 %% for id in pll_ids
 	/// Configure and enable PLL{{id}}
@@ -237,7 +216,7 @@ public:
 		// VCO range
 		cfgr |= (uint32_t(cfg.vcoRange) << RCC_PLL{{id}}CFGR_PLL{{id}}VCOSEL_Pos);
 		// Set PLL fractional value
-		if (cfg.Frac != 0)
+		if (cfg.Frac)
 		{
 			RCC->PLL{{id}}FRACR = uint32_t(cfg.Frac) << RCC_PLL{{id}}FRACR_PLL{{id}}FRACN_Pos;
 			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}FRACEN;
@@ -245,17 +224,17 @@ public:
 
 		// Set all dividers
 		uint32_t divr{(uint32_t(cfg.N - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}N_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}N};
-		if (cfg.R != 0xff)
+		if (cfg.R)
 		{
 			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}REN;
 			divr |= ((uint32_t(cfg.R - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}R_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}R);
 		}
-		if (cfg.Q != 0xff)
+		if (cfg.Q)
 		{
 			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}QEN;
 			divr |= ((uint32_t(cfg.Q - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}Q_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}Q);
 		}
-		if (cfg.P != 0xff)
+		if (cfg.P)
 		{
 			cfgr |= RCC_PLL{{id}}CFGR_PLL{{id}}PEN;
 			divr |= ((uint32_t(cfg.P - 1u) << RCC_PLL{{id}}DIVR_PLL{{id}}P_Pos) & RCC_PLL{{id}}DIVR_PLL{{id}}P);
@@ -266,11 +245,8 @@ public:
 		RCC->PLL{{id}}DIVR = divr;
 		RCC->CR |= RCC_CR_PLL{{id}}ON;
 
-		uint32_t tmp;
-		while (not (tmp = (RCC->CR & RCC_CR_PLL{{id}}RDY)) and --waitCycles)
-			;
-
-		return tmp;
+		while (not (RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	/// Disable PLL{{id}}.
@@ -278,15 +254,13 @@ public:
 	disablePll{{id}}(uint32_t waitCycles = 0x10000)
 	{
 		RCC->CR &= ~RCC_CR_PLL{{id}}ON;
-		while ((RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles)
-			;
+		while ((RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles) ;
 		RCC->PLL{{id}}CFGR = 0;
 		RCC->PLL{{id}}DIVR = 0;
-		return waitCycles > 0;
+		return waitCycles;
 	}
-
-%% endfor
 %#
+%% endfor
 	enum class
 	AhbPrescaler : uint8_t
 	{
@@ -300,12 +274,10 @@ public:
 		Div256 = 0b1110,
 		Div512 = 0b1111,
 	};
-	static inline bool
+	static inline void
 	setAhbPrescaler(AhbPrescaler prescaler)
 	{
-		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_HPRE) |
-					 (uint32_t(prescaler) << RCC_CFGR2_HPRE_Pos);
-		return true;
+		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_HPRE) | (uint32_t(prescaler) << RCC_CFGR2_HPRE_Pos);
 	}
 
 	enum class
@@ -318,12 +290,10 @@ public:
 		Div16  = 0b111
 	};
 %% for id in [1,2,3]
-	static inline bool
+	static inline void
 	setApb{{id}}Prescaler(ApbPrescaler prescaler)
 	{
-		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_PPRE{{id}}) |
-					 (uint32_t(prescaler) << RCC_CFGR2_PPRE{{id}}_Pos);
-		return true;
+		RCC->CFGR2 = (RCC->CFGR2 & ~RCC_CFGR2_PPRE{{id}}) | (uint32_t(prescaler) << RCC_CFGR2_PPRE{{id}}_Pos);
 	}
 %% endfor
 %#
@@ -335,21 +305,14 @@ public:
 		Csi = 0b01,
 		Hse = 0b10,
 		Pll1P = 0b11,
-
-		InternalClock = Hsi,
-		ExternalClock = Hse,
-		ExternalCrystal = Hse,
 	};
 	static inline bool
 	enableSystemClock(SystemClockSource src, uint32_t waitCycles = 0x10000)
 	{
 		RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW) | uint32_t(src);
-
 		// Wait till the main PLL is used as system clock source
-		while ((RCC->CFGR1 & RCC_CFGR1_SWS) != (uint32_t(src) << RCC_CFGR1_SWS_Pos))
-			if (not --waitCycles) return false;
-
-		return true;
+		while ((RCC->CFGR1 & RCC_CFGR1_SWS) != (uint32_t(src) << RCC_CFGR1_SWS_Pos) and --waitCycles) ;
+		return waitCycles;
 	}
 
 	enum class
@@ -359,13 +322,8 @@ public:
 		Lse = 0b01 << RCC_BDCR_RTCSEL_Pos,
 		Lsi = 0b10 << RCC_BDCR_RTCSEL_Pos,
 		Hse = 0b11 << RCC_BDCR_RTCSEL_Pos,
-
-		ExternalClock = Hse,
-		ExternalCrystal = Hse,
-		LowSpeedInternalClock = Lsi,
-		LowSpeedExternalClock = Lse,
-		LowSpeedExternalCrystal = Lse
 	};
+	/// @param hseDiv Division factor for HSE to get ≤1MHz clock for RTC: range 2-63
 	static inline bool
 	enableRealTimeClock(RealTimeClockSource src, uint8_t hseDiv = 0xff)
 	{
@@ -373,15 +331,6 @@ public:
 		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
 		return true;
 	}
-
-	enum class
-	WatchdogClockSource : uint32_t
-	{
-		LowSpeedInternalClock = 0
-	};
-	static inline bool
-	enableWatchdogClock(WatchdogClockSource /*src*/ = WatchdogClockSource::LowSpeedInternalClock)
-	{ return true; }
 
 	// CCIPR1
 	enum class
@@ -400,7 +349,7 @@ public:
 	%% set s = "s" if id in [1,2,3,6,10,11] else ""
 	%% set c = 2 if id in [11,12] else 1
 	static inline void
-	enableU{{s}}art{{id}}ClockSource(UartClockSource src)
+	setU{{s}}art{{id}}ClockSource(UartClockSource src)
 	{
 		RCC->CCIPR{{c}} = (RCC->CCIPR{{c}} & ~RCC_CCIPR{{c}}_U{{s|upper}}ART{{id}}SEL) |
 					  (uint32_t(src) << RCC_CCIPR{{c}}_U{{s|upper}}ART{{id}}SEL_Pos);
@@ -421,10 +370,9 @@ public:
 		Lse   = 0b101
 	};
 	static inline void
-	enableLpUart1ClockSource(LpUartClockSource src)
+	setLpUart1ClockSource(LpUartClockSource src)
 	{
-		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_LPUART1SEL) |
-					  (uint32_t(src) << RCC_CCIPR3_LPUART1SEL_Pos);
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_LPUART1SEL) | (uint32_t(src) << RCC_CCIPR3_LPUART1SEL_Pos);
 	}
 
 	enum class
@@ -440,10 +388,9 @@ public:
 	};
 %% for id in spi_ids | sort if id in [1,2,3]
 	static inline void
-	enableSpi{{id}}ClockSource(Spi123ClockSource src)
+	setSpi{{id}}ClockSource(Spi123ClockSource src)
 	{
-		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) |
-					  (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) | (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
 	}
 %% endfor
 %% if target.name != "03"
@@ -459,10 +406,9 @@ public:
 	};
 %% for id in spi_ids | sort if id in [1,2,3]
 	static inline void
-	enableSpi{{id}}ClockSource(Spi456ClockSource src)
+	setSpi{{id}}ClockSource(Spi456ClockSource src)
 	{
-		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) |
-					  (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
+		RCC->CCIPR3 = (RCC->CCIPR3 & ~RCC_CCIPR3_SPI{{id}}SEL) | (uint32_t(src) << RCC_CCIPR3_SPI{{id}}SEL_Pos);
 	}
 %% endfor
 %% endif
@@ -478,10 +424,9 @@ public:
 	};
 %% for id in i2c_ids | sort
 	static inline void
-	enableI2c{{id}}ClockSource(I2cClockSource src)
+	setI2c{{id}}ClockSource(I2cClockSource src)
 	{
-		RCC->CCIPR4 = (RCC->CCIPR4 & ~RCC_CCIPR4_I2C{{id}}SEL) |
-					  (uint32_t(src) << RCC_CCIPR4_I2C{{id}}SEL_Pos);
+		RCC->CCIPR4 = (RCC->CCIPR4 & ~RCC_CCIPR4_I2C{{id}}SEL) | (uint32_t(src) << RCC_CCIPR4_I2C{{id}}SEL_Pos);
 	}
 %% endfor
 %#
@@ -494,7 +439,7 @@ public:
 		Hsi48 = 0b11 << RCC_CCIPR4_USBSEL_Pos,
 	};
 	static inline void
-	enableUsbClockSource(UsbClockSource src)
+	setUsbClockSource(UsbClockSource src)
 	{
 		RCC->CCIPR4 = (RCC->CCIPR4 & ~RCC_CCIPR4_USBSEL) | uint32_t(src);
 	}
@@ -508,7 +453,7 @@ public:
 		Pll2Q = 0b10 << RCC_CCIPR5_FDCANSEL_Pos,
 		Disabled = 0b11 << RCC_CCIPR5_FDCANSEL_Pos,
 	};
-	static void
+	static inline void
 	setCanClockSource(CanClockSource src)
 	{
 		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_FDCANSEL) | uint32_t(src);
@@ -522,8 +467,8 @@ public:
 		Lse   = 0b10 << RCC_CCIPR5_RNGSEL_Pos,
 		Lsi   = 0b11 << RCC_CCIPR5_RNGSEL_Pos,
 	};
-	static void
-	setCanClockSource(RngClockSource src)
+	static inline void
+	setRngClockSource(RngClockSource src)
 	{
 		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_RNGSEL) | uint32_t(src);
 	}
@@ -538,7 +483,7 @@ public:
 		Hsi    = 0b100 << RCC_CCIPR5_ADCDACSEL_Pos,
 		Csi    = 0b101 << RCC_CCIPR5_ADCDACSEL_Pos,
 	};
-	static void
+	static inline void
 	setAdcDacClockSource(AdcDacClockSource src)
 	{
 		RCC->CCIPR5 = (RCC->CCIPR5 & ~RCC_CCIPR5_ADCDACSEL) | uint32_t(src);
@@ -547,7 +492,7 @@ public:
 public:
 	// outputs
 	enum class
-	ClockOutput1Source : uint32_t
+	Mco1ClockSource : uint32_t
 	{
 		Hsi = 0,
 		Lse = RCC_CFGR1_MCO1SEL_0,
@@ -556,7 +501,7 @@ public:
 		Hsi48 = RCC_CFGR1_MCO1SEL_2
 	};
 	enum class
-	ClockOutput2Source : uint32_t
+	Mco2ClockSource : uint32_t
 	{
 		SystemClock = 0,
 		Pll2P = RCC_CFGR1_MCO2SEL_0,
@@ -566,12 +511,11 @@ public:
 		Lsi = RCC_CFGR1_MCO2SEL_2 | RCC_CFGR1_MCO2SEL_0
 	};
 %% for id in [1,2]
-	static inline bool
-	enableClockOutput{{id}}(ClockOutput{{id}}Source src, uint8_t div)
+	static inline void
+	setMco{{id}}ClockSource(Mco{{id}}ClockSource src, uint8_t div)
 	{
 		RCC->CFGR1 = (RCC->CFGR1 & ~(RCC_CFGR1_MCO{{id}}SEL | RCC_CFGR1_MCO{{id}}PRE)) |
 					 uint32_t(src) | ((div << RCC_CFGR1_MCO{{id}}PRE_Pos) & RCC_CFGR1_MCO{{id}}PRE);
-		return true;
 	}
 %% endfor
 
@@ -593,10 +537,8 @@ public:
 		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
 
 		PWR->VOSCR = (PWR->VOSCR & ~PWR_VOSCR_VOS) | uint32_t(voltage);
-
-		while (PWR->VOSSR & PWR_VOSSR_VOSRDY)
-			if (--waitCycles == 0) return false;
-		return true;
+		while ((PWR->VOSSR & PWR_VOSSR_VOSRDY) and --waitCycles) ;
+		return waitCycles;
 	}
 
 
@@ -614,5 +556,3 @@ private:
 
 
 #include "rcc_impl.hpp"
-
-#endif	//  MODM_STM32_RCC_HPP

--- a/src/modm/platform/clock/stm32/rcc_impl.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_impl.hpp.in
@@ -63,7 +63,7 @@ Rcc::setFlashLatency()
 %% if target.family in ["f2", "f4", "l4", "g4"]
 	// enable flash prefetch and data and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_DCEN | FLASH_ACR_ICEN;
-%% elif target.family in ["c0", "g0"]
+%% elif target.family in ["c0", "g0", "u0"]
 	// enable flash prefetch and instruction cache
 	acr |= FLASH_ACR_PRFTEN | FLASH_ACR_ICEN;
 %% elif target.family == "f7"

--- a/src/modm/platform/clock/stm32/rcc_u0.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_u0.hpp.in
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/architecture/interface/delay.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Reset and Clock Control for STM32U0 devices.
+ *
+ * This class abstracts access to clock settings on the STM32.
+ * You need to use this class to enable internal and external clock
+ * sources & outputs, set PLL parameters and AHB & APB prescalers.
+ * Don't forget to set the flash latencies.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_rcc
+ */
+class Rcc
+{
+public:
+	static constexpr uint32_t LsiFrequency = 32'000;
+	static constexpr uint32_t HsiFrequency = 16'000'000;
+	static constexpr uint32_t BootFrequency = 4'000'000; // MSI
+	static constexpr uint32_t MaxFrequency = 56'000'000;
+
+	/// Connect GPIO signals like MCO to the clock tree
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Rcc, Signals...>;
+		Connector::connect();
+	}
+
+	/// Enable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	enable();
+
+	/// Check if a peripheral clock is enabled
+	template< Peripheral peripheral >
+	static bool
+	isEnabled();
+
+	/// Disable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	disable();
+
+
+public:
+	/** Set flash latency for CPU frequency and voltage.
+	 * Does nothing if CPU frequency is too high for the available
+	 * voltage.
+	 *
+	 * @returns maximum CPU frequency for voltage.
+	 * @retval	<=CPU_Frequency flash latency has been set correctly.
+	 * @retval	>CPU_Frequency requested frequency too high for voltage.
+	 */
+	template< uint32_t Core_Hz, uint16_t Core_mV = 3300>
+	static uint32_t
+	setFlashLatency();
+
+	/// Update the SystemCoreClock and delay variables.
+	template< uint32_t Core_Hz >
+	static void
+	updateCoreFrequency();
+
+
+public:
+	// clock sources
+	static inline bool
+	enableHsi(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSION;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitCycles) ;
+		return waitCycles;
+	}
+%#
+%% if target.name != "31"
+	static inline bool
+	enableHsi48(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CRRCR |= RCC_CRRCR_HSI48ON;
+		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitCycles) ;
+		return waitCycles;
+	}
+%#
+%% endif
+	static inline bool
+	enableHseClock(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	static inline bool
+	enableHseCrystal(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	enum class
+	LsiPrescaler : uint8_t
+	{
+		Div1 = 0,
+		Div128 = RCC_CSR_LSIPREDIV,
+	};
+	static inline bool
+	enableLsiClock(LsiPrescaler div = LsiPrescaler::Div1, uint32_t waitCycles = 0x10000)
+	{
+		RCC->CSR |= RCC_CSR_LSION | uint32_t(div);
+		while (not (RCC->CSR & RCC_CSR_LSIRDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	static inline bool
+	enableLseClock(uint32_t waitCycles = 0x10000)
+	{
+		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	enum class
+	LseDrive : uint8_t
+	{
+		Low        = 0b00,
+		MediumLow  = 0b01,
+		MediumHigh = 0b10,
+		High       = 0b11,
+	};
+	static inline bool
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
+	{
+		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) |
+					(uint32_t(drive) << RCC_BDCR_LSEDRV_Pos) | RCC_BDCR_LSEON;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	enum class
+	MsiFrequency : uint8_t
+	{
+		kHz100 = 0b0000,
+		kHz200 = 0b0001,
+		kHz400 = 0b0010,
+		kHz800 = 0b0011,
+		MHz1   = 0b0100,
+		MHz2   = 0b0101,
+		MHz4   = 0b0110,
+		MHz8   = 0b0111,
+		MHz16  = 0b1000,
+		MHz24  = 0b1001,
+		MHz32  = 0b1010,
+		MHz48  = 0b1011,
+	};
+	static inline bool
+	enableMsiClock(MsiFrequency frequency = MsiFrequency::MHz4, uint32_t waitCycles = 2048)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_MSIRANGE) | RCC_CR_MSIRGSEL | RCC_CR_MSION |
+				  (uint32_t(frequency) << RCC_CR_MSIRANGE_Pos);
+		while (not (RCC->CR & RCC_CR_MSIRDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+
+	// clock modifiers
+	enum class
+	PllSource : uint8_t
+	{
+		Disabled = 0b00,
+		Msi   = 0b01,
+		Hsi16 = 0b10,
+		Hse   = 0b11,
+	};
+	struct PllConfig
+	{
+		uint8_t M; ///< Div 1-8, frequency after div must be in [2.66, 16]MHz
+		uint8_t N; ///< Mul 4-127, frequency after mul must be in [96, 344]MHz
+		uint8_t P = 0; ///< Div 2-32, frequency ≤ 122MHz
+		uint8_t Q = 0; ///< Div 2-8, frequency ≤ 56MHz
+		uint8_t R = 0; ///< Div 2-8, frequency ≤ 56MHz
+	};
+
+	/// Configure and enable PLL
+	static inline bool
+	enablePll(PllSource source, const PllConfig& cfg, uint32_t waitCycles = 0x10000)
+	{
+		if (cfg.R == 1 or cfg.Q == 1 or cfg.P == 1 or cfg.N < 4 or cfg.M == 0) return false;
+
+		// Select clock source
+		uint32_t cfgr{uint32_t(source) & RCC_PLLCFGR_PLLSRC};
+		// Set PLL M divider
+		cfgr |= ((uint32_t(cfg.M - 1u) << RCC_PLLCFGR_PLLM_Pos) & RCC_PLLCFGR_PLLM);
+
+		// Set all dividers
+		cfgr |= ((uint32_t(cfg.N) << RCC_PLLCFGR_PLLN_Pos) & RCC_PLLCFGR_PLLN);
+		if (cfg.R)
+		{
+			cfgr |= RCC_PLLCFGR_PLLREN;
+			cfgr |= ((uint32_t(cfg.R - 1u) << RCC_PLLCFGR_PLLR_Pos) & RCC_PLLCFGR_PLLR);
+		}
+		if (cfg.Q)
+		{
+			cfgr |= RCC_PLLCFGR_PLLQEN;
+			cfgr |= ((uint32_t(cfg.Q - 1u) << RCC_PLLCFGR_PLLQ_Pos) & RCC_PLLCFGR_PLLQ);
+		}
+		if (cfg.P)
+		{
+			cfgr |= RCC_PLLCFGR_PLLPEN;
+			cfgr |= ((uint32_t(cfg.P - 1u) << RCC_PLLCFGR_PLLP_Pos) & RCC_PLLCFGR_PLLP);
+		}
+
+		// enable pll
+		RCC->PLLCFGR = cfgr;
+		RCC->CR |= RCC_CR_PLLON;
+
+		while (not (RCC->CR & RCC_CR_PLLRDY) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	/// Disable PLL.
+	static inline bool
+	disablePll(uint32_t waitCycles = 0x10000)
+	{
+		RCC->CR &= ~RCC_CR_PLLON;
+		while ((RCC->CR & RCC_CR_PLLRDY) and --waitCycles) ;
+		RCC->PLLCFGR = 0;
+		return waitCycles;
+	}
+
+	enum class
+	AhbPrescaler : uint8_t
+	{
+		Div1   = 0b0000,
+		Div2   = 0b1000,
+		Div4   = 0b1001,
+		Div8   = 0b1010,
+		Div16  = 0b1011,
+		Div64  = 0b1100,
+		Div128 = 0b1101,
+		Div256 = 0b1110,
+		Div512 = 0b1111,
+	};
+	static inline void
+	setAhbPrescaler(AhbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | (uint32_t(prescaler) << RCC_CFGR_HPRE_Pos);
+	}
+
+	enum class
+	ApbPrescaler : uint8_t
+	{
+		Div1   = 0b000,
+		Div2   = 0b100,
+		Div4   = 0b101,
+		Div8   = 0b110,
+		Div16  = 0b111
+	};
+	static inline void
+	setApbPrescaler(ApbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE) | (uint32_t(prescaler) << RCC_CFGR_PPRE_Pos);
+	}
+
+	// clock sinks
+	enum class
+	SystemClockSource : uint8_t
+	{
+		Msi = 0b000,
+		Hsi16 = 0b001,
+		Hse = 0b010,
+		PllR = 0b011,
+		Lsi = 0b100,
+		Lse = 0b101,
+	};
+	static inline bool
+	enableSystemClock(SystemClockSource src, uint32_t waitCycles = 0x10000)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | (uint32_t(src) << RCC_CFGR_SW_Pos);
+		// Wait till the main PLL is used as system clock source
+		while ((RCC->CFGR & RCC_CFGR_SWS) != (uint32_t(src) << RCC_CFGR_SWS_Pos) and --waitCycles) ;
+		return waitCycles;
+	}
+
+	enum class
+	RealTimeClockSource : uint32_t
+	{
+		Disabled = 0,
+		Lse      = 0b01 << RCC_BDCR_RTCSEL_Pos,
+		Lsi      = 0b10 << RCC_BDCR_RTCSEL_Pos,
+		HseDiv32 = 0b11 << RCC_BDCR_RTCSEL_Pos,
+	};
+	static inline bool
+	enableRealTimeClock(RealTimeClockSource src)
+	{
+		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
+		return true;
+	}
+
+	// CCIPR
+	enum class
+	PeripheralClockSource : uint8_t
+	{
+		Bus    = 0b00,
+		SysClk = 0b01,
+		Hsi16  = 0b10,
+		Lse    = 0b11,
+	};
+%% for id in uart_ids | sort if id in [1,2]
+	static inline void
+	setUsart{{id}}ClockSource(PeripheralClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_USART{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_USART{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+%% for id in lpuart_ids | sort if id in [1,2,3]
+	static inline void
+	setLpUart{{id}}ClockSource(PeripheralClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPUART{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_LPUART{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	enum class
+	I2cClockSource : uint8_t
+	{
+		Bus    = 0b00,
+		SysClk = 0b01,
+		Hsi16  = 0b10,
+	};
+%% for id in i2c_ids | sort if id in [1,3]
+	static inline void
+	setI2c{{id}}ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_I2C{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_I2C{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+%% for id in lptim_ids | sort if id in [1,2,3]
+	static inline void
+	setLpTimer{{id}}ClockSource(PeripheralClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPTIM{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_LPTIM{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	enum class
+	TimerClockSource : uint8_t
+	{
+		Bus  = 0b0,
+		PllQ = 0b1,
+	};
+%% for id in tim_ids | sort if id in [1,15]
+	static inline void
+	setTimer{{id}}ClockSource(TimerClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_TIM{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_TIM{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	enum class
+	Clock48Source : uint32_t
+	{
+		Disabled = 0,
+		Msi      = 0b01 << RCC_CCIPR_CLK48SEL_Pos,
+		PllQ     = 0b10 << RCC_CCIPR_CLK48SEL_Pos,
+%% if target.name != "31"
+		Hsi48    = 0b11 << RCC_CCIPR_CLK48SEL_Pos,
+%% endif
+	};
+	static inline void
+	setClock48Source(Clock48Source src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_CLK48SEL) | uint32_t(src);
+	}
+
+	enum class
+	AdcClockSource : uint32_t
+	{
+		SysClk = 0,
+		PllP   = 0b01 << RCC_CCIPR_ADCSEL_Pos,
+		Hsi16  = 0b10 << RCC_CCIPR_ADCSEL_Pos,
+	};
+	static inline void
+	setAdcClockSource(AdcClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_ADCSEL) | uint32_t(src);
+	}
+
+public:
+	// outputs
+	enum class
+	McoPrescaler : uint8_t
+	{
+		Div1    = 0b0000,
+		Div2    = 0b0001,
+		Div4    = 0b0010,
+		Div8    = 0b0011,
+		Div16   = 0b0100,
+		Div32   = 0b0101,
+		Div64   = 0b0110,
+		Div128  = 0b0111,
+		Div256  = 0b1000,
+		Div512  = 0b1001,
+		Div1024 = 0b1010,
+	};
+	enum class
+	McoClockSource : uint8_t
+	{
+		Disabled  = 0b0000,
+		SysClk    = 0b0001,
+		Msi       = 0b0010,
+		Hsi16     = 0b0011,
+		Hse       = 0b0100,
+		PllR      = 0b0101,
+		Lsi       = 0b0110,
+		Lse       = 0b0111,
+%% if target.name != "31"
+		Hsi48     = 0b1000,
+%% endif
+		Rtc       = 0b1001,
+		RtcWakeup = 0b1010,
+	};
+%% for id in [1,2]
+	static inline void
+	set{{id}}ClockSource(McoClockSource src, McoPrescaler div)
+	{
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCO{{id}}SEL | RCC_CFGR_MCO{{id}}PRE)) |
+					(uint32_t(src) << RCC_CFGR_MCO{{id}}SEL_Pos) |
+					(uint32_t(div) << RCC_CFGR_MCO{{id}}PRE_Pos);
+	}
+%% endfor
+%#
+public:
+	// TODO: move to Pwr module
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Range1 = 0b01 << PWR_CR1_VOS_Pos,
+		Range2 = 0b10 << PWR_CR1_VOS_Pos,
+	};
+	static inline bool
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 0x10000)
+	{
+		const auto currentSetting = PWR->CR1 & PWR_CR1_VOS;
+		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
+
+		PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | uint32_t(voltage);
+
+		while (not (PWR->SR2 & PWR_SR2_VOSF) and --waitCycles) ;
+		return waitCycles;
+	}
+
+private:
+	struct flash_latency
+	{
+		uint32_t latency;
+		uint32_t max_frequency;
+	};
+	static constexpr flash_latency
+	computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV);
+};
+
+} // namespace modm::platform
+
+#include "rcc_impl.hpp"

--- a/src/modm/platform/core/stm32/module.lb
+++ b/src/modm/platform/core/stm32/module.lb
@@ -75,6 +75,7 @@ def build(env):
         "c0": (3,  4), # CM0+ tested on C031 in RAM
         "l0": (3,  4), # CM0+ tested on L031 in RAM
         "g0": (3,  4), # CM0+ tested on G072 in RAM
+        "u0": (3,  4), # CM0+ tested on U083 in RAM
         "f7": (4,  4), # CM7  tested on F767 in ITCM
         "h5": (4,  4), # CM7  tested on H503 in ITCM
         "h7": (4,  4), # CM7  tested on H743 in ITCM

--- a/src/modm/platform/core/stm32/startup_platform.c.in
+++ b/src/modm/platform/core/stm32/startup_platform.c.in
@@ -29,7 +29,7 @@ void
 __modm_initialize_platform(void)
 {
 	// Enable SYSCFG
-%% if target.family in ["c0", "g0"]
+%% if target.family in ["c0", "g0", "u0"]
 	RCC->APBENR2 |= RCC_APBENR2_SYSCFGEN; __DSB();
 %% elif target.family == "f0"
 	RCC->APB2ENR |= RCC_APB2ENR_SYSCFGCOMPEN; __DSB();

--- a/src/modm/platform/dma/stm32/module.lb
+++ b/src/modm/platform/dma/stm32/module.lb
@@ -36,7 +36,7 @@ def prepare(module, options):
             "stm32-stream-channel",
     ]:
         return False
-    return True
+    return device.identifier.family not in ["u0"]
 
 
 def get_irq_list(device):

--- a/src/modm/platform/extint/stm32/module.lb
+++ b/src/modm/platform/extint/stm32/module.lb
@@ -47,12 +47,12 @@ def validate(env):
 def build(env):
     target = env[":target"].identifier
 
-    separate_flags = target.family in ["c0", "g0", "l5", "u5", "h5"]
+    separate_flags = target.family in ["c0", "g0", "l5", "u5", "h5", "u0"]
     extended = target.family in ["l4", "l5", "g4", "h7"]
     if separate_flags: extended = target.name in ["b1", "c1"]
 
     exti_reg = "SYSCFG"
-    if target.family in ["c0", "g0", "l5", "u5", "h5"]: exti_reg = "EXTI"
+    if target.family in ["c0", "g0", "l5", "u5", "h5", "u0"]: exti_reg = "EXTI"
     if target.family in ["f1"]: exti_reg = "AFIO"
 
     global extimap

--- a/src/modm/platform/gpio/stm32/enable.cpp.in
+++ b/src/modm/platform/gpio/stm32/enable.cpp.in
@@ -28,7 +28,7 @@ modm_gpio_enable(void)
 %%	set prefix = "IOP"
 %% elif target.family in ["l4", "l5", "g4", "h5", "u5"]
 %%  set clock_tree = 'AHB2'
-%% elif target.family in ["c0", "g0", "l0"]
+%% elif target.family in ["c0", "g0", "l0", "u0"]
 %%  set clock_tree = 'IOP'
 %% endif
 

--- a/src/modm/platform/gpio/stm32/module.lb
+++ b/src/modm/platform/gpio/stm32/module.lb
@@ -124,23 +124,14 @@ def validate_alternate_functions(driver, env):
 
 def get_remap_command(family, key):
     reg = 'SYSCFG->CFGR1'
-    mask = {
-        ('c0', 'a9') : 'SYSCFG_CFGR1_PA11_RMP',
-        ('c0', 'a10'): 'SYSCFG_CFGR1_PA12_RMP',
-        ('c0', 'a11'): 'SYSCFG_CFGR1_PA11_RMP',
-        ('c0', 'a12'): 'SYSCFG_CFGR1_PA12_RMP',
-        ('f0', 'a9') : 'SYSCFG_CFGR1_PA11_PA12_RMP',
-        ('f0', 'a10'): 'SYSCFG_CFGR1_PA11_PA12_RMP',
-        ('f0', 'a11'): 'SYSCFG_CFGR1_PA11_PA12_RMP',
-        ('f0', 'a12'): 'SYSCFG_CFGR1_PA11_PA12_RMP',
-        ('g0', 'a9') : 'SYSCFG_CFGR1_PA11_RMP',
-        ('g0', 'a10'): 'SYSCFG_CFGR1_PA12_RMP',
-        ('g0', 'a11'): 'SYSCFG_CFGR1_PA11_RMP',
-        ('g0', 'a12'): 'SYSCFG_CFGR1_PA12_RMP',
-    }.get((family, key))
-    if mask is None:
-        raise ValidateException("Unknown Remap for GPIO: 'P{}'".format(key.upper()))
-    return (reg, mask)
+    if family == "f0":
+        return (reg, 'SYSCFG_CFGR1_PA11_PA12_RMP')
+    else:
+        if key in ['a9', 'a11']:
+            return (reg, 'SYSCFG_CFGR1_PA11_RMP')
+        if key in ['a10', 'a12']:
+            return (reg, 'SYSCFG_CFGR1_PA12_RMP')
+    raise ValidateException("Unknown Remap for GPIO: 'P{}'".format(key.upper()))
 
 bprops = {}
 


### PR DESCRIPTION
- [x] Align RCC naming of STM32H5 with the documentation
- [x] Fix modm-devices https://github.com/modm-io/modm-devices/pull/125
- [x] Port STM32U0 family
  - [x] RCC with aligned naming
  - [x] GPIO
  - [x] Core
  - [x] EXTI
- [x] Added NUCLEO-U083RC board
- [x] Tested in hardware on all added BSPs with Blinky and TinyUSB
- [x] Compile all job passed

Missing: DMA, I2C, ADC

I will also slowly rewrite the RCC driver for all other families to align the naming and get rid of the completely unmaintainable mess we have now.