### PR TITLE
Add support for nRF51, nRF52, nRF53

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -113,6 +113,32 @@ jobs:
           name: samx7-compile-all
           path: test/all/log
 
+  nrf-compile-all:
+    if: github.event.label.name == 'ci:hal'
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Fix Git permission/ownership problem
+        run: |
+          git config --global --add safe.directory /__w/modm/modm
+      - name: Update lbuild
+        run: |
+          pip3 install --upgrade --upgrade-strategy=eager --break-system-packages modm
+      - name: Compile HAL for all nRF5x
+        run: |
+          (cd test/all && python3 run_all.py nrf --quick-remaining)
+      - name: Upload log artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nrf5x-compile-all
+          path: test/all/log
+
   stm32c0-compile-all:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,6 +117,10 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py feather_rp2040 rp_pico thingplus_rp2040)
+      - name: Examples NRF5 Series
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nrf51422-dk nrf52840-dk nrf5340-dk)
       - name: Execute Python Scripts
         if: always()
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Quick compile HAL for Cortex-M Part 1
         if: always()
         run: |
-          (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 0)
+          (cd test/all && python3 run_all.py stm32 sam rp nrf --quick --split 4 --part 0)
       - name: Upload log artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -345,7 +345,7 @@ jobs:
       - name: Quick compile HAL for Cortex-M Part 2
         if: always()
         run: |
-          (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 1)
+          (cd test/all && python3 run_all.py stm32 sam rp nrf --quick --split 4 --part 1)
       - name: Upload log artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -370,7 +370,7 @@ jobs:
       - name: Quick compile HAL for Cortex-M Part 3
         if: always()
         run: |
-          (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 2)
+          (cd test/all && python3 run_all.py stm32 sam rp nrf --quick --split 4 --part 2)
       - name: Upload log artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -395,7 +395,7 @@ jobs:
       - name: Quick compile HAL for Cortex-M Part 4
         if: always()
         run: |
-          (cd test/all && python3 run_all.py stm32 sam rp --quick --split 4 --part 3)
+          (cd test/all && python3 run_all.py stm32 sam rp nrf --quick --split 4 --part 3)
       - name: Upload log artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,3 +75,8 @@ jobs:
         if: always()
         run: |
           (cd examples && ../tools/scripts/examples_compile.py avr)
+
+      - name: Compile NRF Examples
+        if: always()
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nrf51422-dk nrf52840-dk nrf5340-dk)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,3 +136,9 @@ jobs:
         shell: bash
         run: |
           (cd examples && ../tools/scripts/examples_compile.py avr arduino_nano arduino_uno srxe)
+
+      - name: Compile NRF Examples
+        if: always()
+        shell: bash
+        run: |
+          (cd examples && ../tools/scripts/examples_compile.py nrf51422-dk nrf52840-dk nrf5340-dk)

--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "ext/libeigen/eigen"]
 	path = ext/libeigen/eigen
 	url = https://github.com/modm-ext/eigen-partial.git
+[submodule "ext/nordic/nrfx"]
+	path = ext/nordic/nrfx
+	url = https://github.com/modm-ext/nrfx-partial.git

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center" colspan="18">STM32</th>
 <th align="center" colspan="4">SAM</th>
 <th align="center" colspan="1">RP</th>
+<th align="center" colspan="3">NRF</th>
 <th align="center" colspan="3">AT</th>
 </tr><tr>
 <th align="left">Peripheral</th>
@@ -134,6 +135,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <th align="center">E7x<br/>S7x<br/>V7x</th>
 <th align="center">G5x</th>
 <th align="center">20</th>
+<th align="center">51</th>
+<th align="center">52</th>
+<th align="center">53</th>
 <th align="center">90</th>
 <th align="center">Mega</th>
 <th align="center">Tiny</th>
@@ -165,6 +169,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 </tr><tr>
 <td align="left">CAN</td>
 <td align="center">✅</td>
@@ -188,6 +195,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✅</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">○</td>
@@ -221,6 +231,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 </tr><tr>
 <td align="left">DAC</td>
 <td align="center">✕</td>
@@ -244,6 +257,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -272,7 +288,10 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
-<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -305,6 +324,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
 </tr><tr>
 <td align="left">External Interrupt</td>
 <td align="center">✅</td>
@@ -330,6 +352,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -339,7 +364,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✕</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">✕</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✕</td>
@@ -354,15 +379,21 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">○</td>
 <td align="center">✕</td>
-<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
 <td align="left">GPIO</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -414,6 +445,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -442,34 +476,40 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 </tr><tr>
-<td align="left">IWDG</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
-<td align="center">✅</td>
+<td align="left">Power</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -498,6 +538,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -521,6 +564,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
@@ -554,6 +600,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -582,9 +631,12 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 </tr><tr>
 <td align="left">Timer</td>
 <td align="center">✅</td>
@@ -613,8 +665,14 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 </tr><tr>
 <td align="left">UART</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -663,9 +721,12 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
-<td align="center">✕</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
@@ -695,8 +756,42 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">✕</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">✕</td>
 <td align="center">✕</td>
+<td align="center">✕</td>
+</tr><tr>
+<td align="left">Watchdog</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
+<td align="center">○</td>
 </tr>
 </table>
 <!--/alltable-->

--- a/README.md
+++ b/README.md
@@ -843,79 +843,83 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-feather-m4">FEATHER-M4</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-feather-rp2040">FEATHER-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-mega-2560-pro">MEGA-2560-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-c031c6">NUCLEO-C031C6</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nrf51422-dk">NRF51422-DK</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nrf52840-dk">NRF52840-DK</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nrf5340-dk">NRF5340-DK</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-c031c6">NUCLEO-C031C6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f031k6">NUCLEO-F031K6</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f042k6">NUCLEO-F042K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f072rb">NUCLEO-F072RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f091rc">NUCLEO-F091RC</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f103rb">NUCLEO-F103RB</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f207zg">NUCLEO-F207ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303k8">NUCLEO-F303K8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f303re">NUCLEO-F303RE</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f334r8">NUCLEO-F334R8</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f401re">NUCLEO-F401RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f411re">NUCLEO-F411RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f429zi">NUCLEO-F429ZI</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f439zi">NUCLEO-F439ZI</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446re">NUCLEO-F446RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f446ze">NUCLEO-F446ZE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f722ze">NUCLEO-F722ZE</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f746zg">NUCLEO-F746ZG</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-f767zi">NUCLEO-F767ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g070rb">NUCLEO-G070RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g071rb">NUCLEO-G071RB</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g0b1re">NUCLEO-G0B1RE</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431kb">NUCLEO-G431KB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g431rb">NUCLEO-G431RB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h503rb">NUCLEO-H503RB</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h533re">NUCLEO-H533RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u385rg-q">NUCLEO-U385RG-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
+</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h523ce">WEACT-H523CE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
-</tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
+</tr><tr>
 </tr>
 </table>
 <!--/bsptable-->

--- a/docs/targets.md.in
+++ b/docs/targets.md.in
@@ -42,6 +42,14 @@ Identifier format example for `STM32G071GBU6N/revY`:
 ```
 The revision is optional, however, the device variant often means significant
 differences in pinout or peripherals, so check your device's identifier twice!
+%% elif "nRF" in platform
+Identifier format example for `NRF5340-XXAA@net`:
+```
+    nrf      53     40      xx      aa      net
+{platform}{family}{name}-{code}{package}@{core}
+```
+The core suffix is optional and only required for multi-core devices.
+You can select `@app` or `@net` on nRF53 targets.
 %% elif "SAM" in platform
 Identifier format example for `SAMD21G18A-AU`:
 ```

--- a/examples/generic/usb/project.xml
+++ b/examples/generic/usb/project.xml
@@ -27,6 +27,8 @@
   <!-- <extends>modm:weact-h523ce</extends> -->
   <!-- <extends>modm:weact-h562rg</extends> -->
   <!-- <extends>modm:nucleo-u385rg-q</extends> -->
+  <!-- <extends>modm:nrf5340-dk</extends> -->
+  <!-- <extends>modm:nrf52840-dk</extends> -->
   <options>
     <option name="modm:build:build.path">../../../build/generic/usb</option>
     <option name="modm:tinyusb:config">device.cdc,device.msc</option>

--- a/examples/nrf51422-dk/blink/main.cpp
+++ b/examples/nrf51422-dk/blink/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+
+int
+main()
+{
+	Board::initialize();
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Board::Leds::write(1 << (counter % Board::Leds::width));
+		modm::delay(Board::Buttons::read() ? 100ms : 500ms);
+		counter++;
+	}
+}

--- a/examples/nrf51422-dk/blink/project.xml
+++ b/examples/nrf51422-dk/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nrf51422-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf51422-dk/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf51422-dk/uart_logging/main.cpp
+++ b/examples/nrf51422-dk/uart_logging/main.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF51422-DK UART logging
+
+UART logger and echo example using board defaults.
+
+- Uses UART0 logger pins from the BSP (`P0.09` TX, `P0.11` RX).
+- Prints startup log message and echoes received bytes.
+- Toggles LEDs on incoming data.
+
+Useful for validating UART routing and logger setup on nRF51.
+*/
+
+#include <modm/board.hpp>
+
+using LogUart = Board::uart::Uart;
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "nRF51422-DK UART logging via Board BSP" << modm::endl;
+
+	while (true)
+	{
+		uint8_t data;
+		if (Board::uart::Uart::read(data)) {
+			Board::uart::Uart::write(data);
+			MODM_LOG_INFO << "echo: 0x" << modm::hex << uint16_t(data) << modm::endl;
+			Board::Leds::toggle();
+		}
+	}
+}

--- a/examples/nrf51422-dk/uart_logging/project.xml
+++ b/examples/nrf51422-dk/uart_logging/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nrf51422-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf51422-dk/uart_logging</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf52840-dk/adc/main.cpp
+++ b/examples/nrf52840-dk/adc/main.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF52840-DK SAADC + regulators
+
+ADC and power-regulator demonstration.
+
+- Reads `Ain0..Ain3`, `Vdd` and `VddhDiv5`.
+- Demonstrates regulator APIs (`DCDC` enable/disable, `REGOUT0` handling).
+- Uses button input to toggle DCDC state and logs measured voltages.
+
+This example is useful to validate the nRF SAADC channel generation and power
+control APIs.
+*/
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using Adc = modm::platform::Adc;
+using Regulators = modm::platform::Regulators;
+
+int
+main()
+{
+	Board::initialize();
+
+	constexpr auto TargetVddOutput = Regulators::VddOutputVoltage::V3_0;
+	auto voltageToString = [](Regulators::VddOutputVoltage voltage) {
+		switch (voltage)
+		{
+			case Regulators::VddOutputVoltage::V1_8: return "1.8V";
+			case Regulators::VddOutputVoltage::V2_1: return "2.1V";
+			case Regulators::VddOutputVoltage::V2_4: return "2.4V";
+			case Regulators::VddOutputVoltage::V2_7: return "2.7V";
+			case Regulators::VddOutputVoltage::V3_0: return "3.0V";
+			case Regulators::VddOutputVoltage::V3_3: return "3.3V";
+			case Regulators::VddOutputVoltage::Default: return "default(1.8V)";
+		}
+		return "unknown";
+	};
+
+	auto currentVddOutput = Regulators::vddOutputVoltage();
+	MODM_LOG_INFO << "UICR REGOUT0: " << voltageToString(currentVddOutput)
+		<< " target=" << voltageToString(TargetVddOutput) << modm::endl;
+
+	auto writeResult = Regulators::setVddOutputVoltage(TargetVddOutput);
+	switch (writeResult)
+	{
+		case Regulators::VddOutputVoltageWriteResult::Unchanged:
+			MODM_LOG_INFO << "REGOUT0 already configured." << modm::endl;
+			break;
+		case Regulators::VddOutputVoltageWriteResult::EraseRequired:
+			MODM_LOG_INFO << "REGOUT0 change requires UICR erase/reprogram (cannot set 0->1 bits)." << modm::endl;
+			break;
+		case Regulators::VddOutputVoltageWriteResult::Programmed:
+			MODM_LOG_INFO << "REGOUT0 updated in UICR. Resetting to apply." << modm::endl;
+			NVIC_SystemReset();
+			break;
+	}
+
+	bool dcdcEnabled = true;
+	Regulators::setMainDcdcEnabled(dcdcEnabled);
+	Regulators::setVddhDcdcEnabled(dcdcEnabled);
+
+	Board::Led1::setOutput();
+	Adc::connect<GpioP0_2::Ain0, GpioP0_3::Ain1, GpioP0_4::Ain2, GpioP0_5::Ain3>();
+	Adc::initialize<Board::SystemClock>(Adc::Oversampling::Over8x);
+
+	MODM_LOG_INFO << "nRF52840-DK SAADC example" << modm::endl;
+	MODM_LOG_INFO << "Button1 toggles DCDC (main + high)" << modm::endl;
+	MODM_LOG_INFO << "Reading AIN0..AIN3, VDD and VDDH/5" << modm::endl;
+
+	modm::PeriodicTimer sampleTimer(500ms);
+	modm::PeriodicTimer buttonPollTimer(20ms);
+	bool previousButtonPressed = false;
+
+	constexpr uint32_t FullScaleMilliVolts = 3600;
+	constexpr uint32_t FullScaleRaw = (1u << Adc::Resolution) - 1u;
+	auto rawToMillivolts = [](uint16_t raw) {
+		return (uint32_t(raw) * FullScaleMilliVolts) / FullScaleRaw;
+	};
+
+	while (true)
+	{
+		if (buttonPollTimer.execute()) {
+			const bool buttonPressed = Board::Button1::read();
+			if (buttonPressed && !previousButtonPressed) {
+				dcdcEnabled = !dcdcEnabled;
+				Regulators::setMainDcdcEnabled(dcdcEnabled);
+				Regulators::setVddhDcdcEnabled(dcdcEnabled);
+				MODM_LOG_INFO << "DCDC " << (dcdcEnabled ? "enabled" : "disabled") << modm::endl;
+			}
+			previousButtonPressed = buttonPressed;
+		}
+
+		if (sampleTimer.execute())
+		{
+			auto ain0 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain0));
+			auto ain1 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain1));
+			auto ain2 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain2));
+			auto ain3 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain3));
+			auto vdd = rawToMillivolts(Adc::readChannel(Adc::Channel::Vdd));
+			auto vddh = rawToMillivolts(Adc::readChannel(Adc::Channel::VddhDiv5)) * 5u;
+
+			MODM_LOG_INFO.printf("AIN0=%4lumV AIN1=%4lumV AIN2=%4lumV AIN3=%4lumV VDD=%4lumV VDDH=%4lumV DCDC=%s",
+				ain0, ain1, ain2, ain3, vdd, vddh, dcdcEnabled ? "on" : "off");
+			MODM_LOG_INFO << modm::endl;
+
+			Board::Led1::toggle();
+		}
+	}
+}

--- a/examples/nrf52840-dk/adc/project.xml
+++ b/examples/nrf52840-dk/adc/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nrf52840-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf52840-dk/adc</option>
+  </options>
+  <modules>
+    <module>modm:processing:timer</module>
+    <module>modm:platform:power</module>
+    <module>modm:platform:adc</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf52840-dk/blink/main.cpp
+++ b/examples/nrf52840-dk/blink/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2011, Fabian Greif
+ * Copyright (c) 2013-2014, 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF52840-DK blink
+
+Minimal LED blink example for nRF52840-DK.
+
+- Initializes board clock, SysTick, LEDs and buttons.
+- Blinks LEDs to verify basic bring-up.
+
+Good first test after flashing a new toolchain setup.
+*/
+
+#include <modm/board.hpp>
+
+int
+main()
+{
+	Board::initialize();
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Board::Leds::write(1 << (counter % Board::Leds::width));
+		modm::delay(Board::Buttons::read() ? 100ms : 500ms);
+		counter++;
+	}
+}
+

--- a/examples/nrf52840-dk/blink/project.xml
+++ b/examples/nrf52840-dk/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nrf52840-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf52840-dk/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf52840-dk/uart_logging/main.cpp
+++ b/examples/nrf52840-dk/uart_logging/main.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF52840-DK UART logging
+
+EasyDMA UART logger example.
+
+- Uses BSP default UARTE logger on `P0.06` (TX) and `P0.08` (RX).
+- Prints periodic log output.
+
+Use this to validate UARTE wiring and host serial connection.
+*/
+
+#include <modm/board.hpp>
+
+using LogUart = Board::uart::Uart;
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "nRF52840-DK UART logging via Board BSP" << modm::endl;
+
+	while (true)
+	{
+		uint8_t data;
+		if (Board::uart::Uart::read(data)) {
+			Board::uart::Uart::write(data);
+			MODM_LOG_INFO << "echo: 0x" << modm::hex << uint16_t(data) << modm::endl;
+			Board::Leds::toggle();
+		}
+	}
+}

--- a/examples/nrf52840-dk/uart_logging/project.xml
+++ b/examples/nrf52840-dk/uart_logging/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nrf52840-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf52840-dk/uart_logging</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf5340-dk/adc/main.cpp
+++ b/examples/nrf5340-dk/adc/main.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF5340-DK ADC (app core)
+
+SAADC example for the nRF5340 application core.
+
+- Target: `nrf5340-xxaa@app`
+- Demonstrates channel reads and periodic logging.
+- Useful for validating ADC signal/channel mapping on nRF53.
+*/
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using Adc = modm::platform::Adc;
+using Regulators = modm::platform::Regulators;
+
+int
+main()
+{
+	Board::initialize();
+	Regulators::setMainDcdcEnabled();
+	Regulators::setRadioDcdcEnabled();
+	const bool vddhSupplyActive = Regulators::isVddhSupplyActive();
+	const bool usbVbusPresent = Regulators::isUsbVbusPresent();
+	const bool usbRegReady = Regulators::isUsbRegulatorOutputReady();
+	if (vddhSupplyActive) {
+		Regulators::setVddhDcdcEnabled();
+		Regulators::setVddhExternalSilentEnabled(false);
+
+		constexpr auto TargetVddhOutput = Regulators::VddhOutputVoltage::V3_0;
+		auto voltageToString = [](Regulators::VddhOutputVoltage voltage) {
+			switch (voltage)
+			{
+				case Regulators::VddhOutputVoltage::V1_8: return "1.8V";
+				case Regulators::VddhOutputVoltage::V2_1: return "2.1V";
+				case Regulators::VddhOutputVoltage::V2_4: return "2.4V";
+				case Regulators::VddhOutputVoltage::V2_7: return "2.7V";
+				case Regulators::VddhOutputVoltage::V3_0: return "3.0V";
+				case Regulators::VddhOutputVoltage::V3_3: return "3.3V";
+				case Regulators::VddhOutputVoltage::Default: return "default(1.8V)";
+			}
+			return "unknown";
+		};
+
+		auto currentVddhOutput = Regulators::vddhOutputVoltage();
+		MODM_LOG_INFO << "UICR VREGHVOUT: " << voltageToString(currentVddhOutput)
+			<< " target=" << voltageToString(TargetVddhOutput) << modm::endl;
+
+		auto writeResult = Regulators::setVddhOutputVoltage(TargetVddhOutput);
+		switch (writeResult)
+		{
+			case Regulators::VddhOutputVoltageWriteResult::Unchanged:
+				MODM_LOG_INFO << "VREGHVOUT already configured." << modm::endl;
+				break;
+			case Regulators::VddhOutputVoltageWriteResult::EraseRequired:
+				MODM_LOG_INFO << "VREGHVOUT change requires UICR erase/reprogram (cannot set 0->1 bits)." << modm::endl;
+				break;
+			case Regulators::VddhOutputVoltageWriteResult::Programmed:
+				MODM_LOG_INFO << "VREGHVOUT updated in UICR. Resetting to apply." << modm::endl;
+				NVIC_SystemReset();
+				break;
+		}
+	}
+
+	Board::Led1::setOutput();
+	Adc::connect<GpioP0_4::Ain0, GpioP0_5::Ain1, GpioP0_6::Ain2, GpioP0_7::Ain3>();
+	Adc::initialize<Board::SystemClock>(Adc::Oversampling::Over8x);
+
+	MODM_LOG_INFO << "nRF5340-DK SAADC example" << modm::endl;
+	MODM_LOG_INFO << "Main supply mode: " << (vddhSupplyActive ? "VDDH" : "VDD") << modm::endl;
+	MODM_LOG_INFO << "USBREG: VBUS=" << (usbVbusPresent ? "present" : "absent")
+		<< " output=" << (usbRegReady ? "ready" : "not-ready") << modm::endl;
+	MODM_LOG_INFO << "Reading AIN0..AIN3, VDD and optional VDDH" << modm::endl;
+
+	modm::PeriodicTimer timer(500ms);
+	constexpr uint32_t FullScaleMilliVolts = 3600;
+	constexpr uint32_t FullScaleRaw = (1u << Adc::Resolution) - 1u;
+	auto rawToMillivolts = [](uint16_t raw) {
+		return (uint32_t(raw) * FullScaleMilliVolts) / FullScaleRaw;
+	};
+
+	while (true)
+	{
+		if (timer.execute())
+		{
+			auto ain0 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain0));
+			auto ain1 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain1));
+			auto ain2 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain2));
+			auto ain3 = rawToMillivolts(Adc::readChannel(Adc::Channel::Ain3));
+			auto vdd = rawToMillivolts(Adc::readChannel(Adc::Channel::Vdd));
+			bool vddhActive = Regulators::isVddhSupplyActive();
+			auto vddh = vddhActive
+				? rawToMillivolts(Adc::readChannel(Adc::Channel::VddhDiv5)) * 5u
+				: 0u;
+
+			MODM_LOG_INFO.printf("AIN0=%4lumV AIN1=%4lumV AIN2=%4lumV AIN3=%4lumV VDD=%4lumV",
+				ain0, ain1, ain2, ain3, vdd);
+			if (vddhActive) {
+				MODM_LOG_INFO.printf(" VDDH=%4lumV", vddh);
+			}
+			else {
+				MODM_LOG_INFO << " VDDH=n/a";
+			}
+			MODM_LOG_INFO << modm::endl;
+
+			Board::Led1::toggle();
+		}
+	}
+}

--- a/examples/nrf5340-dk/adc/project.xml
+++ b/examples/nrf5340-dk/adc/project.xml
@@ -1,0 +1,12 @@
+<library>
+  <extends>modm:nrf5340-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf5340-dk/adc</option>
+  </options>
+  <modules>
+    <module>modm:processing:timer</module>
+    <module>modm:platform:power</module>
+    <module>modm:platform:adc</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf5340-dk/blink/main.cpp
+++ b/examples/nrf5340-dk/blink/main.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2011, Fabian Greif
+ * Copyright (c) 2013-2014, 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF5340-DK blink (app core)
+
+Basic blink example for the nRF5340 application core.
+
+- Target: `nrf5340-xxaa@app`
+- Uses app-core-owned LEDs/buttons from the BSP.
+- Validates startup, clock configuration and GPIO operation on the app core.
+*/
+
+#include <modm/board.hpp>
+
+int
+main()
+{
+	Board::initialize();
+
+	uint32_t counter(0);
+
+	while (true)
+	{
+		Board::Leds::write(1 << (counter % Board::Leds::width));
+		modm::delay(Board::Buttons::read() ? 100ms : 500ms);
+		counter++;
+	}
+}
+

