### PR TITLE
[fix] nucleo-h7431 updated user led pin and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,43 +884,44 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h533re">NUCLEO-H533RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h723zg">NUCLEO-H723ZG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi2">NUCLEO-H743ZI2</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u385rg-q">NUCLEO-U385RG-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h523ce">WEACT-H523CE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr>
 </table>
 <!--/bsptable-->

--- a/README.md
+++ b/README.md
@@ -886,41 +886,42 @@ We have out-of-box support for many development boards including documentation.
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi">NUCLEO-H743ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h743zi2">NUCLEO-H743ZI2</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-h753zi">NUCLEO-H753ZI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l031k6">NUCLEO-L031K6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l053r8">NUCLEO-L053R8</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l152re">NUCLEO-L152RE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l432kc">NUCLEO-L432KC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l452re">NUCLEO-L452RE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l476rg">NUCLEO-L476RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l496zg-p">NUCLEO-L496ZG-P</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-nucleo-l552ze-q">NUCLEO-L552ZE-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u083rc">NUCLEO-U083RC</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u385rg-q">NUCLEO-U385RG-Q</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-nucleo-u575zi-q">NUCLEO-U575ZI-Q</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-olimexino-stm32">OLIMEXINO-STM32</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-rp-pico">Raspberry Pi Pico</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-mini">SAMD21-MINI</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samd21-xplained-pro">SAMD21-XPLAINED-PRO</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-same54-xplained-pro">SAME54-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-same70-xplained">SAME70-XPLAINED</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samg55-xplained-pro">SAMG55-XPLAINED-PRO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-samv71-xplained-ultra">SAMV71-XPLAINED-ULTRA</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-srxe">Smart Response XE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32_f4ve">STM32-F4VE</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-stm32f030_demo">STM32F030-DEMO</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-thingplus-rp2040">THINGPLUS-RP2040</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-c011f6">WEACT-C011F6</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-g0b1cb">WEACT-G0B1CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h503cb">WEACT-H503CB</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-h523ce">WEACT-H523CE</a></td>
-<td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
 </tr><tr>
+<td align="center"><a href="https://modm.io/reference/config/modm-weact-h562rg">WEACT-H562RG</a></td>
 <td align="center"><a href="https://modm.io/reference/config/modm-weact-u585ci">WEACT-U585CI</a></td>
 </tr>
 </table>

--- a/src/modm/board/nucleo_h743zi/board.hpp.in
+++ b/src/modm/board/nucleo_h743zi/board.hpp.in
@@ -30,9 +30,12 @@ using namespace modm::literals;
 struct SystemClock
 {
 	static constexpr uint32_t Hse = 8_MHz;
-
+	%% if board == "stm32h743zi"
 	// NOTE: revision Y at 400MHz, only revision V runs at 480Mhz!!!
 	static constexpr uint32_t SysClk = 400_MHz;
+	%% else
+	static constexpr uint32_t SysClk = 480_MHz;
+	%% endif
 	static constexpr uint32_t Pll2Q = 120_MHz;
 	// Max 400MHz or 480MHz
 	static constexpr uint32_t Hclk = SysClk / 1; // D1CPRE
@@ -113,7 +116,11 @@ struct SystemClock
 		const Rcc::PllFactors pllFactors1{
 			.range = Rcc::PllInputRange::MHz4_8,
 			.pllM = 2,		//   8MHz / M=   4MHz
+			%% if board == "stm32h743zi"
 			.pllN = 100,	//   4MHz * N= 400MHz
+			%% else
+			.pllN = 120,
+			%% endif
 			.pllP = 1,		// 400MHz / P= 400MHz = F_cpu
 			.pllQ = 10,		// 400MHz / Q=  40MHz
 			.pllR = 10,		// 400MHz / R=  40MHz
@@ -167,9 +174,14 @@ struct SystemClock
 using Button = GpioInputC13;
 
 using LedGreen = GpioOutputB0;
-using LedBlue = GpioOutputB7;
 using LedRed = GpioOutputB14;
+%% if board == "stm32h743zi"
+using LedBlue = GpioOutputB7;
 using Leds = SoftwareGpioPort< LedRed, LedBlue, LedGreen >;
+%% else
+using LedYellow = GpioOutputE1;
+using Leds = SoftwareGpioPort< LedRed, LedYellow, LedGreen >;
+%% endif
 /// @}
 
 namespace usb
@@ -182,8 +194,11 @@ using Dm = GpioA11;
 using Dp = GpioA12;
 
 using Overcurrent = GpioInputG7;	// OTG_FS_OverCurrent
+%% if board == "stm32h743zi"
 using Power = GpioOutputG6;			// OTG_FS_PowerSwitchOn
-
+%% else
+using Power = GpioOutputD10;		// OTG_FS_PowerSwitchOn
+%% endif
 using Device = UsbFs;
 /// @}
 }
@@ -212,9 +227,7 @@ initialize()
 	stlink::Uart::connect<stlink::Tx::Tx, stlink::Rx::Rx>();
 	stlink::Uart::initialize<SystemClock, 115200_Bd>();
 
-	LedGreen::setOutput(modm::Gpio::Low);
-	LedBlue::setOutput(modm::Gpio::Low);
-	LedRed::setOutput(modm::Gpio::Low);
+	Leds::setOutput(modm::Gpio::Low);
 
 	Button::setInput();
 }

