### PR TITLE
[board] Add NUCLEO-H533RE board support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Examples STM32H5 Series
         if: always()
         run: |
-          (cd examples && ../tools/scripts/examples_compile.py nucleo_h503rb weact_h503cb weact_h523ce weact_h562rg)
+          (cd examples && ../tools/scripts/examples_compile.py nucleo_h503rb nucleo_h533re weact_h503cb weact_h523ce weact_h562rg)
       - name: Examples STM32H7 Series
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -781,45 +781,46 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-g474re">NUCLEO-G474RE</a></td>
 </tr><tr>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h503rb">NUCLEO-H503RB</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h533re">NUCLEO-H533RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u385rg-q">NUCLEO-U385RG-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h523ce">WEACT-H523CE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/examples/generic/usb/project.xml
+++ b/examples/generic/usb/project.xml
@@ -22,6 +22,7 @@
   <!-- <extends>modm:weact-u585ci</extends> -->
   <!-- <extends>modm:nucleo-u575zi-q</extends> -->
   <!-- <extends>modm:nucleo-h503rb</extends> -->
+  <!-- <extends>modm:nucleo-h533re</extends> -->
   <!-- <extends>modm:weact-h503cb</extends> -->
   <!-- <extends>modm:weact-h523ce</extends> -->
   <!-- <extends>modm:weact-h562rg</extends> -->