--- a/examples/nrf5340-dk/blink/project.xml
+++ b/examples/nrf5340-dk/blink/project.xml
@@ -1,0 +1,9 @@
+<library>
+  <extends>modm:nrf5340-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf5340-dk/blink</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nrf5340-dk/uart_logging_net/main.cpp
+++ b/examples/nrf5340-dk/uart_logging_net/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF5340-DK UART logging (network core)
+
+UART logger example for the nRF5340 network core.
+
+- Target: `nrf5340-xxaa@net`
+- Uses net-core logger routing configured by the BSP.
+- Demonstrates logging and LED/button interaction on net-core-owned pins.
+
+This example complements app-core examples and is useful to verify dual-core
+BSP behavior.
+*/
+
+#include <modm/board.hpp>
+
+int
+main()
+{
+	Board::initialize();
+
+	uint32_t counter(0);
+	while (true)
+	{
+		Board::Led3::toggle();
+		modm::delay(Board::Button3::read() ? 100ms : 500ms);
+		counter++;
+        MODM_LOG_INFO << "Counter: " << counter << modm::endl;
+	}
+}

--- a/examples/nrf5340-dk/uart_logging_net/project.xml
+++ b/examples/nrf5340-dk/uart_logging_net/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nrf5340-dk</extends>
+  <options>
+    <option name="modm:target">nrf5340-xxaa@net</option>
+    <option name="modm:build:build.path">../../../build/nrf5340-dk/uart_logging_net</option>
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/ext/hathach/module.lb
+++ b/ext/hathach/module.lb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2020, 2024, Niklas Hauser
+# Copyright (c) 2020-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -25,6 +25,7 @@ def prepare(module, options):
     has_otg_hs = device.has_driver("usb_otg_hs")
     has_otg_fs = device.has_driver("usb_otg_fs")
     if not (device.has_driver("usb") or
+            device.has_driver("usbd") or
             has_otg_fs or
             has_otg_hs or
             device.has_driver("udp") or
@@ -126,6 +127,11 @@ def build(env):
             tusb_config["TUD_OPT_RP2040_USB_DEVICE_UFRAME_FIX"] = "0"
             env.copy("tinyusb/src/portable/raspberrypi/rp2040/", "portable/raspberrypi/rp2040/")
 
+    elif target.platform == "nrf":
+        tusb_config["CFG_TUSB_MCU"] = "OPT_MCU_NRF5X"
+        tusb_config["CFG_TUD_NRF_NRFX_VERSION"] = "2"
+        env.copy("tinyusb/src/portable/nordic/nrf5x/", "portable/nordic/nrf5x/")
+
     # TinyUSB has a OS abstraction layer for FreeRTOS, but it is causes problems with modm
     # if env.has_module(":freertos"):
     #    tusb_config["CFG_TUSB_OS"] = "OPT_OS_FREERTOS"
@@ -186,12 +192,18 @@ def build(env):
                 endpoint_counter += 1
             endpoints[itf_prefix + "_IN"] = hex(0x80 | endpoint_counter)
 
+    power_irqs = []
     if target.platform == "stm32":
         irqs = []
         for port, uirqs in env.query(":platform:usb:irqs")["port_irqs"].items():
             port = {"fs": 0, "hs": 1}[port]
             if port in ports:
                 irqs.extend([(irq, port, ports[port]) for irq in uirqs])
+    elif target.platform == "nrf":
+        irqs = []
+        irq_data = env.query(":platform:usb:irqs")
+        irqs.extend([(irq, 0, ports[0]) for irq in irq_data.get("irqs", [])])
+        power_irqs = list(irq_data.get("power_irqs", []))
     elif target.platform == "sam" and target.family in ["g5x"]:
         irqs = [("UDP", 0, "d")]
     elif target.platform == "sam" and target.family in ["d5x/e5x"]:
@@ -206,6 +218,7 @@ def build(env):
         "target": target,
         "config": tusb_config,
         "irqs": irqs,
+        "power_irqs": power_irqs,
         "ports": ports,
         "with_debug": env.has_module(":debug"),
         "with_cdc": env.has_module(":tinyusb:device:cdc"),

--- a/ext/hathach/tusb_port.cpp.in
+++ b/ext/hathach/tusb_port.cpp.in
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Erik Henriksson
- * Copyright (c) 2020, 2024, Niklas Hauser
+ * Copyright (c) 2020-2026, Niklas Hauser
  *
  * This file is part of the modm project.
  *
@@ -22,6 +22,52 @@ MODM_ISR({{irq}})
 	tusb_int_handler({{port}}, true);
 }
 %% endfor
+
+%% if target.platform == "nrf"
+extern "C" void tusb_hal_nrf_power_event(uint32_t event);
+
+static inline void
+modm_tusb_nrf_power_events()
+{
+	// TinyUSB expects 0=Detected, 1=Removed, 2=Ready.
+%% if target.family == "52"
+	if (NRF_POWER->EVENTS_USBDETECTED) {
+		NRF_POWER->EVENTS_USBDETECTED = 0;
+		tusb_hal_nrf_power_event(0);
+	}
+	if (NRF_POWER->EVENTS_USBREMOVED) {
+		NRF_POWER->EVENTS_USBREMOVED = 0;
+		tusb_hal_nrf_power_event(1);
+	}
+	if (NRF_POWER->EVENTS_USBPWRRDY) {
+		NRF_POWER->EVENTS_USBPWRRDY = 0;
+		tusb_hal_nrf_power_event(2);
+	}
+
+%% elif target.family == "53"
+	if (NRF_USBREGULATOR->EVENTS_USBDETECTED) {
+		NRF_USBREGULATOR->EVENTS_USBDETECTED = 0;
+		tusb_hal_nrf_power_event(0);
+	}
+	if (NRF_USBREGULATOR->EVENTS_USBREMOVED) {
+		NRF_USBREGULATOR->EVENTS_USBREMOVED = 0;
+		tusb_hal_nrf_power_event(1);
+	}
+	if (NRF_USBREGULATOR->EVENTS_USBPWRRDY) {
+		NRF_USBREGULATOR->EVENTS_USBPWRRDY = 0;
+		tusb_hal_nrf_power_event(2);
+	}
+
+%% endif
+}
+
+%% for irq in power_irqs | sort
+MODM_ISR({{irq}})
+{
+	modm_tusb_nrf_power_events();
+}
+%% endfor
+%% endif
 
 %% if "samg55" in target.string
 
@@ -54,8 +100,7 @@ modm_ramcode void read_efc_uid(uint32_t *uid)
 extern "C" uint8_t
 tusb_get_device_serial(uint16_t *serial_str)
 {
-	constexpr uint8_t SERIAL_BYTE_LEN = 16;
-	uint8_t raw_id[SERIAL_BYTE_LEN];
+	uint8_t raw_id[16];
 
 %% if "samg55" in target.string
 	read_efc_uid((uint32_t*)raw_id);
@@ -66,6 +111,14 @@ tusb_get_device_serial(uint16_t *serial_str)
 	%% if target.platform in ["stm32"]
 		((uint32_t *) UID_BASE), ((uint32_t *) UID_BASE) + 1,
 		((uint32_t *) UID_BASE) + 2, ((uint32_t *) UID_BASE) + 3
+	%% elif target.platform in ["nrf"]
+		%% if target.family == "53"
+		((uint32_t *) NRF_FICR->INFO.DEVICEID), ((uint32_t *) NRF_FICR->INFO.DEVICEID) + 1,
+		((uint32_t *) NRF_FICR->INFO.DEVICEID) + 2, ((uint32_t *) NRF_FICR->INFO.DEVICEID) + 3,
+		%% else
+		((uint32_t *) NRF_FICR->DEVICEID), ((uint32_t *) NRF_FICR->DEVICEID) + 1,
+		((uint32_t *) &NRF_FICR->INFO.PART), ((uint32_t *) &NRF_FICR->INFO.VARIANT),
+		%% endif
 	%% elif target.platform in ["sam"]
 		%% if "samd51" in target.string or "same5" in target.string
 		(uint32_t *)0x008061FC, (uint32_t *)0x00806010,

--- a/ext/nordic/device.hpp.in
+++ b/ext/nordic/device.hpp.in
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Hannes Ellinger
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_DEVICE_HPP
+#define MODM_DEVICE_HPP
+
+#define DONT_USE_CMSIS_INIT 1
+%% for define in defines
+#define {{ define }} 1
+%% endfor
+
+#include <stdint.h>
+// Defines for example the modm_always_inline macro
+#include <modm/architecture/utils.hpp>
+
+// Include external device headers:
+%% for header in headers
+#include <{{ header }}>
+%% endfor
+
+%% if target.family == "53"
+// Allow nRF5x drivers to be used with the nRF53 without modification.
+%% for peripheral in peripheral_aliases
+#ifndef {{ peripheral }}
+#define {{ peripheral }} {{ peripheral }}_{{ peripheral_alias_suffix }}
+#endif
+%% endfor
+%% endif
+
+#endif  // MODM_DEVICE_HPP

--- a/ext/nordic/module.lb
+++ b/ext/nordic/module.lb
@@ -204,6 +204,7 @@ def build(env):
     env.outbasepath = "modm/ext/cmsis/device"
     for file in pp["headers"]:
         env.copy(localpath(pp["folder"], file), file)
+    env.copy("nrfx_clock.h")
 
     env.substitutions = {
         "headers": ["nrf.h"],

--- a/ext/nordic/module.lb
+++ b/ext/nordic/module.lb
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Hannes Ellinger
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+import re
+from pathlib import Path
+
+
+pp = {}
+
+
+def _translate(name):
+    return name.replace("_", "").capitalize()
+
+
+def _get_driver(signal):
+    name = None
+    if "driver" in signal:
+        name = _translate(signal["driver"])
+    if "instance" in signal:
+        name += _translate(signal["instance"])
+    return name
+
+
+def common_peripherals(env):
+    """
+    All peripherals translated to the modm naming convention.
+
+    :returns: a sorted list of all peripheral names.
+    """
+    device = env[":target"]
+
+    all_peripherals = set()
+
+    gpio_driver = device.get_driver("gpio")
+    # Collect all peripherals from GPIO signal definitions
+    all_peripherals.update(
+        _get_driver(s)
+        for gpio in gpio_driver["gpio"]
+        for s in gpio.get("signal", [])
+    )
+
+    # Collect all peripherals from drivers and their instances
+    all_drivers = (d for d in device._properties["driver"] if d["name"] not in ["gpio", "core"])
+    for d in all_drivers:
+        dname = _translate(d["name"])
+        if "instance" in d:
+            all_peripherals.update(dname + _translate(i) for i in d["instance"])
+        else:
+            all_peripherals.add(dname)
+
+    all_peripherals.discard(None)
+    all_peripherals = sorted(list(all_peripherals))
+    pp["all_peripherals"] = all_peripherals
+    return all_peripherals
+
+
+def _device_root_from_define(define):
+    if define.startswith("NRF5340_"):
+        if "NETWORK" in define:
+            return "nrf5340_network"
+        return "nrf5340_application"
+    if define.startswith("NRF51"):
+        return "nrf51"
+    if define.startswith("NRF52832_"):
+        # In Nordic MDK, nRF52832 uses nrf52.h/system_nrf52.h.
+        return "nrf52"
+
+    match = re.match(r"NRF(\d+)_", define)
+    if match:
+        return "nrf{}".format(match.group(1).lower())
+    return None
+
+
+def _extra_header_patterns(define):
+    if define.startswith("NRF51"):
+        return ["nrf51_deprecated.h"]
+    if define.startswith("NRF52805_"):
+        return ["nrf51_to_nrf52810.h", "nrf52_to_nrf52810.h", "nrf52810_to_nrf52811.h"]
+    if define.startswith("NRF52810_"):
+        return ["nrf51_to_nrf52810.h", "nrf52_to_nrf52810.h", "nrf52810_name_change.h"]
+    if define.startswith("NRF52811_"):
+        return ["nrf51_to_nrf52810.h", "nrf52_to_nrf52810.h", "nrf52810_to_nrf52811.h"]
+    if define.startswith("NRF52820_"):
+        return ["nrf51_to_nrf52.h", "nrf52_to_nrf52833.h", "nrf52833_to_nrf52820.h"]
+    if define.startswith("NRF52832_"):
+        return ["nrf51_to_nrf52.h", "nrf52_name_change.h"]
+    if define.startswith("NRF52833_"):
+        return ["nrf52_to_nrf52833.h", "nrf51_to_nrf52.h"]
+    if define.startswith("NRF52840_"):
+        return ["nrf51_to_nrf52840.h", "nrf52_to_nrf52840.h", "nrf52840_name_change.h"]
+    if define.startswith("NRF5340_") and "NETWORK" in define:
+        return ["nrf5340_network_name_change.h", "system_nrf53_approtect.h", "system_config_sau.h"]
+    if define.startswith("NRF5340_"):
+        return ["nrf5340_application_name_change.h", "system_nrf53_approtect.h", "system_config_sau.h"]
+    if define.startswith("NRF91") or define.startswith("NRF9120_") or define.startswith("NRF9160_"):
+        return ["nrf91_name_change.h", "system_nrf91_approtect.h"]
+    return []
+
+
+def _expand_existing_patterns(src_dir, patterns):
+    headers = []
+    seen = set()
+    for pattern in patterns:
+        for path in sorted(src_dir.glob(pattern)):
+            if not path.is_file():
+                continue
+            name = path.name
+            if name in seen:
+                continue
+            seen.add(name)
+            headers.append(name)
+    return headers
+
+
+def _headers_for_define(src_dir, define):
+    root = _device_root_from_define(define)
+    if root is None:
+        raise ValidateException("Unable to map nRF define '{}' to a device header root!".format(define))
+
+    patterns = [
+        "nrf.h",
+        "compiler_abstraction.h",
+        "{}.h".format(root),
+        "system_{}.h".format(root),
+        "{}_bitfields.h".format(root),
+        "nrf*_erratas.h",
+    ]
+    patterns.extend(_extra_header_patterns(define))
+
+    headers = _expand_existing_patterns(src_dir, patterns)
+    if "nrf.h" not in headers:
+        raise ValidateException("Missing required header 'nrf.h' for '{}'!".format(define))
+    return headers
+
+
+def _peripheral_aliases(src_dir, define):
+    if not define.startswith("NRF5340_"):
+        return [], None
+
+    alias_suffix = "NS" if "NETWORK" in define else "S"
+
+    root = _device_root_from_define(define)
+    header_path = src_dir / "{}.h".format(root)
+    if not header_path.is_file():
+        return [], alias_suffix
+
+    pattern = re.compile(r"^#define\s+(NRF_[A-Z0-9_]+)_(S|NS)\b")
+    aliases = set()
+    for line in header_path.read_text().splitlines():
+        match = pattern.match(line.strip())
+        if match and match.group(2) == alias_suffix:
+            aliases.add(match.group(1))
+    return sorted(aliases), alias_suffix
+
+# -----------------------------------------------------------------------------
+def init(module):
+    module.name = ":cmsis:device"
+
+
+def prepare(module, options):
+    module.add_query(EnvironmentQuery(name="peripherals", factory=common_peripherals))
+    module.depends(":cmsis:core")
+    return options[":target"].identifier.platform == "nrf"
+
+
+def validate(env):
+    device = env[":target"]
+    src_dir = Path(localpath("nrfx/bsp/stable/mdk"))
+    define = device.identifier.string.upper().replace("-", "_")
+    define = define.replace("@APP", "_APPLICATION").replace("@NET", "_NETWORK")
+
+    required_headers = _headers_for_define(src_dir, define)
+    peripheral_aliases, peripheral_alias_suffix = _peripheral_aliases(src_dir, define)
+    if not required_headers:
+        raise ValidateException("No required nRF headers found for '{}'!".format(device.partname))
+
+    family_folder = src_dir.relative_to(localpath("."))
+
+    global pp
+    pp = {
+        "define": define,
+        "folder": family_folder,
+        "headers": required_headers,
+        "peripheral_aliases": peripheral_aliases,
+        "peripheral_alias_suffix": peripheral_alias_suffix,
+    }
+
+
+def build(env):
+    global pp
+    env.query("peripherals")
+    env.collect(":build:path.include", "modm/ext/cmsis/device")
+
+    env.outbasepath = "modm/ext/cmsis/device"
+    for file in pp["headers"]:
+        env.copy(localpath(pp["folder"], file), file)
+
+    env.substitutions = {
+        "headers": ["nrf.h"],
+        "defines": [pp["define"]],
+        "all_peripherals": pp["all_peripherals"],
+        "peripheral_aliases": pp["peripheral_aliases"],
+        "peripheral_alias_suffix": pp["peripheral_alias_suffix"],
+        "target": env[":target"].identifier,
+    }
+    env.outbasepath = "modm/src/modm/platform"
+    env.template("device.hpp.in")
+
+    env.outbasepath = "modm/src/modm/platform/core"
+    env.template("peripherals.hpp.in")

--- a/ext/nordic/nrfx_clock.h
+++ b/ext/nordic/nrfx_clock.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+// Absolute minimum of the nrfx_clock.h header, only to fulfill what TinyUSB uses.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "nrf.h"
+
+typedef uint32_t nrf_clock_hfclk_t;
+typedef uint32_t nrf_clock_event_t;
+typedef uint32_t nrf_clock_task_t;
+
+#ifndef NRF_CLOCK_HFCLK_HIGH_ACCURACY
+#define NRF_CLOCK_HFCLK_HIGH_ACCURACY 1u
+#endif
+
+#ifndef NRF_CLOCK_EVENT_HFCLKSTARTED
+#define NRF_CLOCK_EVENT_HFCLKSTARTED 0u
+#endif
+
+#ifndef NRF_CLOCK_TASK_HFCLKSTART
+#define NRF_CLOCK_TASK_HFCLKSTART 0u
+#endif
+
+#ifndef NRF_CLOCK_TASK_HFCLKSTOP
+#define NRF_CLOCK_TASK_HFCLKSTOP 1u
+#endif
+
+static inline bool
+nrf_clock_hf_is_running(NRF_CLOCK_Type const * p_reg, nrf_clock_hfclk_t source)
+{
+	(void)source;
+#if defined(CLOCK_HFCLKSTAT_STATE_Msk)
+	return (p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk) != 0u;
+#elif defined(CLOCK_HFCLKSTAT_HFCLKRUN_Msk)
+	return (p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_HFCLKRUN_Msk) != 0u;
+#else
+	return p_reg->HFCLKRUN != 0u;
+#endif
+}
+
+static inline void
+nrf_clock_event_clear(NRF_CLOCK_Type * p_reg, nrf_clock_event_t event)
+{
+	(void)event;
+	p_reg->EVENTS_HFCLKSTARTED = 0u;
+}
+
+static inline void
+nrf_clock_task_trigger(NRF_CLOCK_Type * p_reg, nrf_clock_task_t task)
+{
+	if (task == NRF_CLOCK_TASK_HFCLKSTOP) {
+		p_reg->TASKS_HFCLKSTOP = 1u;
+	}
+	else {
+		p_reg->TASKS_HFCLKSTART = 1u;
+	}
+}

--- a/ext/nordic/peripherals.hpp.in
+++ b/ext/nordic/peripherals.hpp.in
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// -----------------------------------------------------------------------------
+
+#pragma once
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_core
+enum class
+Peripheral
+{
+	BitBang,
+%% for per in all_peripherals
+	{{ per }},
+%% endfor
+};
+
+}

--- a/repo.lb
+++ b/repo.lb
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2017, Fabian Greif
-# Copyright (c) 2017-2018, Niklas Hauser
+# Copyright (c) 2017-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -81,6 +81,7 @@ class DevicesCache(dict):
             "stm32h5", "stm32h7",
             "stm32l0", "stm32l1", "stm32l4", "stm32l5",
             "stm32u0", "stm32u3", "stm32u5",
+            "nrf51", "nrf52", "nrf53",
         )
         # Load and filter the device prefixes
         modm_db = json.loads((modm_devices / "db.json").read_text())

--- a/src/modm/board/nrf51422_dk/board.hpp
+++ b/src/modm/board/nrf51422_dk/board.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nrf51422_dk
+#define MODM_BOARD_HAS_LOGGER
+
+/// @ingroup modm_board_nrf51422_dk
+namespace Board
+{
+/// @ingroup modm_board_nrf51422_dk
+/// @{
+using namespace modm::literals;
+
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 16_MHz;
+	static constexpr uint32_t Uart0 = 16_MHz;
+
+	static bool inline
+	enable()
+	{
+		Hfcc::updateCoreFrequency<Frequency>();
+		return true;
+	}
+};
+
+using Led1 = GpioInverted<GpioOutputP0_21>;
+using Led2 = GpioInverted<GpioOutputP0_22>;
+using Led3 = GpioInverted<GpioOutputP0_23>;
+using Led4 = GpioInverted<GpioOutputP0_24>;
+using Leds = SoftwareGpioPort<Led4, Led3, Led2, Led1>;
+
+using Button1 = GpioInverted<GpioInputP0_17>;
+using Button2 = GpioInverted<GpioInputP0_18>;
+using Button3 = GpioInverted<GpioInputP0_19>;
+using Button4 = GpioInverted<GpioInputP0_20>;
+using Buttons = SoftwareGpioPort<Button4, Button3, Button2, Button1>;
+
+namespace uart
+{
+/// @ingroup modm_board_nrf51422_dk
+/// @{
+using Txd = GpioP0_9;
+using Rxd = GpioP0_11;
+using Uart = BufferedUart<UartHal0, UartTxBuffer<2048>, UartRxBuffer<128>>;
+/// @}
+}
+
+/// @ingroup modm_board_nrf51422_dk
+/// @{
+using LoggerDevice = modm::IODeviceWrapper<uart::Uart, modm::IOBuffer::BlockIfFull>;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+	uart::Uart::connect<uart::Txd::Txd, uart::Rxd::Rxd>();
+	uart::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Leds::setOutput(modm::Gpio::Low);
+	Buttons::setInput(Gpio::InputType::PullUp);
+}
+/// @}
+
+} // namespace Board

--- a/src/modm/board/nrf51422_dk/board.xml
+++ b/src/modm/board/nrf51422_dk/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">nrf51422-xxaa</option>
+  </options>
+  <modules>
+    <module>modm:board:nrf51422-dk</module>
+  </modules>
+</library>

--- a/src/modm/board/nrf51422_dk/module.lb
+++ b/src/modm/board/nrf51422_dk/module.lb
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":board:nrf51422-dk"
+    module.description = FileReader("module.md")
+
+
+def prepare(module, options):
+    partname = options[":target"].partname
+    if not partname.startswith("nrf51422"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:clock",
+        ":platform:hfclk",
+        ":platform:gpio",
+        ":platform:uart:0")
+
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy(".")