--- a/src/modm/board/nucleo_h743zi2/board.xml
+++ b/src/modm/board/nucleo_h743zi2/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h743zit6/revV</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-h743zi2</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_h743zi2/module.lb
+++ b/src/modm/board/nucleo_h743zi2/module.lb
@@ -12,29 +12,13 @@
 # -----------------------------------------------------------------------------
 
 def init(module):
-    module.name = ":board:nucleo-h743zi"
+    module.name = ":board:nucleo-h743zi2"
     module.description = """\
-# NUCLEO-H743ZI
+# NUCLEO-H743ZI2
 
-[Nucleo kit for STM32H743ZI](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html)
+[Nucleo kit for STM32H743ZI2](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html)
 
-Please note that this BSP uses the Y revision of the STM32H743, which limits the
-main clock frequency to ≤400MHz and applies an errata bug fix to the SysTick,
-whose reference clock cannot be divided by 8.
-
-See the [STM32H743 errata sheet](https://www.st.com/resource/en/errata_sheet/es0392-stm32h742xig-and-stm32h743xig-device-limitations-stmicroelectronics.pdf).
-
-In case you are using the new revision V of STM32H743, you can overwrite the
-target option in your `project.xml`:
-
-```xml
-<library>
-  <extends>modm:nucleo-h743zi</extends>
-  <options>
-    <option name="modm:target">stm32h743zit6/revV</option>
-  </options>
-</library>
-```
+Please note that this BSP uses the V revision of the STM32H743.
 """
 
 def prepare(module, options):
@@ -57,10 +41,10 @@ def build(env):
     env.substitutions = {
         "with_logger": True,
         "with_assert": env.has_module(":architecture:assert"),
-        "board" : "stm32h743zi"
+        "board" : "nucleo-h743zi2"
     }
 
     env.template("../board.cpp.in", "board.cpp")
-    env.template("board.hpp.in")
+    env.template("../nucleo_h743zi/board.hpp.in", "board.hpp")
     env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
     env.collect(":build:openocd.source", "board/st_nucleo_h743zi.cfg")

--- a/src/modm/board/nucleo_h753zi/board.xml
+++ b/src/modm/board/nucleo_h753zi/board.xml
@@ -1,0 +1,14 @@
+<library>
+  <repositories>
+    <repository>
+      <path>../../../../repo.lb</path>
+    </repository>
+  </repositories>
+
+  <options>
+    <option name="modm:target">stm32h753zit6</option>
+  </options>
+  <modules>
+    <module>modm:board:nucleo-h753zi</module>
+  </modules>
+</library>

--- a/src/modm/board/nucleo_h753zi/module.lb
+++ b/src/modm/board/nucleo_h753zi/module.lb
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016-2018, Niklas Hauser
+# Copyright (c) 2017, Fabian Greif
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":board:nucleo-h753zi"
+    module.description = """\
+# NUCLEO-H753ZI
+
+[Nucleo kit for STM32H753ZI](https://www.st.com/en/evaluation-tools/nucleo-h753zi.html)
+
+Please note that this BSP uses the V revision of the STM32H753.
+"""
+
+def prepare(module, options):
+    if not options[":target"].partname.startswith("stm32h753zit"):
+        return False
+
+    module.depends(
+        ":debug",
+        ":architecture:clock",
+        ":platform:core",
+        ":platform:gpio",
+        ":platform:clock",
+        ":platform:uart:3",
+        ":platform:usb:fs")
+
+    return True
+
+def build(env):
+    env.outbasepath = "modm/src/modm/board"
+    env.substitutions = {
+        "with_logger": True,
+        "with_assert": env.has_module(":architecture:assert"),
+        "board" : "nucleo-h753zi"
+    }
+
+    env.template("../board.cpp.in", "board.cpp")
+    env.template("../nucleo_h743zi/board.hpp.in", "board.hpp")
+    env.copy("../nucleo144_arduino.hpp", "nucleo144_arduino.hpp")
+    env.collect(":build:openocd.source", "board/st_nucleo_h743zi.cfg")


### PR DESCRIPTION
According to section 7.6.1 LEDs of the [NUCLEO-H743ZI](https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf) user manual is no blue user led.

Instead the board has a yellow user led connected to PE1.