### PR TITLE
[rcc] Move STM32G0 to new RCC API

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Examples STM32G0 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py nucleo_g070rb nucleo_g071rb)
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_g070rb nucleo_g071rb weact_g0b1cb)
       - name: Examples STM32L0 Series
         if: always()
         run: |

--- a/examples/weact_g0b1cb/blink/main.cpp
+++ b/examples/weact_g0b1cb/blink/main.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017, Niklas Hauser
+ * Copyright (c) 2017, Sascha Schade
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include <modm/board.hpp>
+
+int main()
+{
+	Board::initialize();
+	Board::Leds::setOutput();
+
+	while (true)
+	{
+		Board::Leds::toggle();
+		modm::delay(Board::Button::read() ? 250ms : 500ms);
+	}
+	return 0;
+}

--- a/examples/weact_g0b1cb/blink/project.xml
+++ b/examples/weact_g0b1cb/blink/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <extends>modm:weact-g0b1cb</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/weact_g0b1cb/blink</option>
+  </options>
+  <modules>
+    <module>modm:architecture:delay</module>
+    <module>modm:build:scons</module>
+  </modules>
+  <collectors>
+    <collect name="modm:build:openocd.source">interface/stlink.cfg</collect>
+  </collectors>
+</library>

--- a/src/modm/board/nucleo_g071rb/board.hpp
+++ b/src/modm/board/nucleo_g071rb/board.hpp
@@ -28,16 +28,26 @@ using namespace modm::literals;
 /// STM32G0x1Rx running at 64MHz generated from the internal 16MHz crystal
 struct SystemClock
 {
-	static constexpr uint32_t Frequency = 64_MHz;
-	static constexpr uint32_t Ahb		= Frequency;
-	static constexpr uint32_t Apb		= Frequency;
+	static constexpr Rcc::PllConfig pll{
+		.M = 1, //  16 MHz / 1 =  16 MHz
+		.N = 8, //  16 MHz * 8 = 128 MHz
+		.R = 2, // 128 MHz / 2 =  64 MHz = F_cpu
+	};
+	static constexpr uint32_t PllR = Rcc::HsiFrequency / pll.M * pll.N / pll.R;
+	static_assert(PllR == Rcc::MaxFrequency);
+
+	static constexpr uint32_t SysClk = PllR;
+	static constexpr uint32_t Frequency = SysClk;
+
+	static constexpr uint32_t Hclk      = SysClk / 1;
+	static constexpr uint32_t Ahb		= Hclk;
+	static constexpr uint32_t Apb		= Hclk / 1;
 
 	static constexpr uint32_t Aes		= Ahb;
 	static constexpr uint32_t Rng		= Ahb;
 	static constexpr uint32_t Crc		= Ahb;
 	static constexpr uint32_t Flash		= Ahb;
 	static constexpr uint32_t Exti		= Ahb;
-	static constexpr uint32_t Rcc		= Ahb;
 	static constexpr uint32_t Dmamux	= Ahb;
 	static constexpr uint32_t Dma		= Ahb;
 	static constexpr uint32_t Dma2		= Ahb;
@@ -95,24 +105,19 @@ struct SystemClock
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableRealTimeClock(Rcc::RealTimeClockSource::LowSpeedExternalCrystal);
-
-		Rcc::enableInternalClock();	// 16MHz
-		// (internal clock / 1_M) * 8_N / 2_R = 128MHz / 2 = 64MHz
-		const Rcc::PllFactors pllFactors{
-			.pllM = 1,
-			.pllN = 8,
-			.pllR = 2,
-		};
-		Rcc::enablePll(Rcc::PllSource::InternalClock, pllFactors);
+		Rcc::enableLseCrystal();
+		Rcc::enableHsiClock();
 		Rcc::setFlashLatency<Frequency>();
-		// switch system clock to PLL output
-		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
+
+		Rcc::enablePll(Rcc::PllSource::Hsi16, pll);
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::PllR);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
 		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div1);
-		// update frequencies for busy-wait delay functions
+
 		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
 		return true;
 	}

