### PR TITLE
fix: stop-token not resetted on start

### DIFF
--- a/src/modm/processing/fiber/stop_token.hpp
+++ b/src/modm/processing/fiber/stop_token.hpp
@@ -52,6 +52,13 @@ public:
 		return not requested.exchange(true, std::memory_order_relaxed);
 	}
 
+	/// @note This function can be called from an interrupt.
+	void inline
+	reset()
+	{
+		requested.store(false, std::memory_order_relaxed);
+	}
+
 	constexpr stop_source
 	get_source();
 

--- a/src/modm/processing/fiber/task_impl.hpp
+++ b/src/modm/processing/fiber/task_impl.hpp
@@ -67,6 +67,7 @@ Task::start()
 {
 	if (isRunning()) return false;
 	modm_context_reset(&ctx);
+	stop.reset();
 	Scheduler::instance().add(this);
 	return true;
 }

--- a/test/modm/processing/fiber/fiber_test.cpp
+++ b/test/modm/processing/fiber/fiber_test.cpp
@@ -270,6 +270,11 @@ FiberTest::testStopToken()
 		TEST_ASSERT_EQUALS(state++, 6u);
 	});
 	modm::fiber::Scheduler::run();
+	// repeat the same test exactly the same
+	state = 0;
+	fiber1.start();
+	fiber2.start();
+	modm::fiber::Scheduler::run();
 }
 
 void


### PR DESCRIPTION
after stopping a fiber with stoken
and then starting it again, the stop-token was still set