### PR TITLE
[stm32] H7 flash driver and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">✅</td>
 <td align="center">✅</td>
 <td align="center">○</td>
-<td align="center">○</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>

--- a/examples/nucleo_h723zg/flash/main.cpp
+++ b/examples/nucleo_h723zg/flash/main.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <cstring>
+#include <modm/board.hpp>
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+extern "C" const uint32_t __flash_reserved_start[];
+
+static Flash::MaxWordType
+makeFlashWord(const uint32_t *data)
+{
+	Flash::MaxWordType word;
+	for (size_t ii = 0; ii < Flash::FlashWordWords; ++ii) {
+		word.data[ii] = data[ii];
+	}
+	return word;
+}
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "STM32H7 Flash write/read example" << modm::endl;
+
+	constexpr uint32_t dummy_data[] = {
+		0xDEADBEEF, 0xCAFEBABE, 0x12345678, 0xAABBCCDD,
+		0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00,
+		0x0BADCAFE, 0xC001D00D, 0xFEEDFACE, 0x8BADF00D,
+		0x13579BDF, 0x2468ACE0, 0x10203040, 0x50607080,
+	};
+	constexpr size_t num_values = std::size(dummy_data);
+	static_assert(num_values % Flash::FlashWordWords == 0);
+	constexpr size_t num_flash_words = num_values / Flash::FlashWordWords;
+
+	const uintptr_t base = reinterpret_cast<uintptr_t>(__flash_reserved_start);
+	const uint8_t sector = Flash::getPage(base - Flash::OriginAddr);
+
+	MODM_LOG_INFO << "Reserved sector: " << sector << "  base: 0x" << modm::hex << base
+				  << modm::endl;
+
+	if (not Flash::unlock())
+	{
+		MODM_LOG_ERROR << "Flash unlock failed!" << modm::endl;
+		while (1);
+	}
+
+	// Erase the reserved sector before writing
+	if (const uint32_t err = Flash::erase(sector); err != 0)
+	{
+		MODM_LOG_ERROR << "Erase error: 0x" << modm::hex << err << modm::endl;
+		while (1);
+	}
+	MODM_LOG_INFO << "Sector erased." << modm::endl;
+
+	// Write dummy data
+	uint32_t err{0};
+	for (size_t i = 0; i < num_flash_words; i++)
+		err |= Flash::program(base + i * Flash::FlashWordSize,
+							  makeFlashWord(&dummy_data[i * Flash::FlashWordWords]));
+
+	if (err != 0)
+	{
+		MODM_LOG_ERROR << "Program error: 0x" << modm::hex << err << modm::endl;
+		while (1);
+	}
+	MODM_LOG_INFO << "Write complete. Verifying..." << modm::endl;
+
+	// Read back and verify
+	for (size_t i = 0; i < num_values; i++)
+	{
+		uint32_t readback;
+		memcpy(&readback, reinterpret_cast<const void *>(base + i * sizeof(uint32_t)),
+			   sizeof(uint32_t));
+		const bool ok = (readback == dummy_data[i]);
+		MODM_LOG_INFO << "[" << i << "] wrote 0x" << modm::hex << dummy_data[i] << "  read 0x"
+					  << readback << (ok ? "  OK" : "  MISMATCH") << modm::endl;
+	}
+
+	while (1);
+	return 0;
+}