--- a/src/modm/board/nucleo_h503rb/board.hpp
+++ b/src/modm/board/nucleo_h503rb/board.hpp
@@ -30,6 +30,7 @@ using namespace modm::literals;
 struct SystemClock
 {
 	static constexpr uint32_t Hse = 24_MHz;
+	static constexpr uint32_t Lse = 32.768_kHz;
 
 	static constexpr Rcc::PllConfig pll1
 	{
@@ -90,6 +91,7 @@ struct SystemClock
 	static constexpr uint32_t Timer6 = Apb1Timer;
 	static constexpr uint32_t Timer7 = Apb1Timer;
 
+	static constexpr uint32_t Rtc = Lse;
 	static constexpr uint32_t Usb = Pll2Q;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 
@@ -114,6 +116,7 @@ struct SystemClock
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
 		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
 		return true;
 	}

--- a/src/modm/board/nucleo_u083rc/board.hpp
+++ b/src/modm/board/nucleo_u083rc/board.hpp
@@ -28,7 +28,7 @@ using namespace modm::literals;
 /// STM32U083RC running at 56MHz from PLL clock generated from internal HSI
 struct SystemClock
 {
-	static constexpr uint32_t Hsi = Rcc::HsiFrequency;
+	static constexpr uint32_t Lse = 32.768_kHz;
 
 	static constexpr Rcc::PllConfig pll
 	{
@@ -37,8 +37,8 @@ struct SystemClock
 		.Q = 7,  // 336 MHz /  7 =  48 MHz = F_usb
 		.R = 6,  // 336 MHz /  6 =  56 MHz = F_cpu
 	};
-	static constexpr uint32_t PllQ = Hsi / pll.M * pll.N / pll.Q;
-	static constexpr uint32_t PllR = Hsi / pll.M * pll.N / pll.R;
+	static constexpr uint32_t PllQ = Rcc::HsiFrequency / pll.M * pll.N / pll.Q;
+	static constexpr uint32_t PllR = Rcc::HsiFrequency / pll.M * pll.N / pll.R;
 	static_assert(PllR == Rcc::MaxFrequency);
 
 	static constexpr uint32_t SysClk = PllR;
@@ -94,6 +94,7 @@ struct SystemClock
 	static constexpr uint32_t Timer15 = ApbTimer;
 	static constexpr uint32_t Timer16 = ApbTimer;
 
+	static constexpr uint32_t Rtc = Lse;
 	static constexpr uint32_t Usb = PllQ;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 
@@ -101,7 +102,7 @@ struct SystemClock
 	enable()
 	{
 		Rcc::enableLseCrystal();
-		Rcc::enableHsi();
+		Rcc::enableHsiClock();
 
 		Rcc::setVoltageScaling(Rcc::VoltageScaling::Range1);
 		Rcc::setFlashLatency<Frequency>();
@@ -115,6 +116,7 @@ struct SystemClock
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::PllR);
 		Rcc::setClock48Source(Rcc::Clock48Source::PllQ);
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
 		return true;
 	}

--- a/src/modm/board/weact_g0b1cb/board.hpp
+++ b/src/modm/board/weact_g0b1cb/board.hpp
@@ -25,17 +25,29 @@ using namespace modm::literals;
 /// STM32G0B1 running at 64MHz generated from the external 8MHz crystal
 struct SystemClock
 {
-	static constexpr uint32_t Frequency = 64_MHz;
-	static constexpr uint32_t Ahb = Frequency;
-	static constexpr uint32_t Apb = Frequency / 2;
-	static constexpr uint32_t ApbTimer = Apb * 2;
+	static constexpr uint32_t Hse = 8_MHz;
+	static constexpr Rcc::PllConfig pll{
+		.M = 2,  //   8 MHz /  2 =   4 MHz
+		.N = 48, //   4 MHz * 48 = 192 MHz
+		.Q = 4,  // 192 MHz /  4 =  48 MHz = F_usb
+		.R = 3,  // 192 MHz /  3 =  64 MHz = F_cpu
+	};
+	static constexpr uint32_t PllR = Hse / pll.M * pll.N / pll.R;
+	static constexpr uint32_t PllQ = Hse / pll.M * pll.N / pll.Q;
+	static_assert(PllR == Rcc::MaxFrequency);
+
+	static constexpr uint32_t SysClk = PllR;
+	static constexpr uint32_t Frequency = SysClk;
+
+	static constexpr uint32_t Ahb = SysClk;
+	static constexpr uint32_t Apb = SysClk / 1;
+	static constexpr uint32_t ApbTimer = Apb * 1;
 
 	static constexpr uint32_t Aes  = Ahb;
 	static constexpr uint32_t Rng  = Ahb;
 	static constexpr uint32_t Crc  = Ahb;
 	static constexpr uint32_t Flash  = Ahb;
 	static constexpr uint32_t Exti = Ahb;
-	static constexpr uint32_t Rcc = Ahb;
 	static constexpr uint32_t DmaMux = Ahb;
 	static constexpr uint32_t Dma2 = Ahb;
 	static constexpr uint32_t Dma1 = Ahb;
@@ -88,39 +100,27 @@ struct SystemClock
 	static constexpr uint32_t Timer3 = ApbTimer;
 	static constexpr uint32_t Timer2 = ApbTimer;
 
-	static constexpr uint32_t Usb = 48_MHz;
+	static constexpr uint32_t Usb = PllQ;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 	static constexpr uint32_t Rtc = 32.768_kHz;
 
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableRealTimeClock(Rcc::RealTimeClockSource::LowSpeedExternalCrystal);
-
-		Rcc::enableExternalCrystal();
-		const Rcc::PllFactors pllFactors{
-			.pllM = 2,		// 8MHz / M=2 -> 4MHz
-			.pllN = 48,		// 4MHz * N=48 -> 192MHz
-			.pllR = 3,		// 192MHz / R=3 -> 64MHz = F_cpu
-			.pllQ = 4,		// 192MHz / Q=4 -> 48MHz = F_usb
-		};
-		Rcc::enablePll(Rcc::PllSource::ExternalCrystal, pllFactors);
-
-		// set flash latency
+		Rcc::enableLseCrystal();
+		Rcc::enableHseCrystal();
 		Rcc::setFlashLatency<Frequency>();
 
-		// Enable 48MHz clock for USB
-		Rcc::enableUsbClockSource(Rcc::UsbClockSource::Pll);
+		Rcc::enablePll(Rcc::PllSource::Hse, pll);
 
-		// switch system clock to PLL output
-		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
-
+		Rcc::enableSystemClock(Rcc::SystemClockSource::PllR);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
-		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div2);
+		Rcc::setApbPrescaler(Rcc::ApbPrescaler::Div1);
 
-		// update frequencies for busy-wait delay functions
 		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
+		Rcc::setUsbClockSource(Rcc::UsbClockSource::PllQ);
 
 		return true;
 	}