--- a/src/modm/board/nrf51422_dk/module.md
+++ b/src/modm/board/nrf51422_dk/module.md
@@ -1,0 +1,13 @@
+# nRF51422-DK
+
+Nordic Semiconductor nRF51422 Development Kit.
+
+This BSP `Board::initialize()` sets the board up with these settings:
+
+- 16MHz CPU clock frequency.
+- SysTick configured for the selected system clock.
+- MODM_LOGGER initialized at 115.2kBaud on UART0 (`P0.09` TX, `P0.11` RX).
+- Four active-low LEDs on `P0.21..P0.24`.
+- Four active-low buttons on `P0.17..P0.20` with pull-ups.
+
+[Product Link](https://www.nordicsemi.com/Products/Development-hardware/nRF51422-DK)

--- a/src/modm/board/nrf52840_dk/board.hpp
+++ b/src/modm/board/nrf52840_dk/board.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nrf52840_dk
+#define MODM_BOARD_HAS_LOGGER
+
+namespace Board
+{
+/// @ingroup modm_board_nrf52840_dk
+/// @{
+using namespace modm::literals;
+
+struct SystemClock
+{
+	static constexpr uint32_t Frequency = 64_MHz;
+	static constexpr uint32_t Uarte0 = 16_MHz;
+
+	static bool inline
+	enable()
+	{
+		Hfcc::updateCoreFrequency<Frequency>();
+		return true;
+	}
+};
+
+using Led1 = GpioInverted<GpioOutputP0_13>;
+using Led2 = GpioInverted<GpioOutputP0_14>;
+using Led3 = GpioInverted<GpioOutputP0_15>;
+using Led4 = GpioInverted<GpioOutputP0_16>;
+using Leds = SoftwareGpioPort<Led4, Led3, Led2, Led1>;
+
+using Button1 = GpioInverted<GpioInputP0_11>;
+using Button2 = GpioInverted<GpioInputP0_12>;
+using Button3 = GpioInverted<GpioInputP0_24>;
+using Button4 = GpioInverted<GpioInputP0_25>;
+using Buttons = SoftwareGpioPort<Button4, Button3, Button2, Button1>;
+/// @}
+
+namespace uart
+{
+/// @ingroup modm_board_nrf52840_dk
+/// @{
+using Txd = GpioP0_6;
+using Rxd = GpioP0_8;
+using Uart = BufferedUart<UarteHal0, UartTxBuffer<2048>, UartRxBuffer<128>>;
+/// @}
+}
+
+namespace usb
+{
+/// @ingroup modm_board_nrf52840_dk
+/// @{
+using Dm = GpioP0_24;
+using Dp = GpioP0_25;
+
+using Device = Usb;
+/// @}
+}
+
+/// @ingroup modm_board_nrf52840_dk
+/// @{
+using LoggerDevice = modm::IODeviceWrapper<uart::Uart, modm::IOBuffer::BlockIfFull>;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	uart::Uart::connect<uart::Txd::Txd, uart::Rxd::Rxd>();
+	uart::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Leds::setOutput(modm::Gpio::Low);
+	Buttons::setInput(Gpio::InputType::PullUp);
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm, usb::Dp>();
+}
+/// @}
+
+} // namespace Board

--- a/src/modm/board/nrf52840_dk/board.xml
+++ b/src/modm/board/nrf52840_dk/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">nrf52840-xxaa</option>
+  </options>
+  <modules>
+    <module>modm:board:nrf52840-dk</module>
+  </modules>
+</library>

--- a/src/modm/board/nrf52840_dk/module.lb
+++ b/src/modm/board/nrf52840_dk/module.lb
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":board:nrf52840-dk"
+    module.description = FileReader("module.md")
+
+
+def prepare(module, options):
+    partname = options[":target"].partname
+    if not partname.startswith("nrf52840"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:clock",
+        ":platform:hfclk",
+        ":platform:gpio",
+        ":platform:usb",
+        ":platform:uarte:0")
+
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy(".")

--- a/src/modm/board/nrf52840_dk/module.md
+++ b/src/modm/board/nrf52840_dk/module.md
@@ -1,0 +1,13 @@
+# nRF52840-DK
+
+Nordic Semiconductor nRF52840 Development Kit.
+
+This BSP `Board::initialize()` sets the board up with these settings:
+
+- 64MHz CPU clock frequency.
+- SysTick configured for the selected system clock.
+- MODM_LOGGER initialized at 115.2kBaud on UARTE0 (`P0.06` TX, `P0.08` RX).
+- Four active-low LEDs on `P0.13..P0.16`.
+- Four active-low buttons on `P0.11`, `P0.12`, `P0.24`, and `P0.25` with pull-ups.
+
+[Product Link](https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dk)

--- a/src/modm/board/nrf5340_dk/board.hpp.in
+++ b/src/modm/board/nrf5340_dk/board.hpp.in
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nrf5340_dk
+#define MODM_BOARD_HAS_LOGGER
+
+namespace Board
+{
+/// @ingroup modm_board_nrf5340_dk
+/// @{
+using namespace modm::literals;
+
+struct SystemClock
+{
+%% if target.core == "app"
+	static constexpr uint32_t Frequency = 128_MHz;
+%% else
+	static constexpr uint32_t Frequency = 64_MHz;
+%% endif
+	static constexpr uint32_t Uarte0 = 16_MHz;
+	static constexpr uint32_t Uarte1 = 16_MHz;
+
+	static bool inline
+	enable()
+	{
+%% if target.core == "app"
+		Hfcc::setPrescaler(Hfcc::Prescaler::Div1);
+%% endif
+		Hfcc::updateCoreFrequency<Frequency>();
+		return true;
+	}
+};
+
+using Led1 = GpioInverted<GpioOutputP0_28>;
+using Led2 = GpioInverted<GpioOutputP0_29>;
+using Led3 = GpioInverted<GpioOutputP0_30>;
+using Led4 = GpioInverted<GpioOutputP0_31>;
+using Leds = SoftwareGpioPort<Led4, Led3, Led2, Led1>;
+
+using Button1 = GpioInverted<GpioInputP0_23>;
+using Button2 = GpioInverted<GpioInputP0_24>;
+using Button3 = GpioInverted<GpioInputP0_8>;
+using Button4 = GpioInverted<GpioInputP0_9>;
+using Buttons = SoftwareGpioPort<Button4, Button3, Button2, Button1>;
+/// @}
+
+namespace uart
+{
+/// @ingroup modm_board_nrf5340_dk
+/// @{
+%% if target.core == "app"
+using Txd = GpioP1_1;
+using Rxd = GpioP1_0;
+using Uart = BufferedUart<UarteHal1, UartTxBuffer<2048>, UartRxBuffer<128>>;
+%% else
+using Txd = GpioP0_20;
+using Rxd = GpioP0_22;
+using Uart = BufferedUart<UarteHal0, UartTxBuffer<2048>, UartRxBuffer<128>>;
+%% endif
+/// @}
+}
+
+%% if target.core == "app"
+namespace usb
+{
+/// @ingroup modm_board_nrf5340_dk
+/// @{
+using Dm = GpioP0_24;
+using Dp = GpioP0_25;
+
+using Device = Usb;
+/// @}
+}
+%% endif
+
+/// @ingroup modm_board_nrf5340_dk
+/// @{
+using LoggerDevice = modm::IODeviceWrapper<uart::Uart, modm::IOBuffer::BlockIfFull>;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+%% if target.core == "app"
+    GpioP0_20::delegateToNetworkCore();
+    GpioP0_22::delegateToNetworkCore();
+    Led3::delegateToNetworkCore();
+    Led4::delegateToNetworkCore();
+    Button3::delegateToNetworkCore();
+    Button4::delegateToNetworkCore();
+
+    Led1::setOutput(modm::Gpio::Low);
+    Led2::setOutput(modm::Gpio::Low);
+    Button1::setInput(Gpio::InputType::PullUp);
+    Button2::setInput(Gpio::InputType::PullUp);
+%% else
+	modm::delay_ms(100);
+    Led3::setOutput(modm::Gpio::Low);
+    Led4::setOutput(modm::Gpio::Low);
+    Button3::setInput(Gpio::InputType::PullUp);
+    Button4::setInput(Gpio::InputType::PullUp);
+%% endif
+
+	uart::Uart::connect<uart::Txd::Txd, uart::Rxd::Rxd>();
+	uart::Uart::initialize<SystemClock, 115200_Bd>();
+
+	// Leds::setOutput(modm::Gpio::Low);
+	// Buttons::setInput(Gpio::InputType::PullUp);
+}
+
+%% if target.core == "app"
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm, usb::Dp>();
+}
+%% endif
+/// @}
+
+} // namespace Board

--- a/src/modm/board/nrf5340_dk/board.xml
+++ b/src/modm/board/nrf5340_dk/board.xml
@@ -1,0 +1,15 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">nrf5340-xxaa@app</option>
+    <!-- <option name="modm:target">nrf5340-xxaa@net</option> -->
+  </options>
+  <modules>
+    <module>modm:board:nrf5340-dk</module>
+  </modules>
+</library>

--- a/src/modm/board/nrf5340_dk/module.lb
+++ b/src/modm/board/nrf5340_dk/module.lb
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":board:nrf5340-dk"
+    module.description = FileReader("module.md")
+
+
+def prepare(module, options):
+    partname = options[":target"].partname
+    if not partname.startswith("nrf5340"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":platform:core",
+        ":platform:clock",
+        ":platform:hfclk",
+        ":platform:gpio")
+
+    if options[":target"].identifier.core == "app":
+        module.depends(":platform:uarte:1", ":platform:usb")
+    else:
+        module.depends(":platform:uarte:0")
+
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "target": env[":target"].identifier,
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.template("board.hpp.in", "board.hpp")
+    env.copy("board.xml")