--- a/examples/nucleo_h723zg/flash/project.xml
+++ b/examples/nucleo_h723zg/flash/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-h723zg</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_h723zg/flash</option>
+    <option name="modm:platform:cortex-m:linkerscript.flash_reserved">1024*128</option>
+  </options>
+  <modules>
+    <module>modm:platform:flash</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/examples/nucleo_h743zi/flash/main.cpp
+++ b/examples/nucleo_h743zi/flash/main.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Henrik Hose
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <cstring>
+#include <modm/board.hpp>
+
+#undef MODM_LOG_LEVEL
+#define MODM_LOG_LEVEL modm::log::INFO
+
+extern "C" const uint32_t __flash_reserved_start[];
+
+static Flash::MaxWordType
+makeFlashWord(const uint32_t *data)
+{
+	Flash::MaxWordType word;
+	for (size_t ii = 0; ii < Flash::FlashWordWords; ++ii) {
+		word.data[ii] = data[ii];
+	}
+	return word;
+}
+
+int
+main()
+{
+	Board::initialize();
+
+	MODM_LOG_INFO << "STM32H7 Flash write/read example" << modm::endl;
+
+	constexpr uint32_t dummy_data[] = {
+		0xDEADBEEF, 0xCAFEBABE, 0x12345678, 0xAABBCCDD,
+		0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00,
+		0x0BADCAFE, 0xC001D00D, 0xFEEDFACE, 0x8BADF00D,
+		0x13579BDF, 0x2468ACE0, 0x10203040, 0x50607080,
+	};
+	constexpr size_t num_values = std::size(dummy_data);
+	static_assert(num_values % Flash::FlashWordWords == 0);
+	constexpr size_t num_flash_words = num_values / Flash::FlashWordWords;
+
+	const uintptr_t base = reinterpret_cast<uintptr_t>(__flash_reserved_start);
+	const uint8_t sector = Flash::getPage(base - Flash::OriginAddr);
+
+	MODM_LOG_INFO << "Reserved sector: " << sector << "  base: 0x" << modm::hex << base
+				  << modm::endl;
+
+	if (not Flash::unlock())
+	{
+		MODM_LOG_ERROR << "Flash unlock failed!" << modm::endl;
+		while (1);
+	}
+
+	// Erase the reserved sector before writing
+	if (const uint32_t err = Flash::erase(sector); err != 0)
+	{
+		MODM_LOG_ERROR << "Erase error: 0x" << modm::hex << err << modm::endl;
+		while (1);
+	}
+	MODM_LOG_INFO << "Sector erased." << modm::endl;
+
+	// Write dummy data
+	uint32_t err{0};
+	for (size_t i = 0; i < num_flash_words; i++)
+		err |= Flash::program(base + i * Flash::FlashWordSize,
+							  makeFlashWord(&dummy_data[i * Flash::FlashWordWords]));
+
+	if (err != 0)
+	{
+		MODM_LOG_ERROR << "Program error: 0x" << modm::hex << err << modm::endl;
+		while (1);
+	}
+	MODM_LOG_INFO << "Write complete. Verifying..." << modm::endl;
+
+	// Read back and verify
+	for (size_t i = 0; i < num_values; i++)
+	{
+		uint32_t readback;
+		memcpy(&readback, reinterpret_cast<const void *>(base + i * sizeof(uint32_t)),
+			   sizeof(uint32_t));
+		const bool ok = (readback == dummy_data[i]);
+		MODM_LOG_INFO << "[" << i << "] wrote 0x" << modm::hex << dummy_data[i] << "  read 0x"
+					  << readback << (ok ? "  OK" : "  MISMATCH") << modm::endl;
+	}
+
+	while (1);
+	return 0;
+}

--- a/examples/nucleo_h743zi/flash/project.xml
+++ b/examples/nucleo_h743zi/flash/project.xml
@@ -1,0 +1,11 @@
+<library>
+  <extends>modm:nucleo-h743zi</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nucleo_h743zi/flash</option>
+    <option name="modm:platform:cortex-m:linkerscript.flash_reserved">1024*128</option>
+  </options>
+  <modules>
+    <module>modm:platform:flash</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/core/cortex/module.lb
+++ b/src/modm/platform/core/cortex/module.lb
@@ -87,27 +87,28 @@ def common_memories(env):
     memories = listify(device.get_driver("core")["memory"])
 
     # Convert from string to int and add offsets
-    flash_size = env.get(":platform:core:boot2_size", 0)
-    if flash_size:
+    if (flash_size := env.get(":platform:core:boot2_size", 0)):
         memories.append({
             "name": "flash",
             "access": "rx",
             "start": "0x10000000",
             "size": hex(flash_size)})
-    flash_offset = env.get(":platform:cortex-m:linkerscript.flash_offset", 0)
-    flash_reserved = env.get(":platform:cortex-m:linkerscript.flash_reserved", 0)
+    # sort by start address, so that we can find the "first" memory sections with a single pass
     for m in memories:
