### PR TITLE
Fix BMI088 driver getting stuck + GenericTimeout::wait() behavior

### DIFF
--- a/src/modm/processing/timer/timeout_impl.hpp
+++ b/src/modm/processing/timer/timeout_impl.hpp
@@ -130,7 +130,7 @@ template< class Clock, class Duration >
 void
 modm::GenericTimeout<Clock, Duration>::wait()
 {
-	modm::this_fiber::poll([this]{ return execute(); });
+	modm::this_fiber::poll([this]{ return !isArmed(); });
 }
 
 // ----------------------------------------------------------------------------

--- a/test/modm/processing/timer/timeout_test.cpp
+++ b/test/modm/processing/timer/timeout_test.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2009-2010, 2012, 2018, Fabian Greif
  * Copyright (c) 2012, 2014-2015, 2017, 2020, Niklas Hauser
  * Copyright (c) 2013, 2016, Sascha Schade
+ * Copyright (c) 2026, Christopher Durand
  *
  * This file is part of the modm project.
  *
@@ -17,6 +18,7 @@
 #include <modm/processing/timer.hpp>
 #include <modm-test/mock/clock.hpp>
 #include <modm/debug.hpp>
+#include "../fiber/shared.hpp"
 
 using namespace std::chrono_literals;
 using test_clock = modm_test::chrono::milli_clock;
@@ -318,4 +320,36 @@ TimeoutTest::testRestart()
 
 	TEST_ASSERT_EQUALS(timeoutShort.remaining(), -40ms);
 	TEST_ASSERT_EQUALS(timeout.remaining(), -40ms);
+}
+
+void
+TimeoutTest::testWait()
+{
+	auto test = [](auto timer) {
+		test_clock::setTime(0);
+
+		// test wait doesn't block if timer is stopped
+		timer.wait();
+		timer.restart(100ms);
+
+		int step = 0;
+		modm::fiber::Task waiter(stack1, [&] {
+			timer.wait();
+			TEST_ASSERT_EQUALS(step, 10);
+		});
+		modm::fiber::Task test(stack2, [&] {
+			do {
+				++step;
+				test_clock::setTime(step * 10ms);
+				modm::this_fiber::yield();
+			} while (step < 12);
+		});
+		modm::fiber::Scheduler::run();
+
+		// test wait doesn't block if timer is expired
+		timer.wait();
+	};
+
+	test(modm::ShortTimeout{});
+	test(modm::Timeout{});
 }

--- a/test/modm/processing/timer/timeout_test.hpp
+++ b/test/modm/processing/timer/timeout_test.hpp
@@ -37,4 +37,7 @@ public:
 
 	void
 	testRestart();
+
+	void
+	testWait();
 };


### PR DESCRIPTION
Fix the BMI088 driver getting stuck during initialization. This was caused by a refactoring using `GenericTimeout::wait()`.

The timer implementation is changed to wait as long as the timer is armed instead of waiting for `execute()` to return true. This prevents several edge cases where the wait function blocks indefinitely.

Fixes #1352 