### PR TITLE
[ext] Fixes for STM32U5 memory map and rcc

### DIFF
--- a/src/modm/platform/clock/stm32/rcc_u5.hpp.in
+++ b/src/modm/platform/clock/stm32/rcc_u5.hpp.in
@@ -763,7 +763,7 @@ public:
 		MsiK     = 0b1001,
 	};
 	static inline void
-	setMco1ClockSource(McoClockSource src, McoPrescaler div)
+	setMcoClockSource(McoClockSource src, McoPrescaler div)
 	{
 		RCC->CFGR1 = (RCC->CFGR1 & ~(RCC_CFGR1_MCOSEL | RCC_CFGR1_MCOPRE)) |
 					 (uint32_t(src) << RCC_CFGR1_MCOSEL_Pos) | (uint32_t(div) << RCC_CFGR1_MCOPRE_Pos);


### PR DESCRIPTION
Fixes an issue on larger STM32U5 devices which have the GFXMMU with a 16MB virtual memory region that is currently considered a physical memory thus the startup code tries to write there.