--- a/src/modm/board/weact_h503cb/board.hpp.in
+++ b/src/modm/board/weact_h503cb/board.hpp.in
@@ -32,6 +32,7 @@ using namespace modm::literals;
 struct SystemClock
 {
 	static constexpr uint32_t Hse = 8_MHz;
+	static constexpr uint32_t Lse = 32.768_kHz;
 
 	static constexpr Rcc::PllConfig pll1
 	{
@@ -92,6 +93,7 @@ struct SystemClock
 	static constexpr uint32_t Timer6 = Apb1Timer;
 	static constexpr uint32_t Timer7 = Apb1Timer;
 
+	static constexpr uint32_t Rtc = Lse;
 	static constexpr uint32_t Usb = Pll2Q;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 
@@ -116,6 +118,7 @@ struct SystemClock
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
 		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll2Q);
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
 		return true;
 	}

--- a/src/modm/board/weact_h562rg/board.hpp.in
+++ b/src/modm/board/weact_h562rg/board.hpp.in
@@ -32,6 +32,7 @@ using namespace modm::literals;
 struct SystemClock
 {
 	static constexpr uint32_t Hse = 8_MHz;
+	static constexpr uint32_t Lse = 32.768_kHz;
 
 	static constexpr Rcc::PllConfig pll1
 	{
@@ -131,6 +132,7 @@ struct SystemClock
 	static constexpr uint32_t Timer16 = Apb2Timer;
 	static constexpr uint32_t Timer17 = Apb2Timer;
 
+	static constexpr uint32_t Rtc = Lse;
 	static constexpr uint32_t Usb = Pll3Q;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 
@@ -155,6 +157,7 @@ struct SystemClock
 
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
 		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll3Q);
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
 		return true;
 	}

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -146,7 +146,7 @@ def build(env):
                 ids += device.get_driver(driver)["instance"]
         return list(map(int, ids))
 
-    if t.family in ["h5", "u0"]:
+    if t.family in ["h5", "u0", "g0"]:
         p["uart_ids"] = instances("usart", "uart")
         p["lpuart_ids"] = instances("lpuart")
         p["spi_ids"] = instances("spi")