-        if m["name"] in ["flash", "flash1"]:
-            m["start"] = int(m["start"], 0) + flash_offset
-            m["size"] = int(m["size"], 0) - flash_offset
-        elif m["name"] in ["flash2", "flash"]:
-            m["start"] = int(m["start"], 0)
-            m["size"] = int(m["size"], 0) - flash_reserved
-        else:
-            m["start"] = int(m["start"], 0)
-            m["size"] = int(m["size"], 0)
-
+        m["start"] = int(m["start"], 0)
+        m["size"] = int(m["size"], 0)
     memories.sort(key=lambda m: m["start"])
+    physical_memories = list(m for m in memories if "alias" not in m)
+    # Flash offset is counted from the start of flash, which could be flash or flash1
+    if (flash_offset := env.get(":platform:cortex-m:linkerscript.flash_offset", 0)):
+        offset_flash = next(m for name in ["flash", "flash1", "flash2"] for m in memories if m["name"] == name)
+        offset_flash["start"] = offset_flash["start"] + flash_offset
+        offset_flash["size"] = offset_flash["size"] - flash_offset
+    # Reserved flash is counted from the end of flash, which could be flash2, flash1 or flash
+    if (flash_reserved := env.get(":platform:cortex-m:linkerscript.flash_reserved", 0)):
+        reserved_flash = next(m for name in ["flash2", "flash1", "flash"] for m in memories if m["name"] == name)
+        reserved_flash["size"] = reserved_flash["size"] - flash_reserved
+
     # Find all continuous memory sections
     cont = []
     index = 0