--- a/src/modm/board/nrf5340_dk/module.md
+++ b/src/modm/board/nrf5340_dk/module.md
@@ -1,0 +1,24 @@
+# nRF5340-DK
+
+Nordic Semiconductor nRF5340 Development Kit.
+
+This BSP supports both cores and `Board::initialize()` configures the selected
+core with these settings:
+
+- Application core target: `nrf5340-xxaa@app`
+  - 128MHz CPU clock frequency.
+  - MODM_LOGGER initialized at 115.2kBaud on UARTE1 (`P1.01` TX, `P1.00` RX).
+  - Owns LED1/LED2 and Button1/Button2.
+  - Transfers selected GPIO ownership to the network core.
+
+- Network core target: `nrf5340-xxaa@net`
+  - 64MHz CPU clock frequency.
+  - MODM_LOGGER initialized at 115.2kBaud on UARTE0 (`P0.20` TX, `P0.22` RX).
+  - Owns LED3/LED4 and Button3/Button4.
+
+The default board core in [board.xml](src/modm/board/nrf5340_dk/board.xml)
+is the application core (`nrf5340-xxaa@app`). To use this board with the network
+core you must inherit and then overwrite the the `modm:target` with
+`nrf5340-xxaa@net`.
+
+[Product Link](https://www.nordicsemi.com/Products/Development-hardware/nRF5340-DK)

--- a/src/modm/platform/adc/nrf/adc.hpp.in
+++ b/src/modm/platform/adc/nrf/adc.hpp.in
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+#include <modm/architecture/interface/adc.hpp>
+#include <modm/platform/device.hpp>
+#include <modm/platform/gpio/base.hpp>
+#include <modm/processing/fiber.hpp>
+
+namespace modm::platform
+{
+template<class GpioData>
+class GpioStatic;
+
+/**
+ * SAADC for nRF52/nRF53.
+ *
+ * Minimal synchronous implementation of the generic ADC interface.
+ *
+ * \ingroup\tmodm_platform_adc
+ */
+class Adc : public modm::Adc
+{
+public:
+	static constexpr uint8_t Resolution = 12;
+
+	enum class Channel : uint32_t
+	{
+%% for channel in ain_channels
+		Ain{{ channel }} = SAADC_CH_PSELP_PSELP_AnalogInput{{ channel }},
+%% endfor
+		Vdd = SAADC_CH_PSELP_PSELP_VDD,
+%% if has_vddh_div5
+		VddhDiv5 = SAADC_CH_PSELP_PSELP_VDDHDIV5,
+%% endif
+	};
+
+	enum class NegativeInput : uint32_t
+	{
+		Disabled = SAADC_CH_PSELN_PSELN_NC,
+%% for channel in ain_channels
+		Ain{{ channel }} = SAADC_CH_PSELN_PSELN_AnalogInput{{ channel }},
+%% endfor
+	};
+
+	enum class Resistor : uint32_t
+	{
+		Bypass = SAADC_CH_CONFIG_RESP_Bypass,
+		PullDown = SAADC_CH_CONFIG_RESP_Pulldown,
+		PullUp = SAADC_CH_CONFIG_RESP_Pullup,
+		Vdd1_2 = SAADC_CH_CONFIG_RESP_VDD1_2,
+	};
+
+	enum class Gain : uint32_t
+	{
+		Gain1_6 = SAADC_CH_CONFIG_GAIN_Gain1_6,
+		Gain1_5 = SAADC_CH_CONFIG_GAIN_Gain1_5,
+		Gain1_4 = SAADC_CH_CONFIG_GAIN_Gain1_4,
+		Gain1_3 = SAADC_CH_CONFIG_GAIN_Gain1_3,
+		Gain1_2 = SAADC_CH_CONFIG_GAIN_Gain1_2,
+		Gain1 = SAADC_CH_CONFIG_GAIN_Gain1,
+		Gain2 = SAADC_CH_CONFIG_GAIN_Gain2,
+		Gain4 = SAADC_CH_CONFIG_GAIN_Gain4,
+	};
+
+	enum class Reference : uint32_t
+	{
+		Internal = SAADC_CH_CONFIG_REFSEL_Internal,
+		Vdd1_4 = SAADC_CH_CONFIG_REFSEL_VDD1_4,
+	};
+
+	enum class AcquisitionTime : uint32_t
+	{
+		Us3 = SAADC_CH_CONFIG_TACQ_3us,
+		Us5 = SAADC_CH_CONFIG_TACQ_5us,
+		Us10 = SAADC_CH_CONFIG_TACQ_10us,
+		Us15 = SAADC_CH_CONFIG_TACQ_15us,
+		Us20 = SAADC_CH_CONFIG_TACQ_20us,
+		Us40 = SAADC_CH_CONFIG_TACQ_40us,
+	};
+
+	enum class Burst : uint32_t
+	{
+		Disabled = SAADC_CH_CONFIG_BURST_Disabled,
+		Enabled = SAADC_CH_CONFIG_BURST_Enabled,
+	};
+
+	enum class ResolutionSetting : uint32_t
+	{
+		Bit8 = SAADC_RESOLUTION_VAL_8bit,
+		Bit10 = SAADC_RESOLUTION_VAL_10bit,
+		Bit12 = SAADC_RESOLUTION_VAL_12bit,
+		Bit14 = SAADC_RESOLUTION_VAL_14bit,
+	};
+
+	enum class Oversampling : uint32_t
+	{
+		Bypass = SAADC_OVERSAMPLE_OVERSAMPLE_Bypass,
+		Over2x = SAADC_OVERSAMPLE_OVERSAMPLE_Over2x,
+		Over4x = SAADC_OVERSAMPLE_OVERSAMPLE_Over4x,
+		Over8x = SAADC_OVERSAMPLE_OVERSAMPLE_Over8x,
+		Over16x = SAADC_OVERSAMPLE_OVERSAMPLE_Over16x,
+		Over32x = SAADC_OVERSAMPLE_OVERSAMPLE_Over32x,
+		Over64x = SAADC_OVERSAMPLE_OVERSAMPLE_Over64x,
+		Over128x = SAADC_OVERSAMPLE_OVERSAMPLE_Over128x,
+		Over256x = SAADC_OVERSAMPLE_OVERSAMPLE_Over256x,
+	};
+
+	struct ChannelConfiguration
+	{
+		NegativeInput negativeInput = NegativeInput::Disabled;
+		Resistor resistorP = Resistor::Bypass;
+		Resistor resistorN = Resistor::Bypass;
+		Gain gain = Gain::Gain1_6;
+		Reference reference = Reference::Internal;
+		AcquisitionTime acquisitionTime = AcquisitionTime::Us10;
+		Burst burst = Burst::Disabled;
+	};
+
+public:
+	template<class T>
+	inline static constexpr bool AlwaysFalse = false;
+
+	template<class... Signals>
+	static inline void
+	connect()
+	{
+		if constexpr (sizeof...(Signals) > 0) {
+			(Adc::template disconnectSignal<Signals>(), ...);
+		}
+	}
+
+	template<class SystemClock, frequency_t frequency=200_kHz, percent_t tolerance=10_pct>
+	static inline void
+	initialize(
+		Oversampling oversampling = Oversampling::Bypass,
+		ResolutionSetting resolution = ResolutionSetting::Bit12)
+	{
+		(void)sizeof(SystemClock);
+		(void)frequency;
+		(void)tolerance;
+		currentOversampling = oversampling;
+
+		NRF_SAADC->ENABLE = SAADC_ENABLE_ENABLE_Enabled;
+		NRF_SAADC->RESOLUTION = static_cast<uint32_t>(resolution);
+		NRF_SAADC->OVERSAMPLE = static_cast<uint32_t>(oversampling);
+		NRF_SAADC->SAMPLERATE = 0;
+
+		NRF_SAADC->CH[0].CONFIG = 0;
+		NRF_SAADC->CH[0].PSELP = SAADC_CH_PSELP_PSELP_NC;
+
+		NRF_SAADC->RESULT.PTR = reinterpret_cast<uint32_t>(&sampleBuffer);
+		NRF_SAADC->RESULT.MAXCNT = 1;
+		NRF_SAADC->EVENTS_END = 0;
+		NRF_SAADC->EVENTS_STARTED = 0;
+		NRF_SAADC->EVENTS_STOPPED = 0;
+	}
+
+	static inline void
+	disable()
+	{
+		NRF_SAADC->CH[0].PSELP = SAADC_CH_PSELP_PSELP_NC;
+		NRF_SAADC->CH[0].PSELN = SAADC_CH_PSELN_PSELN_NC;
+		NRF_SAADC->ENABLE = SAADC_ENABLE_ENABLE_Disabled;
+	}
+
+	static inline void
+	startConversion()
+	{
+		NRF_SAADC->RESULT.PTR = reinterpret_cast<uint32_t>(&sampleBuffer);
+		NRF_SAADC->RESULT.MAXCNT = 1;
+		NRF_SAADC->EVENTS_END = 0;
+		NRF_SAADC->EVENTS_STARTED = 0;
+		NRF_SAADC->EVENTS_STOPPED = 0;
+		NRF_SAADC->TASKS_START = 1;
+		modm::this_fiber::poll([]{ return NRF_SAADC->EVENTS_STARTED != 0; });
+		NRF_SAADC->TASKS_SAMPLE = 1;
+	}
+
+	static inline bool
+	isConversionFinished()
+	{
+		return (NRF_SAADC->EVENTS_END != 0);
+	}
+
+	static inline uint16_t
+	getValue()
+	{
+		if (sampleBuffer < 0) {
+			return 0;
+		}
+		return static_cast<uint16_t>(sampleBuffer);
+	}
+
+	static inline uint16_t
+	readChannel(Channel channel)
+	{
+		return readChannel(channel, ChannelConfiguration{});
+	}
+
+	static inline uint16_t
+	readChannel(Channel channel, const ChannelConfiguration& config)
+	{
+		if (!setChannel(channel, config)) return 0;
+		startConversion();
+		modm::this_fiber::poll([]{ return isConversionFinished(); });
+		return getValue();
+	}
+
+	static inline bool
+	setChannel(Channel channel)
+	{
+		return setChannel(channel, ChannelConfiguration{});
+	}
+
+	static inline bool
+	setChannel(Channel channel, const ChannelConfiguration& config)
+	{
+		setChannelConfigRegisters(config);
+		NRF_SAADC->CH[0].PSELP = static_cast<uint32_t>(channel);
+		NRF_SAADC->CH[0].PSELN = static_cast<uint32_t>(config.negativeInput);
+		return true;
+	}
+
+	template<class Signal>
+	static inline bool
+	setPinChannel()
+	{
+		return setChannel(getPinChannel<Signal>(), ChannelConfiguration{});
+	}
+
+	template<class Signal>
+	static inline bool
+	setPinChannel(const ChannelConfiguration& config)
+	{
+		return setChannel(getPinChannel<Signal>(), config);
+	}
+
+	template<class Signal>
+	static inline constexpr Channel
+	getPinChannel()
+	{
+%% if ain_channels | length
+%% for channel in ain_channels
+%% if loop.first
+		if constexpr (Signal::Signal == Gpio::Signal::Ain{{ channel }}) {
+			return Channel::Ain{{ channel }};
+		}
+%% else
+		else if constexpr (Signal::Signal == Gpio::Signal::Ain{{ channel }}) {
+			return Channel::Ain{{ channel }};
+		}
+%% endif
+%% endfor
+		else {
+			static_assert(AlwaysFalse<Signal>, "Signal does not have an SAADC channel!");
+			return Channel::Vdd;
+		}
+%% else
+		static_assert(AlwaysFalse<Signal>, "Signal does not have an SAADC channel!");
+		return Channel::Vdd;
+%% endif
+	}
+
+	static inline Channel
+	getChannel()
+	{
+		return Channel(NRF_SAADC->CH[0].PSELP);
+	}
+
+private:
+	template<class Signal>
+	static inline void
+	disconnectSignal()
+	{
+		if constexpr (requires { Signal::disconnect(); }) {
+			Signal::disconnect();
+		}
+		else {
+			GpioStatic<typename Signal::Data>::disconnect();
+		}
+	}
+
+	static inline void
+	setChannelConfigRegisters(const ChannelConfiguration& config)
+	{
+		const uint32_t mode = (config.negativeInput == NegativeInput::Disabled)
+			? SAADC_CH_CONFIG_MODE_SE
+			: SAADC_CH_CONFIG_MODE_Diff;
+		const Burst burst = (currentOversampling == Oversampling::Bypass)
+			? config.burst
+			: Burst::Enabled;
+
+		NRF_SAADC->CH[0].CONFIG =
+			(static_cast<uint32_t>(config.resistorP) << SAADC_CH_CONFIG_RESP_Pos) |
+			(static_cast<uint32_t>(config.resistorN) << SAADC_CH_CONFIG_RESN_Pos) |
+			(static_cast<uint32_t>(config.gain) << SAADC_CH_CONFIG_GAIN_Pos) |
+			(static_cast<uint32_t>(config.reference) << SAADC_CH_CONFIG_REFSEL_Pos) |
+			(static_cast<uint32_t>(config.acquisitionTime) << SAADC_CH_CONFIG_TACQ_Pos) |
+			(mode << SAADC_CH_CONFIG_MODE_Pos) |
+			(static_cast<uint32_t>(burst) << SAADC_CH_CONFIG_BURST_Pos);
+		NRF_SAADC->CH[0].PSELN = static_cast<uint32_t>(config.negativeInput);
+	}
+
+	static inline Oversampling currentOversampling = Oversampling::Bypass;
+	static inline int16_t sampleBuffer{};
+};
+} // namespace modm::platform

--- a/src/modm/platform/adc/nrf/module.lb
+++ b/src/modm/platform/adc/nrf/module.lb
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":platform:adc"
+    module.description = "Analog-to-Digital Converter (SAADC)"
+
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("saadc:nrf*"):
+        return False
+
+    module.depends(
+        ":architecture:adc",
+        ":platform:gpio",
+        ":cmsis:device")
+
+    return True
+
+
+def build(env):
+    target = env[":target"].identifier
+    gpio = env[":target"].get_driver("gpio")
+
+    ain_channels = set()
+    for pin in listify(gpio.get("gpio", [])):
+        for signal in listify(pin.get("signal", [])):
+            if not isinstance(signal, dict):
+                continue
+            if signal.get("driver") != "saadc":
+                continue
+            name = str(signal.get("name", "")).lower()
+            if name.startswith("ain") and name[3:].isdigit():
+                ain_channels.add(int(name[3:]))
+
+    ain_channels = sorted(ain_channels)
+    default_channel = "Ain{}".format(ain_channels[0]) if ain_channels else "Vdd"
+
+    has_vddh_div5 = (
+        target.family == "53" or
+        (target.family == "52" and target.series == "840")
+    )
+
+    env.substitutions = {
+        "target": target,
+        "has_vddh_div5": has_vddh_div5,
+        "ain_channels": ain_channels,
+        "default_channel": default_channel,
+    }
+    env.outbasepath = "modm/src/modm/platform/adc"
+
+    env.template("adc.hpp.in")

--- a/src/modm/platform/clock/nrf/hfclk.cpp.in
+++ b/src/modm/platform/clock/nrf/hfclk.cpp.in
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Hannes Ellinger
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "hfclk.hpp"
+
+// CMSIS Core compliance
+constinit uint32_t modm_fastdata SystemCoreClock(modm::platform::Hfcc::BootFrequency);
+modm_weak void SystemCoreClockUpdate() { /* Nothing to update */ }
+
+namespace modm::platform
+{
+constinit uint16_t modm_fastdata delay_fcpu_MHz(computeDelayMhz(Hfcc::BootFrequency));
+constinit uint16_t modm_fastdata delay_ns_per_loop(computeDelayNsPerLoop(Hfcc::BootFrequency));
+
+}

--- a/src/modm/platform/clock/nrf/hfclk.hpp.in
+++ b/src/modm/platform/clock/nrf/hfclk.hpp.in
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+#include "../device.hpp"
+#include <modm/architecture/interface/delay.hpp>
+
+namespace modm::platform
+{
+
+/**
+ * Clock management
+ *
+ * \ingroup modm_platform_hfclk
+ */
+class Hfcc
+{
+public:
+	static constexpr uint32_t BootFrequency = 64'000'000;
+
+%% if has_hfclk_prescaler
+	enum class
+	Prescaler : uint32_t
+	{
+		Div1 = CLOCK_HFCLKCTRL_HCLK_Div1,
+		Div2 = CLOCK_HFCLKCTRL_HCLK_Div2,
+	};
+
+	static inline void
+	setPrescaler(Prescaler prescaler)
+	{
+		NRF_CLOCK->HFCLKCTRL = (NRF_CLOCK->HFCLKCTRL & ~CLOCK_HFCLKCTRL_HCLK_Msk) |
+			((uint32_t(prescaler) << CLOCK_HFCLKCTRL_HCLK_Pos) & CLOCK_HFCLKCTRL_HCLK_Msk);
+	}
+%#
+%% endif
+	template< uint32_t Core_Hz >
+	static void
+	updateCoreFrequency();
+};
+
+}
+
+#include "hfclk_impl.hpp"

--- a/src/modm/platform/clock/nrf/hfclk_impl.hpp.in
+++ b/src/modm/platform/clock/nrf/hfclk_impl.hpp.in
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <cmath>
+
+namespace modm::platform
+{
+
+template< uint32_t Core_Hz >
+void
+Hfcc::updateCoreFrequency()
+{
+	SystemCoreClock = Core_Hz;
+	delay_fcpu_MHz = computeDelayMhz(Core_Hz);
+	delay_ns_per_loop = computeDelayNsPerLoop(Core_Hz);
+}
+
+}

--- a/src/modm/platform/clock/nrf/module.lb
+++ b/src/modm/platform/clock/nrf/module.lb
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Hannes Ellinger
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":platform:hfclk"
+    module.description = "High Frequency Clock Controller (HFCLK)"
+
+def prepare(module, options):
+    if not options[":target"].has_driver("clock:nrf5*"):
+        return False
+
+    module.depends(":cmsis:device", ":platform:clock", ":architecture:delay")
+    return True
+
+def build(env):
+    device = env[":target"]
+    core = device.get_driver("core")["type"]
+    target = device.identifier
+
+    if "m0" in core:
+        loops = 4
+    elif "m7" in core:
+        loops = 1
+    else:
+        loops = 3
+
+    env.substitutions = {
+        "loops": loops,
+        "has_hfclk_prescaler": target.family == "53",
+    }
+    env.outbasepath = "modm/src/modm/platform/clock"
+    env.template("hfclk.hpp.in", "hfclk.hpp")
+    env.template("hfclk.cpp.in")
+    env.template("hfclk_impl.hpp.in")

--- a/src/modm/platform/clock/systick/module.lb
+++ b/src/modm/platform/clock/systick/module.lb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016-2018, 2020, Niklas Hauser
+# Copyright (c) 2016-2026, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
 #
 # This file is part of the modm project.
@@ -74,6 +74,9 @@ def build(env):
         freq = 100
     elif target.platform == "sam" and target.family == "d5x/e5x":
         # Up to 120MHz, but no /8 prescaler available!
+        freq = 8
+    elif target.platform == "nrf" and target.family == "53":
+        # Up to 128MHz
         freq = 8
     elif target.platform == "sam" and target.family == "e7x/s7x/v7x":
         # Up to 300MHz

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016-2021, Niklas Hauser
+# Copyright (c) 2016-2026, Niklas Hauser
 # Copyright (c) 2017, Fabian Greif
 #
 # This file is part of the modm project.
@@ -366,7 +366,7 @@ def build(env):
     core = env.substitutions["core"]
     enable_dcache = env.get("enable_dcache", False) and not (env.has_module(":platform:dma") or env.has_module(":platform:bdma"))
     env.substitutions.update({
-        "target": env[":target"].identifier,
+        "target": (target := env[":target"].identifier),
         "with_fault_storage": env.has_module(":platform:fault"),
         "with_memory_traits": env.has_module(":architecture:memory"),
         "with_assert": env.has_module(":architecture:assert"),
@@ -449,11 +449,14 @@ def build(env):
 
     # Compilation for FPU
     core = env[":target"].get_driver("core")
-    env.collect(":build:archflags", "-mcpu=" + core["type"], "-mthumb")
-
     single_precision = True
     if (fpu_spec := core.get("fpu")):
         env.collect(":build:archflags", "-mfloat-abi=" + env["float-abi"], "-mfpu=" + fpu_spec)
         single_precision = ("-sp-" in fpu_spec)
     if single_precision:
         env.collect(":build:ccflags", "-Wdouble-promotion")
+
+    cpu = core["type"]
+    # Cortex-M33 without FPU also has no DSP instructions
+    if "m33" in cpu and not fpu_spec: cpu += "+nodsp"
+    env.collect(":build:archflags", "-mcpu=" + cpu, "-mthumb")

--- a/src/modm/platform/core/nrf/module.lb
+++ b/src/modm/platform/core/nrf/module.lb
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Hannes Ellinger
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+import math
+
+def init(module):
+    module.name = ":platform:core"
+    module.description = FileReader("module.md")
+
+def prepare(module, options):
+    if options[":target"].identifier.platform != "nrf":
+        return False
+
+    module.add_option(
+        BooleanOption(
+            name="enable_icache",
+            description=enable_icache_descr,
+            default=True))
+
+    module.depends(":platform:cortex-m")
+    return True
+
+
+def build(env):
+    target = env[":target"].identifier
+
+    reset_pin = None
+    if target.family == "52":
+        reset_pin = 18 if target.series in ("820", "833", "840") else 21
+
+    has_nvmc_icache = (
+        (target.family == "52" and target.series in ("832", "833", "840")) or
+        (target.family == "53" and target.core == "net")
+    )
+    has_cache_peripheral = (target.family == "53" and target.core == "app")
+
+    env.substitutions = {
+        "target": target,
+        "reset_pin": reset_pin,
+        "enable_icache": env.get("enable_icache", False),
+        "has_nvmc_icache": has_nvmc_icache,
+        "has_cache_peripheral": has_cache_peripheral,
+    }
+    env.outbasepath = "modm/src/modm/platform/core"
+    # startup helper code
+    env.template("startup_platform.c.in")
+
+    # us_shift is an optimization to limit error via fractional math
+    frequency = 64e6
+    us_shift = 32 - math.ceil(math.log2(frequency))
+
+    env.substitutions.update({
+        "with_cm0": env[":target"].has_driver("core:cortex-m0*"),
+        "with_cm7": env[":target"].has_driver("core:cortex-m7*"),
+        "loop": 4,
+        "shift": 4,
+        "us_shift": us_shift,
+        "with_assert": env.has_module(":architecture:assert")
+    })
+    env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
+    env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
+    env.template("../cortex/delay_impl.hpp.in", "delay_impl.hpp")
+
+
+def post_build(env):
+    env.substitutions = env.query("::cortex-m:linkerscript")
+    env.substitutions.update(env.query("::cortex-m:vector_table"))
+    env.outbasepath = "modm/link"
+    env.template("../cortex/ram.ld.in", "linkerscript.ld")
+
+
+enable_icache_descr = """
+Enable instruction cache during startup.
+
+This enables the cache that exists on the selected target:
+- nRF52 (selected variants): NVMC instruction cache.
+- nRF5340 network core: NVMC instruction cache.
+- nRF5340 application core: CACHE peripheral.
+"""

--- a/src/modm/platform/core/nrf/module.md
+++ b/src/modm/platform/core/nrf/module.md
@@ -1,0 +1,46 @@
+# Nordic nRF core module
+
+This module specializes the generic `modm:platform:cortex-m` module with
+nRF-specific startup code and linkerscript generation.
+
+
+## Startup
+
+The `__modm_initialize_platform()` callback performs only early platform setup:
+
+### nRF52
+
+- configures reset pin mapping in UICR (device-dependent),
+- disables APPROTECT,
+- enables instruction cache (if `modm:platform:core:enable_icache` is enabled
+  and supported by the selected target).
+
+### nRF53
+
+- copies trimming values from FICR into their target registers,
+- disables APPROTECT (and SECUREAPPROTECT on the app core),
+- enables instruction cache (NVMC on net core, CACHE peripheral on app core,
+  if `enable_icache` is enabled).
+
+
+## Linkerscript
+
+nRF currently reuses the generic Cortex-M RAM/Flash linker layout and does not
+require a dedicated, family-specific linker template like STM32.
+
+For most targets this yields one continuous RAM region plus per-memory helper
+sections that can be targeted explicitly via `modm_section`:
+
+```cpp
+// copied from flash at startup
+modm_section(".data_ram0")
+uint32_t data0 = 0x12345678;
+
+// zero-initialized at startup
+modm_section(".bss_ram1")
+uint8_t dmaBuffer[1024];
+
+// left uninitialized
+modm_section(".noinit_ram2")
+uint8_t retained[256];
+```

--- a/src/modm/platform/core/nrf/startup_platform.c.in
+++ b/src/modm/platform/core/nrf/startup_platform.c.in
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "../device.hpp"
+
+/**
+ * This code should _only_ enable internal memories and nothing else.
+ * Since this is the first code executed after a reset, you do not
+ * have access to _any_ data stored in RAM, since it has not yet been
+ * initialized.
+ * In the worst case you won't even have access to the stack, if the
+ * memory containing the stack is not physically enabled yet.
+ * In that case, consider using inline assembly to manage stack access
+ * manually, until the memory is enabled.
+ */
+void
+__modm_initialize_platform(void)
+{
+%% if target.family == "52"
+%% if reset_pin
+	if (((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)) ||
+		((NRF_UICR->PSELRESET[1] & UICR_PSELRESET_CONNECT_Msk) != (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)))
+	{
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+		NRF_UICR->PSELRESET[0] = {{reset_pin}}ul;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+		NRF_UICR->PSELRESET[1] = {{reset_pin}}ul;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+		NVIC_SystemReset();
+	}
+%% endif
+
+	NRF_APPROTECT->DISABLE = APPROTECT_DISABLE_DISABLE_SwDisable;
+%% elif target.family == "53"
+	// Trimming of the device. Copy all the trimming values from FICR into the target addresses. Trim until one ADDR is not initialized.
+	for (uint32_t index = 0ul; index < 32ul && NRF_FICR->TRIMCNF[index].ADDR != 0xFFFFFFFFul; index++){
+		*((volatile uint32_t *)NRF_FICR->TRIMCNF[index].ADDR) = NRF_FICR->TRIMCNF[index].DATA;
+	}
+
+%% if target.core == "app"
+	NRF_CTRLAP->SECUREAPPROTECT.DISABLE = UICR_SECUREAPPROTECT_PALL_Unprotected;
+%% endif
+	NRF_CTRLAP->APPROTECT.DISABLE = UICR_APPROTECT_PALL_Unprotected;
+%% endif
+%#
+%% if enable_icache
+	// Enable instruction cache
+%% if has_nvmc_icache
+	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
+%% elif has_cache_peripheral
+	NRF_CACHE->ENABLE = CACHE_ENABLE_ENABLE_Msk;
+%% endif
+%% endif
+}

--- a/src/modm/platform/gpio/common/connector.hpp.in
+++ b/src/modm/platform/gpio/common/connector.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Niklas Hauser
+ * Copyright (c) 2017-2026, Niklas Hauser
  * Copyright (c) 2022, Andrey Kunitsyn
  *
  * This file is part of the modm project.
@@ -89,6 +89,8 @@ struct GpioConnector
 		if constexpr (Connection::func >= 0) {
 			Pin::setFunction(Connection::func);
 		}
+%% elif target.platform in ["nrf"]
+		static Connection check [[maybe_unused]];
 %% endif
 	}
 

--- a/src/modm/platform/gpio/common/pins.hpp.in
+++ b/src/modm/platform/gpio/common/pins.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Niklas Hauser
+ * Copyright (c) 2021-2026, Niklas Hauser
  * Copyright (c) 2022, Andrey Kunitsyn
  *
  * This file is part of the modm project.
@@ -23,6 +23,8 @@ namespace modm::platform
 %% for gpio in gpios
 %% if target.platform in ["rp"]
 %% set name = gpio.gpio.name | capitalize
+%% elif target.platform in ["nrf"]
+%% set name = "P" ~ gpio.gpio.port | upper ~ "_" ~ gpio.gpio.pin
 %% else
 %% set name = gpio.gpio.port | upper ~ gpio.gpio.pin
 %% endif

--- a/src/modm/platform/gpio/common/unused.hpp.in
+++ b/src/modm/platform/gpio/common/unused.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, 2021, Niklas Hauser
+ * Copyright (c) 2017-2026, Niklas Hauser
  * Copyright (c) 2022, Andrey Kunitsyn
  *
  * This file is part of the modm project.
@@ -65,6 +65,9 @@ public:
 	static constexpr bool isInverted = false;
 	static constexpr Port port = Port(-1);
 	static constexpr uint8_t pin = uint8_t(-1);
+%% if target.platform in ["nrf"]
+	static constexpr uint32_t number = uint32_t(-1);
+%% endif
 	static constexpr uint{{8 if target.platform == "avr" else 16}}_t mask = 0;
 %% if target.platform in ["stm32"]
 protected:

--- a/src/modm/platform/gpio/nrf/base.hpp.in
+++ b/src/modm/platform/gpio/nrf/base.hpp.in
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, Hannes Ellinger
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_GPIO_BASE_HPP
+#define MODM_NRF_GPIO_BASE_HPP
+
+#include "../device.hpp"
+#include <modm/architecture/interface/gpio.hpp>
+#include <modm/math/utils/bit_operation.hpp>
+#include <modm/platform/core/peripherals.hpp>
+
+%% if target.family == "51"
+#ifndef NRF_P0
+#define NRF_P0 NRF_GPIO
+#endif
+%% endif
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_gpio
+struct Gpio
+{
+	enum class
+	InputType
+	{
+		Floating = 0,
+		PullUp = 1,
+		PullDown = 2,
+	};
+
+	enum class
+	Dir
+	{
+		Input = 0,
+		Output = 1,
+	};
+
+	enum class
+	Input
+	{
+		Connect = 0,
+		Disconnect = 1,
+	};
+
+	enum class
+	Pull
+	{
+		Disabled = 0,
+		Pulldown = 1,
+		Pullup = 3,
+	};
+
+	enum class
+	OutputType
+	{
+		// Raw Nordic drive modes (match GPIO_PIN_CNF.DRIVE values)
+		S0S1 = 0,
+		H0S1 = 1,
+		S0H1 = 2,
+		H0H1 = 3,
+		D0S1 = 4,
+		D0H1 = 5,
+		S0D1 = 6,
+		H0D1 = 7,
+
+		// Readable aliases
+		PushPull = S0S1,
+		HighDrive = H0H1,
+		HighDriveLow = H0S1,
+		HighDriveHigh = S0H1,
+
+		// One-side disconnected drive styles
+		OpenSource = D0S1,
+		HighDriveOpenSource = D0H1,
+		OpenDrain = S0D1,
+		HighDriveOpenDrain = H0D1,
+	};
+
+	enum class
+	Sense
+	{
+		Disabled = 0,
+		High = 2,
+		Low = 3,
+	};
+
+	/// @cond
+	enum class
+	Signal
+	{
+		BitBang,
+%% for signal in all_signals
+%%   if signal != "BitBang"
+		{{ signal }},
+%%   endif
+%% endfor
+	};
+
+	enum class
+	Port
+	{
+%% for port in ports
+		{{ port }},
+%% endfor
+	};
+	/// @endcond
+
+protected:
+
+	// Enum Class To Integer helper functions.
+	static constexpr uint32_t
+	i(InputType inputType) {return uint32_t(inputType); }
+	static constexpr uint32_t
+	i(OutputType outputType) {return uint32_t(outputType); }
+	static constexpr uint32_t
+	i(Dir dir) {return uint32_t(dir); }
+	static constexpr uint32_t
+	i(Input input) {return uint32_t(input); }
+	static constexpr uint32_t
+	i(Pull pull) {return uint32_t(pull); }
+	static constexpr uint32_t
+	i(Sense sense) {return uint32_t(sense); }
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_GPIO_BASE_HPP

--- a/src/modm/platform/gpio/nrf/data.hpp.in
+++ b/src/modm/platform/gpio/nrf/data.hpp.in
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_GPIO_DATA_HPP
+#define MODM_NRF_GPIO_DATA_HPP
+
+#include "base.hpp"
+
+/// @cond
+namespace modm::platform::detail
+{
+
+template<class Signal, Peripheral p>
+struct SignalConnection;
+
+struct DataUnused {};
+%% for gpio in gpios
+%% set name = "P" ~ gpio.gpio.port | upper ~ "_" ~ gpio.gpio.pin
+%#
+struct Data{{ name }}
+{
+	static constexpr Gpio::Port port = Gpio::Port::P{{ gpio.gpio.port | upper }};
+	static constexpr uint8_t pin = {{ gpio.gpio.pin }};
+	struct BitBang {
+		using Data = Data{{ name }};
+		static constexpr Gpio::Signal Signal = Gpio::Signal::BitBang;
+		template<Peripheral peripheral>
+		inline static void connect() { static SignalConnection<BitBang, peripheral> check [[maybe_unused]]; }
+	};
+%% for signal_name in gpio.signals
+	struct {{ signal_name }} {
+		using Data = Data{{ name }};
+		static constexpr Gpio::Signal Signal = Gpio::Signal::{{ signal_name }};
+		template<Peripheral peripheral>
+		inline static void connect() { static SignalConnection<{{ signal_name }}, peripheral> check [[maybe_unused]]; }
+	};
+%% endfor
+};
+
+template<Peripheral p>
+struct SignalConnection<Data{{ name }}::BitBang, p>
+{
+	static_assert(p == Peripheral::BitBang,
+		"Gpio{{ name }}::BitBang only connects to software drivers!");
+};
+
+%% for signal_name, signal_group in gpio.signals.items()
+template<Peripheral p>
+struct SignalConnection<Data{{ name }}::{{ signal_name }}, p>
+{
+	static_assert((p == Peripheral::{{ signal_group | map(attribute="driver") | join(") or (p == Peripheral::") }}),
+		"Gpio{{ name }}::{{ signal_name }} only connects to {{ signal_group | map(attribute="driver") | join(" or ") }}!");
+};
+%% endfor
+
+template<>
+struct SignalConnection<Data{{ name }}::BitBang, Peripheral::BitBang> {};
+%% for signal_group in gpio.signals.values()
+	%% for signal in signal_group
+template<>
+struct SignalConnection<Data{{ name }}::{{ signal.name }}, Peripheral::{{ signal.driver }}> {};
+	%% endfor
+%% endfor
+
+%% endfor
+
+} // namespace modm::platform::detail
+/// @endcond
+
+#endif // MODM_NRF_GPIO_DATA_HPP

--- a/src/modm/platform/gpio/nrf/module.lb
+++ b/src/modm/platform/gpio/nrf/module.lb
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Hannes Ellinger
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+from collections import defaultdict, OrderedDict
+
+def port_ranges(gpios):
+    ports = {p: (32, 0) for p in set(p["port"] for p in gpios)}
+    for gpio in gpios:
+        pin = int(gpio["pin"])
+        pmin, pmax = ports[gpio["port"]]
+        ports[gpio["port"]] = (min(pin, pmin), max(pin, pmax))
+
+    ports = [{"name": k.upper(), "start": v[0], "width": v[1] - v[0] + 1} for k,v in ports.items()]
+    ports.sort(key=lambda p: p["name"])
+    return ports
+
+
+def translate(s):
+    name = ""
+    for part in s.split("_"):
+        name += part.capitalize()
+    return name
+
+
+def normalize_instance_value(instance):
+    if isinstance(instance, dict):
+        return instance.get("value")
+    return instance
+
+
+# -----------------------------------------------------------------------------
+def init(module):
+    module.name = ":platform:gpio"
+    module.description = "General Purpose I/O (GPIO)"
+
+
+def prepare(module, options):
+    module.depends(":architecture:register", ":architecture:gpio", ":cmsis:device", ":math:utils")
+    return options[":target"].has_driver("gpio:nrf*")
+
+
+def build(env):
+    device = env[":target"]
+    driver = device.get_driver("gpio")
+
+    driver_instances = {}
+    for drv in device._properties["driver"]:
+        name = drv["name"]
+        if name in driver_instances:
+            continue
+        resolved = device.get_driver(name)
+        if resolved is None:
+            continue
+        instances = listify(resolved.get("instance", []))
+        driver_instances[name] = [str(i) for i in instances if i is not None]
+
+    def signal_peripherals(signal):
+        dname = signal["driver"]
+        instance = signal.get("instance")
+
+        if instance is not None:
+            return [translate(dname) + translate(str(instance))]
+
+        instances = driver_instances.get(dname, [])
+        if len(instances):
+            return [translate(dname) + translate(i) for i in instances]
+        return [translate(dname)]
+
+    excluded_flexible_drivers = {"qspi"}
+    flexible_signals = []
+    for drv in device._properties["driver"]:
+        name = drv["name"]
+        if name in ["gpio", "core"] or name in excluded_flexible_drivers:
+            continue
+
+        signals = listify(drv.get("signal", []))
+        if not signals:
+            continue
+
+        instances = driver_instances.get(name, [])
+        if not instances:
+            instances = [None]
+
+        for instance in instances:
+            peripheral = translate(name) + (translate(instance) if instance is not None else "")
+            for signal in signals:
+                signal_name = (signal["name"] if isinstance(signal, dict) else signal).lower()
+                flexible_signals.append((peripheral, translate(signal_name)))
+
+    ranges = port_ranges(driver["gpio"])
+    ranges = [{"name": "P" + p["name"], "start": p["start"], "width": p["width"]} for p in ranges]
+    ports = OrderedDict([(k, i) for i, k in enumerate([p["name"] for p in ranges])])
+
+    all_signals = set()
+    gpios = []
+    for gpio in driver["gpio"]:
+        signals = defaultdict(list)
+        for signal in gpio.get("signal", []):
+            name = translate(signal["name"].lower())
+            for driver_name in signal_peripherals(signal):
+                signals[name].append({
+                    "driver": driver_name,
+                    "name": name,
+                })
+
+        for driver_name, signal_name in flexible_signals:
+            existing = set(s["driver"] for s in signals[signal_name])
+            if driver_name in existing:
+                continue
+            signals[signal_name].append({
+                "driver": driver_name,
+                "name": signal_name,
+            })
+
+        all_signals.update(signals.keys())
+        gpios.append({
+            "gpio": gpio,
+            "signals": signals,
+        })
+
+    subs = device.properties
+    subs["target"] = device.identifier
+    subs["driver"] = driver
+    subs["gpios"] = gpios
+    subs["ranges"] = ranges
+    subs["ports"] = ports
+    subs["port_width"] = 32
+    subs["all_signals"] = sorted(list(all_signals))
+
+    env.substitutions = subs
+    env.outbasepath = "modm/src/modm/platform/gpio"
+
+    env.template("data.hpp.in")
+    env.template("static.hpp.in")
+    env.template("../common/pins.hpp.in", "pin.hpp")
+    env.template("../common/pins.hpp.in", "pins.hpp")
+    env.template("../common/unused.hpp.in", "unused.hpp")
+    env.copy("../common/inverted.hpp", "inverted.hpp")
+    env.template("base.hpp.in")
+    env.template("set.hpp.in")
+    env.template("port.hpp.in")
+    env.template("software_port.hpp.in")
+    env.template("../common/port_shim.hpp.in", "port_shim.hpp")
+    env.template("../common/connector.hpp.in", "connector.hpp",
+                 filters={"formatPeripheral": "", "printSignalMap": ""})

--- a/src/modm/platform/gpio/nrf/port.hpp.in
+++ b/src/modm/platform/gpio/nrf/port.hpp.in
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "port_shim.hpp"
+#include "set.hpp"
+#include <type_traits>
+#include <modm/math/utils/bit_operation.hpp>
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_gpio
+template< class StartGpio, int8_t Width >
+class GpioPort : public ::modm::GpioPort/** @cond */, public detail::GpioSetShim<StartGpio, Width> /** @endcond */
+{
+	using PinSet = detail::GpioSetShim<StartGpio, Width>;
+public:
+	using PinSet::width;
+	static_assert(width <= 32, "Only a maximum of 32 pins are supported by GpioPort!");
+	using PortType = std::conditional_t< (width > 8),
+					 std::conditional_t< (width > 16), uint32_t, uint16_t >,
+					 uint8_t >;
+	static constexpr DataOrder getDataOrder()
+	{ return Width > 0 ? GpioPort::DataOrder::Normal : GpioPort::DataOrder::Reversed; }
+
+protected:
+	using PinSet::mask;
+	using PinSet::inverted;
+	static constexpr uint8_t StartPin = Width > 0 ? StartGpio::pin : StartGpio::pin - width + 1;
+	static constexpr uint8_t StartPinReversed = (16 - StartPin - width) + 16;
+
+public:
+	static PortType isSet()
+	{
+		uint32_t r{0};
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) r = (NRF_{{port}}->OUT & mask({{id}})) ^ inverted({{id}});
+%% endfor
+		if constexpr (getDataOrder() == modm::GpioPort::DataOrder::Reversed)
+			 return bitReverse(r) >> StartPinReversed;
+		else return            r  >> StartPin;
+	}
+
+	static PortType read()
+	{
+		uint32_t r{0};
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) r = (NRF_{{port}}->IN & mask({{id}})) ^ inverted({{id}});
+%% endfor
+		if constexpr (getDataOrder() == modm::GpioPort::DataOrder::Reversed)
+			 return bitReverse(r) >> StartPinReversed;
+		else return            r  >> StartPin;
+	}
+
+	static void write(PortType data)
+	{
+		uint32_t p;
+		if constexpr (getDataOrder() == modm::GpioPort::DataOrder::Reversed)
+			 p = bitReverse(uint32_t(uint32_t(data) << StartPinReversed));
+		else p =            uint32_t(data) << StartPin;
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) {
+			p ^= inverted({{id}});
+			NRF_{{port}}->OUTSET = p & mask({{id}});
+			NRF_{{port}}->OUTCLR = (~p) & mask({{id}});
+		}
+%% endfor
+	}
+};
+
+} // namespace modm::platform

