### PR TITLE
[nrf] Add watchdog timer implementation for NRF5x

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,9 +787,9 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
-<td align="center">○</td>
-<td align="center">○</td>
-<td align="center">○</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>

--- a/examples/nrf5340-dk/wdt/main.cpp
+++ b/examples/nrf5340-dk/wdt/main.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+/*
+# nRF5340-DK watchdog (app core)
+
+Watchdog example for the nRF5340 application core.
+
+- Target: `nrf5340-xxaa@app`
+- Uses app-core-owned `Led1` and `Button1` from the BSP.
+- If `Button1` is held for more than 4 seconds after the watchdog starts,
+  the MCU resets.
+- A watchdog reset is indicated by a faster LED blink sequence after startup.
+*/
+
+#include <modm/board.hpp>
+
+using namespace Board;
+using namespace std::chrono_literals;
+
+int
+main()
+{
+	Board::initialize();
+	Wdt::initialize<SystemClock, 4s>();
+	auto startupDelay = 100ms;
+
+	MODM_LOG_INFO << "nRF5340-DK watchdog example" << modm::endl;
+	MODM_LOG_INFO << "Press and hold Button1 for more than 4s to trigger a watchdog reset." << modm::endl;
+	if (NRF_RESET->RESETREAS & RESET_RESETREAS_DOG0_Msk) {
+		NRF_RESET->RESETREAS = RESET_RESETREAS_DOG0_Msk;
+		MODM_LOG_INFO << "Previous reset reason: watchdog." << modm::endl;
+		startupDelay = 50ms;
+	}
+
+	uint32_t counter(0);
+	while (counter < 10)
+	{
+		Led1::toggle();
+		modm::delay(startupDelay);
+		MODM_LOG_INFO << "startup: " << counter++ << modm::endl;
+	}
+
+	Wdt::enable();
+	MODM_LOG_INFO << "Watchdog started." << modm::endl;
+
+	while (true)
+	{
+		Led1::toggle();
+		modm::delay(500ms);
+		if (!Button1::read()) { Wdt::trigger(); }
+		MODM_LOG_INFO << "loop: " << counter++ << modm::endl;
+	}
+
+	return 0;
+}

--- a/examples/nrf5340-dk/wdt/project.xml
+++ b/examples/nrf5340-dk/wdt/project.xml
@@ -1,0 +1,10 @@
+<library>
+  <extends>modm:nrf5340-dk</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/nrf5340-dk/wdt</option>
+  </options>
+  <modules>
+    <module>modm:platform:wdt</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/board/nrf51422_dk/board.hpp
+++ b/src/modm/board/nrf51422_dk/board.hpp
@@ -31,6 +31,7 @@ struct SystemClock
 {
 	static constexpr uint32_t Frequency = 16_MHz;
 	static constexpr uint32_t Uart0 = 16_MHz;
+	static constexpr uint32_t Wdt = 32.768_kHz;
 
 	static bool inline
 	enable()

--- a/src/modm/board/nrf52840_dk/board.hpp
+++ b/src/modm/board/nrf52840_dk/board.hpp
@@ -30,6 +30,7 @@ struct SystemClock
 {
 	static constexpr uint32_t Frequency = 64_MHz;
 	static constexpr uint32_t Uarte0 = 16_MHz;
+	static constexpr uint32_t Wdt = 32.768_kHz;
 
 	static bool inline
 	enable()

--- a/src/modm/board/nrf5340_dk/board.hpp.in
+++ b/src/modm/board/nrf5340_dk/board.hpp.in
@@ -34,6 +34,7 @@ struct SystemClock
 %% endif
 	static constexpr uint32_t Uarte0 = 16_MHz;
 	static constexpr uint32_t Uarte1 = 16_MHz;
+	static constexpr uint32_t Wdt = 32.768_kHz;
 
 	static bool inline
 	enable()

--- a/src/modm/platform/iwdg/nrf/module.lb
+++ b/src/modm/platform/iwdg/nrf/module.lb
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":platform:wdt"
+    module.description = "Watchdog Timer"
+
+
+def prepare(module, options):
+    device = options[":target"]
+
+    module.depends(":cmsis:device", ":math:algorithm")
+    return device.has_driver("wdt:nrf*")
+
+
+def build(env):
+    target = env[":target"].identifier
+
+    if target.family == "53":
+        peripheral = "NRF_WDT0" if target.core == "app" else "NRF_WDT_NS"
+    else:
+        peripheral = "NRF_WDT"
+
+    env.outbasepath = "modm/src/modm/platform/wdt"
+    env.substitutions = {
+        "peripheral": peripheral,
+    }
+    env.template("wdt.hpp.in")

--- a/src/modm/platform/iwdg/nrf/wdt.hpp.in
+++ b/src/modm/platform/iwdg/nrf/wdt.hpp.in
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <algorithm>
+#include <modm/architecture/interface/peripheral.hpp>
+#include <modm/math/algorithm/prescaler.hpp>
+#include "../device.hpp"
+
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_wdt
+class Wdt : public ::modm::PeripheralDriver
+{
+public:
+	static inline void
+	initialize(uint32_t reload)
+	{
+		{{ peripheral }}->CRV = reload;
+		{{ peripheral }}->RREN = WDT_RREN_RR0_Enabled;
+	}
+
+	template< class SystemClock, milliseconds_t timeout, percent_t tolerance=pct(1) >
+	static void
+	initialize()
+	{
+		constexpr auto result = modm::GenericPrescaler<double>::from_linear(
+				SystemClock::Wdt, 1000.0 / timeout.count(), 0xFul, 0xFFFFFFFFul);
+		assertDurationInTolerance< double(result.prescaler) / SystemClock::Wdt,
+				timeout.count() / 1000.0, tolerance >();
+		initialize(result.prescaler - 1);
+	}
+
+	static inline void
+	enable()
+	{
+		{{ peripheral }}->TASKS_START = 1ul;
+	}
+
+	static inline void
+	trigger()
+	{
+		{{ peripheral }}->RR[0] = WDT_RR_RR_Reload;
+	}
+
+	static inline bool
+	isRunning()
+	{
+		return {{ peripheral }}->RUNSTATUS;
+	}
+};
+
+}

--- a/tools/scripts/generate_hal_matrix.py
+++ b/tools/scripts/generate_hal_matrix.py
@@ -108,6 +108,7 @@ def hal_get_modules():
                 "fsmc": "External Memory",
                 "flash": "Internal Flash",
                 "iwdg": "Watchdog",
+                "wdt": "Watchdog",
                 "timer": "Timer",
                 "i2c": "I<sup>2</sup>C",
                 "usart": "UART",


### PR DESCRIPTION
Add a simple implementation of the Watchdog Timer for NRF5x.

- [x] Tested in hardware on NRF5340-DK.