### PR TITLE
[build] Update to GCC15

### DIFF
--- a/.github/workflows/compile-all.yml
+++ b/.github/workflows/compile-all.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-avr:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -221,7 +221,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -273,7 +273,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -299,7 +299,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -325,7 +325,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -351,7 +351,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -377,7 +377,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -403,7 +403,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -430,7 +430,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -456,7 +456,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -482,7 +482,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -508,7 +508,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -534,7 +534,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -560,7 +560,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -586,7 +586,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -612,7 +612,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -638,7 +638,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -664,7 +664,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -690,7 +690,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -716,7 +716,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -742,7 +742,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -768,7 +768,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -794,7 +794,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -820,7 +820,7 @@ jobs:
     if: github.event.label.name == 'ci:hal'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ jobs:
   build-upload-docs:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-base:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-base:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
   unittests-linux-generic:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
 
     steps:
       - name: Check out repository
@@ -127,7 +127,7 @@ jobs:
   stm32-examples:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -211,7 +211,7 @@ jobs:
   stm32f4-examples-1:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -231,7 +231,7 @@ jobs:
   stm32f4-examples-2:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -254,7 +254,7 @@ jobs:
   avr-examples:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-avr:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-avr:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -305,7 +305,7 @@ jobs:
   hal-compile-quick-1:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -330,7 +330,7 @@ jobs:
   hal-compile-quick-2:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -355,7 +355,7 @@ jobs:
   hal-compile-quick-3:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -380,7 +380,7 @@ jobs:
   hal-compile-quick-4:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/modm-ext/modm-build-cortex-m:2025-05-18
+      image: ghcr.io/modm-ext/modm-build-cortex-m:2026-03-07
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,8 +21,8 @@ jobs:
           export HOMEBREW_NO_INSTALL_CLEANUP=1 # saves time
           brew update
           # brew unlink gcc
-          brew install doxygen boost gcc@14 avr-gcc@14 arm-gcc-bin@14 || true
-          brew link --force avr-gcc@14 arm-gcc-bin@14
+          brew install doxygen boost gcc@15 avr-gcc@15 arm-gcc-bin@15 || true
+          brew link --force avr-gcc@15 arm-gcc-bin@15
           # brew upgrade boost gcc git cmake || true
 
       - name: Setup environment - Python pip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,15 +54,15 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           Start-Job {
             Set-Location $using:PWD
-            Invoke-WebRequest -OutFile gcc-arm-none-eabi-win64-14.zip https://github.com/modm-io/avr-gcc/releases/download/v14.2.0/arm-gnu-toolchain-14.2.rel1-mingw-w64-x86_64-arm-none-eabi.zip
-            New-Item -Path "C:\" -Name "arm-none-eabi-14" -ItemType "Directory"
-            Expand-Archive -Path gcc-arm-none-eabi-win64-14.zip -DestinationPath C:\arm-none-eabi-14 -Force
-            Remove-Item gcc-arm-none-eabi-win64-14.zip
+            Invoke-WebRequest -OutFile gcc-arm-none-eabi-win64.zip https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-mingw-w64-x86_64-arm-none-eabi.zip
+            New-Item -Path "C:\" -Name "arm-none-eabi" -ItemType "Directory"
+            Expand-Archive -Path gcc-arm-none-eabi-win64.zip -DestinationPath C:\arm-none-eabi -Force
+            Remove-Item gcc-arm-none-eabi-win64.zip
           }
           Start-Job {
             Set-Location $using:PWD
             Add-Type -Assembly "System.IO.Compression.Filesystem"
-            Invoke-WebRequest -OutFile gcc-avr-win64.zip https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-windows.zip
+            Invoke-WebRequest -OutFile gcc-avr-win64.zip https://github.com/ZakKemble/avr-gcc-build/releases/download/v15.2.0-1/avr-gcc-15.2.0-x64-windows.zip
             [System.IO.Compression.ZipFile]::ExtractToDirectory("gcc-avr-win64.zip", "C:\")
             Remove-Item gcc-avr-win64.zip
           }
@@ -77,12 +77,12 @@ jobs:
         shell: powershell
         run: |
           dir C:\
-          dir C:\arm-none-eabi-14\
-          dir C:\arm-none-eabi-14\bin
-          dir C:\avr-gcc-14.1.0-x64-windows
-          dir C:\avr-gcc-14.1.0-x64-windows\bin
-          echo "C:\arm-none-eabi-14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\avr-gcc-14.1.0-x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          dir C:\arm-none-eabi\
+          dir C:\arm-none-eabi\bin
+          dir C:\avr-gcc-15.2.0-x64-windows
+          dir C:\avr-gcc-15.2.0-x64-windows\bin
+          echo "C:\arm-none-eabi\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\avr-gcc-15.2.0-x64-windows\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Python
         if: always()

--- a/src/modm/platform/gpio/stm32/data.hpp.in
+++ b/src/modm/platform/gpio/stm32/data.hpp.in
@@ -26,9 +26,8 @@ AdcPolarity
 };
 %% endif
 template<class Signal, Peripheral p> struct SignalConnection;