--- a/src/modm/platform/clock/stm32/rcc_g0.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_g0.hpp.in
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/architecture/interface/delay.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Reset and Clock Control for STM32G0 devices.
+ *
+ * This class abstracts access to clock settings on the STM32.
+ * You need to use this class to enable internal and external clock
+ * sources & outputs, set PLL parameters and AHB & APB prescalers.
+ * Don't forget to set the flash latencies.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_rcc
+ */
+class Rcc
+{
+public:
+	static constexpr uint32_t LsiFrequency = 32'000;
+	static constexpr uint32_t HsiFrequency = 16'000'000;
+	static constexpr uint32_t BootFrequency = HsiFrequency; // HSI after reset
+	static constexpr uint32_t MaxFrequency = 64'000'000;
+
+	/// Connect GPIO signals like MCO to the clock tree
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Rcc, Signals...>;
+		Connector::connect();
+	}
+
+	/// Enable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	enable();
+
+	/// Check if a peripheral clock is enabled
+	template< Peripheral peripheral >
+	static bool
+	isEnabled();
+
+	/// Disable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	disable();
+
+
+public:
+	/** Set flash latency for CPU frequency and voltage.
+	 * Does nothing if CPU frequency is too high for the available
+	 * voltage.
+	 *
+	 * @returns maximum CPU frequency for voltage.
+	 * @retval	<=CPU_Frequency flash latency has been set correctly.
+	 * @retval	>CPU_Frequency requested frequency too high for voltage.
+	 */
+	template< uint32_t Core_Hz, uint16_t Core_mV = 3300>
+	static uint32_t
+	setFlashLatency();
+
+	/// Update the SystemCoreClock and delay variables.
+	template< uint32_t Core_Hz >
+	static void
+	updateCoreFrequency();
+
+
+public:
+	// clock sources
+	enum class
+	HsiPrescaler : uint8_t
+	{
+		Div1   = 0b000,
+		Div2   = 0b001,
+		Div4   = 0b010,
+		Div8   = 0b011,
+		Div16  = 0b100,
+		Div32  = 0b101,
+		Div64  = 0b110,
+		Div128 = 0b111,
+	};
+	static inline bool
+	enableHsiClock(HsiPrescaler div = HsiPrescaler::Div1, uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_HSIDIV_Msk) | (uint32_t(div) << RCC_CR_HSIDIV_Pos) | RCC_CR_HSION;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+%#
+%% if target.name >= "b1"
+	static inline bool
+	enableHsi48Clock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSI48ON;
+		while (not (RCC->CR & RCC_CR_HSI48RDY) and --waitLoops) ;
+		return waitLoops;
+	}
+%#
+%% endif
+	static inline bool
+	enableHseClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableHseCrystal(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableLsiClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CSR |= RCC_CSR_LSION;
+		while (not (RCC->CSR & RCC_CSR_LSIRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableLseClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	enum class
+	LseDrive : uint8_t
+	{
+		Low        = 0b00,
+		MediumLow  = 0b01,
+		MediumHigh = 0b10,
+		High       = 0b11,
+	};
+	static inline bool
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitLoops = 0x10000)
+	{
+		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) |
+					(uint32_t(drive) << RCC_BDCR_LSEDRV_Pos) | RCC_BDCR_LSEON;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+
+	// clock modifiers
+	enum class
+	PllSource : uint8_t
+	{
+		Disabled = 0b00,
+		Hsi16 = 0b10,
+		Hse   = 0b11,
+	};
+	struct PllConfig
+	{
+		uint8_t M; ///< Div 1-8, frequency after div must be in [2.66, 16]MHz
+		uint8_t N; ///< Mul 8-86, frequency after mul must be in [96, 344]MHz
+		uint8_t P = 0; ///< Div 2-32, frequency ≤ 122MHz
+%% if target.name not in ("30", "50", "70")
+		uint8_t Q = 0; ///< Div 2-8, frequency ≤ 56MHz
+%% endif
+		uint8_t R = 0; ///< Div 2-8, frequency ≤ 56MHz
+	};
+
+	/// Configure and enable PLL
+	static inline bool
+	enablePll(PllSource source, const PllConfig& cfg, uint32_t waitLoops = 0x10000)
+	{
+		if (cfg.R == 1{% if target.name not in ("30", "50", "70") %} or cfg.Q == 1{% endif %} or cfg.P == 1 or cfg.N < 4 or cfg.M == 0) return false;
+
+		// Select clock source
+		uint32_t cfgr{uint32_t(source) & RCC_PLLCFGR_PLLSRC};
+		// Set PLL M divider
+		cfgr |= ((uint32_t(cfg.M - 1u) << RCC_PLLCFGR_PLLM_Pos) & RCC_PLLCFGR_PLLM);
+
+		// Set all dividers
+		cfgr |= ((uint32_t(cfg.N) << RCC_PLLCFGR_PLLN_Pos) & RCC_PLLCFGR_PLLN);
+		if (cfg.R)
+		{
+			cfgr |= RCC_PLLCFGR_PLLREN;
+			cfgr |= ((uint32_t(cfg.R - 1u) << RCC_PLLCFGR_PLLR_Pos) & RCC_PLLCFGR_PLLR);
+		}
+%% if target.name not in ("30", "50", "70")
+		if (cfg.Q)
+		{
+			cfgr |= RCC_PLLCFGR_PLLQEN;
+			cfgr |= ((uint32_t(cfg.Q - 1u) << RCC_PLLCFGR_PLLQ_Pos) & RCC_PLLCFGR_PLLQ);
+		}
+%% endif
+		if (cfg.P)
+		{
+			cfgr |= RCC_PLLCFGR_PLLPEN;
+			cfgr |= ((uint32_t(cfg.P - 1u) << RCC_PLLCFGR_PLLP_Pos) & RCC_PLLCFGR_PLLP);
+		}
+
+		// enable pll
+		RCC->PLLCFGR = cfgr;
+		RCC->CR |= RCC_CR_PLLON;
+
+		while (not (RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	/// Disable PLL.
+	static inline bool
+	disablePll(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR &= ~RCC_CR_PLLON;
+		while ((RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
+		RCC->PLLCFGR = 0;
+		return waitLoops;
+	}
+
+	enum class
+	AhbPrescaler : uint8_t
+	{
+		Div1   = 0b0000,
+		Div2   = 0b1000,
+		Div4   = 0b1001,
+		Div8   = 0b1010,
+		Div16  = 0b1011,
+		Div64  = 0b1100,
+		Div128 = 0b1101,
+		Div256 = 0b1110,
+		Div512 = 0b1111,
+	};
+	static inline void
+	setAhbPrescaler(AhbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | (uint32_t(prescaler) << RCC_CFGR_HPRE_Pos);
+	}
+
+	enum class
+	ApbPrescaler : uint8_t
+	{
+		Div1   = 0b000,
+		Div2   = 0b100,
+		Div4   = 0b101,
+		Div8   = 0b110,
+		Div16  = 0b111
+	};
+	static inline void
+	setApbPrescaler(ApbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE) | (uint32_t(prescaler) << RCC_CFGR_PPRE_Pos);
+	}
+
+	// clock sinks
+	enum class
+	SystemClockSource : uint8_t
+	{
+		HsiSys = 0b000,
+		Hse    = 0b001,
+		PllR   = 0b010,
+		Lsi    = 0b011,
+		Lse    = 0b100,
+	};
+	static inline bool
+	enableSystemClock(SystemClockSource src, uint32_t waitLoops = 0x10000)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | (uint32_t(src) << RCC_CFGR_SW_Pos);
+		// Wait till the main PLL is used as system clock source
+		while ((RCC->CFGR & RCC_CFGR_SWS) != (uint32_t(src) << RCC_CFGR_SWS_Pos) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	enum class
+	RealTimeClockSource : uint32_t
+	{
+		Disabled = 0,
+		Lse      = 0b01 << RCC_BDCR_RTCSEL_Pos,
+		Lsi      = 0b10 << RCC_BDCR_RTCSEL_Pos,
+		HseDiv32 = 0b11 << RCC_BDCR_RTCSEL_Pos,
+	};
+	static inline void
+	setRealTimeClockSource(RealTimeClockSource src)
+	{
+		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
+	}
+
+	// CCIPR
+	enum class
+	UartClockSource : uint8_t
+	{
+		Bus    = 0b00,
+		SysClk = 0b01,
+		Hsi16  = 0b10,
+		Lse    = 0b11,
+	};
+%% for id in uart_ids | sort if (id == 1 or (id == 2 and target.name >= "70") or (id == 3 and target.name >= "b0"))
+	static inline void
+	setUsart{{id}}ClockSource(UartClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_USART{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_USART{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+%% for id in lpuart_ids | sort if id in [1,2]
+	static inline void
+	setLpUart{{id}}ClockSource(UartClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPUART{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_LPUART{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+	enum class
+	I2cClockSource : uint8_t
+	{
+		Bus    = 0b00,
+		SysClk = 0b01,
+		Hsi16  = 0b10,
+	};
+%% for id in i2c_ids | sort if id in ([1,2] if target.name >= "b0" else [1])
+	static inline void
+	setI2c{{id}}ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_I2C{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_I2C{{id}}SEL_Pos);
+	}
+%% endfor
+%% if 2 in i2c_ids and target.name < "b0"
+	static inline void
+	setI2c2ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_I2S1SEL) | (uint32_t(src) << RCC_CCIPR_I2S1SEL_Pos);
+	}
+%% endif
+%#
+	enum class
+	LpTimerClockSource : uint8_t
+	{
+		Bus   = 0b00,
+		Lsi   = 0b01,
+		Hsi16 = 0b10,
+		Lse   = 0b11,
+	};
+%% for id in lptim_ids | sort if id in [1,2,3]
+	static inline void
+	setLpTimer{{id}}ClockSource(LpTimerClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPTIM{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_LPTIM{{id}}SEL_Pos);
+	}
+%% endfor
+%#
+%% if target.name[1] == "1"
+	enum class
+	TimerClockSource : uint8_t
+	{
+		Bus  = 0b0,
+		PllQ = 0b1,
+	};
+%% for id in tim_ids | sort if id in [1,15]
+	static inline void
+	setTimer{{id}}ClockSource(TimerClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_TIM{{id}}SEL) | (uint32_t(src) << RCC_CCIPR_TIM{{id}}SEL_Pos);
+	}
+%% endfor
+%% endif
+%#
+%% if target.name >= "b1"
+	// USB clock source (only on G0B1/G0C1)
+	enum class
+	UsbClockSource : uint32_t
+	{
+		Hsi48 = 0b00 << RCC_CCIPR2_USBSEL_Pos,
+		Hse   = 0b01 << RCC_CCIPR2_USBSEL_Pos,
+		PllQ  = 0b10 << RCC_CCIPR2_USBSEL_Pos,
+	};
+	static inline void
+	setUsbClockSource(UsbClockSource src)
+	{
+		RCC->CCIPR2 = (RCC->CCIPR2 & ~RCC_CCIPR2_USBSEL) | uint32_t(src);
+	}
+%% endif
+
+	enum class
+	AdcClockSource : uint32_t
+	{
+		SysClk = 0,
+		PllP   = 0b01u << RCC_CCIPR_ADCSEL_Pos,
+		Hsi16  = 0b10u << RCC_CCIPR_ADCSEL_Pos,
+	};
+	static inline void
+	setAdcClockSource(AdcClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_ADCSEL) | uint32_t(src);
+	}
+
+public:
+	// MCO outputs
+	enum class
+	McoPrescaler : uint8_t
+	{
+		Div1    = 0b0000,
+		Div2    = 0b0001,
+		Div4    = 0b0010,
+		Div8    = 0b0011,
+		Div16   = 0b0100,
+		Div32   = 0b0101,
+		Div64   = 0b0110,
+		Div128  = 0b0111,
+%% if target.name >= "b1"
+		Div256  = 0b1000,
+		Div512  = 0b1001,
+		Div1024 = 0b1010,
+%% endif
+	};
+	enum class
+	McoClockSource : uint8_t
+	{
+		Disabled  = 0b0000,
+		SysClk    = 0b0001,
+		Hsi16     = 0b0011,
+		Hse       = 0b0100,
+		PllR      = 0b0101,
+		Lsi       = 0b0110,
+		Lse       = 0b0111,
+%% if target.name >= "b1"
+		Hsi48     = 0b1000,
+%% endif
+	};
+	static inline void
+%% if target.name >= "b1"
+	setMco1ClockSource(McoClockSource src, McoPrescaler div)
+%% else
+	setMcoClockSource(McoClockSource src, McoPrescaler div)
+%% endif
+	{
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE)) |
+					(uint32_t(src) << RCC_CFGR_MCOSEL_Pos) |
+					(uint32_t(div) << RCC_CFGR_MCOPRE_Pos);
+	}
+%% if target.name >= "b1"
+	static inline void
+	setMco2ClockSource(McoClockSource src, McoPrescaler div)
+	{
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCO2SEL | RCC_CFGR_MCO2PRE)) |
+					(uint32_t(src) << RCC_CFGR_MCO2SEL_Pos) |
+					(uint32_t(div) << RCC_CFGR_MCO2PRE_Pos);
+	}
+%% endif
+%#
+public:
+	// TODO: move to Pwr module
+	enum class
+	VoltageScaling : uint32_t
+	{
+		Range1 = 0b01 << PWR_CR1_VOS_Pos,
+		Range2 = 0b10 << PWR_CR1_VOS_Pos,
+	};
+	static inline bool
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitLoops = 0x10000)
+	{
+		const auto currentSetting = PWR->CR1 & PWR_CR1_VOS;
+		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
+
+		PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | uint32_t(voltage);
+
+		while (not (PWR->SR2 & PWR_SR2_VOSF) and --waitLoops) ;
+		return waitLoops;
+	}
+
+private:
+	struct flash_latency
+	{
+		uint32_t latency;
+		uint32_t max_frequency;
+	};
+	static constexpr flash_latency
+	computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV);
+};
+
+} // namespace modm::platform
+
+#include "rcc_impl.hpp"

