### PR TITLE
[rcc] Move STM32L0 RCC to new API

### DIFF
--- a/src/modm/board/nucleo_l031k6/board.hpp
+++ b/src/modm/board/nucleo_l031k6/board.hpp
@@ -31,54 +31,51 @@ using namespace modm::literals;
 /// STM32L031K6 running at 32MHz generated from 16 MHz HSI16 clock
 struct SystemClock
 {
-	static constexpr uint32_t Frequency = 32_MHz;
+	static constexpr Rcc::PllConfig pll{.Mul = Rcc::PllMultiplier::Mul4, .Div = 2};
+	static constexpr uint32_t Pll = Rcc::HsiFrequency * Rcc::value(pll.Mul) / pll.Div;
+	static constexpr uint32_t Frequency = Pll;
+	static_assert(Frequency == Rcc::MaxFrequency);
+
 	static constexpr uint32_t Ahb  = Frequency;
 	static constexpr uint32_t Apb1 = Frequency;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Apb1Timer = Apb1;
-	static constexpr uint32_t Apb2Timer = Apb2;
+	static constexpr uint32_t Crc  = Ahb;
 
-	static constexpr uint32_t Adc = Apb2;
-
+	static constexpr uint32_t Adc   = Apb2;
 	static constexpr uint32_t Comp1 = Apb2;
 	static constexpr uint32_t Comp2 = Apb2;
+	static constexpr uint32_t Spi1  = Apb2;
 
-	static constexpr uint32_t I2c1 = Apb1;
+	static constexpr uint32_t I2c1    = Apb1;
+	static constexpr uint32_t Lptim1  = Apb1;
+	static constexpr uint32_t Lpuart1 = Apb1;
+	static constexpr uint32_t Usart2  = Apb1;
+	static constexpr uint32_t Wwdg    = Apb1;
 
-	static constexpr uint32_t Spi1 = Apb2;
-
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
 	static constexpr uint32_t Timer2  = Apb1Timer;
 	static constexpr uint32_t Timer21 = Apb2Timer;
 	static constexpr uint32_t Timer22 = Apb2Timer;
-
-	static constexpr uint32_t Usart2 = Apb1;
 	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
 	static constexpr uint32_t Rtc = 32.768_kHz;
 
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableRealTimeClock(Rcc::RealTimeClockSource::LowSpeedExternalCrystal);
+		Rcc::enableLseCrystal();
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
-		Rcc::enableInternalClock();	// 16MHz
-		// (internal clock / 1) * 4 / 2 = 32MHz
-		const Rcc::PllFactors pllFactors{
-			.pllMul = Rcc::PllMultiplier::Mul4,
-			.pllDiv = 2,
-			.enableHsiPrediv4 = false
-		};
-		Rcc::enablePll(Rcc::PllSource::Hsi16, pllFactors);
-		// set flash latency for 32MHz
+		Rcc::enableHsiClock();
 		Rcc::setFlashLatency<Frequency>();
-		// switch system clock to PLL output
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enablePll(Rcc::PllSource::Hsi, pll);
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
-		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
-		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
-		// update frequencies for busy-wait delay functions
-		Rcc::updateCoreFrequency<Frequency>();
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
 
 		return true;
 	}

