### PR TITLE
[fix] allow cmsis dsp on hosted linux

### DIFF
--- a/examples/linux/cmsis_dsp/bayes/main.cpp
+++ b/examples/linux/cmsis_dsp/bayes/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define while     \
+	return index; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_bayes_example/arm_bayes_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "bayes"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/bayes/project.xml
+++ b/examples/linux/cmsis_dsp/bayes/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/bayes</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:bayes</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/class_marks/main.cpp
+++ b/examples/linux/cmsis_dsp/class_marks/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define std  var_std
+#define while                \
+	return ARM_MATH_SUCCESS; \
+	void  // has no status variable
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_class_marks_example/arm_class_marks_example_f32.c"
+#undef while
+#undef main
+#undef std
+
+#define example_name "class_marks"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/class_marks/project.xml
+++ b/examples/linux/cmsis_dsp/class_marks/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/class_marks</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:matrix</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/convolution/main.cpp
+++ b/examples/linux/cmsis_dsp/convolution/main.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_convolution_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_convolution_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_convolution_example/arm_convolution_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "convolution"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/convolution/math_helper.h
+++ b/examples/linux/cmsis_dsp/convolution/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/convolution/project.xml
+++ b/examples/linux/cmsis_dsp/convolution/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/convolution</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:support</module>
+    <module>modm:cmsis:dsp:complex_math</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/dotproduct/main.cpp
+++ b/examples/linux/cmsis_dsp/dotproduct/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "dotproduct"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/dotproduct/project.xml
+++ b/examples/linux/cmsis_dsp/dotproduct/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/dotproduct</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:build:make</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/fft_bin/main.cpp
+++ b/examples/linux/cmsis_dsp/fft_bin/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fft_bin_example/arm_fft_bin_data.c"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fft_bin_example/arm_fft_bin_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "fft_bin"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/fft_bin/project.xml
+++ b/examples/linux/cmsis_dsp/fft_bin/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/fft_bin</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:transform</module>
+    <module>modm:cmsis:dsp:complex_math</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/fir/main.cpp
+++ b/examples/linux/cmsis_dsp/fir/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fir_example/arm_fir_data.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fir_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fir_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_fir_example/arm_fir_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "fir"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/fir/math_helper.h
+++ b/examples/linux/cmsis_dsp/fir/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/fir/project.xml
+++ b/examples/linux/cmsis_dsp/fir/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/fir</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:filtering</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/graphic_equalizer/main.cpp
+++ b/examples/linux/cmsis_dsp/graphic_equalizer/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_data.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_graphic_equalizer_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_graphic_equalizer_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example_q31.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "graphic_equalizer"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/graphic_equalizer/math_helper.h
+++ b/examples/linux/cmsis_dsp/graphic_equalizer/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/graphic_equalizer/project.xml
+++ b/examples/linux/cmsis_dsp/graphic_equalizer/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/graphic_equalizer</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:filtering</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/linear_interp/main.cpp
+++ b/examples/linux/cmsis_dsp/linear_interp/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_linear_interp_example/arm_linear_interp_data.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_linear_interp_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_linear_interp_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "linear_interp"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/linear_interp/math_helper.h
+++ b/examples/linux/cmsis_dsp/linear_interp/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/linear_interp/project.xml
+++ b/examples/linux/cmsis_dsp/linear_interp/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/linear_interp</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:build:make</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+    <module>modm:cmsis:dsp:interpolation</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/matrix/main.cpp
+++ b/examples/linux/cmsis_dsp/matrix/main.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_matrix_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_matrix_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_matrix_example/arm_matrix_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "matrix"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/matrix/math_helper.h
+++ b/examples/linux/cmsis_dsp/matrix/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/matrix/project.xml
+++ b/examples/linux/cmsis_dsp/matrix/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/matrix</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:matrix</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/runner.cpp
+++ b/examples/linux/cmsis_dsp/runner.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+int
+main()
+{
+	const int status = arm_cmsis_dsp_example();
+
+	if (status != ARM_MATH_TEST_FAILURE)
+	{
+		MODM_LOG_INFO << "Example '" << example_name << "' passed!" << modm::endl;
+	} else
+	{
+		MODM_LOG_ERROR << "Example '" << example_name << "' failed!" << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/linux/cmsis_dsp/signal_converge/main.cpp
+++ b/examples/linux/cmsis_dsp/signal_converge/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#define main arm_cmsis_dsp_example
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_signal_converge_example/arm_signal_converge_data.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_signal_converge_example/math_helper.c"
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_signal_converge_example/math_helper.h"
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_signal_converge_example/arm_signal_converge_example_f32.c"
+#undef while
+#undef main
+#pragma GCC diagnostic pop
+
+#define example_name "signal_converge"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/signal_converge/math_helper.h
+++ b/examples/linux/cmsis_dsp/signal_converge/math_helper.h
@@ -1,0 +1,1 @@
+// Empty file to satisfy CPP

--- a/examples/linux/cmsis_dsp/signal_converge/project.xml
+++ b/examples/linux/cmsis_dsp/signal_converge/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/signal_converge</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:filtering</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:statistics</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/sin_cos/main.cpp
+++ b/examples/linux/cmsis_dsp/sin_cos/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "sin_cos"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/sin_cos/project.xml
+++ b/examples/linux/cmsis_dsp/sin_cos/project.xml
@@ -1,0 +1,13 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/sin_cos</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/svm/main.cpp
+++ b/examples/linux/cmsis_dsp/svm/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define while      \
+	return result; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_svm_example/arm_svm_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "svm"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/svm/project.xml
+++ b/examples/linux/cmsis_dsp/svm/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/svm</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:svm</module>
+  </modules>
+</library>

--- a/examples/linux/cmsis_dsp/variance/main.cpp
+++ b/examples/linux/cmsis_dsp/variance/main.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <arm_math.h>
+
+#include <modm/debug/logger.hpp>
+#include <modm/platform.hpp>
+
+#define main arm_cmsis_dsp_example
+#define while      \
+	return status; \
+	void
+#include "../../../../ext/arm/cmsis-dsp/CMSIS-DSP/Examples/ARM/arm_variance_example/arm_variance_example_f32.c"
+#undef while
+#undef main
+
+#define example_name "variance"
+#include "../runner.cpp"

--- a/examples/linux/cmsis_dsp/variance/project.xml
+++ b/examples/linux/cmsis_dsp/variance/project.xml
@@ -1,0 +1,14 @@
+<library>
+  <options>
+    <option name="modm:target">hosted-linux</option>
+    <option name="modm:build:build.path">../../../../build/linux/cmsis_dsp/variance</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:platform:core</module>
+    <module>modm:debug</module>
+    <module>modm:cmsis:dsp:basic_math</module>
+    <module>modm:cmsis:dsp:fast_math</module>
+    <module>modm:cmsis:dsp:support</module>
+  </modules>
+</library>

--- a/ext/arm/arm_math.h.in
+++ b/ext/arm/arm_math.h.in
@@ -31,7 +31,9 @@ extern "C"
 {
 #endif
 
+%% if is_cortex_m
 #include <modm/platform/device.hpp>
+%% endif
 
 /* Local configuration file */
 #if __has_include(<arm_math_local.h>)

--- a/ext/arm/cmsis.lb
+++ b/ext/arm/cmsis.lb
@@ -16,7 +16,7 @@ def init(module):
     module.description = FileReader("cmsis.md")
 
 def prepare(module, options):
-    return options[":target"].has_driver("core:cortex-m*")
+    return (options[":target"].has_driver("core:cortex-m*")) or (options[":target"].identifier.string == "hosted-linux")
 
 def build(env):
     pass

--- a/ext/arm/dsp.lb
+++ b/ext/arm/dsp.lb
@@ -95,8 +95,7 @@ def init(module):
     module.description = FileReader("dsp.md")
 
 def prepare(module, options):
-    device = options[":target"]
-    if not device.has_driver("core:cortex-m*"):
+    if not (options[":target"].has_driver("core:cortex-m*") or options[":target"].identifier.string == "hosted-linux"):
         return False
 
     module.add_option(
@@ -115,6 +114,9 @@ def build(env):
     env.collect(":build:path.include", "modm/ext/cmsis/dsp/")
     env.outbasepath = "modm/ext/cmsis/dsp"
 
+    if env[":target"].identifier.string == "hosted-linux":
+        env.collect(":build:cppdefines", "__GNUC_PYTHON__")
+
     for path in Path(localpath("cmsis-dsp/CMSIS-DSP/Include/")).iterdir():
         if path.is_file() and not ("_f16" in path.name and not env["with_f16"]):
             # We need to replace this file to include the <cmsis_dsp_local.h>
@@ -131,6 +133,7 @@ def build(env):
         "core": core,
         "includes": includes,
         "with_fpu": env.get(":platform:cortex-m:float-abi", "soft") != "soft",
+        "is_cortex_m": env[":target"].has_driver("core:cortex-m*")
     }
     env.template("arm_math.h.in")
     if env["with_f16"]: env.template("arm_math_f16.h.in")


### PR DESCRIPTION
It can be annoyingly hard to develop numerics directly on bare-metal microcontroller.
The CMSIS DSP compiles just fine on the `hosted-linux` target.

Is there any reason to not allow for this target in the lbuild module?