--- a/src/modm/platform/gpio/nrf/set.hpp.in
+++ b/src/modm/platform/gpio/nrf/set.hpp.in
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_GPIO_SET_HPP
+#define MODM_NRF_GPIO_SET_HPP
+
+#include "base.hpp"
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_gpio
+template< class... Gpios >
+class GpioSet : public Gpio
+{
+protected:
+	static constexpr uint32_t inverteds[{{ ports | length }}] = {
+%% for port in ports
+		(((Gpios::port == Port::{{port}} and Gpios::isInverted) ? Gpios::mask : 0) | ...),
+%% endfor
+	};
+	static constexpr uint32_t inverted(uint8_t id) { return inverteds[id]; }
+
+	static constexpr uint32_t masks[{{ ports | length }}] = {
+%% for port in ports
+		(((Gpios::port == Port::{{port}}) ? Gpios::mask : 0) | ...),
+%% endfor
+	};
+	static constexpr uint32_t mask(uint8_t id) { return masks[id]; }
+	static constexpr uint8_t numberOfPorts() {
+		uint8_t r{0};
+		for (const auto &m: masks) r += (m) ? 1 : 0;
+		return r;
+	}
+
+	static constexpr uint32_t
+	inputConfig(InputType type)
+	{
+		const Pull pull =
+			(type == InputType::PullUp) ? Pull::Pullup :
+			(type == InputType::PullDown) ? Pull::Pulldown :
+			Pull::Disabled;
+		return (i(Dir::Input) << GPIO_PIN_CNF_DIR_Pos)
+			| (i(Input::Connect) << GPIO_PIN_CNF_INPUT_Pos)
+			| (i(pull) << GPIO_PIN_CNF_PULL_Pos)
+			| (i(OutputType::PushPull) << GPIO_PIN_CNF_DRIVE_Pos)
+			| (i(Sense::Disabled) << GPIO_PIN_CNF_SENSE_Pos);
+	}
+
+	static constexpr uint32_t
+	outputConfig(OutputType drive)
+	{
+		return (i(Dir::Output) << GPIO_PIN_CNF_DIR_Pos)
+			| (i(Input::Connect) << GPIO_PIN_CNF_INPUT_Pos)
+			| (i(Pull::Disabled) << GPIO_PIN_CNF_PULL_Pos)
+			| (i(drive) << GPIO_PIN_CNF_DRIVE_Pos)
+			| (i(Sense::Disabled) << GPIO_PIN_CNF_SENSE_Pos);
+	}
+
+	template<typename PortT>
+	static void
+	configurePins(PortT *port, uint32_t m, uint32_t cnf)
+	{
+		for (uint8_t pin{0}; pin < 32; ++pin)
+			if (m & (1ul << pin))
+				port->PIN_CNF[pin] = cnf;
+	}
+
+public:
+	static constexpr uint8_t width = sizeof...(Gpios);
+	static constexpr uint8_t number_of_ports = numberOfPorts();
+
+public:
+	static void
+	setOutput()
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) NRF_{{port}}->DIRSET = mask({{id}});
+%% endfor
+	}
+
+	static void
+	setOutput(bool status)
+	{
+		set(status);
+		setOutput();
+	}
+
+	static void
+	setOutput(OutputType type)
+	{
+		configure(type);
+		setOutput();
+	}
+
+	static void
+	configure(OutputType type)
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) configurePins(NRF_{{port}}, mask({{id}}), outputConfig(type));
+%% endfor
+	}
+
+	static void
+	setInput()
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) NRF_{{port}}->DIRCLR = mask({{id}});
+%% endfor
+	}
+
+	static void
+	setInput(InputType type)
+	{
+		configure(type);
+		setInput();
+	}
+
+	static void
+	configure(InputType type)
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) configurePins(NRF_{{port}}, mask({{id}}), inputConfig(type));
+%% endfor
+	}
+
+	static void
+	set()
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}}) & ~inverted({{id}}))
+			NRF_{{port}}->OUTSET = mask({{id}}) & ~inverted({{id}});
+		if constexpr (mask({{id}}) &  inverted({{id}}))
+			NRF_{{port}}->OUTCLR = mask({{id}}) &  inverted({{id}});
+%% endfor
+	}
+
+	static void
+	set(bool status)
+	{
+		if (status) set();
+		else reset();
+	}
+
+	static void
+	reset()
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}}) &  inverted({{id}}))
+			NRF_{{port}}->OUTSET = mask({{id}}) &  inverted({{id}});
+		if constexpr (mask({{id}}) & ~inverted({{id}}))
+			NRF_{{port}}->OUTCLR = mask({{id}}) & ~inverted({{id}});
+%% endfor
+	}
+
+	static void
+	toggle()
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) {
+			const uint32_t are_set = (NRF_{{port}}->OUT & mask({{id}}));
+			const uint32_t are_reset = mask({{id}}) ^ are_set;
+			NRF_{{port}}->OUTSET = are_reset;
+			NRF_{{port}}->OUTCLR = are_set;
+		}
+%% endfor
+	}
+
+	static void
+	disconnect()
+	{
+		(Gpios::disconnect(), ...);
+	}
+
+%% if target.family == "53" and target.core == "app"
+	static void
+	delegateToNetworkCore()
+	{
+		(Gpios::delegateToNetworkCore(), ...);
+	}
+%% endif
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_GPIO_SET_HPP

--- a/src/modm/platform/gpio/nrf/software_port.hpp.in
+++ b/src/modm/platform/gpio/nrf/software_port.hpp.in
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// -----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_GPIO_SOFTWARE_PORT_HPP
+#define MODM_NRF_GPIO_SOFTWARE_PORT_HPP
+
+#include "set.hpp"
+#include <type_traits>
+
+namespace modm::platform
+{
+
+/**
+ * Create an up to 32-bit port from arbitrary pins.
+ *
+ * This class optimizes the data type for the `read()` and `write()` methods.
+ * Supplying up to 8 Gpios will use `uint8_t`, up to 16 Gpios `uint16_t` and
+ * up to 32 Gpios `uint32_t`.
+ *
+ * @note Since the bit order is explicitly given by the order of arguments,
+ *       this class only supports `DataOrder::Normal`.
+ *       If you need reverse bit order, reverse the order of `Gpios`!
+ *
+ * @tparam Gpios	Up to 32 GpioIO classes, ordered MSB to LSB
+ *
+ * @author	Niklas Hauser
+ * @ingroup	modm_platform_gpio
+ */
+template< class... Gpios >
+class SoftwareGpioPort : public ::modm::GpioPort, public GpioSet<Gpios...>
+{
+	using Set = GpioSet<Gpios...>;
+public:
+	using Set::width;
+	static_assert(width <= 32, "Only a maximum of 32 pins are supported by this Port!");
+	using PortType = std::conditional_t< (width > 8),
+					 std::conditional_t< (width > 16),
+										 uint32_t,
+										 uint16_t >,
+										 uint8_t >;
+	static constexpr DataOrder getDataOrder()
+	{ return ::modm::GpioPort::DataOrder::Normal; }
+
+protected:
+	static constexpr int8_t shift_masks[{{ ports | length }}][width] = {
+%% for port in ports
+		{(Gpios::port == Gpio::Port::{{port}} ? Gpios::pin : -1)...},
+%% endfor
+	};
+	static constexpr int8_t shift_mask(uint8_t id, uint8_t pos) { return shift_masks[id][width - 1 - pos]; }
+	using Set::mask;
+	using Set::inverted;
+
+public:
+	static PortType isSet()
+	{
+		PortType r{0};
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) {
+			const uint32_t p = (NRF_{{port}}->OUT & mask({{id}})) ^ inverted({{id}});
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) if constexpr (constexpr auto pos = shift_mask({{id}}, {{pos}}); pos >= 0) r |= ((p >> pos) & 1) << {{pos}};
+	%% endfor
+		}
+%% endfor
+		return r;
+	}
+
+	static void write(PortType data)
+	{
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) { uint32_t ps{0}; uint32_t pr{0};
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) if constexpr (constexpr auto pos = shift_mask({{id}}, {{pos}}); pos >= 0) { if (data & (1ul << {{pos}})) { ps |= (1ul << pos); } else { pr |= (1ul << pos); }}
+	%% endfor
+			ps ^= inverted({{id}});
+			pr ^= inverted({{id}});
+			if (ps) NRF_{{port}}->OUTSET = ps;
+			if (pr) NRF_{{port}}->OUTCLR = pr;
+		}
+%% endfor
+	}
+
+	static PortType read()
+	{
+		PortType r{0};
+%% for port, id in ports.items()
+		if constexpr (mask({{id}})) {
+			const uint32_t p = (NRF_{{port}}->IN & mask({{id}})) ^ inverted({{id}});
+	%% for pos in range(32)
+			if constexpr ({{pos}} < width) if constexpr (constexpr auto pos = shift_mask({{id}}, {{pos}}); pos >= 0) r |= ((p >> pos) & 1) << {{pos}};
+	%% endfor
+		}
+%% endfor
+		return r;
+	}
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_GPIO_SOFTWARE_PORT_HPP

--- a/src/modm/platform/gpio/nrf/static.hpp.in
+++ b/src/modm/platform/gpio/nrf/static.hpp.in
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_GPIO_STATIC_HPP
+#define MODM_NRF_GPIO_STATIC_HPP
+
+#include <type_traits>
+
+#include "../device.hpp"
+#include "base.hpp"
+#include "set.hpp"
+#include <modm/architecture/interface/gpio.hpp>
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_gpio
+template<class GpioData>
+class GpioStatic : public Gpio, public GpioData
+{
+	template<class... Gpios>
+	friend class GpioSet;
+	using PinSet = GpioSet<GpioStatic<GpioData>>;
+public:
+	using Direction = ::modm::Gpio::Direction;
+	using Type = GpioStatic<GpioData>;
+	using Output = Type;
+	using Input = Type;
+	using IO = Type;
+	using Data = GpioData;
+	using GpioData::port;
+	using GpioData::pin;
+	static constexpr Direction direction = Direction::InOut;
+	static constexpr bool isInverted = false;
+	static constexpr uint32_t mask = 1ul << pin;
+	static constexpr uint32_t number = (uint32_t(port) * 32u) + uint32_t(pin);
+
+	template<Peripheral peripheral, class Signal = typename GpioData::BitBang>
+	inline static void connect() { Signal::template connect<peripheral>(); }
+
+	template<Peripheral peripheral, Gpio::Signal signal>
+	inline static void connect()
+	{
+		if constexpr (signal == Gpio::Signal::BitBang) {
+			GpioData::BitBang::template connect<peripheral>();
+		}
+%% for signal in all_signals | sort
+		else if constexpr (signal == Gpio::Signal::{{ signal }}) {
+			if constexpr (requires { typename GpioData::{{ signal }}; }) {
+				GpioData::{{ signal }}::template connect<peripheral>();
+			}
+			else {
+				static_assert(signal != Gpio::Signal::{{ signal }}, "Requested signal is not available on this pin!");
+			}
+		}
+%% endfor
+	}
+
+protected:
+	static NRF_GPIO_Type* gport()
+	{
+%% for port in ports
+		if constexpr (port == Gpio::Port::{{port}}) return NRF_{{port}};
+%% endfor
+		return nullptr;
+	}
+
+	static constexpr uint32_t
+	defaultCnf(Gpio::Dir dir)
+	{
+		return (i(dir) << GPIO_PIN_CNF_DIR_Pos)
+			| (i(Gpio::Input::Connect) << GPIO_PIN_CNF_INPUT_Pos)
+			| (i(Gpio::Pull::Disabled) << GPIO_PIN_CNF_PULL_Pos)
+			| (i(Gpio::OutputType::PushPull) << GPIO_PIN_CNF_DRIVE_Pos)
+			| (i(Gpio::Sense::Disabled) << GPIO_PIN_CNF_SENSE_Pos);
+	}
+
+public:
+	inline static void
+	setOutput()
+	{
+		PinSet::setOutput();
+	}
+
+%% if target.family == "53" and target.core == "app"
+	inline static void
+	delegateToNetworkCore()
+	{
+		gport()->PIN_CNF[pin] = (gport()->PIN_CNF[pin] & ~GPIO_PIN_CNF_MCUSEL_Msk) |
+				(GPIO_PIN_CNF_MCUSEL_NetworkMCU << GPIO_PIN_CNF_MCUSEL_Pos);
+	}
+%% endif
+
+	inline static void
+	setOutput(bool status)
+	{
+		PinSet::setOutput(status);
+	}
+
+	inline static void
+	setOutput(OutputType type)
+	{
+		PinSet::setOutput(type);
+	}
+
+	inline static void
+	configure(OutputType type)
+	{
+		PinSet::configure(type);
+	}
+
+	inline static void
+	set()
+	{
+		PinSet::set();
+	}
+
+	inline static void
+	set(bool status)
+	{
+		PinSet::set(status);
+	}
+
+	inline static void
+	reset()
+	{
+		PinSet::reset();
+	}
+
+	inline static void
+	toggle()
+	{
+		PinSet::toggle();
+	}
+
+	inline static bool
+	isSet()
+	{
+		return (gport()->OUT & mask);
+	}
+
+	inline static void
+	setInput()
+	{
+		PinSet::setInput();
+	}
+
+	inline static void
+	setInput(InputType type)
+	{
+		PinSet::setInput(type);
+	}
+
+	inline static void
+	configure(InputType type)
+	{
+		PinSet::configure(type);
+	}
+
+	inline static bool
+	read()
+	{
+		return (gport()->IN & mask);
+	}
+
+	inline static Direction
+	getDirection()
+	{
+		return (gport()->DIR & mask) ? Direction::Out : Direction::In;
+	}
+
+	inline static void
+	disconnect()
+	{
+		gport()->PIN_CNF[pin] = (i(Dir::Input) << GPIO_PIN_CNF_DIR_Pos)
+			| (i(Gpio::Input::Disconnect) << GPIO_PIN_CNF_INPUT_Pos)
+			| (i(Gpio::Pull::Disabled) << GPIO_PIN_CNF_PULL_Pos)
+			| (i(Gpio::OutputType::PushPull) << GPIO_PIN_CNF_DRIVE_Pos)
+			| (i(Gpio::Sense::Disabled) << GPIO_PIN_CNF_SENSE_Pos);
+	}
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_GPIO_STATIC_HPP

--- a/src/modm/platform/power/nrf/module.lb
+++ b/src/modm/platform/power/nrf/module.lb
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+
+def init(module):
+    module.name = ":platform:power"
+    module.description = "Power and regulator control (POWER)"
+
+
+def prepare(module, options):
+    module.depends(":cmsis:device")
+
+    device = options[":target"]
+    return device.has_driver("power:nrf*") or device.has_driver("regulators:nrf*")
+
+
+def build(env):
+    target = env[":target"].identifier
+
+    has_vddh_dcdc = target.family == "53" or (target.family == "52" and target.series == "840")
+    has_vdd_regout0 = target.family == "52" and target.series in ("820", "833", "840")
+
+    env.outbasepath = "modm/src/modm/platform/power"
+    env.template("regulators.hpp.in", "regulators.hpp", substitutions={
+        "target": target,
+        "has_vddh_dcdc": has_vddh_dcdc,
+        "has_vdd_regout0": has_vdd_regout0,
+    })

--- a/src/modm/platform/power/nrf/regulators.hpp.in
+++ b/src/modm/platform/power/nrf/regulators.hpp.in
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+#include <modm/platform/device.hpp>
+
+namespace modm::platform
+{
+
+class Regulators
+{
+public:
+%% if target.family == "53" and target.core == "app"
+	enum class
+	MainSupplyStatus
+	{
+		NormalVoltageMode,
+		HighVoltageMode,
+	};
+
+	static inline MainSupplyStatus
+	mainSupplyStatus()
+	{
+		return (NRF_REGULATORS->MAINREGSTATUS & REGULATORS_MAINREGSTATUS_VREGH_Msk)
+			? MainSupplyStatus::HighVoltageMode
+			: MainSupplyStatus::NormalVoltageMode;
+	}
+
+	static inline bool
+	isVddhSupplyActive()
+	{
+		return mainSupplyStatus() == MainSupplyStatus::HighVoltageMode;
+	}
+
+	static inline void
+	setMainDcdcEnabled(bool enable = true)
+	{
+		NRF_REGULATORS->VREGMAIN.DCDCEN = enable
+			? REGULATORS_VREGMAIN_DCDCEN_DCDCEN_Enabled
+			: REGULATORS_VREGMAIN_DCDCEN_DCDCEN_Disabled;
+	}
+
+	static inline void
+	setRadioDcdcEnabled(bool enable = true)
+	{
+		NRF_REGULATORS->VREGRADIO.DCDCEN = enable
+			? REGULATORS_VREGRADIO_DCDCEN_DCDCEN_Enabled
+			: REGULATORS_VREGRADIO_DCDCEN_DCDCEN_Disabled;
+	}
+
+	static inline void
+	setVddhDcdcEnabled(bool enable = true)
+	{
+		NRF_REGULATORS->VREGH.DCDCEN = enable
+			? REGULATORS_VREGH_DCDCEN_DCDCEN_Enabled
+			: REGULATORS_VREGH_DCDCEN_DCDCEN_Disabled;
+	}
+
+	static inline void
+	setVddhExternalSilentEnabled(bool enable = true)
+	{
+		NRF_REGULATORS->VREGH.EXTSILENTEN = enable
+			? REGULATORS_VREGH_EXTSILENTEN_EXTSILENTEN_Enabled
+			: REGULATORS_VREGH_EXTSILENTEN_EXTSILENTEN_Disabled;
+	}
+
+	static inline bool
+	isUsbVbusPresent()
+	{
+		return (NRF_USBREGULATOR->USBREGSTATUS & USBREG_USBREGSTATUS_VBUSDETECT_Msk);
+	}
+
+	static inline bool
+	isUsbRegulatorOutputReady()
+	{
+		return (NRF_USBREGULATOR->USBREGSTATUS & USBREG_USBREGSTATUS_OUTPUTRDY_Msk);
+	}
+
+	enum class VddhOutputVoltage : uint32_t
+	{
+		V1_8 = UICR_VREGHVOUT_VREGHVOUT_1V8,
+		V2_1 = UICR_VREGHVOUT_VREGHVOUT_2V1,
+		V2_4 = UICR_VREGHVOUT_VREGHVOUT_2V4,
+		V2_7 = UICR_VREGHVOUT_VREGHVOUT_2V7,
+		V3_0 = UICR_VREGHVOUT_VREGHVOUT_3V0,
+		V3_3 = UICR_VREGHVOUT_VREGHVOUT_3V3,
+		Default = UICR_VREGHVOUT_VREGHVOUT_DEFAULT,
+	};
+	static inline VddhOutputVoltage
+	vddhOutputVoltage()
+	{
+		const auto raw = (NRF_UICR->VREGHVOUT & UICR_VREGHVOUT_VREGHVOUT_Msk) >> UICR_VREGHVOUT_VREGHVOUT_Pos;
+		return static_cast<VddhOutputVoltage>(raw);
+	}
+
+	enum class
+	VddhOutputVoltageWriteResult
+	{
+		Unchanged,
+		Programmed,
+		EraseRequired,
+	};
+	static inline VddhOutputVoltageWriteResult
+	setVddhOutputVoltage(VddhOutputVoltage voltage)
+	{
+		const uint32_t currentWord = NRF_UICR->VREGHVOUT;
+		const uint32_t current = (currentWord & UICR_VREGHVOUT_VREGHVOUT_Msk) >> UICR_VREGHVOUT_VREGHVOUT_Pos;
+		const uint32_t target = static_cast<uint32_t>(voltage);
+
+		if (current == target) return VddhOutputVoltageWriteResult::Unchanged;
+		if (target & ~current) return VddhOutputVoltageWriteResult::EraseRequired;
+
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		NRF_UICR->VREGHVOUT = (currentWord & ~UICR_VREGHVOUT_VREGHVOUT_Msk) |
+				((target << UICR_VREGHVOUT_VREGHVOUT_Pos) & UICR_VREGHVOUT_VREGHVOUT_Msk);
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		return VddhOutputVoltageWriteResult::Programmed;
+	}
+%% elif target.family in ("51", "52")
+%% if has_vdd_regout0
+	enum class VddOutputVoltage : uint32_t
+	{
+		V1_8 = UICR_REGOUT0_VOUT_1V8,
+		V2_1 = UICR_REGOUT0_VOUT_2V1,
+		V2_4 = UICR_REGOUT0_VOUT_2V4,
+		V2_7 = UICR_REGOUT0_VOUT_2V7,
+		V3_0 = UICR_REGOUT0_VOUT_3V0,
+		V3_3 = UICR_REGOUT0_VOUT_3V3,
+		Default = UICR_REGOUT0_VOUT_DEFAULT,
+	};
+
+	enum class VddOutputVoltageWriteResult : uint8_t
+	{
+		Unchanged,
+		Programmed,
+		EraseRequired,
+	};
+%% endif
+
+%% if has_vdd_regout0
+	static inline VddOutputVoltage
+	vddOutputVoltage()
+	{
+		const auto raw = (NRF_UICR->REGOUT0 & UICR_REGOUT0_VOUT_Msk) >> UICR_REGOUT0_VOUT_Pos;
+		return static_cast<VddOutputVoltage>(raw);
+	}
+
+	static inline VddOutputVoltageWriteResult
+	setVddOutputVoltage(VddOutputVoltage voltage)
+	{
+		const uint32_t currentWord = NRF_UICR->REGOUT0;
+		const uint32_t current = (currentWord & UICR_REGOUT0_VOUT_Msk) >> UICR_REGOUT0_VOUT_Pos;
+		const uint32_t target = static_cast<uint32_t>(voltage);
+
+		if (current == target) return VddOutputVoltageWriteResult::Unchanged;
+		if (target & ~current) return VddOutputVoltageWriteResult::EraseRequired;
+
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		NRF_UICR->REGOUT0 = (currentWord & ~UICR_REGOUT0_VOUT_Msk) |
+				((target << UICR_REGOUT0_VOUT_Pos) & UICR_REGOUT0_VOUT_Msk);
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) ;
+
+		return VddOutputVoltageWriteResult::Programmed;
+	}
+%% endif
+
+	static inline void
+	setMainDcdcEnabled(bool enable = true)
+	{
+		NRF_POWER->DCDCEN = enable
+			? POWER_DCDCEN_DCDCEN_Enabled
+			: POWER_DCDCEN_DCDCEN_Disabled;
+	}
+
+%% if has_vddh_dcdc
+	static inline void
+	setVddhDcdcEnabled(bool enable = true)
+	{
+		NRF_POWER->DCDCEN0 = enable
+			? POWER_DCDCEN0_DCDCEN_Enabled
+			: POWER_DCDCEN0_DCDCEN_Disabled;
+	}
+%% endif
+%% endif
+};
+
+} // namespace modm::platform