-template<class Data, Peripheral p{% if target.family in ["h5", "h7"] %}, AdcPolarity ap{% endif %}> static constexpr int8_t AdcChannel = -1;
-template<class Data, Peripheral p> static constexpr int8_t DacChannel = -1;
-
+template<class Data, Peripheral p{% if target.family in ["h5", "h7"] %}, AdcPolarity ap{% endif %}> constexpr int8_t AdcChannel = -1;
+template<class Data, Peripheral p> constexpr int8_t DacChannel = -1;
 struct DataUnused {};
 %% for gpio in gpios
 %% set port = gpio.gpio.port | upper
@@ -63,10 +62,10 @@ template<> struct SignalConnection<Data{{ port ~ pin }}::{{ signal.name }}, Peri
 %% for signal_name, signal_group in gpio.signals.items()
 	%% for signal in signal_group
 		%% if signal.driver.startswith("Adc") and signal.name.startswith("In")
-template<> constexpr int8_t AdcChannel<Data{{ port ~ pin }}, Peripheral::{{ signal.driver }}{% if signal.name.startswith("Inn") %}, AdcPolarity::Negative{% endif %}{% if signal.name.startswith("Inp") %}, AdcPolarity::Positive{% endif %}> = {{ signal.name | to_adc_channel }};
+template<> constexpr inline int8_t AdcChannel<Data{{ port ~ pin }}, Peripheral::{{ signal.driver }}{% if signal.name.startswith("Inn") %}, AdcPolarity::Negative{% endif %}{% if signal.name.startswith("Inp") %}, AdcPolarity::Positive{% endif %}> = {{ signal.name | to_adc_channel }};
 		%% endif
 		%% if signal.driver.startswith("Dac") and signal.name.startswith("Out")
-template<> constexpr int8_t DacChannel<Data{{ port ~ pin }}, Peripheral::{{ signal.driver }}> = {{ signal.name | to_adc_channel }};
+template<> constexpr inline int8_t DacChannel<Data{{ port ~ pin }}, Peripheral::{{ signal.driver }}> = {{ signal.name | to_adc_channel }};
 		%% endif
 	%% endfor
 %% endfor

--- a/tools/build_script_generator/make/resources/compiler.mk.in
+++ b/tools/build_script_generator/make/resources/compiler.mk.in
@@ -18,7 +18,7 @@ else
 %% if platform == "hosted"
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
-		C_SUFFIX := -14
+		C_SUFFIX := -15
 		# Using homebrew include and lib paths on macOS
 		CPPDEFINES += -I/usr/local/include
 		LIBPATH += -L/usr/local/lib


### PR DESCRIPTION
GCC15 was released a while ago, let's see what breaks. Depends on https://github.com/modm-ext/docker-modm-build/pull/34

- avrlibstdc++ needs to be upgraded for GCC15. It is missing important pieces anyways (date stuff), so needs to be done anyways. big issue
- ~~[osx-cross/homebrew-arm](https://github.com/osx-cross/homebrew-arm/tree/master/Formula) doesn't have v15 yet, lol!~~ fixed, need to upgrade the macos CI
- ~~Something is wrong with `modm::platform::detail::AdcChannel<modm::platform::detail::DataC4, (modm::platform::Peripheral)1>` on Cortex-M~~ fixed