--- a/src/modm/board/nucleo_l053r8/board.hpp
+++ b/src/modm/board/nucleo_l053r8/board.hpp
@@ -28,30 +28,36 @@ using namespace modm::literals;
 /// STM32L053R8 running at 32MHz generated from 16 MHz HSI16 clock
 struct SystemClock
 {
-	static constexpr uint32_t Frequency = 32_MHz;
+	static constexpr Rcc::PllConfig pll{.Mul = Rcc::PllMultiplier::Mul4, .Div = 2};
+	static constexpr uint32_t Pll = Rcc::HsiFrequency * Rcc::value(pll.Mul) / pll.Div;
+	static constexpr uint32_t Frequency = Pll;
+	static_assert(Frequency == Rcc::MaxFrequency);
+
 	static constexpr uint32_t Ahb = Frequency;
 	static constexpr uint32_t Apb1 = Frequency;
 	static constexpr uint32_t Apb2 = Frequency;
 
-	static constexpr uint32_t Adc     = Apb2;
+	static constexpr uint32_t Crc  = Ahb;
+	static constexpr uint32_t Rng  = Ahb;
+	static constexpr uint32_t Tsc  = Ahb;
 
+	static constexpr uint32_t Adc    = Apb2;
+	static constexpr uint32_t Comp1  = Apb2;
+	static constexpr uint32_t Comp2  = Apb2;
+	static constexpr uint32_t Spi1   = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+
+	static constexpr uint32_t Crs     = Apb1;
 	static constexpr uint32_t Dac     = Apb1;
-
-	static constexpr uint32_t Comp1   = Apb2;
-	static constexpr uint32_t Comp2   = Apb2;
-
-	static constexpr uint32_t Spi1    = Apb2;
-	static constexpr uint32_t Spi2    = Apb1;
-
-	static constexpr uint32_t Usart1  = Apb2;
-	static constexpr uint32_t Usart2  = Apb1;
-
-	static constexpr uint32_t Lpuart1 = Apb1;
-
 	static constexpr uint32_t I2c1    = Apb1;
 	static constexpr uint32_t I2c2    = Apb1;
-
+	static constexpr uint32_t Lcd     = Apb1;
+	static constexpr uint32_t Lptim1  = Apb1;
+	static constexpr uint32_t Lpuart1 = Apb1;
+	static constexpr uint32_t Spi2    = Apb1;
+	static constexpr uint32_t Usart2  = Apb1;
 	static constexpr uint32_t Usb     = Apb1;
+	static constexpr uint32_t Wwdg    = Apb1;
 
 	static constexpr uint32_t Apb1Timer = Apb1 * 1;
 	static constexpr uint32_t Apb2Timer = Apb2 * 1;
@@ -65,26 +71,18 @@ struct SystemClock
 	static bool inline
 	enable()
 	{
-		Rcc::enableLowSpeedExternalCrystal();
-		Rcc::enableRealTimeClock(Rcc::RealTimeClockSource::LowSpeedExternalCrystal);
+		Rcc::enableLseCrystal();
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
 
-		Rcc::enableInternalClock();	// 16MHz
-		// (internal clock / 1) * 4 / 2 = 32MHz
-		const Rcc::PllFactors pllFactors{
-			.pllMul = Rcc::PllMultiplier::Mul4,
-			.pllDiv = 2,
-			.enableHsiPrediv4 = false
-		};
-		Rcc::enablePll(Rcc::PllSource::Hsi16, pllFactors);
-		// set flash latency for 32MHz
+		Rcc::enableHsiClock();
 		Rcc::setFlashLatency<Frequency>();
-		// switch system clock to PLL output
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enablePll(Rcc::PllSource::Hsi, pll);
 		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll);
 		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
-		Rcc::setApb1Prescaler(Rcc::Apb1Prescaler::Div1);
-		Rcc::setApb2Prescaler(Rcc::Apb2Prescaler::Div1);
-		// update frequencies for busy-wait delay functions
-		Rcc::updateCoreFrequency<Frequency>();
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
 
 		return true;
 	}

--- a/src/modm/platform/clock/stm32/module.lb
+++ b/src/modm/platform/clock/stm32/module.lb
@@ -146,7 +146,7 @@ def build(env):
                 ids += device.get_driver(driver)["instance"]
         return list(map(int, ids))
 
-    if t.family in ["h5", "u0", "g0", "u3", "c0", "f0"]:
+    if t.family in ["h5", "u0", "g0", "u3", "c0", "f0", "l0"]:
         p["uart_ids"] = instances("usart", "uart")
         p["lpuart_ids"] = instances("lpuart")
         p["spi_ids"] = instances("spi")

