### PR TITLE
[docs] Revert back to Doxygen for API docs generation

### DIFF
--- a/docs/src/guide/custom-project.md
+++ b/docs/src/guide/custom-project.md
@@ -159,7 +159,7 @@ which contains the full API documentation for all BSPs. Alternatively you can
 generate your own API docs locally:
 
 ```sh
-(cd modm/docs && doxypress doxypress.json)
+(cd modm/docs && doxygen doxyfile.cfg)
 # open modm/docs/html/index.html
 ```
 
@@ -212,7 +212,7 @@ Remember to include the `modm:docs` module, since you need to generate your own
 API docs from your specific configuration:
 
 ```sh
-(cd modm/docs && doxypress doxypress.json)
+(cd modm/docs && doxygen doxyfile.cfg)
 # open modm/docs/html/index.html
 ```
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -8,7 +8,7 @@ with modm:
 - [Library Builder][lbuild].
 - AVR toolchain: [avr-gcc][] and [avrdude][].
 - ARM toolchain: [toolchain-arm-xpack][] and [OpenOCD][] (at least v0.12!).
-- Optional: [Doxypress][].
+- Optional: [Doxygen][].
 - Optional: [gdbgui][] for IDE-independent debugging.
 
 Note that the modm examples use the SCons build system by default, however,
@@ -54,17 +54,10 @@ pip3 install gdbgui
     export PATH="$HOME/.local/bin:$PATH"
     ```
 
-We use [Doxypress][doxypress_binaries] to generate the API documentation:
+We use Doxygen to generate the API documentation:
 
 ```sh
-sudo mkdir /opt/doxypress
-wget -O- https://github.com/copperspice/doxypress/releases/download/dp-2.0.0/doxypress-2.0.0-ubuntu24.04-x64.tar.bz2 | sudo tar xj -C /opt/doxypress
-```
-
-Add the directory to your `PATH` variable in `~/.bashrc`:
-
-```sh
-export PATH="/opt/doxypress:$PATH"
+sudo apt install doxygen
 ```
 
 
@@ -155,13 +148,6 @@ We recommend using a graphical frontend for GDB called [gdbgui][]:
 pip3 install gdbgui
 ```
 
-We use [Doxypress][] to generate the API documentation:
-
-```sh
-brew tap modm-ext/modm
-brew install doxypress
-```
-
 
 #### ARM Cortex-M
 
@@ -240,8 +226,8 @@ lbuild --version
 scons --version
 ```
 
-We use [Doxypress][] to generate the API documentation.
-Download and run the [Installer][doxypress_binaries].
+We use [Doxygen][] to generate the API documentation.
+Download and run the [Installer][doxygen_binaries].
 
 Please use the free and open-source [7-Zip file archiver][7_zip] to extract the
 files in the next steps.
@@ -394,6 +380,7 @@ picocom --baud 115200 --imap lfcrlf --echo /dev/ttyACM0
 [cmake]: https://www.cmake.org
 [openocd_binaries]: https://gnutoolchains.com/arm-eabi/openocd/
 [doxygen]: http://www.doxygen.nl
+[doxygen_binaries]: https://www.doxygen.nl/download.html
 [doxypress]: https://www.copperspice.com/documentation-doxypress.html
 [doxypress_binaries]: https://download.copperspice.com/doxypress/binary/
 [gdbgui]: https://www.gdbgui.com

--- a/docs/src/reference/documentation.md
+++ b/docs/src/reference/documentation.md
@@ -54,29 +54,31 @@ available for {target}*". Additionally the view does not show peripheral
 instance submodule to reduce visual noise.
 
 
-## Doxypress / Doxygen
+## Doxygen
 
-The generated C/C++ API is documented using Doxypress and therefore only
+The generated C/C++ API is documented using Doxygen and therefore only
 available *after* code generation.
 
 To view this documentation, include the `modm:docs` module in your `project.xml`
 configuration and run `lbuild build`. A `modm/docs` folder is created containing
-the `doxypress.json` for modm as well as all the `@defgroup`s mirroring the
+the `doxyfile.cfg` for modm as well as all the `@defgroup`s mirroring the
 module structure.
 
-You must then run Doxypress manually, which can take several minutes, and
+You must then run Doxygen manually, which can take several minutes, and
 compiles the target-specific documentation into `modm/docs/html`:
 
 ```sh
 lbuild build -m "modm:docs"
 
+# With Doxygen
+(cd modm/docs && doxygen doxyfile.cfg)
 # With Doxypress
 (cd modm/docs && doxypress doxypress.json)
 
 # then open: modm/docs/html/index.html
 ```
 
-The generated Doxypress/Doxygen documentation contains the original module
+The generated Doxygen documentation contains the original module
 documentation *including the option choices you made*. This makes it easier to
 map the lbuild options to changes in the generated source code.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,10 +36,10 @@ scons program profile=debug
 scons debug profile=debug
 ```
 
-To generate your target specific Doxypress documentation:
+To generate your target specific Doxygen documentation:
 
 ```sh
-(cd modm/docs && doxypress doxypress.json)
+(cd modm/docs && doxygen doxyfile.cfg)
 # open modm/docs/html/index.html
 ```
 


### PR DESCRIPTION
Doxypress is unmaintained and gets stuck on both macos and Linux. In the CI we have to use the ancient version for this reason.
We'll have to switch this soon too.