--- a/src/modm/platform/clock/stm32/rcc_h5.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_h5.hpp.in
@@ -87,59 +87,59 @@ public:
 public:
 	// clock sources
 	static inline bool
-	enableHsi(uint32_t waitCycles = 0x10000)
+	enableHsiClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_HSION;
-		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableCsi(uint32_t waitCycles = 0x10000)
+	enableCsiClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_CSION;
-		while (not (RCC->CR & RCC_CR_CSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_CSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableHsi48(uint32_t waitCycles = 0x10000)
+	enableHsi48Clock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_HSI48ON;
-		while (not (RCC->CR & RCC_CR_HSI48RDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSI48RDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableHseClock(uint32_t waitCycles = 0x10000)
+	enableHseClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
-		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableHseCrystal(uint32_t waitCycles = 0x10000)
+	enableHseCrystal(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
-		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableLsi(uint32_t waitCycles = 0x10000)
+	enableLsiClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->BDCR |= RCC_BDCR_LSION;
-		while (not (RCC->BDCR & RCC_BDCR_LSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->BDCR & RCC_BDCR_LSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableLseClock(uint32_t waitCycles = 0x10000)
+	enableLseClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
-		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -151,12 +151,12 @@ public:
 		High       = 0b11,
 	};
 	static inline bool
-	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitLoops = 0x10000)
 	{
 		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) |
 					(uint32_t(drive) << RCC_BDCR_LSEDRV_Pos) | RCC_BDCR_LSEON;
-		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	// clock modifiers
@@ -198,7 +198,7 @@ public:
 %% for id in pll_ids
 	/// Configure and enable PLL{{id}}
 	static inline bool
-	enablePll{{id}}(PllSource source, const PllConfig& cfg, uint32_t waitCycles = 0x10000)
+	enablePll{{id}}(PllSource source, const PllConfig& cfg, uint32_t waitLoops = 0x10000)
 	{
 	%% if id == 1
 		// PLLxP divider must be even!
@@ -245,19 +245,19 @@ public:
 		RCC->PLL{{id}}DIVR = divr;
 		RCC->CR |= RCC_CR_PLL{{id}}ON;
 
-		while (not (RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	/// Disable PLL{{id}}.
 	static inline bool
-	disablePll{{id}}(uint32_t waitCycles = 0x10000)
+	disablePll{{id}}(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR &= ~RCC_CR_PLL{{id}}ON;
-		while ((RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitCycles) ;
+		while ((RCC->CR & RCC_CR_PLL{{id}}RDY) and --waitLoops) ;
 		RCC->PLL{{id}}CFGR = 0;
 		RCC->PLL{{id}}DIVR = 0;
-		return waitCycles;
+		return waitLoops;
 	}
 %#
 %% endfor
@@ -307,12 +307,12 @@ public:
 		Pll1P = 0b11,
 	};
 	static inline bool
-	enableSystemClock(SystemClockSource src, uint32_t waitCycles = 0x10000)
+	enableSystemClock(SystemClockSource src, uint32_t waitLoops = 0x10000)
 	{
 		RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW) | uint32_t(src);
 		// Wait till the main PLL is used as system clock source
-		while ((RCC->CFGR1 & RCC_CFGR1_SWS) != (uint32_t(src) << RCC_CFGR1_SWS_Pos) and --waitCycles) ;
-		return waitCycles;
+		while ((RCC->CFGR1 & RCC_CFGR1_SWS) != (uint32_t(src) << RCC_CFGR1_SWS_Pos) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -324,12 +324,11 @@ public:
 		Hse = 0b11 << RCC_BDCR_RTCSEL_Pos,
 	};
 	/// @param hseDiv Division factor for HSE to get ≤1MHz clock for RTC: range 2-63
-	static inline bool
-	enableRealTimeClock(RealTimeClockSource src, uint8_t hseDiv = 0xff)
+	static inline void
+	setRealTimeClockSource(RealTimeClockSource src, uint8_t hseDiv = 0xff)
 	{
 		RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_RTCPRE) | ((uint8_t(hseDiv) << RCC_CFGR1_RTCPRE_Pos) & RCC_CFGR1_RTCPRE);
 		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
-		return true;
 	}
 
 	// CCIPR1
@@ -531,14 +530,14 @@ public:
 		Scale3 = 0b00,
 	};
 	static inline bool
-	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 0x10000)
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitLoops = 0x10000)
 	{
 		const auto currentSetting = PWR->VOSCR & PWR_VOSCR_VOS;
 		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
 
 		PWR->VOSCR = (PWR->VOSCR & ~PWR_VOSCR_VOS) | uint32_t(voltage);
-		while ((PWR->VOSSR & PWR_VOSSR_VOSRDY) and --waitCycles) ;
-		return waitCycles;
+		while ((PWR->VOSSR & PWR_VOSSR_VOSRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 

--- a/src/modm/platform/clock/stm32/rcc_u0.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_u0.hpp.in
@@ -86,37 +86,37 @@ public:
 public:
 	// clock sources
 	static inline bool
-	enableHsi(uint32_t waitCycles = 0x10000)
+	enableHsiClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_HSION;
-		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 %#
 %% if target.name != "31"
 	static inline bool
-	enableHsi48(uint32_t waitCycles = 0x10000)
+	enableHsi48Clock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CRRCR |= RCC_CRRCR_HSI48ON;
-		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitLoops) ;
+		return waitLoops;
 	}
 %#
 %% endif
 	static inline bool
-	enableHseClock(uint32_t waitCycles = 0x10000)
+	enableHseClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
-		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableHseCrystal(uint32_t waitCycles = 0x10000)
+	enableHseCrystal(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
-		while (not (RCC->CR & RCC_CR_HSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -126,19 +126,19 @@ public:
 		Div128 = RCC_CSR_LSIPREDIV,
 	};
 	static inline bool
-	enableLsiClock(LsiPrescaler div = LsiPrescaler::Div1, uint32_t waitCycles = 0x10000)
+	enableLsiClock(LsiPrescaler div = LsiPrescaler::Div1, uint32_t waitLoops = 0x10000)
 	{
 		RCC->CSR |= RCC_CSR_LSION | uint32_t(div);
-		while (not (RCC->CSR & RCC_CSR_LSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CSR & RCC_CSR_LSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	static inline bool
-	enableLseClock(uint32_t waitCycles = 0x10000)
+	enableLseClock(uint32_t waitLoops = 0x10000)
 	{
 		RCC->BDCR |= RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
-		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -150,12 +150,12 @@ public:
 		High       = 0b11,
 	};
 	static inline bool
-	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitCycles = 0x10000)
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitLoops = 0x10000)
 	{
 		RCC->BDCR = (RCC->BDCR & ~(RCC_BDCR_LSEDRV | RCC_BDCR_LSEBYP)) |
 					(uint32_t(drive) << RCC_BDCR_LSEDRV_Pos) | RCC_BDCR_LSEON;
-		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->BDCR & RCC_BDCR_LSERDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -175,12 +175,12 @@ public:
 		MHz48  = 0b1011,
 	};
 	static inline bool
-	enableMsiClock(MsiFrequency frequency = MsiFrequency::MHz4, uint32_t waitCycles = 2048)
+	enableMsiClock(MsiFrequency frequency = MsiFrequency::MHz4, uint32_t waitLoops = 2048)
 	{
 		RCC->CR = (RCC->CR & ~RCC_CR_MSIRANGE) | RCC_CR_MSIRGSEL | RCC_CR_MSION |
 				  (uint32_t(frequency) << RCC_CR_MSIRANGE_Pos);
-		while (not (RCC->CR & RCC_CR_MSIRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_MSIRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 
@@ -204,7 +204,7 @@ public:
 
 	/// Configure and enable PLL
 	static inline bool
-	enablePll(PllSource source, const PllConfig& cfg, uint32_t waitCycles = 0x10000)
+	enablePll(PllSource source, const PllConfig& cfg, uint32_t waitLoops = 0x10000)
 	{
 		if (cfg.R == 1 or cfg.Q == 1 or cfg.P == 1 or cfg.N < 4 or cfg.M == 0) return false;
 
@@ -235,18 +235,18 @@ public:
 		RCC->PLLCFGR = cfgr;
 		RCC->CR |= RCC_CR_PLLON;
 
-		while (not (RCC->CR & RCC_CR_PLLRDY) and --waitCycles) ;
-		return waitCycles;
+		while (not (RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	/// Disable PLL.
 	static inline bool
-	disablePll(uint32_t waitCycles = 0x10000)
+	disablePll(uint32_t waitLoops = 0x10000)
 	{
 		RCC->CR &= ~RCC_CR_PLLON;
-		while ((RCC->CR & RCC_CR_PLLRDY) and --waitCycles) ;
+		while ((RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
 		RCC->PLLCFGR = 0;
-		return waitCycles;
+		return waitLoops;
 	}
 
 	enum class
@@ -295,12 +295,12 @@ public:
 		Lse = 0b101,
 	};
 	static inline bool
-	enableSystemClock(SystemClockSource src, uint32_t waitCycles = 0x10000)
+	enableSystemClock(SystemClockSource src, uint32_t waitLoops = 0x10000)
 	{
 		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | (uint32_t(src) << RCC_CFGR_SW_Pos);
 		// Wait till the main PLL is used as system clock source
-		while ((RCC->CFGR & RCC_CFGR_SWS) != (uint32_t(src) << RCC_CFGR_SWS_Pos) and --waitCycles) ;
-		return waitCycles;
+		while ((RCC->CFGR & RCC_CFGR_SWS) != (uint32_t(src) << RCC_CFGR_SWS_Pos) and --waitLoops) ;
+		return waitLoops;
 	}
 
 	enum class
@@ -311,11 +311,10 @@ public:
 		Lsi      = 0b10 << RCC_BDCR_RTCSEL_Pos,
 		HseDiv32 = 0b11 << RCC_BDCR_RTCSEL_Pos,
 	};
-	static inline bool
-	enableRealTimeClock(RealTimeClockSource src)
+	static inline void
+	setRealTimeClockSource(RealTimeClockSource src)
 	{
 		RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCEN | uint32_t(src);
-		return true;
 	}
 
 	// CCIPR
@@ -462,15 +461,15 @@ public:
 		Range2 = 0b10 << PWR_CR1_VOS_Pos,
 	};
 	static inline bool
-	setVoltageScaling(VoltageScaling voltage, uint32_t waitCycles = 0x10000)
+	setVoltageScaling(VoltageScaling voltage, uint32_t waitLoops = 0x10000)
 	{
 		const auto currentSetting = PWR->CR1 & PWR_CR1_VOS;
 		if (voltage == static_cast<VoltageScaling>(currentSetting)) return true;
 
 		PWR->CR1 = (PWR->CR1 & ~PWR_CR1_VOS) | uint32_t(voltage);
 
-		while (not (PWR->SR2 & PWR_SR2_VOSF) and --waitCycles) ;
-		return waitCycles;
+		while (not (PWR->SR2 & PWR_SR2_VOSF) and --waitLoops) ;
+		return waitLoops;
 	}
 
 private:


### PR DESCRIPTION
I tried to add a backward compatibility layer, but it's so verbose that I'm just making this a breaking change.

- [x] Tested in Hardware on NUCLEO-G071RB and NUCLEO-G0B1RE