--- a/src/modm/platform/clock/stm32/rcc_l0.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_l0.hpp.in
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include "../device.hpp"
+#include <modm/platform/core/peripherals.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/architecture/interface/delay.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Reset and Clock Control for STM32L0 devices.
+ *
+ * This class abstracts access to clock settings on the STM32.
+ * You need to use this class to enable internal and external clock
+ * sources & outputs, set PLL parameters and AHB & APB prescalers.
+ * Don't forget to set the flash latencies.
+ *
+ * @author		Niklas Hauser
+ * @ingroup		modm_platform_rcc
+ */
+class Rcc
+{
+public:
+	static constexpr uint32_t LsiFrequency = 37'000;
+	static constexpr uint32_t HsiFrequency = 16'000'000;
+	static constexpr uint32_t MsiFrequency = 2'097'000; ///< Default MSI frequency at boot
+	static constexpr uint32_t BootFrequency = MsiFrequency;
+	static constexpr uint32_t MaxFrequency = 32'000'000;
+
+	/// Connect GPIO signals like MCO to the clock tree
+	template< class... Signals >
+	static void
+	connect()
+	{
+		using Connector = GpioConnector<Peripheral::Rcc, Signals...>;
+		Connector::connect();
+	}
+
+	/// Enable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	enable();
+
+	/// Check if a peripheral clock is enabled
+	template< Peripheral peripheral >
+	static bool
+	isEnabled();
+
+	/// Disable the clock for a peripheral
+	template< Peripheral peripheral >
+	static void
+	disable();
+
+
+public:
+	/** Set flash latency for CPU frequency and voltage.
+	 * Does nothing if CPU frequency is too high for the available
+	 * voltage.
+	 *
+	 * @returns maximum CPU frequency for voltage.
+	 * @retval	<=CPU_Frequency flash latency has been set correctly.
+	 * @retval	>CPU_Frequency requested frequency too high for voltage.
+	 */
+	template< uint32_t Core_Hz, uint16_t Core_mV = 3300>
+	static uint32_t
+	setFlashLatency();
+
+	/// Update the SystemCoreClock and delay variables.
+	template< uint32_t Core_Hz >
+	static void
+	updateCoreFrequency();
+
+
+public:
+	// clock sources
+	enum class
+	MsiRange : uint32_t
+	{
+		kHz65   = 0b000 << RCC_ICSCR_MSIRANGE_Pos,  ///< 65.536 kHz
+		kHz131  = 0b001 << RCC_ICSCR_MSIRANGE_Pos,  ///< 131.072 kHz
+		kHz262  = 0b010 << RCC_ICSCR_MSIRANGE_Pos,  ///< 262.144 kHz
+		kHz524  = 0b011 << RCC_ICSCR_MSIRANGE_Pos,  ///< 524.288 kHz
+		MHz1    = 0b100 << RCC_ICSCR_MSIRANGE_Pos,  ///< 1.048 MHz
+		MHz2    = 0b101 << RCC_ICSCR_MSIRANGE_Pos,  ///< 2.097 MHz (default)
+		MHz4    = 0b110 << RCC_ICSCR_MSIRANGE_Pos,  ///< 4.194 MHz
+	};
+	static inline bool
+	enableMsiClock(MsiRange range = MsiRange::MHz2, uint32_t waitLoops = 0x10000)
+	{
+		RCC->ICSCR = (RCC->ICSCR & ~RCC_ICSCR_MSIRANGE) | uint32_t(range);
+		RCC->CR |= RCC_CR_MSION;
+		while (not (RCC->CR & RCC_CR_MSIRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableHsiClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSION;
+		while (not (RCC->CR & RCC_CR_HSIRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+	/// Enable HSI4 clock by dividing HSI16 by 4
+	static inline bool
+	enableHsi4Clock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSION | RCC_CR_HSIDIVEN;
+		while (not (RCC->CR & RCC_CR_HSIDIVF) and --waitLoops) ;
+		return waitLoops;
+	}
+%% set with_hsi48 = target.name[1] in "23"
+%% if with_hsi48
+%#
+	static inline bool
+	enableHsi48Clock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CRRCR |= RCC_CRRCR_HSI48ON;
+		while (not (RCC->CRRCR & RCC_CRRCR_HSI48RDY) and --waitLoops) ;
+		return waitLoops;
+	}
+%% endif
+%#
+	static inline bool
+	enableHseClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR |= RCC_CR_HSEBYP | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableHseCrystal(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_HSEBYP) | RCC_CR_HSEON;
+		while (not (RCC->CR & RCC_CR_HSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableLsiClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CSR |= RCC_CSR_LSION;
+		while (not (RCC->CSR & RCC_CSR_LSIRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	static inline bool
+	enableLseClock(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CSR |= RCC_CSR_LSEBYP | RCC_CSR_LSEON;
+		while (not (RCC->CSR & RCC_CSR_LSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	enum class
+	LseDrive : uint8_t
+	{
+		Low        = 0b00,
+		MediumLow  = 0b01,
+		MediumHigh = 0b10,
+		High       = 0b11,
+	};
+	static inline bool
+	enableLseCrystal(LseDrive drive = LseDrive::Low, uint32_t waitLoops = 0x10000)
+	{
+		RCC->CSR = (RCC->CSR & ~(RCC_CSR_LSEDRV | RCC_CSR_LSEBYP)) |
+					(uint32_t(drive) << RCC_CSR_LSEDRV_Pos) | RCC_CSR_LSEON;
+		while (not (RCC->CSR & RCC_CSR_LSERDY) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	// clock modifiers
+	enum class
+	PllSource : uint8_t
+	{
+		Hsi = 0b0, ///< HSI16
+		Hse = 0b1, ///< HSE
+	};
+
+	enum class
+	PllMultiplier : uint8_t
+	{
+		Mul3  = 0b0000,
+		Mul4  = 0b0001,
+		Mul6  = 0b0010,
+		Mul8  = 0b0011,
+		Mul12 = 0b0100,
+		Mul16 = 0b0101,
+		Mul24 = 0b0110,
+		Mul32 = 0b0111,
+		Mul48 = 0b1000,
+	};
+	struct PllConfig
+	{
+		PllMultiplier Mul;
+		uint8_t Div;    ///< Division factor: 2, 3, 4
+	};
+	/// Configure and enable the PLL
+	static inline bool
+	enablePll(PllSource src, const PllConfig& cfg, uint32_t waitLoops = 0x10000)
+	{
+		if (cfg.Div <= 1) return false;
+
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_PLLSRC | RCC_CFGR_PLLMUL | RCC_CFGR_PLLDIV)) |
+					(uint32_t(src) << RCC_CFGR_PLLSRC_Pos) |
+					(uint32_t(cfg.Mul) << RCC_CFGR_PLLMUL_Pos) |
+					(((cfg.Div - 1) << RCC_CFGR_PLLDIV_Pos) & RCC_CFGR_PLLDIV);
+
+		RCC->CR |= RCC_CR_PLLON;
+		while (not (RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+	/// Disable PLL
+	static inline bool
+	disablePll(uint32_t waitLoops = 0x10000)
+	{
+		RCC->CR &= ~RCC_CR_PLLON;
+		while ((RCC->CR & RCC_CR_PLLRDY) and --waitLoops) ;
+		return waitLoops;
+	}
+	static constexpr uint8_t
+	value(PllMultiplier m)
+	{
+		static constexpr uint8_t lut[] = {3u, 4u, 6u, 8u, 12u, 16u, 24u, 32u, 48u};
+		const auto idx = static_cast<uint8_t>(m);
+		return (idx < sizeof(lut)) ? lut[idx] : 0u;
+	}
+
+	enum class
+	AhbPrescaler : uint8_t
+	{
+		Div1   = 0b0000,
+		Div2   = 0b1000,
+		Div4   = 0b1001,
+		Div8   = 0b1010,
+		Div16  = 0b1011,
+		Div64  = 0b1100,
+		Div128 = 0b1101,
+		Div256 = 0b1110,
+		Div512 = 0b1111,
+	};
+	static inline void
+	setAhbPrescaler(AhbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | (uint32_t(prescaler) << RCC_CFGR_HPRE_Pos);
+	}
+
+	enum class
+	ApbPrescaler : uint8_t
+	{
+		Div1   = 0b000,
+		Div2   = 0b100,
+		Div4   = 0b101,
+		Div8   = 0b110,
+		Div16  = 0b111
+	};
+	static inline void
+	setApb1Prescaler(ApbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE1) | (uint32_t(prescaler) << RCC_CFGR_PPRE1_Pos);
+	}
+	static inline void
+	setApb2Prescaler(ApbPrescaler prescaler)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE2) | (uint32_t(prescaler) << RCC_CFGR_PPRE2_Pos);
+	}
+
+	// clock sinks
+	enum class
+	SystemClockSource : uint32_t
+	{
+		Msi = 0b00,
+		Hsi = 0b01,
+		Hse = 0b10,
+		Pll = 0b11,
+	};
+	static inline bool
+	enableSystemClock(SystemClockSource src, uint32_t waitLoops = 0x10000)
+	{
+		RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_SW) | uint32_t(src);
+		// Wait till the main clock source is switched
+		while ((RCC->CFGR & RCC_CFGR_SWS) != (uint32_t(src) << RCC_CFGR_SWS_Pos) and --waitLoops) ;
+		return waitLoops;
+	}
+
+	enum class
+	RealTimeClockSource : uint32_t
+	{
+		Disabled = 0,
+		Lse = 0b01 << RCC_CSR_RTCSEL_Pos,
+		Lsi = 0b10 << RCC_CSR_RTCSEL_Pos,
+		Hse = 0b11 << RCC_CSR_RTCSEL_Pos,  ///< HSE divided by RTC prescaler (2, 4, 8, 16)
+	};
+	enum class
+	RtcPrescaler : uint8_t
+	{
+		Div2  = 0b00,
+		Div4  = 0b01,
+		Div8  = 0b10,
+		Div16 = 0b11,
+	};
+	static inline void
+	setRealTimeClockSource(RealTimeClockSource src, RtcPrescaler prescaler = RtcPrescaler::Div2)
+	{
+		RCC->CR = (RCC->CR & ~RCC_CR_RTCPRE) | (uint32_t(prescaler) << RCC_CR_RTCPRE_Pos);
+		RCC->CSR = (RCC->CSR & ~RCC_CSR_RTCSEL) | RCC_CSR_RTCEN | uint32_t(src);
+	}
+
+	// CCIPR - Peripheral clock sources
+	enum class
+	UsartClockSource : uint8_t
+	{
+		Bus = 0b00,
+		SysClk = 0b01,
+		Hsi = 0b10,
+		Lse = 0b11,
+	};
+%% if target.name >= "51"
+	static inline void
+	setUsart1ClockSource(UsartClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_USART1SEL) | (uint32_t(src) << RCC_CCIPR_USART1SEL_Pos);
+	}
+%% endif
+	static inline void
+	setUsart2ClockSource(UsartClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_USART2SEL) | (uint32_t(src) << RCC_CCIPR_USART2SEL_Pos);
+	}
+
+	static inline void
+	setLpuart1ClockSource(UsartClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPUART1SEL) | (uint32_t(src) << RCC_CCIPR_LPUART1SEL_Pos);
+	}
+
+	enum class
+	I2cClockSource : uint8_t
+	{
+		Bus = 0b00,
+		SysClk = 0b01,
+		Hsi = 0b10,
+	};
+	static inline void
+	setI2c1ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_I2C1SEL) | (uint32_t(src) << RCC_CCIPR_I2C1SEL_Pos);
+	}
+%% if target.name >= "71"
+	static inline void
+	setI2c3ClockSource(I2cClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_I2C3SEL) | (uint32_t(src) << RCC_CCIPR_I2C3SEL_Pos);
+	}
+%% endif
+
+	enum class
+	Lptim1ClockSource : uint8_t
+	{
+		Bus = 0b00,
+		Lsi = 0b01,
+		Hsi = 0b10,
+		Lse = 0b11,
+	};
+	static inline void
+	setLptim1ClockSource(Lptim1ClockSource src)
+	{
+		RCC->CCIPR = (RCC->CCIPR & ~RCC_CCIPR_LPTIM1SEL) | (uint32_t(src) << RCC_CCIPR_LPTIM1SEL_Pos);
+	}
+%% if with_hsi48
+	static inline void
+	setHsi48ClockSource(bool usePll)
+	{
+		if (usePll)
+			RCC->CCIPR |= RCC_CCIPR_HSI48SEL;
+		else
+			RCC->CCIPR &= ~RCC_CCIPR_HSI48SEL;
+	}
+%% endif
+
+	enum class
+	McoClockSource : uint32_t
+	{
+		Disabled = 0b0000 << RCC_CFGR_MCOSEL_Pos,
+		SysClk   = 0b0001 << RCC_CFGR_MCOSEL_Pos,
+		Hsi      = 0b0010 << RCC_CFGR_MCOSEL_Pos,
+		Msi      = 0b0011 << RCC_CFGR_MCOSEL_Pos,
+		Hse      = 0b0100 << RCC_CFGR_MCOSEL_Pos,
+		Pll      = 0b0101 << RCC_CFGR_MCOSEL_Pos,
+		Lsi      = 0b0110 << RCC_CFGR_MCOSEL_Pos,
+		Lse      = 0b0111 << RCC_CFGR_MCOSEL_Pos,
+%% if with_hsi48
+		Hsi48    = 0b1000 << RCC_CFGR_MCOSEL_Pos,
+%% endif
+	};
+	enum class
+	McoPrescaler : uint8_t
+	{
+		Div1  = 0b000,
+		Div2  = 0b001,
+		Div4  = 0b010,
+		Div8  = 0b011,
+		Div16 = 0b100,
+	};
+	static inline void
+	setMcoClockSource(McoClockSource src, McoPrescaler prescaler = McoPrescaler::Div1)
+	{
+		RCC->CFGR = (RCC->CFGR & ~(RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE)) |
+					uint32_t(src) | (uint32_t(prescaler) << RCC_CFGR_MCOPRE_Pos);
+	}
+
+private:
+	struct flash_latency
+	{
+		uint32_t latency;
+		uint32_t max_frequency;
+	};
+	static constexpr flash_latency
+	computeFlashLatency(uint32_t Core_Hz, uint16_t Core_mV);
+};
+
+} // namespace modm::platform
+
+#include "rcc_impl.hpp"


### PR DESCRIPTION
- [x] Extract RCC driver to separate file and significantly improve the API
- [x] Tested in hardware on a NUCLEO-L053R8.