--- a/src/modm/platform/uart/nrf/module.lb
+++ b/src/modm/platform/uart/nrf/module.lb
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+props = {}
+
+
+def _translate(name):
+    return name.replace("_", "").capitalize()
+
+
+def _instance_value(instance):
+    if isinstance(instance, dict):
+        return instance.get("value")
+    return instance
+
+
+def _find_irq(core_vectors, kind, instance):
+    instance = str(instance)
+    candidates = ["UART{}".format(instance), "SERIAL{}".format(instance)]
+
+    for vector in core_vectors:
+        vname = vector["name"].upper()
+        for candidate in candidates:
+            if candidate in vname:
+                return vector["name"]
+    return None
+
+
+class Instance(Module):
+    def __init__(self, kind, instance, irq):
+        self.kind = kind
+        self.instance = int(instance)
+        self.irq = irq
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "{} instance {}".format(self.kind.upper(), self.instance)
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        global props
+
+        kind_name = _translate(self.kind)
+        suffix = "Hal{}".format(self.instance)
+
+        local = dict(props)
+        local.update({
+            "kind": self.kind,
+            "id": self.instance,
+            "name": "{}{}".format(kind_name, self.instance),
+            "hal": "{}{}".format(kind_name, suffix),
+            "irq": self.irq,
+            "uart_peripheral": "{}{}".format(kind_name, self.instance),
+        })
+
+        env.substitutions = local
+        env.outbasepath = "modm/src/modm/platform/uart"
+
+        env.template("uart_hal.hpp.in", "{}_hal_{}.hpp".format(self.kind, self.instance))
+        env.template("uart_hal_impl.hpp.in", "{}_hal_{}_impl.hpp".format(self.kind, self.instance))
+        env.template("uart.cpp.in", "{}_{}.cpp".format(self.kind, self.instance))
+
+
+def init(module):
+    module.name = ":platform:uart"
+    module.description = "Universal Asynchronous Receiver Transmitter (UART)"
+
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("uart:nrf*"):
+        return False
+
+    module.depends(
+        ":architecture:atomic",
+        ":architecture:interrupt",
+        ":architecture:register",
+        ":architecture:uart",
+        ":architecture:fiber",
+        ":math:algorithm",
+        ":cmsis:device",
+        ":platform:gpio",
+        ":utils")
+
+    global props
+    props = {
+        "target": device.identifier,
+    }
+
+    core_vectors = device.get_driver("core").get("vector", [])
+
+    uart_instances = [_instance_value(i) for i in listify(device.get_driver("uart").get("instance", []))]
+    uarte_instances = []
+    if device.has_driver("uarte:nrf*"):
+        uarte_instances = [_instance_value(i) for i in listify(device.get_driver("uarte").get("instance", []))]
+
+    uarte_set = {str(i) for i in uarte_instances if i is not None}
+    selected_instances = [i for i in uart_instances if (i is not None) and (str(i) not in uarte_set)]
+
+    if not selected_instances:
+        return False
+
+    for instance in selected_instances:
+        irq = _find_irq(core_vectors, "uart", instance)
+        module.add_submodule(Instance("uart", instance, irq))
+
+    return True
+
+
+def build(env):
+    env.substitutions = props
+    env.outbasepath = "modm/src/modm/platform/uart"
+    device = env[":target"]
+    if not device.has_driver("uarte:nrf*"):
+        env.template("uart_base.hpp.in")
+        env.copy("uart.hpp")
+        env.copy("uart_buffer.hpp")

--- a/src/modm/platform/uart/nrf/uart.cpp.in
+++ b/src/modm/platform/uart/nrf/uart.cpp.in
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "{{ kind }}_hal_{{ id }}.hpp"
+
+%% if irq
+MODM_ISR({{ irq }})
+{
+	using namespace modm::platform;
+	if ({{ hal }}::InterruptCallback) {
+		{{ hal }}::InterruptCallback(true);
+	}
+}
+%% endif

--- a/src/modm/platform/uart/nrf/uart.hpp
+++ b/src/modm/platform/uart/nrf/uart.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_BUFFERED_UART_HPP
+#define MODM_NRF_BUFFERED_UART_HPP
+
+#include <modm/architecture/interface/uart.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/processing/fiber.hpp>
+#include "uart_base.hpp"
+
+namespace modm::platform
+{
+
+template< class Hal, typename... Buffers>
+struct BufferedUart : public UartBase, public ::modm::Uart
+{
+	static constexpr size_t RxBufferSize = 0;
+	static constexpr size_t TxBufferSize = 0;
+
+	template< class... Signals >
+	static void
+	connect(Gpio::InputType inputType = Gpio::InputType::PullUp,
+			Gpio::OutputType outputType = Gpio::OutputType::PushPull)
+	{
+		using Connector = GpioConnector<Hal::UartPeripheral, Signals...>;
+		using Txd = typename Connector::template GetSignal< Gpio::Signal::Txd >;
+		using Rxd = typename Connector::template GetSignal< Gpio::Signal::Rxd >;
+		static constexpr bool hasTxd = not std::is_same_v<Txd, GpioUnused>;
+		static constexpr bool hasRxd = not std::is_same_v<Rxd, GpioUnused>;
+		static_assert(((hasTxd and hasRxd) and sizeof...(Signals) == 2) or
+					  ((hasTxd or  hasRxd) and sizeof...(Signals) == 1),
+					  "BufferedUart::connect() requires one Txd and/or one Rxd signal!");
+
+		if constexpr (hasTxd) {
+			Txd::setOutput(true);
+			Txd::setOutput(outputType);
+		}
+		if constexpr (hasRxd) {
+			Rxd::setInput(inputType);
+		}
+		Connector::connect();
+		Hal::connectPins(Txd::number, Rxd::number);
+	}
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Hal::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::enableInterruptVector(true, 12);
+		Hal::setTransmitterEnable(true);
+		Hal::setReceiverEnable(true);
+		Hal::enableOperation();
+	}
+
+	static void writeBlocking(uint8_t data)
+	{
+		modm::this_fiber::poll([&]{ return Hal::isTransmitRegisterEmpty(); });
+		Hal::write(data);
+	}
+
+	static void writeBlocking(const uint8_t *data, std::size_t length)
+	{
+		while (length-- != 0) {
+			writeBlocking(*data++);
+		}
+	}
+
+	static void flushWriteBuffer()
+	{
+		modm::this_fiber::poll([&]{ return isWriteFinished(); });
+	}
+
+	static bool write(uint8_t data)
+	{
+		if(!Hal::isTransmitRegisterEmpty())
+			return false;
+
+		Hal::write(data);
+		return true;
+	}
+
+	static std::size_t write(const uint8_t *data, std::size_t length)
+	{
+		uint32_t count = 0;
+		for (; count < length; ++count)
+		{
+			if (!write(*data++)) {
+				return count;
+			}
+		}
+		return count;
+	}
+
+	static bool isWriteFinished() { return Hal::isTransmitRegisterEmpty(); }
+	static std::size_t transmitBufferSize() { return Hal::isTransmitRegisterEmpty() ? 0 : 1; }
+	static std::size_t discardTransmitBuffer() { return 0; }
+
+	static bool read(uint8_t &data)
+	{
+		if(!Hal::isReceiveRegisterNotEmpty())
+			return false;
+
+		Hal::read(data);
+		return true;
+	}
+
+	static std::size_t read(uint8_t *buffer, std::size_t) { return read(*buffer) ? 1 : 0; }
+	static std::size_t receiveBufferSize() { return Hal::isReceiveRegisterNotEmpty() ? 1 : 0; }
+	static std::size_t discardReceiveBuffer() { return 0; }
+
+	static bool hasError()
+	{
+		return Hal::getInterruptFlags().any(Hal::InterruptFlag::OverrunError |
+										 Hal::InterruptFlag::FramingError |
+										 Hal::InterruptFlag::ParityError);
+	}
+
+	static void clearError()
+	{
+		Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError |
+								   Hal::InterruptFlag::FramingError |
+								   Hal::InterruptFlag::ParityError);
+	}
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_BUFFERED_UART_HPP

--- a/src/modm/platform/uart/nrf/uart_base.hpp.in
+++ b/src/modm/platform/uart/nrf/uart_base.hpp.in
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_UART_BASE_HPP
+#define MODM_NRF_UART_BASE_HPP
+
+#include <stdint.h>
+#include "../device.hpp"
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/interrupt.hpp>
+#include <modm/architecture/interface/peripheral.hpp>
+#include <modm/platform/gpio/connector.hpp>
+
+namespace modm::platform
+{
+
+class UartBase
+{
+public:
+	enum class
+	Parity : uint32_t
+	{
+		Disabled = 0,
+		Even = 7,
+		Odd = 14,
+	};
+
+	enum class
+	WordLength : uint32_t
+	{
+		Bit8 = 0,
+	};
+
+	static consteval uint32_t
+	baudrateRegisterValue(uint32_t peripheralClock, baudrate_t baudrate)
+	{
+		return uint32_t((uint64_t(baudrate) << 32) / peripheralClock);
+	}
+    static consteval uint32_t
+	baudrateFromRegister(uint32_t peripheralClock, uint32_t registerValue)
+    {
+        return uint32_t((uint64_t(registerValue) * peripheralClock) >> 32);
+    }
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_UART_BASE_HPP

--- a/src/modm/platform/uart/nrf/uart_buffer.hpp
+++ b/src/modm/platform/uart/nrf/uart_buffer.hpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/driver/atomic/queue.hpp>
+#include <modm/architecture/interface/uart.hpp>
+#include "uart_base.hpp"
+
+namespace modm::platform
+{
+
+template <size_t SIZE>
+class UartRxBuffer : public modm::Uart::RxBuffer, public modm::atomic::Queue<uint8_t, SIZE> {};
+template <size_t SIZE>
+class UartTxBuffer : public modm::Uart::TxBuffer, public modm::atomic::Queue<uint8_t, SIZE> {};
+
+template< class Hal, class... Buffers >
+class BufferedUart;
+
+template<size_t SIZE, class Hal, class... Buffers>
+class BufferedUart<Hal, UartTxBuffer<SIZE>, Buffers...>: public BufferedUart<Hal, Buffers...>
+{
+	template< class Hal_, class... Buffers_> friend class BufferedUart;
+	using Parent = BufferedUart<Hal, Buffers...>;
+	static_assert(not Parent::TxBufferSize, "BufferedUart accepts at most one TxBuffer type");
+	static inline UartTxBuffer<SIZE> txBuffer;
+	static inline uint8_t txBurstBuffer[SIZE];
+	static inline std::size_t txBurstLength = 0;
+
+	static inline void
+	serviceTxBurst()
+	{
+		if ((txBurstLength != 0) and Hal::completedWriteBuffer()) {
+			txBurstLength = 0;
+		}
+	}
+
+	static inline bool
+	startTxBurst()
+	{
+		if ((txBurstLength != 0) or txBuffer.isEmpty()) {
+			return false;
+		}
+
+		std::size_t count = 0;
+		while ((count < SIZE) and (not txBuffer.isEmpty()))
+		{
+			txBurstBuffer[count++] = txBuffer.get();
+			txBuffer.pop();
+		}
+
+		if ((count != 0) and Hal::startWriteBuffer(txBurstBuffer, count)) {
+			txBurstLength = count;
+			return true;
+		}
+
+		return false;
+	}
+
+	static bool
+	InterruptCallback(bool first)
+	{
+		atomic::Lock lock;
+		if constexpr (Parent::RxBufferSize) Parent::InterruptCallback(false);
+		serviceTxBurst();
+		if (txBurstLength == 0) {
+			if (not startTxBurst()) {
+				Hal::disableInterrupt(Hal::Interrupt::TxEmpty);
+			}
+		}
+		if (first) Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError);
+		return true;
+	}
+
+public:
+	static constexpr size_t TxBufferSize = SIZE;
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Parent::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::InterruptCallback = InterruptCallback;
+		Hal::enableInterrupt(Hal::Interrupt::TxEmpty);
+		startTxBurst();
+	}
+
+	static bool
+	write(uint8_t data)
+	{
+		atomic::Lock lock;
+		serviceTxBurst();
+
+		if ((txBurstLength == 0) and txBuffer.isEmpty())
+		{
+			txBurstBuffer[0] = data;
+			if (Hal::startWriteBuffer(txBurstBuffer, 1)) {
+				txBurstLength = 1;
+				return true;
+			}
+		}
+
+		if (not txBuffer.push(data)) {
+			return false;
+		}
+
+		Hal::enableInterrupt(Hal::Interrupt::TxEmpty);
+		if (txBurstLength == 0) {
+			startTxBurst();
+		}
+		return true;
+	}
+
+	static std::size_t
+	write(const uint8_t *data, std::size_t length)
+	{
+		std::size_t count{0};
+		for (; count < length; ++count) if (not write(*data++)) break;
+		return count;
+	}
+
+	static void flushWriteBuffer() { modm::this_fiber::poll([&]{ return isWriteFinished(); }); }
+	static bool
+	isWriteFinished()
+	{
+		atomic::Lock lock;
+		serviceTxBurst();
+		return txBuffer.isEmpty() and (txBurstLength == 0) and Hal::isTransmitRegisterEmpty();
+	}
+
+	static std::size_t
+	transmitBufferSize()
+	{
+		atomic::Lock lock;
+		serviceTxBurst();
+		return txBuffer.getSize() + txBurstLength;
+	}
+
+	static std::size_t
+	discardTransmitBuffer()
+	{
+		atomic::Lock lock;
+		serviceTxBurst();
+		std::size_t count = txBuffer.getSize();
+		if (txBurstLength != 0) {
+			count += txBurstLength;
+			txBurstLength = 0;
+			Hal::setTransmitterEnable(false);
+		}
+
+		while(not txBuffer.isEmpty())
+		{
+			txBuffer.pop();
+		}
+		return count;
+	}
+};
+
+template<size_t SIZE, class Hal, class... Buffers>
+class BufferedUart<Hal, UartRxBuffer<SIZE>, Buffers...>: public BufferedUart<Hal, Buffers...>
+{
+	template< class Hal_, class... Buffers_> friend class BufferedUart;
+	using Parent = BufferedUart<Hal, Buffers...>;
+	static_assert(not Parent::RxBufferSize, "BufferedUart accepts at most one RxBuffer type");
+	static inline UartRxBuffer<SIZE> rxBuffer;
+
+	static bool
+	InterruptCallback(bool first)
+	{
+		if (Hal::isReceiveRegisterNotEmpty())
+		{
+			uint8_t data;
+			Hal::read(data);
+			rxBuffer.push(data);
+		}
+
+		if constexpr (Parent::TxBufferSize) Parent::InterruptCallback(false);
+
+		if (first) Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError);
+		return true;
+	}
+
+public:
+	static constexpr size_t RxBufferSize = SIZE;
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Parent::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::InterruptCallback = InterruptCallback;
+		Hal::enableInterrupt(Hal::Interrupt::RxNotEmpty);
+	}
+
+	static bool
+	read(uint8_t &data)
+	{
+		if (rxBuffer.isEmpty()) return false;
+
+		data = rxBuffer.get();
+		rxBuffer.pop();
+		return true;
+	}
+
+	static std::size_t
+	read(uint8_t *data, std::size_t length)
+	{
+		std::size_t count{0};
+		for (; count < length; ++count)
+		{
+			if (rxBuffer.isEmpty()) break;
+
+			*data++ = rxBuffer.get();
+			rxBuffer.pop();
+		}
+		return count;
+	}
+
+	static std::size_t receiveBufferSize() { return rxBuffer.getSize(); }
+
+	static std::size_t
+	discardReceiveBuffer()
+	{
+		std::size_t count{0};
+		while(not rxBuffer.isEmpty())
+		{
+			++count;
+			rxBuffer.pop();
+		}
+		return count;
+	}
+};
+
+} // namespace modm::platform

--- a/src/modm/platform/uart/nrf/uart_hal.hpp.in
+++ b/src/modm/platform/uart/nrf/uart_hal.hpp.in
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_{{ kind|upper }}HAL_{{ id }}_HPP
+#define MODM_NRF_{{ kind|upper }}HAL_{{ id }}_HPP
+
+#include <stdint.h>
+#include <cstddef>
+#include "../device.hpp"
+#include "uart_base.hpp"
+#include <modm/architecture/interface/peripheral.hpp>
+#include <modm/utils/inplace_function.hpp>
+
+namespace modm::platform
+{
+
+class {{ hal }} : public UartBase
+{
+public:
+	static const Peripheral UartPeripheral = Peripheral::{{ uart_peripheral }};
+	static inline modm::inplace_function<bool(bool)> InterruptCallback;
+
+	enum class
+	Interrupt : uint32_t
+	{
+		TxEmpty = UART_INTENSET_TXDRDY_Msk,
+		RxNotEmpty = UART_INTENSET_RXDRDY_Msk,
+		Error = UART_INTENSET_ERROR_Msk,
+	};
+	MODM_FLAGS32(Interrupt);
+
+	enum class
+	InterruptFlag : uint32_t
+	{
+		TxEmpty = UART_INTENSET_TXDRDY_Msk,
+		RxNotEmpty = UART_INTENSET_RXDRDY_Msk,
+		OverrunError = UART_ERRORSRC_OVERRUN_Msk,
+		FramingError = UART_ERRORSRC_FRAMING_Msk,
+		ParityError = UART_ERRORSRC_PARITY_Msk,
+	};
+	MODM_FLAGS32(InterruptFlag);
+
+	static inline void enable();
+	static inline void disable();
+	static inline void enableOperation();
+	static inline void disableOperation();
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance >
+	static inline void initialize(Parity parity, WordLength);
+
+	static inline void write(uint16_t data);
+	static inline void read(uint8_t &data);
+	static inline void read(uint16_t &data);
+	static inline bool startWriteBuffer(const uint8_t *data, std::size_t length);
+	static inline bool completedWriteBuffer();
+
+	static inline void setTransmitterEnable(bool enable);
+	static inline void setReceiverEnable(bool enable);
+	static inline void connectPins(uint32_t tx, uint32_t rx, uint32_t rts=0xfffffffful, uint32_t cts=0xfffffffful);
+
+	static inline bool isReceiveRegisterNotEmpty();
+	static inline bool isTransmitRegisterEmpty();
+	static inline bool isTransmissionComplete();
+
+	static inline void enableInterruptVector(bool enable, uint32_t priority);
+	static inline void enableInterrupt(Interrupt_t interrupt);
+	static inline void disableInterrupt(Interrupt_t interrupt);
+	static inline void setInterruptPriority(uint32_t priority);
+
+	static inline InterruptFlag_t getInterruptFlags();
+	static inline void acknowledgeInterruptFlags(InterruptFlag_t flags);
+
+private:
+	static inline const uint8_t *txBuffer = nullptr;
+	static inline std::size_t txLength = 0;
+	static inline std::size_t txIndex = 0;
+	static inline bool txBusy = false;
+	static inline bool rxEnabled = false;
+};
+
+} // namespace modm::platform
+
+#include "{{ kind }}_hal_{{ id }}_impl.hpp"
+
+#endif

