### PR TITLE
[gcc/cabi_cortex] pin noreturn contract on _exit/abort (fixes #1298)

### DIFF
--- a/ext/gcc/cabi_cortex.c
+++ b/ext/gcc/cabi_cortex.c
@@ -13,16 +13,25 @@
 #include <modm/architecture/interface/assert.h>
 
 // ------------------------------------------------------------------------
+// _exit() and abort() are declared __noreturn__ in newlib's <stdlib.h>.
+// modm_assert(false, ...) typically halts via the modm_assert_report()
+// handler, but a user-installed handler is allowed to return; in that
+// case the function would otherwise fall through and GCC raises
+// `'noreturn' function does return` (-Wsuggest-attribute=noreturn).
+// The trailing for(;;){} loop pins the noreturn contract regardless of
+// what modm_assert_report does. See modm-io/modm#1298.
 modm_weak void _exit(int status)
 {
 	modm_assert(false, "libc.exit",
 			"The libc exit(status) function was called!", status);
+	for (;;) { }
 }
 
 modm_weak void abort(void)
 {
 	modm_assert(false, "libc.abort",
 			"The libc abort() function was called!");
+	for (;;) { }
 }
 
 modm_weak int atexit(void (*fn)(void))


### PR DESCRIPTION
Closes #1298.

### The warning

```
ext/gcc/cabi_cortex.c: In function '_exit':
ext/gcc/cabi_cortex.c:20:1: warning: 'noreturn' function does return
   20 | }
ext/gcc/cabi_cortex.c: In function 'abort':
ext/gcc/cabi_cortex.c:26:1: warning: 'noreturn' function does return
   26 | }
```

`_exit()` and `abort()` are declared `__noreturn__` in newlib's `<stdlib.h>`. The modm definitions are weak overrides of those declarations, so the compiler enforces the noreturn contract.

### Why GCC is right

Inside the modm assertion macro:

```c
modm_assert_report(&info);
if (behavior & 4) __builtin_unreachable();
```

For `modm_assert(false, ...)` the behaviour is `0x04`, so `__builtin_unreachable()` does fire — but **only when `modm_assert_report()` actually returns**. `modm_assert_report` is a public override point (`modm_extern_c void modm_assert_report(_modm_assertion_info *info);`), so a user can install a handler that returns normally (debug logging, fault injection, soft assertions, etc.). When they do, the function falls through past `__builtin_unreachable()` and returns — violating the noreturn contract that newlib promised.

That's what's happening on the reporter's build. `_exit()` and `abort()` need to be unconditionally non-returning.

### Fix

Add a `for(;;){}` after the assert call in each function. It's unreachable when the assertion handler halts as designed (zero overhead, dead code), and it's the safety net that pins the noreturn contract when the handler chooses to continue. Either way the function never returns.

```diff
 modm_weak void _exit(int status)
 {
        modm_assert(false, "libc.exit",
                        "The libc exit(status) function was called!", status);
+       for (;;) { }
 }

 modm_weak void abort(void)
 {
        modm_assert(false, "libc.abort",
                        "The libc abort() function was called!");
+       for (;;) { }
 }
```

Also added a comment block above the functions documenting why the loop is there (so it doesn't get optimised out by a well-meaning future cleanup).

### Why not `[[noreturn]]` / `modm_noreturn`?

Adding a noreturn attribute to the definitions doesn't fix the underlying analysis problem — GCC would still warn that a noreturn-marked function falls through. And it risks attribute-mismatch errors against newlib's declaration. The infinite loop is the canonical fix and is what the language-lawyer interpretation expects.

### Answer to @salkinium's question on the issue thread

> *"What happens if you remove the return statements?"*

There aren't any return statements to remove — the functions just end after the assert. The right move is to add a noreturn-satisfying construct, which is what this PR does.

### No behavioural change

When the assertion handler halts as intended (default modm behaviour), the loop is unreachable and the warning goes away. When a user-supplied handler returns, the loop now correctly pins noreturn instead of falling through into undefined behaviour.

### Credit

Thanks to @Tecnologic for filing the report with the exact warning output and to @salkinium for pointing the investigation in the right direction.