--- a/examples/nucleo_h533re/blink/main.cpp
+++ b/examples/nucleo_h533re/blink/main.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2017, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/processing.hpp>
+
+using namespace Board;
+
+int
+main()
+{
+	Board::initialize();
+	Leds::setOutput();
+
+	// Use the logging streams to print some messages.
+	// Change MODM_LOG_LEVEL above to enable or disable these messages
+	MODM_LOG_DEBUG   << "debug"   << modm::endl;
+	MODM_LOG_INFO    << "info"    << modm::endl;
+	MODM_LOG_WARNING << "warning" << modm::endl;
+	MODM_LOG_ERROR   << "error"   << modm::endl;
+
+	for (const auto [traits, start, end, size] : modm::platform::HeapTable())
+	{
+		MODM_LOG_INFO.printf("Memory section %#x @[0x%p,0x%p](%u)\n",
+							 traits.value, start, end, size);
+	}
+
+	uint32_t counter(0);
+	modm::ShortTimeout tmr;
+
+	while (true)
+	{
+		Leds::write(1 << (counter % (Leds::width+1) ));
+		// modm::delay(Button::read() ? 100ms : 500ms);
+		tmr.restart(Button::read() ? 100ms : 500ms);
+		while(not tmr.execute()) ;
+
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nucleo_h533re/blink/project.xml
+++ b/examples/nucleo_h533re/blink/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-h533re</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_h533re/blink</option>
+  </options>
+  <modules>
+    <module>modm:architecture:memory</module>
+    <module>modm:build:scons</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_h533re/board.hpp
+++ b/src/modm/board/nucleo_h533re/board.hpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <modm/platform.hpp>
+#include <modm/architecture.hpp>
+#include <modm/debug.hpp>
+
+using namespace modm::platform;
+
+/// @ingroup modm_board_nucleo_h533re
+#define MODM_BOARD_HAS_LOGGER
+
+namespace Board
+{
+/// @ingroup modm_board_nucleo_h533re
+/// @{
+using namespace modm::literals;
+
+/// STM32H533RE running at 250MHz from PLL clock generated from 24 MHz HSE
+struct SystemClock
+{
+	static constexpr uint32_t Hse = 24_MHz;
+	static constexpr uint32_t Lse = 32.768_kHz;
+
+	static constexpr Rcc::PllConfig pll1
+	{
+		.range = Rcc::PllInputRange::MHz2_4,
+		.M = 12,  //  24 MHz /  12 =   2 MHz
+		.N = 250, //   2 MHz * 120 = 500 MHz
+		.P = 2,   // 500 MHz /   2 = 250 MHz = F_cpu
+	};
+	static constexpr uint32_t Pll1P = Hse / pll1.M * pll1.N / pll1.P;
+	static_assert(Pll1P == Rcc::MaxFrequency);
+
+	static constexpr Rcc::PllConfig pll3
+	{
+		.range = Rcc::PllInputRange::MHz8_16,
+		.M = 3,  //  24 MHz /  3 =   8 MHz
+		.N = 18, //   8 MHz * 18 = 144 MHz
+		.Q = 3,  // 144 MHz /  3 =  48 MHz = F_usb
+	};
+	static constexpr uint32_t Pll3Q = Hse / pll3.M * pll3.N / pll3.Q;
+
+	static constexpr uint32_t SysClk = Pll1P;
+	static constexpr uint32_t Frequency = SysClk;
+
+	// AHB Bus - Max 250MHz
+	static constexpr uint32_t Hclk = SysClk / 1;
+	static constexpr uint32_t Ahb = Hclk;
+
+	// APB Buses - Max 250MHz
+	static constexpr uint32_t Apb1 = Hclk / 1;
+	static constexpr uint32_t Apb2 = Hclk / 1;
+	static constexpr uint32_t Apb3 = Hclk / 1;
+
+	// Peripherals on AHB2
+	static constexpr uint32_t Adc1 = Hclk;
+	static constexpr uint32_t Dac1 = Hclk;
+
+	// Peripherals on APB2
+	static constexpr uint32_t Spi1 = Apb2;
+	static constexpr uint32_t Usart1 = Apb2;
+
+	// Peripherals on APB1
+	static constexpr uint32_t Spi2 = Apb1;
+	static constexpr uint32_t Spi3 = Apb1;
+	static constexpr uint32_t Usart2 = Apb1;
+	static constexpr uint32_t Usart3 = Apb1;
+	static constexpr uint32_t Fdcan1 = Apb1;
+
+	// Peripherals on APB3
+	static constexpr uint32_t LpUart1 = Apb3;
+
+	// Timer Clocks
+	static constexpr uint32_t Apb1Timer = Apb1 * 1;
+	static constexpr uint32_t Apb2Timer = Apb2 * 1;
+
+	static constexpr uint32_t Timer1 = Apb2Timer;
+	static constexpr uint32_t Timer2 = Apb1Timer;
+	static constexpr uint32_t Timer3 = Apb1Timer;
+	static constexpr uint32_t Timer6 = Apb1Timer;
+	static constexpr uint32_t Timer7 = Apb1Timer;
+
+	static constexpr uint32_t Rtc = Lse;
+	static constexpr uint32_t Usb = Pll3Q;
+	static constexpr uint32_t Iwdg = Rcc::LsiFrequency;
+
+	static bool inline
+	enable()
+	{
+		Rcc::enableLseCrystal();
+		Rcc::enableHseCrystal();
+
+		Rcc::setVoltageScaling(Rcc::VoltageScaling::Scale0);
+		Rcc::setFlashLatency<Frequency>();
+
+		Rcc::enablePll1(Rcc::PllSource::Hse, pll1);
+		Rcc::enablePll3(Rcc::PllSource::Hse, pll3);
+
+		Rcc::setAhbPrescaler(Rcc::AhbPrescaler::Div1);
+		Rcc::setApb1Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb2Prescaler(Rcc::ApbPrescaler::Div1);
+		Rcc::setApb3Prescaler(Rcc::ApbPrescaler::Div1);
+
+		Rcc::updateCoreFrequency<Frequency>();
+
+		Rcc::enableSystemClock(Rcc::SystemClockSource::Pll1P);
+		Rcc::setUsbClockSource(Rcc::UsbClockSource::Pll3Q);
+		Rcc::setRealTimeClockSource(Rcc::RealTimeClockSource::Lse);
+
+		return true;
+	}
+};
+
+using A0 = GpioA0;
+using A1 = GpioA1;
+using A2 = GpioB1;
+using A3 = GpioB0;
+using A4 = GpioC1;
+using A5 = GpioC0;
+
+using D0  = GpioB15;
+using D1  = GpioB14;
+using D2  = GpioC8;
+using D3  = GpioB3;
+using D4  = GpioB5;
+using D5  = GpioB4;
+using D6  = GpioB10;
+using D7  = GpioA8;
+using D8  = GpioC7;
+using D9  = GpioC6;
+using D10 = GpioC9;
+using D11 = GpioA7;
+using D12 = GpioA6;
+using D13 = GpioA5;
+using D14 = GpioB7;
+using D15 = GpioB6;
+
+using Button = GpioInputC13;
+
+using Led = GpioOutputA5;
+using Leds = SoftwareGpioPort< Led >;
+/// @}
+
+namespace usb
+{
+/// @ingroup modm_board_nucleo_h533re
+/// @{
+using Dm = GpioA11;
+using Dp = GpioA12;
+
+using Device = UsbFs;
+/// @}
+}
+
+namespace stlink
+{
+/// @ingroup modm_board_nucleo_h533re
+/// @{
+using Tx = GpioOutputA2;
+using Rx = GpioInputA3;
+using Uart = BufferedUart<UsartHal2, UartTxBuffer<2048>>;
+/// @}
+}
+
+/// @ingroup modm_board_nucleo_h533re
+/// @{
+using LoggerDevice = modm::IODeviceWrapper< stlink::Uart, modm::IOBuffer::BlockIfFull >;
+
+inline void
+initialize()
+{
+	SystemClock::enable();
+	SysTickTimer::initialize<SystemClock>();
+
+	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
+	stlink::Uart::initialize<SystemClock, 115200_Bd>();
+
+	Led::setOutput(modm::Gpio::Low);
+	Button::setInput();
+}
+
+inline void
+initializeUsb(uint8_t priority=3)
+{
+	usb::Device::initialize<SystemClock>(priority);
+	usb::Device::connect<usb::Dm::Dm, usb::Dp::Dp>();
+}
+/// @}
+
+}

--- a/src/modm/board/nucleo_h533re/board.xml
+++ b/src/modm/board/nucleo_h533re/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h533ret6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-h533re</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_h533re/module.lb
+++ b/src/modm/board/nucleo_h533re/module.lb
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-h533re"
+    module.description = """
+# NUCLEO-H533RE
+
+[Nucleo kit for STM32H533RE](https://www.st.com/en/evaluation-tools/nucleo-h533re.html)
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32h533ret"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:2",
+        ":platform:usb")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert")
+    }
+    env.template("../board.cpp.in", "board.cpp")
+    env.copy(".")
+    env.collect(":build:openocd.source", "board/st_nucleo_h5.cfg")


### PR DESCRIPTION
It's almost identical to the NUCLEO-H503RB, but uses a different PLL for USB clock, a different UART for logging and mapped two different pins on the connectors.