@@ -138,12 +139,13 @@ def common_memories(env):
         memories.append({
             "name": "flash_reserved",
             "access": "rx",
-            "start": next(m["start"] + m["size"] for m in memories if m["name"] in ["flash2", "flash1", "flash"]),
+            "start": reserved_flash["start"] + reserved_flash["size"],
             "size": flash_reserved})
         memories.sort(key=lambda m: m["start"])
 
     properties = {
         "memories": memories,
+        "physical_memories": physical_memories,
         "regions": [m["name"] for m in memories],
         "ram_regions": ram_regions,
         "cont_flash_regions": cont_flash_regions,

--- a/src/modm/platform/flash/stm32/flash.cpp.in
+++ b/src/modm/platform/flash/stm32/flash.cpp.in
@@ -11,7 +11,16 @@
 
 #include "flash.hpp"
 
+%% if family == "h7" and not h7_ab
+static constexpr uint32_t FLASH_SR_ERR =
+    FLASH_SR_WRPERR | FLASH_SR_PGSERR | FLASH_SR_STRBERR |
+    FLASH_SR_INCERR | FLASH_SR_OPERR;
+%% elif family == "h7"
+static constexpr uint32_t FLASH_SR_ERR =
+    FLASH_SR_WRPERR | FLASH_SR_PGSERR | FLASH_SR_STRBERR | FLASH_SR_INCERR;
+%% else
 static constexpr uint32_t FLASH_SR_ERR = 0xfffe;
+%% endif
 
 namespace modm::platform
 {
@@ -20,19 +29,44 @@ bool
 Flash::unlock()
 {
 	Flash::enable();
+%% if family == "h7"
+	if (FLASH->CR1 & FLASH_CR_LOCK)
+	{
+		FLASH->KEYR1 = 0x45670123;
+		FLASH->KEYR1 = 0xCDEF89AB;
+	}
+%% if dual_bank
+	if (FLASH->CR2 & FLASH_CR_LOCK)
+	{
+		FLASH->KEYR2 = 0x45670123;
+		FLASH->KEYR2 = 0xCDEF89AB;
+	}
+%% endif
+	return not isLocked();
+%% else
 	if (isLocked())
 	{
 		FLASH->KEYR = 0x45670123;
 		FLASH->KEYR = 0xCDEF89AB;
 	}
 	return not isLocked();
+%% endif
 }
 
 uint8_t
 Flash::getPage(uintptr_t offset)
 {
+%% if family == "h7"
+	const uintptr_t addr = OriginAddr + offset;
+%% if dual_bank
+	if (addr >= Bank2Addr) {
+		return SectorsPerBank + ((addr - Bank2Addr) >> {{ shift }});
+	}
+%% endif
+	return (addr - Bank1Addr) >> {{ shift }};
+%% else
 	const uint8_t index = (offset >> {{ shift }});
-%% if has_sectors
+%% if has_sectors and family != "h7"
 	uint8_t small_index{0};
 	// 128kB Block 0 and 8 are subdivided into 4x16kB + 64kB
 	if (index == 0 or index == 8)
@@ -49,12 +83,21 @@ Flash::getPage(uintptr_t offset)
 %% else
 	return index;
 %% endif
+%% endif
 }
 
 uint32_t
 Flash::getOffset(uint8_t index)
 {
-%% if has_sectors
+%% if family == "h7"
+%% if dual_bank
+	if (index >= SectorsPerBank) {
+		return (Bank2Addr - OriginAddr) + (1ul << {{shift}}) * (index - SectorsPerBank);
+	}
+%% endif
+	return (Bank1Addr - OriginAddr) + (1ul << {{shift}}) * index;
+%% else
+%% if has_sectors and family != "h7"
 	switch(index) {
 		case 0: return (1ul << 14);
 		case 1: return (2ul << 14);
@@ -65,12 +108,13 @@ Flash::getOffset(uint8_t index)
 	}
 %% endif
 	return (1ul << {{shift}}) * index;
+%% endif
 }
 
 size_t
 Flash::getSize([[maybe_unused]] uint8_t index)
 {
-%% if has_sectors
+%% if has_sectors and family != "h7"
 	if (index < 4) return (1ul << 14);
 	if (index == 5) return (1ul << 16);
 %% endif
@@ -78,12 +122,38 @@ Flash::getSize([[maybe_unused]] uint8_t index)
 }
 
 modm_ramcode uint32_t
-%% if has_sectors
+%% if has_sectors and family != "h7"
 Flash::erase(uint8_t index, WordSize size)
 %% else
 Flash::erase(uint8_t index)
 %% endif
 {
+%% if family == "h7"
+%% if dual_bank
+	const bool bank2 = (index >= {{sectors_per_bank}});
+	const uint8_t local = bank2 ? (index - {{sectors_per_bank}}) : index;
+	volatile uint32_t *cr  = bank2 ? &FLASH->CR2  : &FLASH->CR1;
+	volatile uint32_t *sr  = bank2 ? &FLASH->SR2  : &FLASH->SR1;
+	volatile uint32_t *ccr = bank2 ? &FLASH->CCR2 : &FLASH->CCR1;
+	*ccr = FLASH_SR_ERR;
+	*cr = FLASH_CR_START | FLASH_CR_SER | {{h7_erase_psize}} |
+	      ((local << FLASH_CR_SNB_Pos) & FLASH_CR_SNB_Msk);
+	while (*sr & (FLASH_SR_BSY | FLASH_SR_QW)) ;
+	const uint32_t err = *sr & FLASH_SR_ERR;
+	*cr = 0;
+	SCB_InvalidateDCache_by_Addr(getAddr(index), SectorSize);
+	return err;
+%% else
+	FLASH->CCR1 = FLASH_SR_ERR;
+	FLASH->CR1 = FLASH_CR_START | FLASH_CR_SER | {{h7_erase_psize}} |
+	             ((index << FLASH_CR_SNB_Pos) & FLASH_CR_SNB_Msk);
+	while(isBusy()) ;
+	const uint32_t err = FLASH->SR1 & FLASH_SR_ERR;
+	FLASH->CR1 = 0;
+	SCB_InvalidateDCache_by_Addr(getAddr(index), SectorSize);
+	return err;
+%% endif
+%% else
 %% if family != "f1"
 	FLASH->SR = FLASH_SR_ERR;
 %% endif
@@ -122,15 +192,62 @@ Flash::erase(uint8_t index)
 	FLASH->CR = 0;
 	return FLASH->SR & FLASH_SR_ERR;
 %% endif
+%% endif
 }
 
 modm_ramcode uint32_t
-%% if has_sectors
+%% if family == "h7"
+Flash::program(uintptr_t addr, const MaxWordType &data)
+%% elif has_sectors
 Flash::program(uintptr_t addr, MaxWordType data, WordSize size)
 %% else
 Flash::program(uintptr_t addr, MaxWordType data)
 %% endif
 {
+%% if family == "h7"
+	if (addr & (FlashWordSize - 1)) return FLASH_SR_PGSERR;
+%% if dual_bank
+	const bool bank2 = (addr >= Bank2Addr);
+	volatile uint32_t *cr  = bank2 ? &FLASH->CR2  : &FLASH->CR1;
+	volatile uint32_t *sr  = bank2 ? &FLASH->SR2  : &FLASH->SR1;
+	volatile uint32_t *ccr = bank2 ? &FLASH->CCR2 : &FLASH->CCR1;
+	*ccr = FLASH_SR_ERR;
+	*cr = FLASH_CR_PG | {{h7_erase_psize}};
+	__ISB(); __DSB();
+	volatile uint32_t *dst = reinterpret_cast<volatile uint32_t *>(addr);
+	dst[0] = data.data[0];
+	__DSB();
+	while (not (*sr & FLASH_SR_WBNE)) ;
+	for (size_t ii = 1; ii < FlashWordWords; ++ii) {
+		dst[ii] = data.data[ii];
+	}
+	__DSB();
+	while (*sr & FLASH_SR_WBNE) ;
+	while (*sr & (FLASH_SR_BSY | FLASH_SR_QW)) ;
+	const uint32_t err = *sr & FLASH_SR_ERR;
+	*cr = 0;
+	SCB_InvalidateDCache_by_Addr(reinterpret_cast<void *>(addr & ~uintptr_t(0x1f)), FlashWordSize);
+	return err;
+%% else
+	FLASH->CCR1 = FLASH_SR_ERR;
+	FLASH->CR1 = FLASH_CR_PG | {{h7_erase_psize}};
+	__ISB(); __DSB();
+	volatile uint32_t *dst = reinterpret_cast<volatile uint32_t *>(addr);
+	dst[0] = data.data[0];
+	__DSB();
+	while (not (FLASH->SR1 & FLASH_SR_WBNE)) ;
+	for (size_t ii = 1; ii < FlashWordWords; ++ii) {
+		dst[ii] = data.data[ii];
+	}
+	__DSB();
+	while (FLASH->SR1 & FLASH_SR_WBNE) ;
+	while(isBusy()) ;
+	const uint32_t err = FLASH->SR1 & FLASH_SR_ERR;
+	FLASH->CR1 = 0;
+	SCB_InvalidateDCache_by_Addr(reinterpret_cast<void *>(addr & ~uintptr_t(0x1f)), FlashWordSize);
+	return err;
+%% endif
+%% else
 %% if family != "f1"
 	FLASH->SR = FLASH_SR_ERR;
 %% endif
@@ -169,6 +286,7 @@ Flash::program(uintptr_t addr, MaxWordType data)
 	FLASH->SR |= FLASH_SR_EOP;
 	FLASH->CR = 0;
 	return FLASH->SR & FLASH_SR_ERR;
+%% endif
 %% endif
 }
 

--- a/src/modm/platform/flash/stm32/flash.hpp.in
+++ b/src/modm/platform/flash/stm32/flash.hpp.in
@@ -24,13 +24,26 @@ public:
 	static constexpr uintptr_t OriginAddr{ 0x{{ "%0x" | format(start) }} };
 	static constexpr size_t Size{ 0x{{ "%0x" | format(size) }} };
 	static inline uint8_t *const Origin{(uint8_t*)OriginAddr};
-%% if family=="f1"
+%% if family=="h7"
+	static constexpr uintptr_t Bank1Addr{ 0x{{ "%0x" | format(bank1_start) }} };
+	static constexpr uintptr_t Bank2Addr{ 0x{{ "%0x" | format(bank2_start) }} };
+	static constexpr size_t SectorSize{ 1ul << {{shift}} };
+	static constexpr uint8_t SectorsPerBank{ {{sectors_per_bank}} };
+	static constexpr size_t FlashWordWords{ FLASH_NB_32BITWORD_IN_FLASHWORD };
+	static constexpr size_t FlashWordSize{ FlashWordWords * sizeof(uint32_t) };
+	struct alignas(4) MaxWordType
+	{
+		uint32_t data[FlashWordWords];
+	};
+	static_assert(sizeof(MaxWordType) == FlashWordSize);
+	static_assert(alignof(MaxWordType) == alignof(uint32_t));
+%% elif family=="f1"
 	using MaxWordType = uint16_t;
 %% else
 	using MaxWordType = uint{{ 32 if has_sectors else 64 }}_t;
 %% endif
 
-%% if has_sectors
+%% if has_sectors and family != "h7"
 	enum class
 	WordSize : uint32_t
 	{
@@ -59,11 +72,25 @@ public:
 
 	static bool
 	isLocked()
-	{ return FLASH->CR & FLASH_CR_LOCK; }
+	{
+%% if family == "h7" and dual_bank
+		return (FLASH->CR1 & FLASH_CR_LOCK) || (FLASH->CR2 & FLASH_CR_LOCK);
+%% elif family == "h7"
+		return FLASH->CR1 & FLASH_CR_LOCK;
+%% else
+		return FLASH->CR & FLASH_CR_LOCK;
+%% endif
+	}
 
 	static inline bool
 	isBusy()
-	{ return FLASH->SR & {{ busy_bit }}; }
+	{
+%% if family == "h7"
+		return FLASH->SR1 & {{ busy_bit }};
+%% else
+		return FLASH->SR & {{ busy_bit }};
+%% endif
+	}
 
 	static bool
 	unlock();
@@ -85,7 +112,16 @@ public:
 
 	static inline uint8_t*
 	getAddr(uint8_t {{ type }})
-	{ return Origin + getOffset({{ type }}); }
+	{
+%% if family=="h7" and dual_bank
+		const bool bank2 = ({{ type }} >= SectorsPerBank);
+		const uint8_t local = bank2 ? ({{ type }} - SectorsPerBank) : {{ type }};
+		const uintptr_t bank = bank2 ? Bank2Addr : Bank1Addr;
+		return reinterpret_cast<uint8_t*>(bank + uintptr_t(local) * SectorSize);
+%% else
+		return Origin + getOffset({{ type }});
+%% endif
+	}
 
 	static uint32_t
 	getOffset(uint8_t {{ type }});
@@ -94,13 +130,16 @@ public:
 	getSize(uint8_t {{ type }});
 
 	static uint32_t
-%% if has_sectors
+%% if has_sectors and family != "h7"
 	erase(uint8_t {{ type }}, WordSize size = WordSize::B32);
 %% else
 	erase(uint8_t {{ type }});
 %% endif
 
-%% if has_sectors
+%% if family == "h7"
+	static uint32_t
+	program(uintptr_t addr, const MaxWordType &data);
+%% elif has_sectors
 	static inline uint32_t
 	program(uintptr_t addr, uint8_t data)
 	{ return program(addr, data, WordSize::B8); }

--- a/src/modm/platform/flash/stm32/module.lb
+++ b/src/modm/platform/flash/stm32/module.lb
@@ -15,25 +15,41 @@ def init(module):
     module.name = ":platform:flash"
     module.description = "Flash Memory"
 
+_H7RS = ["r3", "r7", "s3", "s7"]
+
 def prepare(module, options):
     device = options[":target"]
-    if device.identifier.family not in ["g0","g4", "f1", "f4"]:
+    if device.identifier.family not in ["g0","g4", "f1", "f4", "h7"]:
+        return False
+    # Exclude H745/H747/H755/H757 dual-core devices and H7RS with a different controller.
+    if device.identifier.family == "h7" and device.identifier.name in _H7RS:
         return False
     if not device.has_driver("flash:stm32*"):
         return False
 
     module.depends(":cmsis:device", ":platform:rcc",
+                   ":platform:cortex-m",
                    ":architecture:register")
     return True
 
 def build(env):
     target = env[":target"].identifier
-    flash = env.query(":platform:cortex-m:memories")["cont_flash"]
+    memory_properties = env.query(":platform:cortex-m:memories")
+    flash = memory_properties["cont_flash"]
+    physical_flash = [m for m in memory_properties["physical_memories"] if m["name"].startswith("flash")]
+    usable_flash = [m for m in memory_properties["memories"] if m["name"].startswith("flash")]
+    flash_start = flash["start"]
+    flash_size = flash["size"]
 
     dual_bank = False
+    h7_ab = False
     family = target.family
     busy_bit = "FLASH_SR_BSY"
     ftype = "page"
+    bank1_start = flash_start
+    bank2_start = flash_start
+    sectors_per_bank = 0
+    h7_erase_psize = "0"
     if target.family in ["f4"]:
         block_shift = 17
         ftype = "sector"
@@ -53,16 +69,54 @@ def build(env):
         if target.name[0] in ["7", "8"]:
             dual_bank = "FLASH_OPTR_DBANK"
             block_shift = "(FLASH->OPTR & FLASH_OPTR_DBANK ? 11 : 12)"
+    elif target.family in ["h7"]:
+        ftype = "sector"
+        busy_bit = "(FLASH_SR_BSY | FLASH_SR_QW)"
+        # H7A3/H7B0/H7B3: 8 KB sectors; all other H7: 128 KB sectors
+        h7_ab = target.name in ["a3", "b0", "b3"]
+        if h7_ab:
+            block_shift = 13
+        else:
+            block_shift = 17
+        # Dual-bank devices have separate CR1/SR1 and CR2/SR2 registers
+        if target.name in ["42", "43", "53", "a3", "b3"]:
+            dual_bank = True
+        flash1 = next((m for m in physical_flash if m["name"] != "flash2"), None)
+        flash2 = next((m for m in physical_flash if m["name"] == "flash2"), None)
+        if dual_bank:
+            if flash1 is None or flash2 is None:
+                raise RuntimeError("H7 dual-bank flash requires explicit flash1 and flash2 regions")
+            bank1_start = flash1["start"]
+            bank2_start = flash2["start"]
+            sectors_per_bank = (flash1["size"] >> block_shift)
+        else:
+            flash1 = flash1 or physical_flash[0]
+            bank2_start = bank1_start = flash1["start"]
+            sectors_per_bank = (flash1["size"] >> block_shift)
+
+        h7_flash_end = max(m["start"] + m["size"] for m in usable_flash)
+        flash_size = h7_flash_end - flash_start
+
+        if not h7_ab:
+            if target.name in ["42", "43", "50", "53"]:
+                h7_erase_psize = "FLASH_CR_PSIZE_1"
+            else:
+                h7_erase_psize = "FLASH_CR_PSIZE"
 
     env.substitutions = {
-        "start": flash["start"],
-        "size": flash["size"],
+        "start": flash_start,
+        "size": flash_size,
         "type": ftype,
         "shift": block_shift,
         "has_sectors": ftype == "sector",
         "busy_bit": busy_bit,
         "family": family,
-        "dual_bank": dual_bank
+        "dual_bank": dual_bank,
+        "bank1_start": bank1_start,
+        "bank2_start": bank2_start,
+        "sectors_per_bank": sectors_per_bank,
+        "h7_erase_psize": h7_erase_psize,
+        "h7_ab": h7_ab,
     }
     env.outbasepath = "modm/src/modm/platform/flash"
     env.template("flash.hpp.in")


### PR DESCRIPTION
## H7 Flash Configuration
I hope I didn't miss any:

| Devices | Reference Manual | Banks | Sectors/Bank | Sector Size |
|-----------|-----------|-------|-------------|------------|
| H723, H725 | RM0468 | 1 | 8 | 128 KB |
| H730 | RM0468 | 1 | 1 | 128 KB |
| H733, H735 | RM0468 | 1 | 8 | 128 KB |
| H742xG | RM0433 | 2 | 4/bank | 128 KB |
| H742xI | RM0433 | 2 | 8/bank | 128 KB |
| H743xG, H753xG | RM0433 | 2 | 4/bank | 128 KB |
| H743xI, H753xI | RM0433 | 2 | 8/bank | 128 KB |
| H750 | RM0433 | 1 | 1 | 128 KB |
| H745xG, H747xG | RM0399 | 2 | 4/bank | 128 KB |
| H745xI, H747xI | RM0399 | 2 | 8/bank | 128 KB |
| H755xI, H757xI | RM0399 | 2 | 8/bank | 128 KB |
| H7A3xG | RM0455 | 2 | 64/bank | 8 KB |
| H7A3xI | RM0455 | 2 | 128/bank | 8 KB |
| H7B0 | RM0455 | 1 | 16 | 8 KB |
| H7B3xI | RM0455 | 2 | 128/bank | 8 KB |
| H7R3, H7S3 | RM0477 | 1 | 8 | 8 KB |

Bank 2 always starts at `0x08100000`

The H7R/H7S devices seem to use a different flash controller; I therefore excluded them.


## Examples:
- [x] Nucleo H723 with single bank flash
- [x] Nucleo H743 with dual bank flash