--- a/src/modm/platform/uart/nrf/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/nrf/uart_hal_impl.hpp.in
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+namespace modm::platform
+{
+
+inline void
+{{ hal }}::enable()
+{
+	NRF_UART{{ id }}->ENABLE = UART_ENABLE_ENABLE_Enabled;
+	NRF_UART{{ id }}->EVENTS_TXDRDY = 1;
+	NRF_UART{{ id }}->EVENTS_RXDRDY = 0;
+	txBusy = false;
+	rxEnabled = false;
+	txBuffer = nullptr;
+	txLength = 0;
+	txIndex = 0;
+}
+
+inline void
+{{ hal }}::disable()
+{
+	NRF_UART{{ id }}->TASKS_STOPTX = 1;
+	NRF_UART{{ id }}->TASKS_STOPRX = 1;
+	NRF_UART{{ id }}->ENABLE = 0;
+	NRF_UART{{ id }}->PSELTXD = uint32_t(-1);
+	NRF_UART{{ id }}->PSELRXD = uint32_t(-1);
+	NRF_UART{{ id }}->PSELRTS = uint32_t(-1);
+	NRF_UART{{ id }}->PSELCTS = uint32_t(-1);
+	txBusy = false;
+	txBuffer = nullptr;
+	txLength = 0;
+	txIndex = 0;
+}
+
+inline void
+{{ hal }}::enableOperation()
+{
+	setReceiverEnable(true);
+	setTransmitterEnable(true);
+}
+
+inline void
+{{ hal }}::disableOperation()
+{
+	setReceiverEnable(false);
+	setTransmitterEnable(false);
+}
+
+template< class SystemClock, baudrate_t baudrate, percent_t tolerance >
+inline void
+{{ hal }}::initialize(Parity parity, WordLength)
+{
+	constexpr uint32_t baudRegister = baudrateRegisterValue(SystemClock::{{ uart_peripheral }}, baudrate);
+	constexpr uint32_t achievedBaudrate = baudrateFromRegister(SystemClock::{{ uart_peripheral }}, baudRegister);
+	modm::PeripheralDriver::assertBaudrateInTolerance<achievedBaudrate, baudrate, tolerance>();
+
+	enable();
+	NRF_UART{{ id }}->BAUDRATE = baudRegister;
+	NRF_UART{{ id }}->CONFIG = (static_cast<uint32_t>(parity) << UART_CONFIG_PARITY_Pos);
+	acknowledgeInterruptFlags(InterruptFlag::OverrunError | InterruptFlag::FramingError | InterruptFlag::ParityError);
+}
+
+inline void
+{{ hal }}::connectPins(uint32_t tx, uint32_t rx, uint32_t rts, uint32_t cts)
+{
+	NRF_UART{{ id }}->PSELTXD = tx;
+	NRF_UART{{ id }}->PSELRXD = rx;
+	NRF_UART{{ id }}->PSELRTS = rts;
+	NRF_UART{{ id }}->PSELCTS = cts;
+}
+
+inline void
+{{ hal }}::write(uint16_t data)
+{
+	if (txBusy) {
+		return;
+	}
+	txBusy = true;
+	NRF_UART{{ id }}->EVENTS_TXDRDY = 0;
+	NRF_UART{{ id }}->TXD = static_cast<uint8_t>(data);
+}
+
+inline bool
+{{ hal }}::startWriteBuffer(const uint8_t *data, std::size_t length)
+{
+	if ((length == 0) or txBusy or (data == nullptr)) {
+		return false;
+	}
+	txBuffer = data;
+	txLength = length;
+	txIndex = 1;
+	txBusy = true;
+	NRF_UART{{ id }}->EVENTS_TXDRDY = 0;
+	NRF_UART{{ id }}->TXD = txBuffer[0];
+	return true;
+}
+
+inline bool
+{{ hal }}::completedWriteBuffer()
+{
+	if (txBusy and NRF_UART{{ id }}->EVENTS_TXDRDY != 0) {
+		NRF_UART{{ id }}->EVENTS_TXDRDY = 0;
+		if (txIndex < txLength) {
+			NRF_UART{{ id }}->TXD = txBuffer[txIndex++];
+		}
+		else {
+			txBusy = false;
+			txBuffer = nullptr;
+			txLength = 0;
+			txIndex = 0;
+			return true;
+		}
+	}
+	return false;
+}
+
+inline void
+{{ hal }}::read(uint8_t &data)
+{
+	data = static_cast<uint8_t>(NRF_UART{{ id }}->RXD);
+	NRF_UART{{ id }}->EVENTS_RXDRDY = 0;
+}
+
+inline void
+{{ hal }}::read(uint16_t &data)
+{
+	uint8_t value;
+	read(value);
+	data = value;
+}
+
+inline void
+{{ hal }}::setTransmitterEnable(bool enable)
+{
+	if (enable) NRF_UART{{ id }}->TASKS_STARTTX = 1;
+	else NRF_UART{{ id }}->TASKS_STOPTX = 1;
+}
+
+inline void
+{{ hal }}::setReceiverEnable(bool enable)
+{
+	rxEnabled = enable;
+	if (enable) {
+		NRF_UART{{ id }}->TASKS_STARTRX = 1;
+	}
+	else {
+		NRF_UART{{ id }}->TASKS_STOPRX = 1;
+	}
+}
+
+inline bool
+{{ hal }}::isReceiveRegisterNotEmpty()
+{
+	return NRF_UART{{ id }}->EVENTS_RXDRDY != 0;
+}
+
+inline bool
+{{ hal }}::isTransmitRegisterEmpty()
+{
+	if (txBusy) {
+		(void)completedWriteBuffer();
+	}
+	return not txBusy;
+}
+
+inline bool
+{{ hal }}::isTransmissionComplete()
+{
+	return isTransmitRegisterEmpty();
+}
+
+inline void
+{{ hal }}::enableInterruptVector(bool enable, uint32_t priority)
+{
+	if (enable) {
+		setInterruptPriority(priority);
+%% if irq
+		NVIC_EnableIRQ({{ irq }}_IRQn);
+%% endif
+	}
+	else {
+%% if irq
+		NVIC_DisableIRQ({{ irq }}_IRQn);
+%% endif
+	}
+}
+
+inline void
+{{ hal }}::enableInterrupt(Interrupt_t interrupt)
+{
+	NRF_UART{{ id }}->INTENSET = interrupt.value;
+}
+
+inline void
+{{ hal }}::disableInterrupt(Interrupt_t interrupt)
+{
+	NRF_UART{{ id }}->INTENCLR = interrupt.value;
+}
+
+inline void
+{{ hal }}::setInterruptPriority(uint32_t priority)
+{
+%% if irq
+	NVIC_SetPriority({{ irq }}_IRQn, priority);
+%% else
+	(void) priority;
+%% endif
+}
+
+inline {{ hal }}::InterruptFlag_t
+{{ hal }}::getInterruptFlags()
+{
+	uint32_t flags = NRF_UART{{ id }}->ERRORSRC;
+	if (isReceiveRegisterNotEmpty()) {
+		flags |= static_cast<uint32_t>(InterruptFlag::RxNotEmpty);
+	}
+	if (isTransmitRegisterEmpty()) {
+		flags |= static_cast<uint32_t>(InterruptFlag::TxEmpty);
+	}
+	return InterruptFlag_t(flags);
+}
+
+inline void
+{{ hal }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
+{
+	if (flags.any(InterruptFlag::OverrunError)) NRF_UART{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::OverrunError);
+	if (flags.any(InterruptFlag::FramingError)) NRF_UART{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::FramingError);
+	if (flags.any(InterruptFlag::ParityError)) NRF_UART{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::ParityError);
+}
+
+}

--- a/src/modm/platform/uart/nrfe/module.lb
+++ b/src/modm/platform/uart/nrfe/module.lb
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+props = {}
+
+
+def _translate(name):
+    return name.replace("_", "").capitalize()
+
+
+def _instance_value(instance):
+    if isinstance(instance, dict):
+        return instance.get("value")
+    return instance
+
+
+def _find_irq(core_vectors, kind, instance):
+    instance = str(instance)
+    candidates = ["UARTE{}".format(instance), "SERIAL{}".format(instance)]
+
+    for vector in core_vectors:
+        vname = vector["name"].upper()
+        for candidate in candidates:
+            if candidate in vname:
+                return vector["name"]
+    return None
+
+
+class Instance(Module):
+    def __init__(self, kind, instance, irq):
+        self.kind = kind
+        self.instance = int(instance)
+        self.irq = irq
+
+    def init(self, module):
+        module.name = str(self.instance)
+        module.description = "{} instance {}".format(self.kind.upper(), self.instance)
+
+    def prepare(self, module, options):
+        return True
+
+    def build(self, env):
+        global props
+
+        kind_name = _translate(self.kind)
+        suffix = "Hal{}".format(self.instance)
+
+        local = dict(props)
+        local.update({
+            "kind": self.kind,
+            "id": self.instance,
+            "name": "{}{}".format(kind_name, self.instance),
+            "hal": "{}{}".format(kind_name, suffix),
+            "irq": self.irq,
+            "uart_peripheral": "{}{}".format(kind_name, self.instance),
+        })
+
+        env.substitutions = local
+        env.outbasepath = "modm/src/modm/platform/uart"
+
+        env.template("uart_hal.hpp.in", "{}_hal_{}.hpp".format(self.kind, self.instance))
+        env.template("uart_hal_impl.hpp.in", "{}_hal_{}_impl.hpp".format(self.kind, self.instance))
+        env.template("uart.cpp.in", "{}_{}.cpp".format(self.kind, self.instance))
+
+
+def init(module):
+    module.name = ":platform:uarte"
+    module.description = "Universal Asynchronous Receiver Transmitter with EasyDMA (UARTE)"
+
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("uarte:nrf*"):
+        return False
+
+    module.depends(
+        ":architecture:atomic",
+        ":architecture:interrupt",
+        ":architecture:register",
+        ":architecture:uart",
+        ":architecture:fiber",
+        ":math:algorithm",
+        ":cmsis:device",
+        ":platform:gpio",
+        ":utils")
+
+    global props
+    props = {
+        "target": device.identifier,
+    }
+
+    core_vectors = device.get_driver("core").get("vector", [])
+
+    for instance in listify(device.get_driver("uarte").get("instance", [])):
+        instance = _instance_value(instance)
+        irq = _find_irq(core_vectors, "uarte", instance)
+        module.add_submodule(Instance("uarte", instance, irq))
+
+    return True
+
+
+def build(env):
+    env.substitutions = props
+    env.outbasepath = "modm/src/modm/platform/uart"
+    env.template("uart_base.hpp.in")
+    env.copy("uart.hpp")
+    env.copy("uart_buffer.hpp")

--- a/src/modm/platform/uart/nrfe/uart.cpp.in
+++ b/src/modm/platform/uart/nrfe/uart.cpp.in
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "{{ kind }}_hal_{{ id }}.hpp"
+
+%% if irq
+MODM_ISR({{ irq }})
+{
+	using namespace modm::platform;
+	if ({{ hal }}::InterruptCallback) {
+		{{ hal }}::InterruptCallback(true);
+	}
+}
+%% endif

--- a/src/modm/platform/uart/nrfe/uart.hpp
+++ b/src/modm/platform/uart/nrfe/uart.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_BUFFERED_UART_HPP
+#define MODM_NRF_BUFFERED_UART_HPP
+
+#include <modm/architecture/interface/uart.hpp>
+#include <modm/platform/gpio/connector.hpp>
+#include <modm/processing/fiber.hpp>
+#include "uart_base.hpp"
+
+namespace modm::platform
+{
+
+template< class Hal, typename... Buffers>
+struct BufferedUart : public UartBase, public ::modm::Uart
+{
+	static constexpr size_t RxBufferSize = 0;
+	static constexpr size_t TxBufferSize = 0;
+
+	template< class... Signals >
+	static void
+	connect(Gpio::InputType inputType = Gpio::InputType::PullUp,
+			Gpio::OutputType outputType = Gpio::OutputType::PushPull)
+	{
+		using Connector = GpioConnector<Hal::UartPeripheral, Signals...>;
+		using Txd = typename Connector::template GetSignal< Gpio::Signal::Txd >;
+		using Rxd = typename Connector::template GetSignal< Gpio::Signal::Rxd >;
+		static constexpr bool hasTxd = not std::is_same_v<Txd, GpioUnused>;
+		static constexpr bool hasRxd = not std::is_same_v<Rxd, GpioUnused>;
+		static_assert(((hasTxd and hasRxd) and sizeof...(Signals) == 2) or
+					  ((hasTxd or  hasRxd) and sizeof...(Signals) == 1),
+					  "BufferedUart::connect() requires one Txd and/or one Rxd signal!");
+
+		if constexpr (hasTxd) {
+			Txd::setOutput(true);
+			Txd::setOutput(outputType);
+		}
+		if constexpr (hasRxd) {
+			Rxd::setInput(inputType);
+		}
+		Connector::connect();
+		Hal::connectPins(Txd::number, Rxd::number);
+	}
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Hal::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::enableInterruptVector(true, 12);
+		Hal::setTransmitterEnable(true);
+		Hal::setReceiverEnable(true);
+		Hal::enableOperation();
+	}
+
+	static void writeBlocking(uint8_t data)
+	{
+		modm::this_fiber::poll([&]{ return Hal::isTransmitRegisterEmpty(); });
+		Hal::write(data);
+	}
+
+	static void writeBlocking(const uint8_t *data, std::size_t length)
+	{
+		while (length-- != 0) {
+			writeBlocking(*data++);
+		}
+	}
+
+	static void flushWriteBuffer()
+	{
+		modm::this_fiber::poll([&]{ return isWriteFinished(); });
+	}
+
+	static bool write(uint8_t data)
+	{
+		if(!Hal::isTransmitRegisterEmpty())
+			return false;
+
+		Hal::write(data);
+		return true;
+	}
+
+	static std::size_t write(const uint8_t *data, std::size_t length)
+	{
+		uint32_t count = 0;
+		for (; count < length; ++count)
+		{
+			if (!write(*data++)) {
+				return count;
+			}
+		}
+		return count;
+	}
+
+	static bool isWriteFinished() { return Hal::isTransmitRegisterEmpty(); }
+	static std::size_t transmitBufferSize() { return Hal::isTransmitRegisterEmpty() ? 0 : 1; }
+	static std::size_t discardTransmitBuffer() { return 0; }
+
+	static bool read(uint8_t &data)
+	{
+		if(!Hal::isReceiveRegisterNotEmpty())
+			return false;
+
+		Hal::read(data);
+		return true;
+	}
+
+	static std::size_t read(uint8_t *buffer, std::size_t) { return read(*buffer) ? 1 : 0; }
+	static std::size_t receiveBufferSize() { return Hal::isReceiveRegisterNotEmpty() ? 1 : 0; }
+	static std::size_t discardReceiveBuffer() { return 0; }
+
+	static bool hasError()
+	{
+		return Hal::getInterruptFlags().any(Hal::InterruptFlag::OverrunError |
+										 Hal::InterruptFlag::FramingError |
+										 Hal::InterruptFlag::ParityError);
+	}
+
+	static void clearError()
+	{
+		Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError |
+								   Hal::InterruptFlag::FramingError |
+								   Hal::InterruptFlag::ParityError);
+	}
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_BUFFERED_UART_HPP

--- a/src/modm/platform/uart/nrfe/uart_base.hpp.in
+++ b/src/modm/platform/uart/nrfe/uart_base.hpp.in
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_UART_BASE_HPP
+#define MODM_NRF_UART_BASE_HPP
+
+#include <stdint.h>
+#include "../device.hpp"
+#include <modm/architecture/interface/register.hpp>
+#include <modm/architecture/interface/interrupt.hpp>
+#include <modm/architecture/interface/peripheral.hpp>
+#include <modm/platform/gpio/connector.hpp>
+
+namespace modm::platform
+{
+
+class UartBase
+{
+public:
+	enum class
+	Parity : uint32_t
+	{
+		Disabled = 0,
+		Even = 7,
+		Odd = 14,
+	};
+
+	enum class
+	WordLength : uint32_t
+	{
+		Bit8 = 0,
+	};
+
+	static consteval uint32_t
+	baudrateRegisterValue(uint32_t peripheralClock, baudrate_t baudrate)
+	{
+		return uint32_t((uint64_t(baudrate) << 32) / peripheralClock);
+	}
+    static consteval uint32_t
+	baudrateFromRegister(uint32_t peripheralClock, uint32_t registerValue)
+    {
+        return uint32_t((uint64_t(registerValue) * peripheralClock) >> 32);
+    }
+};
+
+} // namespace modm::platform
+
+#endif // MODM_NRF_UART_BASE_HPP

--- a/src/modm/platform/uart/nrfe/uart_buffer.hpp
+++ b/src/modm/platform/uart/nrfe/uart_buffer.hpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/architecture/driver/atomic/queue.hpp>
+#include <modm/architecture/interface/uart.hpp>
+#include "uart_base.hpp"
+
+namespace modm::platform
+{
+
+template <size_t SIZE>
+class UartRxBuffer : public modm::Uart::RxBuffer, public modm::atomic::Queue<uint8_t, SIZE> {};
+template <size_t SIZE>
+class UartTxBuffer : public modm::Uart::TxBuffer, public modm::atomic::Queue<uint8_t, SIZE> {};
+
+template< class Hal, class... Buffers >
+class BufferedUart;
+
+template<size_t SIZE, class Hal, class... Buffers>
+class BufferedUart<Hal, UartTxBuffer<SIZE>, Buffers...>: public BufferedUart<Hal, Buffers...>
+{
+	template< class Hal_, class... Buffers_> friend class BufferedUart;
+	using Parent = BufferedUart<Hal, Buffers...>;
+	static_assert(not Parent::TxBufferSize, "BufferedUart accepts at most one TxBuffer type");
+	static inline UartTxBuffer<SIZE> txBuffer;
+	static inline uint8_t dmaTxBuffer[SIZE];
+	static inline std::size_t dmaTxLength = 0;
+
+	static inline void
+	serviceDmaTx()
+	{
+		if ((dmaTxLength != 0) and Hal::completedWriteBuffer()) {
+			dmaTxLength = 0;
+		}
+	}
+
+	static inline bool
+	startDmaBurst()
+	{
+		if ((dmaTxLength != 0) or txBuffer.isEmpty()) {
+			return false;
+		}
+
+		std::size_t count = 0;
+		while ((count < SIZE) and (not txBuffer.isEmpty()))
+		{
+			dmaTxBuffer[count++] = txBuffer.get();
+			txBuffer.pop();
+		}
+
+		if ((count != 0) and Hal::startWriteBuffer(dmaTxBuffer, count)) {
+			dmaTxLength = count;
+			return true;
+		}
+
+		return false;
+	}
+
+	static bool
+	InterruptCallback(bool first)
+	{
+		atomic::Lock lock;
+		if constexpr (Parent::RxBufferSize) Parent::InterruptCallback(false);
+		serviceDmaTx();
+		if (dmaTxLength == 0) {
+			if (not startDmaBurst()) {
+				Hal::disableInterrupt(Hal::Interrupt::TxEmpty);
+			}
+		}
+		if (first) Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError);
+		return true;
+	}
+
+public:
+	static constexpr size_t TxBufferSize = SIZE;
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Parent::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::InterruptCallback = InterruptCallback;
+		Hal::enableInterrupt(Hal::Interrupt::TxEmpty);
+		startDmaBurst();
+	}
+
+	static bool
+	write(uint8_t data)
+	{
+		atomic::Lock lock;
+		serviceDmaTx();
+
+		if ((dmaTxLength == 0) and txBuffer.isEmpty())
+		{
+			dmaTxBuffer[0] = data;
+			if (Hal::startWriteBuffer(dmaTxBuffer, 1)) {
+				dmaTxLength = 1;
+				return true;
+			}
+		}
+
+		if (not txBuffer.push(data)) {
+			return false;
+		}
+
+		Hal::enableInterrupt(Hal::Interrupt::TxEmpty);
+		if (dmaTxLength == 0) {
+			startDmaBurst();
+		}
+		return true;
+	}
+
+	static std::size_t
+	write(const uint8_t *data, std::size_t length)
+	{
+		std::size_t count{0};
+		for (; count < length; ++count) if (not write(*data++)) break;
+		return count;
+	}
+
+	static void flushWriteBuffer() { modm::this_fiber::poll([&]{ return isWriteFinished(); }); }
+	static bool
+	isWriteFinished()
+	{
+		atomic::Lock lock;
+		serviceDmaTx();
+		return txBuffer.isEmpty() and (dmaTxLength == 0) and Hal::isTransmitRegisterEmpty();
+	}
+
+	static std::size_t
+	transmitBufferSize()
+	{
+		atomic::Lock lock;
+		serviceDmaTx();
+		return txBuffer.getSize() + dmaTxLength;
+	}
+
+	static std::size_t
+	discardTransmitBuffer()
+	{
+		atomic::Lock lock;
+		serviceDmaTx();
+		std::size_t count = txBuffer.getSize();
+		if (dmaTxLength != 0) {
+			count += dmaTxLength;
+			dmaTxLength = 0;
+			Hal::setTransmitterEnable(false);
+		}
+
+		while(not txBuffer.isEmpty())
+		{
+			txBuffer.pop();
+		}
+		return count;
+	}
+};
+
+template<size_t SIZE, class Hal, class... Buffers>
+class BufferedUart<Hal, UartRxBuffer<SIZE>, Buffers...>: public BufferedUart<Hal, Buffers...>
+{
+	template< class Hal_, class... Buffers_> friend class BufferedUart;
+	using Parent = BufferedUart<Hal, Buffers...>;
+	static_assert(not Parent::RxBufferSize, "BufferedUart accepts at most one RxBuffer type");
+	static inline UartRxBuffer<SIZE> rxBuffer;
+
+	static bool
+	InterruptCallback(bool first)
+	{
+		if (Hal::isReceiveRegisterNotEmpty())
+		{
+			uint8_t data;
+			Hal::read(data);
+			rxBuffer.push(data);
+		}
+
+		if constexpr (Parent::TxBufferSize) Parent::InterruptCallback(false);
+
+		if (first) Hal::acknowledgeInterruptFlags(Hal::InterruptFlag::OverrunError);
+		return true;
+	}
+
+public:
+	static constexpr size_t RxBufferSize = SIZE;
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance=pct(1) >
+	static inline void
+	initialize(Hal::Parity parity=Hal::Parity::Disabled, Hal::WordLength length=Hal::WordLength::Bit8)
+	{
+		Parent::template initialize<SystemClock, baudrate, tolerance>(parity, length);
+		Hal::InterruptCallback = InterruptCallback;
+		Hal::enableInterrupt(Hal::Interrupt::RxNotEmpty);
+	}
+
+	static bool
+	read(uint8_t &data)
+	{
+		if (rxBuffer.isEmpty()) return false;
+
+		data = rxBuffer.get();
+		rxBuffer.pop();
+		return true;
+	}
+
+	static std::size_t
+	read(uint8_t *data, std::size_t length)
+	{
+		std::size_t count{0};
+		for (; count < length; ++count)
+		{
+			if (rxBuffer.isEmpty()) break;
+
+			*data++ = rxBuffer.get();
+			rxBuffer.pop();
+		}
+		return count;
+	}
+
+	static std::size_t receiveBufferSize() { return rxBuffer.getSize(); }
+
+	static std::size_t
+	discardReceiveBuffer()
+	{
+		std::size_t count{0};
+		while(not rxBuffer.isEmpty())
+		{
+			++count;
+			rxBuffer.pop();
+		}
+		return count;
+	}
+};
+
+} // namespace modm::platform

--- a/src/modm/platform/uart/nrfe/uart_hal.hpp.in
+++ b/src/modm/platform/uart/nrfe/uart_hal.hpp.in
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#ifndef MODM_NRF_{{ kind|upper }}HAL_{{ id }}_HPP
+#define MODM_NRF_{{ kind|upper }}HAL_{{ id }}_HPP
+
+#include <stdint.h>
+#include <cstddef>
+#include "../device.hpp"
+#include "uart_base.hpp"
+#include <modm/architecture/interface/peripheral.hpp>
+#include <modm/utils/inplace_function.hpp>
+
+namespace modm::platform
+{
+
+class {{ hal }} : public UartBase
+{
+public:
+	static const Peripheral UartPeripheral = Peripheral::{{ uart_peripheral }};
+	static inline modm::inplace_function<bool(bool)> InterruptCallback;
+
+	enum class
+	Interrupt : uint32_t
+	{
+		TxEmpty = UARTE_INTENSET_ENDTX_Msk,
+		RxNotEmpty = UARTE_INTENSET_ENDRX_Msk,
+		Error = UARTE_INTENSET_ERROR_Msk,
+	};
+	MODM_FLAGS32(Interrupt);
+
+	enum class
+	InterruptFlag : uint32_t
+	{
+		TxEmpty = UARTE_INTENSET_ENDTX_Msk,
+		RxNotEmpty = UARTE_INTENSET_ENDRX_Msk,
+		OverrunError = UARTE_ERRORSRC_OVERRUN_Msk,
+		FramingError = UARTE_ERRORSRC_FRAMING_Msk,
+		ParityError = UARTE_ERRORSRC_PARITY_Msk,
+	};
+	MODM_FLAGS32(InterruptFlag);
+
+	static inline void enable();
+	static inline void disable();
+	static inline void enableOperation();
+	static inline void disableOperation();
+
+	template< class SystemClock, baudrate_t baudrate, percent_t tolerance >
+	static inline void initialize(Parity parity, WordLength);
+
+	static inline void write(uint16_t data);
+	static inline void read(uint8_t &data);
+	static inline void read(uint16_t &data);
+	static inline bool startWriteBuffer(const uint8_t *data, std::size_t length);
+	static inline bool completedWriteBuffer();
+
+	static inline void setTransmitterEnable(bool enable);
+	static inline void setReceiverEnable(bool enable);
+	static inline void connectPins(uint32_t tx, uint32_t rx, uint32_t rts=0xfffffffful, uint32_t cts=0xfffffffful);
+
+	static inline bool isReceiveRegisterNotEmpty();
+	static inline bool isTransmitRegisterEmpty();
+	static inline bool isTransmissionComplete();
+
+	static inline void enableInterruptVector(bool enable, uint32_t priority);
+	static inline void enableInterrupt(Interrupt_t interrupt);
+	static inline void disableInterrupt(Interrupt_t interrupt);
+	static inline void setInterruptPriority(uint32_t priority);
+
+	static inline InterruptFlag_t getInterruptFlags();
+	static inline void acknowledgeInterruptFlags(InterruptFlag_t flags);
+
+private:
+	static inline uint8_t txByte;
+	static inline uint8_t rxByte;
+	static inline bool txBusy = false;
+	static inline bool rxReady = false;
+	static inline bool rxEnabled = false;
+	static inline bool rxArmed = false;
+	static inline void armRx();
+};
+
+} // namespace modm::platform
+
+#include "{{ kind }}_hal_{{ id }}_impl.hpp"
+
+#endif

--- a/src/modm/platform/uart/nrfe/uart_hal_impl.hpp.in
+++ b/src/modm/platform/uart/nrfe/uart_hal_impl.hpp.in
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+namespace modm::platform
+{
+
+inline void
+{{ hal }}::enable()
+{
+	NRF_UARTE{{ id }}->ENABLE = UARTE_ENABLE_ENABLE_Enabled;
+	txBusy = false;
+	rxReady = false;
+	rxEnabled = false;
+	rxArmed = false;
+}
+
+inline void
+{{ hal }}::disable()
+{
+	NRF_UARTE{{ id }}->TASKS_STOPTX = 1;
+	NRF_UARTE{{ id }}->TASKS_STOPRX = 1;
+	NRF_UARTE{{ id }}->ENABLE = 0;
+	NRF_UARTE{{ id }}->PSEL.TXD = uint32_t(-1);
+	NRF_UARTE{{ id }}->PSEL.RXD = uint32_t(-1);
+	NRF_UARTE{{ id }}->PSEL.RTS = uint32_t(-1);
+	NRF_UARTE{{ id }}->PSEL.CTS = uint32_t(-1);
+}
+
+inline void
+{{ hal }}::enableOperation()
+{
+	setReceiverEnable(true);
+	setTransmitterEnable(true);
+}
+
+inline void
+{{ hal }}::disableOperation()
+{
+	setReceiverEnable(false);
+	setTransmitterEnable(false);
+}
+
+template< class SystemClock, baudrate_t baudrate, percent_t tolerance >
+inline void
+{{ hal }}::initialize(Parity parity, WordLength)
+{
+	constexpr uint32_t baudRegister = baudrateRegisterValue(SystemClock::{{ uart_peripheral }}, baudrate);
+	constexpr uint32_t achievedBaudrate = baudrateFromRegister(SystemClock::{{ uart_peripheral }}, baudRegister);
+	modm::PeripheralDriver::assertBaudrateInTolerance<achievedBaudrate, baudrate, tolerance>();
+
+	enable();
+	NRF_UARTE{{ id }}->BAUDRATE = baudRegister;
+	NRF_UARTE{{ id }}->CONFIG = (static_cast<uint32_t>(parity) << UARTE_CONFIG_PARITY_Pos);
+	acknowledgeInterruptFlags(InterruptFlag::OverrunError | InterruptFlag::FramingError | InterruptFlag::ParityError);
+}
+
+inline void
+{{ hal }}::connectPins(uint32_t tx, uint32_t rx, uint32_t rts, uint32_t cts)
+{
+	NRF_UARTE{{ id }}->PSEL.TXD = tx;
+	NRF_UARTE{{ id }}->PSEL.RXD = rx;
+	NRF_UARTE{{ id }}->PSEL.RTS = rts;
+	NRF_UARTE{{ id }}->PSEL.CTS = cts;
+}
+
+inline void
+{{ hal }}::write(uint16_t data)
+{
+	txByte = static_cast<uint8_t>(data);
+	(void)startWriteBuffer(reinterpret_cast<const uint8_t*>(&txByte), 1);
+}
+
+inline bool
+{{ hal }}::startWriteBuffer(const uint8_t *data, std::size_t length)
+{
+	if ((length == 0) or txBusy) {
+		return false;
+	}
+	txBusy = true;
+	NRF_UARTE{{ id }}->EVENTS_ENDTX = 0;
+	NRF_UARTE{{ id }}->TXD.PTR = reinterpret_cast<uint32_t>(data);
+	NRF_UARTE{{ id }}->TXD.MAXCNT = length;
+	NRF_UARTE{{ id }}->TASKS_STARTTX = 1;
+	return true;
+}
+
+inline bool
+{{ hal }}::completedWriteBuffer()
+{
+	if (txBusy and NRF_UARTE{{ id }}->EVENTS_ENDTX != 0) {
+		NRF_UARTE{{ id }}->EVENTS_ENDTX = 0;
+		txBusy = false;
+		return true;
+	}
+	return false;
+}
+
+inline void
+{{ hal }}::read(uint8_t &data)
+{
+	if (NRF_UARTE{{ id }}->EVENTS_ENDRX != 0) {
+		NRF_UARTE{{ id }}->EVENTS_ENDRX = 0;
+		rxArmed = false;
+		rxReady = true;
+	}
+	data = rxByte;
+	rxReady = false;
+	if (rxEnabled and not rxArmed) {
+		armRx();
+	}
+}
+
+inline void
+{{ hal }}::read(uint16_t &data)
+{
+	uint8_t value;
+	read(value);
+	data = value;
+}
+
+inline void
+{{ hal }}::setTransmitterEnable(bool enable)
+{
+	if (enable) NRF_UARTE{{ id }}->TASKS_STARTTX = 1;
+	else NRF_UARTE{{ id }}->TASKS_STOPTX = 1;
+}
+
+inline void
+{{ hal }}::setReceiverEnable(bool enable)
+{
+	rxEnabled = enable;
+	if (enable) {
+		armRx();
+	}
+	else {
+		rxArmed = false;
+		NRF_UARTE{{ id }}->TASKS_STOPRX = 1;
+	}
+}
+
+inline bool
+{{ hal }}::isReceiveRegisterNotEmpty()
+{
+	if (NRF_UARTE{{ id }}->EVENTS_ENDRX != 0) {
+		NRF_UARTE{{ id }}->EVENTS_ENDRX = 0;
+		rxArmed = false;
+		rxReady = true;
+	}
+	return rxReady;
+}
+
+inline bool
+{{ hal }}::isTransmitRegisterEmpty()
+{
+	if (txBusy and NRF_UARTE{{ id }}->EVENTS_ENDTX != 0) {
+		NRF_UARTE{{ id }}->EVENTS_ENDTX = 0;
+		txBusy = false;
+	}
+	return not txBusy;
+}
+
+inline bool
+{{ hal }}::isTransmissionComplete()
+{
+	return isTransmitRegisterEmpty();
+}
+
+inline void
+{{ hal }}::enableInterruptVector(bool enable, uint32_t priority)
+{
+	if (enable) {
+		setInterruptPriority(priority);
+%% if irq
+		NVIC_EnableIRQ({{ irq }}_IRQn);
+%% endif
+	}
+	else {
+%% if irq
+		NVIC_DisableIRQ({{ irq }}_IRQn);
+%% endif
+	}
+}
+
+inline void
+{{ hal }}::enableInterrupt(Interrupt_t interrupt)
+{
+	NRF_UARTE{{ id }}->INTENSET = interrupt.value;
+}
+
+inline void
+{{ hal }}::disableInterrupt(Interrupt_t interrupt)
+{
+	NRF_UARTE{{ id }}->INTENCLR = interrupt.value;
+}
+
+inline void
+{{ hal }}::setInterruptPriority(uint32_t priority)
+{
+%% if irq
+	NVIC_SetPriority({{ irq }}_IRQn, priority);
+%% else
+	(void) priority;
+%% endif
+}
+
+inline {{ hal }}::InterruptFlag_t
+{{ hal }}::getInterruptFlags()
+{
+	uint32_t flags = NRF_UARTE{{ id }}->ERRORSRC;
+	if (isReceiveRegisterNotEmpty()) {
+		flags |= static_cast<uint32_t>(InterruptFlag::RxNotEmpty);
+	}
+	if (isTransmitRegisterEmpty()) {
+		flags |= static_cast<uint32_t>(InterruptFlag::TxEmpty);
+	}
+	return InterruptFlag_t(flags);
+}
+
+inline void
+{{ hal }}::acknowledgeInterruptFlags(InterruptFlag_t flags)
+{
+	if (flags.any(InterruptFlag::OverrunError)) NRF_UARTE{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::OverrunError);
+	if (flags.any(InterruptFlag::FramingError)) NRF_UARTE{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::FramingError);
+	if (flags.any(InterruptFlag::ParityError)) NRF_UARTE{{ id }}->ERRORSRC = static_cast<uint32_t>(InterruptFlag::ParityError);
+}
+
+inline void
+{{ hal }}::armRx()
+{
+	if (rxArmed) {
+		return;
+	}
+	rxArmed = true;
+	NRF_UARTE{{ id }}->EVENTS_ENDRX = 0;
+	NRF_UARTE{{ id }}->RXD.PTR = reinterpret_cast<uint32_t>(&rxByte);
+	NRF_UARTE{{ id }}->RXD.MAXCNT = 1;
+	NRF_UARTE{{ id }}->TASKS_STARTRX = 1;
+}
+
+}

--- a/src/modm/platform/usb/nrf/module.lb
+++ b/src/modm/platform/usb/nrf/module.lb
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def common_usb_irqs(env):
+    target = env[":target"]
+    if target.identifier.family == "53":
+        power_irqs = ["USBREGULATOR"]
+    else:
+        core_vectors = [v["name"] for v in target.get_driver("core").get("vector", [])]
+        power_irqs = [i for i in core_vectors if "POWER" in i.upper()]
+
+    return {
+        "irqs": ["USBD"],
+        "power_irqs": power_irqs,
+    }
+
+
+def init(module):
+    module.name = ":platform:usb"
+    module.description = "Universal Serial Bus (USB)"
+
+
+def prepare(module, options):
+    device = options[":target"]
+    if not device.has_driver("usbd:nrf*"):
+        return False
+
+    module.depends(
+        ":architecture:interrupt",
+        ":cmsis:device",
+        ":platform:gpio")
+
+    module.add_query(EnvironmentQuery(name="irqs", factory=common_usb_irqs))
+
+    return True
+
+
+def build(env):
+    env.outbasepath = "modm/src/modm/platform/usb"
+    irq_data = env.query(":platform:usb:irqs")
+    env.substitutions = {
+        "target": env[":target"].identifier,
+        **irq_data
+    }
+    env.template("usb.hpp.in")
+
+    if env.has_module(":tinyusb:device:cdc"):
+        env.copy(repopath("ext/hathach/uart.hpp"), "uart.hpp")

--- a/src/modm/platform/usb/nrf/usb.hpp.in
+++ b/src/modm/platform/usb/nrf/usb.hpp.in
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform/device.hpp>
+#include <modm/platform/gpio/base.hpp>
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_usb
+class Usb
+{
+public:
+	template<class SystemClock>
+	static void
+	initialize(uint8_t priority=3)
+	{
+%% for irq in irqs | sort
+		NVIC_SetPriority({{ irq }}_IRQn, priority);
+%% endfor
+%% for irq in power_irqs | sort
+		NVIC_SetPriority({{ irq }}_IRQn, priority);
+		NVIC_EnableIRQ({{ irq }}_IRQn);
+%% endfor
+%#
+%% if target.family == "52"
+		NRF_POWER->EVENTS_USBDETECTED = 0;
+		NRF_POWER->EVENTS_USBPWRRDY = 0;
+		NRF_POWER->EVENTS_USBREMOVED = 0;
+		NRF_POWER->INTENSET = POWER_INTENSET_USBDETECTED_Msk |
+			POWER_INTENSET_USBPWRRDY_Msk |
+			POWER_INTENSET_USBREMOVED_Msk;
+%% elif target.family == "53"
+		NRF_USBREGULATOR->EVENTS_USBDETECTED = 0;
+		NRF_USBREGULATOR->EVENTS_USBPWRRDY = 0;
+		NRF_USBREGULATOR->EVENTS_USBREMOVED = 0;
+		NRF_USBREGULATOR->INTENSET = USBREG_INTENSET_USBDETECTED_Msk |
+			USBREG_INTENSET_USBPWRRDY_Msk |
+			USBREG_INTENSET_USBREMOVED_Msk;
+%% endif
+	}
+
+	template<class... Signals>
+	static void
+	connect()
+	{
+		(GpioStatic<typename Signals::Data>::disconnect(), ...);
+	}
+};
+
+} // namespace modm::platform

--- a/test/all/run_all.py
+++ b/test/all/run_all.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2017, Fabian Greif
-# Copyright (c) 2018, Niklas Hauser
+# Copyright (c) 2018-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -63,6 +63,12 @@ def get_targets(prefix=None, short=False):
 
             elif target.platform == "sam":
                 short_id.naming_schema = "{platform}{family}{series}"
+
+            elif target.platform == "nrf":
+                if "@" in short_id.naming_schema:
+                    short_id.naming_schema = "{platform}{family}{series}@{core}"
+                else:
+                    short_id.naming_schema = "{platform}{family}{series}"
         else:
             # Remove temperature key for stm32
             if target.platform == "stm32":

--- a/tools/build_script_generator/common.py
+++ b/tools/build_script_generator/common.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2018, Niklas Hauser
+# Copyright (c) 2018-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -98,6 +98,8 @@ def common_target(env):
     jlink_partname = device.partname
     if device.partname.startswith("stm32"):
         jlink_partname = device.partname[:11]
+    if device.partname.startswith("nrf"):
+        jlink_partname = device.partname.replace("-", "_").replace("@", "_")
     p = {
         "core": core,
         "mcu": mcu,

--- a/tools/modm_tools/jlink.py
+++ b/tools/modm_tools/jlink.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2023, Niklas Hauser
+# Copyright (c) 2023-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -38,6 +38,7 @@ export MODM_JLINK_BINARY=/path/to/other/JLinkGDBServer
 import os
 import time
 import signal
+import tempfile
 import platform
 import subprocess
 
@@ -90,6 +91,28 @@ def call(device, blocking=True, silent=False, verbose=False):
     return subprocess.Popen(command_jlink, **kwargs)
 
 
+def _call_commander(device, commands, verbose=True):
+    binary = "JLinkExe"
+    if "Windows" in platform.platform():
+        binary += ".exe"
+    binary = os.environ.get("MODM_JLINK_COMMANDER_BINARY", binary)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jlink") as script:
+        script.write("\n".join(commands) + "\n")
+        script.flush()
+        command = [
+            binary,
+            "-device", device,
+            "-if", "swd",
+            "-speed", "4000",
+            "-nogui", "1",
+            "-ExitOnError", "1",
+            "-CommandFile", script.name,
+        ]
+        if verbose: print(" ".join(command))
+        return subprocess.call(command, cwd=os.getcwd())
+
+
 # -----------------------------------------------------------------------------
 def itm(device, baudrate=None):
     command_jlink = "JLinkSWOViewerCL -device {} -itmport 0".format(device)
@@ -105,13 +128,12 @@ def rtt(backend, channel=0):
 
 
 # -----------------------------------------------------------------------------
-_RESET_QUIT = ["monitor reset", "disconnect", "set confirm off", "quit"]
 def program(device, source):
-    gdb.call(JLinkBackend(device), source, commands=["load"] + _RESET_QUIT)
+    return _call_commander(device, ["reset", f"loadfile {source}", "reset", "exit"])
 
 
 def reset(device):
-    gdb.call(JLinkBackend(device), commands=_RESET_QUIT)
+    return _call_commander(device, ["reset", "exit"])
 
 
 # -----------------------------------------------------------------------------

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018, Niklas Hauser
+# Copyright (c) 2018-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -96,17 +96,22 @@ def hal_get_modules():
                 "eth": "Ethernet",
                 "random": "Random Generator",
                 "id": "Unique ID",
+                "power": "Power",
+                "pwr": "Power",
                 "rcc": "System Clock",
                 "gclk": "System Clock",
+                "hfclk": "System Clock",
                 "clocks": "System Clock",
                 "clockgen": "System Clock",
                 "extint": "External Interrupt",
                 "exti": "External Interrupt",
                 "fsmc": "External Memory",
                 "flash": "Internal Flash",
+                "iwdg": "Watchdog",
                 "timer": "Timer",
                 "i2c": "I<sup>2</sup>C",
-                "usart": "UART"
+                "usart": "UART",
+                "uarte": "UART",
             }
             mname = remap.get(mname, mname.upper())
             modules.add(mname)
@@ -115,26 +120,34 @@ def hal_get_modules():
         # External interrupt is currently part of the GPIO module
         if target.platform in ["avr"] and "GPIO" in modules:
             modules.add("External Interrupt")
+        # EasyDMA is part of the peripherals, thus not queryable
+        if target.platform in ["nrf"]:
+            modules.add("DMA")
 
         # print(target, dict(modules))
         print(target, end=" ", flush=True)
         all_targets[target] = (drivers, modules)
 
     # Some information cannot be extracted from the module.lb files
-    mapping["ADC"].add("afec")
+    mapping["ADC"].update({"afec", "saadc", "sdadc"})
     mapping["DAC"].add("dacc")
     mapping["Ethernet"].add("gmac")
     mapping["Random Generator"].add("trng")
-    mapping["UART"].update({"usi", "sercom"})
-    mapping["Timer"].update({"tc", "tcc", "timer"})
-    mapping["SPI"].add("sercom")
-    mapping["I<sup>2</sup>C"].update({"sercom", "twihs"})
-    mapping["USB"].update({"usb", "usbhs"})
+    mapping["UART"].update({"usi", "sercom", "uarte", "lpuart"})
+    mapping["Timer"].update({"tc", "tcc", "timer", "tim", "lptim", "hrtim"})
+    mapping["SPI"].update({"sercom", "spim", "spis"})
+    mapping["I<sup>2</sup>C"].update({"sercom", "twihs", "twi", "twim", "twis", "fmpi2c", "i2c"})
+    mapping["USB"].update({"usb", "usbhs", "usbd", "usb_otg_fs", "usb_otg_hs", "udp", "uhp", "utmi", "usb_dpram"})
     mapping["CAN"].update({"fdcan", "mcan"})
-    mapping["DMA"].update({"dmac", "xdmac", "gpdma"})
-    mapping["Comparator"].update({"ac", "acc"})
-    mapping["Internal Flash"].update({"efc", "nvmctrl"})
-    mapping["External Memory"].update({"sdramc", "smc", "quadspi", "xip_ssi", "octospi"})
+    mapping["DMA"].update({"dmac", "xdmac", "gpdma", "bdma", "dma", "hpdma", "lpdma", "mdma", "mem2mem"})
+    mapping["Comparator"].update({"ac", "acc", "lpcomp"})
+    mapping["External Interrupt"].update({"gpiote", "eic"})
+    mapping["Internal Flash"].update({"efc", "nvmctrl", "nvmc", "flash"})
+    mapping["External Memory"].update({"sdramc", "smc", "quadspi", "xip_ssi", "octospi", "qspi", "fmc", "fsmc", "xspi", "hspi", "octospim", "xspim", "sdio", "sdmmc", "ebi", "hsmci", "qmi", "xip", "xip_aux", "ssi"})
+    mapping["System Clock"].update({"clock", "oscillators", "rcc", "mclk", "pm", "sysctrl", "oscctrl", "osc32kctrl", "clocks", "resets", "rosc"})
+    mapping["Power"].update({"power", "regulators", "usbregulator", "vmc", "vreqctrl", "pwr", "supc", "powman", "psm", "vreg_and_chip_reset"})
+    mapping["Watchdog"].update({"wdt", "iwdg", "wwdg", "rswdt", "watchdog"})
+    mapping["Unique ID"].update({"ficr", "uicr", "chipid", "sysinfo", "otp", "otp_data", "otp_data_raw"})
 
     print(); print()
     return (all_targets, mapping)
@@ -228,7 +241,7 @@ def hal_format_tables():
     # tables["stm32"] = hal_create_table(targets, ["stm32"])
     # tables["sam"] = hal_create_table(targets, ["sam"])
 
-    tables["all"] = hal_create_table(targets, ["avr", "stm32", "sam", "rp"])
+    tables["all"] = hal_create_table(targets, ["avr", "stm32", "sam", "rp", "nrf"])
 
     return tables
 

--- a/tools/scripts/generate_module_docs.py
+++ b/tools/scripts/generate_module_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018, Niklas Hauser
+# Copyright (c) 2018-2026, Niklas Hauser
 #
 # This file is part of the modm project.
 #
@@ -367,6 +367,11 @@ if __name__ == "__main__":
     for target in otarget.values:
         if target.startswith("stm32"):
             targets["STMicroelectronics STM32"][target[:7].upper()][target[:9].upper()].append(target)
+        elif target.startswith("nrf"):
+            base = target.split("@", 1)[0]
+            prefix = base.split("-", 1)[0].upper()
+            family = prefix[:5]
+            targets["Nordic Semiconductor nRF"]["nRF5x"][family].append(target)
         elif target.startswith("sam"):
             targets["Microchip SAM"][target[:4].upper()][target[:6].upper()].append(target)
         elif target.startswith("at90"):


### PR DESCRIPTION
This is a continuation of the work in #410.

- [x] Add minimal support for nRF51
  - [x] modm-device support
  - [x] Add Core driver
  - [x] Add GPIO driver
  - [x] Add UART driver
  - [x] Add BSP for nRF51422-DK
  - [x] Tested in Hardware
- [x] Add minimal support for nRF52
  - [x] modm-device support
  - [x] Add Core driver
  - [x] Add GPIO driver
  - [x] Add UART driver
  - [x] Add TinyUSB port
  - [x] Add BSP for nRF52840-DK
  - [x] Tested in Hardware
- [x] Add minimal support for nRF53
  - [x] modm-device support
  - [x] Add Core driver
  - [x] Add GPIO driver
  - [x] Add UART driver
  - [x] Add ADC driver
  - [x] Add Regulators driver
  - [x] Add TinyUSB port
  - [x] Add BSP for nRF5340-DK
  - [x] Tested in Hardware
  - [x] Support running code on the network core
- [x] compile all job passes
- [x] Add documentation for nRF5x platform
- [x] Use JLinkExe directly instead of GDB for uploading firmware
- [x] Unsquash the mega commit
  - [x] give proper attribution to @el-han
  - [x] update copyrights