### PR TITLE
[ext] Add CMSIS-DAP integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,6 @@
 [submodule "ext/nordic/nrfx"]
 	path = ext/nordic/nrfx
 	url = https://github.com/modm-ext/nrfx-partial.git
+[submodule "ext/arm/cmsis-dap"]
+	path = ext/arm/cmsis-dap
+	url = https://github.com/modm-ext/cmsis-dap-partial.git

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ git clone --recurse-submodules --jobs 8 https://github.com/modm-io/modm.git
 - Lightweight unit testing system (suitable for AVRs).
 - Hundreds of tests to ensure correct functionality.
 - Integration of useful third-party software:
-	- [CMSIS][] and [CMSIS-DSP][] interfaces.
+	- [CMSIS][] interfaces and headers.
+	- [CMSIS-DAP][]: USB to SWD/JTAG bridge.
+	- [CMSIS-DSP][]: Embedded compute library.
 	- [CrashCatcher][]: Crash reports for HardFaults.
 	- [Eigen][]: Linear Algebra Library.
 	- [ETL][]: Embedded Template Library.

--- a/examples/generic/cmsis-dap/main.cpp
+++ b/examples/generic/cmsis-dap/main.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <tusb.h>
+#include <modm/board.hpp>
+#include <cmsis/dap.hpp>
+
+static uint8_t swd_port{0};
+uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response)
+{
+	if (request[0] == ID_DAP_Vendor(0))
+	{
+		DAP_PinSwclkTck(DAP_PIN_DIR_IN);
+		DAP_PinSwdioTms(DAP_PIN_DIR_IN);
+		swd_port = request[1];
+
+		response[0] = ID_DAP_Vendor(0);
+		response[1] = 0;
+		return (2U << 16) | 2U;
+	}
+
+	// Default fallback for unknown vendor commands
+	*response = ID_DAP_Invalid;
+	return ((1U << 16) | 1U);
+}
+
+// Select the port
+// openocd -f interface/cmsis-dap.cfg -c "transport select swd" -c init -c "cmsis-dap cmd 128 [0-3]" -c shutdown
+#ifdef STATIC_PINS
+using Swclk0 = Board::A0;
+using Swdio0 = Board::A1;
+using Swclk1 = Board::A2;
+using Swdio1 = Board::A3;
+using Swclk2 = Board::A4;
+using Swdio2 = Board::A5;
+using Swclk3 = Board::A6;
+using Swdio3 = Board::A7;
+
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd)
+{
+	if (swd_port == 0) return modm::dap::cmd<Swclk0>(cmd);
+	if (swd_port == 1) return modm::dap::cmd<Swclk1>(cmd);
+	if (swd_port == 2) return modm::dap::cmd<Swclk2>(cmd);
+	return modm::dap::cmd<Swclk3>(cmd);
+}
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd)
+{
+	if (swd_port == 0)  return modm::dap::cmd<Swdio0>(cmd);
+	if (swd_port == 1)  return modm::dap::cmd<Swdio1>(cmd);
+	if (swd_port == 2)  return modm::dap::cmd<Swdio2>(cmd);
+	return modm::dap::cmd<Swdio3>(cmd);
+}
+#else
+const modm::dap::Pin swclk[4]{
+	modm::dap::Pin::from<Board::A0>(),
+	modm::dap::Pin::from<Board::A2>(),
+	modm::dap::Pin::from<Board::A4>(),
+	modm::dap::Pin::from<Board::A6>(),
+};
+const modm::dap::Pin swdio[4]{
+	modm::dap::Pin::from<Board::A1>(),
+	modm::dap::Pin::from<Board::A3>(),
+	modm::dap::Pin::from<Board::A5>(),
+	modm::dap::Pin::from<Board::A7>(),
+};
+
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd)
+{
+	return swclk[swd_port & 0b11](cmd);
+}
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd)
+{
+	return swdio[swd_port & 0b11](cmd);
+}
+#endif
+
+void DAP_LedConnectedOut(DAP_Command_t cmd) { Board::LedRed::set(cmd); }
+
+extern "C"
+{
+const char*
+tud_string_desc_arr[] =
+{
+	NULL,			// 0: Language
+	"modm",			// 1: Manufacturer
+	"Multi-DAP",	// 2: Product
+	NULL,			// 3: Serials, should use chip ID
+	"CMSIS-DAP v2",	// 4: Interface 0 must contain "CMSIS-DAP"
+};
+}
+
+static uint8_t request_buf[CFG_TUD_VENDOR_RX_BUFSIZE];
+static uint8_t response_buf[CFG_TUD_VENDOR_TX_BUFSIZE];
+
+int main()
+{
+	Board::initialize();
+	DAP_Setup();
+
+	Board::initializeUsb();
+	tusb_init();
+
+	while (true)
+	{
+		tud_task();
+
+		if (tud_vendor_available()) {
+			if (tud_vendor_read(request_buf, sizeof(request_buf)) > 0) {
+				const uint32_t response_size = DAP_ExecuteCommand(request_buf, response_buf);
+				tud_vendor_write(response_buf, (uint16_t)response_size);
+				tud_vendor_write_flush();
+			}
+		}
+		// modm::this_fiber::yield(); when running in a fiber!
+	}
+
+	return 0;
+}
+

--- a/examples/generic/cmsis-dap/project.xml
+++ b/examples/generic/cmsis-dap/project.xml
@@ -1,0 +1,55 @@
+<library>
+  <!-- <extends>modm:blue-pill-f103</extends> -->
+  <!-- <extends>modm:black-pill-f401</extends> -->
+  <!-- <extends>modm:black-pill-f411</extends> -->
+  <!-- <extends>modm:disco-f072rb</extends> -->
+  <!-- <extends>modm:disco-f303vc</extends> -->
+  <!-- <extends>modm:disco-f407vg</extends> -->
+  <!-- <extends>modm:disco-f411ve</extends> -->
+  <!-- <extends>modm:disco-f429zi</extends> -->
+  <!-- <extends>modm:disco-f469ni</extends> -->
+  <!-- <extends>modm:disco-f723ie</extends> -->
+  <!-- <extends>modm:disco-f746ng</extends> -->
+  <!-- <extends>modm:disco-l476vg</extends> -->
+  <!-- <extends>modm:feather-m0</extends> -->
+  <!-- <extends>modm:nucleo-f207zg</extends> -->
+  <!-- <extends>modm:nucleo-f429zi</extends> -->
+  <!-- <extends>modm:nucleo-h723zg</extends> -->
+  <!-- <extends>modm:nucleo-h743zi</extends> -->
+  <!-- <extends>modm:rp-pico</extends> -->
+  <!-- <extends>modm:samd21-mini</extends> -->
+  <!-- <extends>modm:weact-g0b1cb</extends> -->
+  <!-- <extends>modm:weact-u585ci</extends> -->
+  <!-- <extends>modm:nucleo-u575zi-q</extends> -->
+  <!-- <extends>modm:nucleo-h503rb</extends> -->
+  <!-- <extends>modm:nucleo-h533re</extends> -->
+  <extends>modm:nucleo-h563zi</extends>
+  <!-- <extends>modm:weact-h503cb</extends> -->
+  <!-- <extends>modm:weact-h523ce</extends> -->
+  <!-- <extends>modm:weact-h562rg</extends> -->
+  <!-- <extends>modm:nucleo-u385rg-q</extends> -->
+  <!-- <extends>modm:nrf5340-dk</extends> -->
+  <!-- <extends>modm:nrf52840-dk</extends> -->
+  <options>
+    <option name="modm:build:build.path">../../../build/generic/cmsis-dap</option>
+    <option name="modm:tinyusb:config">device.vendor</option>
+
+    <!-- Required for modm:disco-f429zi -->
+    <!-- <option name="modm:tinyusb:device:port">hs</option> -->
+
+    <!-- Required for modm:nucleo-h723zg, modm:disco-f429zi -->
+    <!-- <option name="modm:tinyusb:max-speed">full</option> -->
+  </options>
+  <modules>
+    <module>modm:build:scons</module>
+    <module>modm:tinyusb</module>
+    <module>modm:cmsis:dap</module>
+    <module>modm:processing:timer</module>
+    <module>modm:io</module>
+  </modules>
+  <collectors>
+    <!-- <collect name="modm:build:cppdefines">CFG_TUSB_DEBUG=3</collect> -->
+    <!-- <collect name="modm:build:openocd.source">interface/stlink.cfg</collect> -->
+    <!-- <collect name="modm:build:openocd.source">interface/stlink-dap.cfg</collect> -->
+  </collectors>
+</library>

--- a/ext/arm/DAP_config.h.in
+++ b/ext/arm/DAP_config.h.in
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2013-2021 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        16. June 2021
+ * $Revision:    V2.1.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
+
+#ifndef __DAP_CONFIG_H__
+#define __DAP_CONFIG_H__
+
+//**************************************************************************************************
+
+#include <cmsis/dap.hpp>
+
+#if __has_include(<DAP_config_local.h>)
+#	include <DAP_config_local.h>
+#endif
+
+// See the template in the CMSIS-DAP repository for documentation of the configuration options.
+
+extern uint32_t SystemCoreClock;
+#define CPU_CLOCK               SystemCoreClock
+#define IO_PORT_WRITE_CYCLES    {% if "m0+" in core %}1U{% else %}2U{% endif %}
+
+#ifndef DAP_SWD
+#define DAP_SWD                 1
+#endif
+#ifndef DAP_JTAG
+#define DAP_JTAG                0
+#endif
+#ifndef DAP_DEFAULT_PORT
+#define DAP_DEFAULT_PORT        1U
+#endif
+#ifndef DAP_DEFAULT_SWJ_CLOCK
+#define DAP_DEFAULT_SWJ_CLOCK   1000000U
+#endif
+#ifndef DAP_PACKET_SIZE
+#define DAP_PACKET_SIZE         64U
+#endif
+#ifndef DAP_PACKET_COUNT
+#define DAP_PACKET_COUNT        1U
+#endif
+
+#ifndef TIMESTAMP_CLOCK
+#define TIMESTAMP_CLOCK         1000000U
+#endif
+#ifndef TIMESTAMP_GET
+#define TIMESTAMP_GET()         DAP_GetTimestamp()
+#endif
+
+#define SWO_UART                0
+#define SWO_MANCHESTER          0
+#define SWO_STREAM              0
+#define DAP_UART                0
+#define DAP_UART_USB_COM_PORT   0
+
+#ifndef PIN_SWCLK_TCK_IN
+#define PIN_SWCLK_TCK_IN()      (DAP_PinSwclkTck(DAP_PIN_READ) ? 1u : 0u)
+#endif
+#ifndef PIN_SWCLK_TCK_SET
+#define PIN_SWCLK_TCK_SET()     DAP_PinSwclkTck(DAP_PIN_SET_HIGH)
+#endif
+#ifndef PIN_SWCLK_TCK_CLR
+#define PIN_SWCLK_TCK_CLR()     DAP_PinSwclkTck(DAP_PIN_SET_LOW)
+#endif
+
+#ifndef PIN_SWDIO_TMS_IN
+#define PIN_SWDIO_TMS_IN()      (DAP_PinSwdioTms(DAP_PIN_READ) ? 1u : 0u)
+#endif
+#ifndef PIN_SWDIO_TMS_SET
+#define PIN_SWDIO_TMS_SET()     DAP_PinSwdioTms(DAP_PIN_SET_HIGH)
+#endif
+#ifndef PIN_SWDIO_TMS_CLR
+#define PIN_SWDIO_TMS_CLR()     DAP_PinSwdioTms(DAP_PIN_SET_LOW)
+#endif
+#ifndef PIN_SWDIO_IN
+#define PIN_SWDIO_IN()          (DAP_PinSwdioTms(DAP_PIN_READ) ? 1u : 0u) // Used in SW_DP.c
+#endif
+#ifndef PIN_SWDIO_OUT
+#define PIN_SWDIO_OUT(bit)      DAP_PinSwdioTms((bit) & 1u) // Used in SW_DP.c
+#endif
+#ifndef PIN_SWDIO_OUT_ENABLE
+#define PIN_SWDIO_OUT_ENABLE()  DAP_PinSwdioTms(DAP_PIN_DIR_OUT)
+#endif
+#ifndef PIN_SWDIO_OUT_DISABLE
+#define PIN_SWDIO_OUT_DISABLE() DAP_PinSwdioTms(DAP_PIN_DIR_IN)
+#endif
+
+#ifndef PIN_TDI_IN
+#define PIN_TDI_IN()            (DAP_PinTdi(DAP_PIN_READ) ? 1u : 0u)
+#endif
+#ifndef PIN_TDI_OUT
+#define PIN_TDI_OUT(bit)        DAP_PinTdi((bit) & 1u) // Used in SW_DP.c
+#endif
+
+#ifndef PIN_TDO_IN
+#define PIN_TDO_IN()            (DAP_PinTdo(DAP_PIN_READ) ? 1u : 0u)
+#endif
+
+#ifndef PIN_nTRST_IN
+#define PIN_nTRST_IN()          (DAP_PinnTrst(DAP_PIN_READ) ? 1u : 0u)
+#endif
+#ifndef PIN_nTRST_OUT
+#define PIN_nTRST_OUT(bit)      DAP_PinnTrst((bit) & 1u) // Used in SW_DP.c
+#endif
+
+#ifndef PIN_nRESET_IN
+#define PIN_nRESET_IN()         (DAP_PinnReset(DAP_PIN_READ) ? 1u : 0u)
+#endif
+#ifndef PIN_nRESET_OUT
+#define PIN_nRESET_OUT(bit)     DAP_PinnReset((bit) & 1u) // Used in SW_DP.c
+#endif
+
+#ifndef LED_CONNECTED_OUT
+#define LED_CONNECTED_OUT(bit)  DAP_LedConnectedOut((bit) & 1u) // Used in SW_DP.c
+#endif
+#ifndef LED_RUNNING_OUT
+#define LED_RUNNING_OUT(bit)    DAP_LedRunningOut((bit) & 1u) // Used in SW_DP.c
+#endif
+
+#ifndef PORT_JTAG_SETUP
+#define PORT_JTAG_SETUP()       DAP_Port(DAP_PORT_SETUP_JTAG)
+#endif
+#ifndef PORT_SWD_SETUP
+#define PORT_SWD_SETUP()        DAP_Port(DAP_PORT_SETUP_SWD)
+#endif
+#ifndef PORT_OFF
+#define PORT_OFF()              DAP_Port(DAP_PORT_OFF)
+#endif
+
+#ifndef DAP_SETUP
+#define DAP_SETUP()             // just do it after calling DAP_Setup()
+#endif
+#ifndef RESET_TARGET
+#define RESET_TARGET()          DAP_Reset()
+#endif
+
+#endif /* __DAP_CONFIG_H__ */

--- a/ext/arm/dap.hpp
+++ b/ext/arm/dap.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @ingroup modm_cmsis_dap
+/// @{
+
+// Original functions by DAP.h
+void DAP_Setup(void);
+
+// DAP Vendor Command IDs 0-31
+#define ID_DAP_Vendor(id) (0x80U + (id))
+#ifndef ID_DAP_Invalid
+#define ID_DAP_Invalid 0xFFU
+#endif
+uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response);
+
+uint32_t DAP_ExecuteCommand(const uint8_t *request, uint8_t *response);
+
+// Original functions by DAP config
+uint8_t DAP_GetVendorString(char *str);
+uint8_t DAP_GetProductString(char *str);
+uint8_t DAP_GetSerNumString(char *str);
+uint8_t DAP_GetTargetDeviceVendorString(char *str);
+uint8_t DAP_GetTargetDeviceNameString(char *str);
+uint8_t DAP_GetTargetBoardVendorString(char *str);
+uint8_t DAP_GetTargetBoardNameString(char *str);
+uint8_t DAP_GetProductFirmwareVersionString(char *str);
+uint32_t DAP_GetTimestamp(void);
+
+// Additional functions by modm
+typedef enum
+{
+	DAP_PIN_SET_LOW = 0,
+	DAP_PIN_SET_HIGH = 1,
+	DAP_PIN_READ,
+	DAP_PIN_DIR_OUT,
+	DAP_PIN_DIR_IN,
+
+	DAP_PORT_SETUP_JTAG,
+	DAP_PORT_SETUP_SWD,
+	DAP_PORT_OFF,
+} DAP_Command_t;
+
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd);
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd);
+uint32_t DAP_PinTdi(DAP_Command_t cmd);
+uint32_t DAP_PinTdo(DAP_Command_t cmd);
+uint32_t DAP_PinnTrst(DAP_Command_t cmd);
+uint32_t DAP_PinnReset(DAP_Command_t cmd);
+
+void DAP_LedConnectedOut(DAP_Command_t cmd);
+void DAP_LedRunningOut(DAP_Command_t cmd);
+
+void DAP_Port(DAP_Command_t cmd);
+
+uint8_t DAP_Reset(void);
+
+/// @}
+
+#ifdef __cplusplus
+}
+
+namespace modm::dap
+{
+
+/// @ingroup modm_cmsis_dap
+/// @{
+
+template<typename Pin>
+uint32_t cmd(DAP_Command_t cmd)
+{
+	switch (cmd)
+	{
+		case DAP_PIN_SET_LOW: Pin::reset(); break;
+		case DAP_PIN_SET_HIGH: Pin::set(); break;
+		case DAP_PIN_READ: return Pin::read();
+		case DAP_PIN_DIR_OUT: Pin::setOutput(); break;
+		case DAP_PIN_DIR_IN: Pin::setInput(); break;
+		default: break;
+	}
+	return 0u;
+}
+
+struct Pin
+{
+	void (*set)();
+	void (*reset)();
+	bool (*read)();
+	void (*setOutput)();
+	void (*setInput)();
+
+	template<typename Gpio>
+	static Pin from()
+	{
+		return Pin{
+			.set = &Gpio::set,
+			.reset = &Gpio::reset,
+			.read = &Gpio::read,
+			.setOutput = &Gpio::setOutput,
+			.setInput = &Gpio::setInput};
+	}
+
+	uint32_t operator()(DAP_Command_t cmd) const
+	{
+		switch (cmd)
+		{
+			case DAP_PIN_SET_LOW: reset(); break;
+			case DAP_PIN_SET_HIGH: set(); break;
+			case DAP_PIN_READ: return read();
+			case DAP_PIN_DIR_OUT: setOutput(); break;
+			case DAP_PIN_DIR_IN: setInput(); break;
+			default: break;
+		}
+		return 0u;
+	}
+};
+
+/// @}
+
+} // namespace modm::dap
+
+#endif

--- a/ext/arm/dap.lb
+++ b/ext/arm/dap.lb
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+# =============================================================================
+def init(module):
+    module.name = ":cmsis:dap"
+    module.description = FileReader("dap.md")
+
+
+def prepare(module, options):
+    module.depends(":architecture:clock")
+    return options[":target"].has_driver("core:cortex-m*")
+
+
+def build(env):
+    env.outbasepath = "modm/ext/cmsis/"
+    env.copy("dap.hpp")
+
+    env.outbasepath = "modm/ext/cmsis/dap"
+    env.copy("cmsis-dap/Firmware/Include/DAP.h", "DAP.h")
+    env.copy("cmsis-dap/Firmware/Source/DAP.c", "DAP.c")
+    env.copy("cmsis-dap/Firmware/Source/SW_DP.c", "SW_DP.c")
+    env.copy("cmsis-dap/Firmware/Source/JTAG_DP.c", "JTAG_DP.c")
+
+    env.copy("dap_defaults.cpp")
+    env.substitutions = {
+        "core": env[":target"].get_driver("core")["type"],
+    }
+    env.template("DAP_config.h.in")

--- a/ext/arm/dap.md
+++ b/ext/arm/dap.md
@@ -1,0 +1,213 @@
+# ARM CMSIS-DAP
+
+This module provides the CMSIS-DAP library to implement the SWD and JTAG debug
+protocols and present a CMSIS-DAP interface to OpenOCD or PyOCD via TinyUSB.
+Please [see the API documentation][docs] for protocol-level details.
+
+Note that only the SWD and JTAG protocols are supported, as the UART and SWO
+implementation of CMSIS-DAP depend on the CMSIS-OS2 interface, which modm does
+not provide. These interface need to be reimplemented in native modm in the
+future.
+
+The aim of this project is to make the integration simple at the cost of speed.
+If you need a highly performant debug probe, you should look into using DMA
+accelerated SPI to generate SWD and JTAG waveforms instead of bit banging them.
+
+Since CMSIS-DAP is configured using CPP macros, especially the GPIO functions
+cannot be implemented using the native C++ API. Therefore, all macros are
+collapsed into weakly linked C callback functions.
+The [original configuration API is documented here][config].
+
+## Configuration Hooks
+
+All callback functions are defaulted except SWCLK/TCK and SWDIO/TMS:
+
+```cpp
+// Required pins
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd);
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd);
+// Optional pins
+uint32_t DAP_PinTdi(DAP_Command_t cmd) { return 0u; }
+uint32_t DAP_PinTdo(DAP_Command_t cmd) { return 0u; }
+uint32_t DAP_PinnTrst(DAP_Command_t cmd) { return 1u; }
+uint32_t DAP_PinnReset(DAP_Command_t cmd) { return 1u; }
+// Optional special reset handling
+uint8_t DAP_Reset(void) { return 0u; }
+
+// Optional indicators
+void DAP_LedConnectedOut(DAP_Command_t cmd) {}
+void DAP_LedRunningOut(DAP_Command_t cmd) {}
+
+// Original hooks from CMSIS-DAP
+uint8_t DAP_GetVendorString (char *) { return 0u; }
+uint8_t DAP_GetProductString (char *) { return 0u; }
+uint8_t DAP_GetSerNumString (char *) { return 0u; }
+uint8_t DAP_GetTargetDeviceVendorString (char *) { return 0u; }
+uint8_t DAP_GetTargetDeviceNameString (char *) { return 0u; }
+uint8_t DAP_GetTargetBoardVendorString (char *) { return 0u; }
+uint8_t DAP_GetTargetBoardNameString (char *) { return 0u; }
+uint8_t DAP_GetProductFirmwareVersionString (char *) { return 0u; }
+// Provided by modm using 1µs clock
+uint32_t DAP_GetTimestamp(void);
+// Implemented by modm
+void DAP_Port(DAP_Command_t cmd);
+```
+
+To simplify the GPIO implementation in modm, two adapters are provided.
+For single port operations, where the GPIOs stay the same, a template function
+implements the command dispatch very efficiently:
+
+```cpp
+#include <cmsis/dap.hpp>
+
+using Swclk = Board::A0;
+using Swdio = Board::A1;
+
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd)
+{
+	return modm::dap::cmd<Swclk>(cmd);
+}
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd)
+{
+	return modm::dap::cmd<Swdio>(cmd);
+}
+```
+
+For projects where multiple SWD ports are required, a dynamic command dispatch
+helper struct is available:
+
+```cpp
+const modm::dap::Pin swclk[]{
+	modm::dap::Pin::from<Board::A0>(),
+	modm::dap::Pin::from<Board::A2>(),
+};
+const modm::dap::Pin swdio[]{
+	modm::dap::Pin::from<Board::A1>(),
+	modm::dap::Pin::from<Board::A3>(),
+};
+
+uint32_t DAP_PinSwclkTck(DAP_Command_t cmd)
+{
+	return swclk[swd_port & 0b1](cmd);
+}
+uint32_t DAP_PinSwdioTms(DAP_Command_t cmd)
+{
+	return swdio[swd_port & 0b1](cmd);
+}
+```
+
+To switch ports, use a custom CMSIS-DAP vendor command:
+
+```cpp
+static uint8_t swd_port{0};
+uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response)
+{
+	if (request[0] == ID_DAP_Vendor(0))
+	{
+		DAP_PinSwclkTck(DAP_PIN_DIR_IN);
+		DAP_PinSwdioTms(DAP_PIN_DIR_IN);
+		swd_port = request[1];
+
+		response[0] = ID_DAP_Vendor(0);
+		response[1] = 0;
+		return (2U << 16) | 2U;
+	}
+
+	// Default fallback for unknown vendor commands
+	*response = ID_DAP_Invalid;
+	return ((1U << 16) | 1U);
+}
+```
+
+You can then switch ports from within OpenOCD scripts and the CLI without
+requiring a second USB interface like a serial port to do so:
+
+```sh
+// Port 0
+openocd -f interface/cmsis-dap.cfg -c "transport select swd" -c init -c "cmsis-dap cmd 128 0" -c shutdown
+// Port1
+openocd -f interface/cmsis-dap.cfg -c "transport select swd" -c init -c "cmsis-dap cmd 128 1" -c shutdown
+```
+
+## TinyUSB Configuration
+
+TinyUSB implements the vendor class for CMSIS-DAP natively and is fully
+integrated into modm. The lbuild configuration is as simple as this:
+
+```xml
+<library>
+  <options>
+    <option name="modm:tinyusb:config">device.vendor</option>
+  </options>
+  <modules>
+    <module>modm:tinyusb</module>
+    <module>modm:cmsis:dap</module>
+  </modules>
+</library>
+```
+
+Note that the USB endpoint corresponding to the vendor class must include the
+string `CMSIS-DAP` in its description, the easiest way is to overwrite the
+TinyUSB descriptor array:
+
+```cpp
+extern "C"
+{
+const char*
+tud_string_desc_arr[] =
+{
+	NULL,			// 0: Language
+	"modm",			// 1: Manufacturer
+	"Multi-DAP",	// 2: Product
+	NULL,			// 3: Serials, should use chip ID
+	"CMSIS-DAP v2",	// 4: Interface 0 must contain "CMSIS-DAP"
+};
+}
+```
+
+!!! note "Using multiple endpoints"
+	When using multiple endpoints (for example with a CDC port), you must make
+	sure the description string order is the same as in the lbuild option.
+
+The data interface between TinyUSB and CMSIS-DAP is implemented using just two
+buffers:
+
+```cpp
+static uint8_t request_buf[CFG_TUD_VENDOR_RX_BUFSIZE];
+static uint8_t response_buf[CFG_TUD_VENDOR_TX_BUFSIZE];
+
+int main()
+{
+	Board::initialize();
+	DAP_Setup();
+
+	Board::initializeUsb();
+	tusb_init();
+
+	while (true)
+	{
+		tud_task();
+
+		if (tud_vendor_available()) {
+			if (tud_vendor_read(request_buf, sizeof(request_buf)) > 0) {
+				const uint32_t response_size = DAP_ExecuteCommand(request_buf, response_buf);
+				tud_vendor_write(response_buf, (uint16_t)response_size);
+				tud_vendor_write_flush();
+			}
+		}
+		// modm::this_fiber::yield(); when running in a fiber!
+	}
+
+	return 0;
+}
+```
+
+See `examples/generic/cmsis-dap/main.cpp` for a complete working reference.
+
+!!! warning "DAP Packet Count"
+	`DAP_PACKET_COUNT` is configured to be 1. While this is the least performant
+	setting, higher counts have all had unsolvable reliability issues. So be
+	prepared to debug when increasing this count on USB HS systems for example.
+
+[docs]: https://arm-software.github.io/CMSIS-DAP/latest/
+[config]: https://arm-software.github.io/CMSIS-DAP/latest/group__DAP__ConfigIO__gr.html

--- a/ext/arm/dap_defaults.cpp
+++ b/ext/arm/dap_defaults.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, Niklas Hauser
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <cstring>
+#include <cmsis/dap.hpp>
+#include <modm/architecture/interface/clock.hpp>
+
+modm_weak uint32_t DAP_GetTimestamp(void)
+{
+	return modm::PreciseClock::now().time_since_epoch().count();
+}
+
+modm_weak uint8_t DAP_GetVendorString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetProductString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetSerNumString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetTargetDeviceVendorString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetTargetDeviceNameString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetTargetBoardVendorString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetTargetBoardNameString (char *) { return 0u; }
+modm_weak uint8_t DAP_GetProductFirmwareVersionString (char *) { return 0u; }
+//**************************************************************************************************
+
+modm_weak uint32_t DAP_PinTdi(DAP_Command_t) { return 0u; }
+modm_weak uint32_t DAP_PinTdo(DAP_Command_t) { return 0u; }
+modm_weak uint32_t DAP_PinnTrst(DAP_Command_t) { return 1u; }
+modm_weak uint32_t DAP_PinnReset(DAP_Command_t) { return 1u; }
+
+modm_weak void DAP_LedConnectedOut(DAP_Command_t) {}
+modm_weak void DAP_LedRunningOut(DAP_Command_t) {}
+
+modm_weak uint8_t DAP_Reset(void) { return 0u; }
+
+modm_weak void DAP_Port(DAP_Command_t cmd)
+{
+	if (cmd == DAP_PORT_SETUP_SWD)
+	{
+		DAP_PinTdi(DAP_PIN_DIR_IN);
+		DAP_PinTdo(DAP_PIN_DIR_IN);
+		DAP_PinnTrst(DAP_PIN_DIR_IN);
+
+		DAP_PinSwclkTck(DAP_PIN_SET_LOW);
+		DAP_PinSwdioTms(DAP_PIN_SET_HIGH);
+		DAP_PinnReset(DAP_PIN_SET_HIGH);
+
+		DAP_PinSwclkTck(DAP_PIN_DIR_OUT);
+		DAP_PinSwdioTms(DAP_PIN_DIR_OUT);
+		DAP_PinnReset(DAP_PIN_DIR_OUT);
+	}
+	else if (cmd == DAP_PORT_SETUP_JTAG)
+	{
+		DAP_PinSwclkTck(DAP_PIN_SET_LOW);
+		DAP_PinSwdioTms(DAP_PIN_SET_HIGH);
+		DAP_PinTdi(DAP_PIN_SET_HIGH);
+		DAP_PinnTrst(DAP_PIN_SET_HIGH);
+		DAP_PinnReset(DAP_PIN_SET_HIGH);
+
+		DAP_PinSwclkTck(DAP_PIN_DIR_OUT);
+		DAP_PinSwdioTms(DAP_PIN_DIR_OUT);
+		DAP_PinTdi(DAP_PIN_DIR_OUT);
+		DAP_PinTdo(DAP_PIN_DIR_IN);
+		DAP_PinnTrst(DAP_PIN_DIR_OUT);
+		DAP_PinnReset(DAP_PIN_DIR_OUT);
+	}
+	else if (cmd == DAP_PORT_OFF)
+	{
+		DAP_PinSwclkTck(DAP_PIN_DIR_IN);
+		DAP_PinSwdioTms(DAP_PIN_DIR_IN);
+		DAP_PinTdi(DAP_PIN_DIR_IN);
+		DAP_PinTdo(DAP_PIN_DIR_IN);
+		DAP_PinnTrst(DAP_PIN_DIR_IN);
+		DAP_PinnReset(DAP_PIN_DIR_IN);
+	}
+}
+
+#if __has_include(<tusb.h>)
+#include <tusb.h>
+
+// MS OS 2.0 descriptor set header for TinyUSB. Will be discarded if TinyUSB not used.
+#define MS_OS_20_DESC_LEN 0xA2
+extern "C" {
+const uint8_t desc_ms_os_20[] =
+{
+	// Set header: length, type, windows version, total length
+	U16_TO_U8S_LE(0x000A), U16_TO_U8S_LE(MS_OS_20_SET_HEADER_DESCRIPTOR), U32_TO_U8S_LE(0x06030000), U16_TO_U8S_LE(MS_OS_20_DESC_LEN),
+
+	// MS OS 2.0 Compatible ID descriptor: length, type, compatible ID, sub compatible ID
+	U16_TO_U8S_LE(0x0014), U16_TO_U8S_LE(MS_OS_20_FEATURE_COMPATBLE_ID), 'W', 'I', 'N', 'U', 'S', 'B', 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,// sub-compatible
+
+	// MS OS 2.0 Registry property descriptor: length, type
+	U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A - 0x14), U16_TO_U8S_LE(MS_OS_20_FEATURE_REG_PROPERTY),
+	U16_TO_U8S_LE(0x0007), U16_TO_U8S_LE(0x002A),// wPropertyDataType, wPropertyNameLength and PropertyName "DeviceInterfaceGUIDs\0" in UTF-16
+	'D', 0, 'e', 0, 'v', 0, 'i', 0, 'c', 0, 'e', 0,
+	'I', 0, 'n', 0, 't', 0, 'e', 0, 'r', 0, 'f', 0, 'a', 0, 'c', 0, 'e', 0,
+	'G', 0, 'U', 0, 'I', 0, 'D', 0, 's', 0, 0, 0,
+	U16_TO_U8S_LE(0x0050),// wPropertyDataLength
+	//bPropertyData: {CDB3B5AD-293B-4663-AA36-1AAE46463776}.
+	'{', 0, 'C', 0, 'D', 0, 'B', 0, '3', 0, 'B', 0, '5', 0, 'A', 0, 'D', 0, '-', 0,
+	'2', 0, '9', 0, '3', 0, 'B', 0, '-', 0, '4', 0, '6', 0, '6', 0, '3', 0, '-', 0,
+	'A', 0, 'A', 0, '3', 0, '6', 0, '-', 0, '1', 0, 'A', 0, 'A', 0, 'E', 0, '4', 0,
+	'6', 0, '4', 0, '6', 0, '3', 0, '7', 0, '7', 0, '6', 0, '}', 0, 0, 0, 0, 0
+};
+}
+
+#endif

--- a/ext/hathach/tusb_descriptors.c.in
+++ b/ext/hathach/tusb_descriptors.c.in
@@ -193,7 +193,108 @@ tud_descriptor_other_speed_configuration_cb(uint8_t index)
 }
 
 %% endif
-//
+
+
+//--------------------------------------------------------------------+
+// BOS Descriptor
+//--------------------------------------------------------------------+
+
+/* Microsoft OS 2.0 registry property descriptor
+  Per MS requirements https://msdn.microsoft.com/en-us/library/windows/hardware/hh450799(v=vs.85).aspx
+  device should create DeviceInterfaceGUIDs. It can be done by driver and
+  in case of real PnP solution device should expose MS "Microsoft OS 2.0
+  registry property descriptor". Such descriptor can insert any record
+  into Windows registry per device/configuration/interface. In our case it
+  will insert "DeviceInterfaceGUIDs" multistring property.
+  GUID is freshly generated and should be OK to use.
+  https://developers.google.com/web/fundamentals/native-hardware/build-for-webusb/
+  (Section Microsoft OS compatibility descriptors)
+*/
+
+#define BOS_TOTAL_LEN (TUD_BOS_DESC_LEN + TUD_BOS_MICROSOFT_OS_DESC_LEN)
+#define MS_OS_20_DESC_LEN 0xA2
+#define VENDOR_REQUEST_MICROSOFT 1
+
+// BOS Descriptor is required for webUSB
+modm_weak const uint8_t desc_bos[] =
+{
+	// total length, number of device caps
+	TUD_BOS_DESCRIPTOR(BOS_TOTAL_LEN, 1),
+
+	// Microsoft OS 2.0 descriptor
+	TUD_BOS_MS_OS_20_DESCRIPTOR(MS_OS_20_DESC_LEN, 1)
+};
+
+const uint8_t *tud_descriptor_bos_cb(void) {
+  return desc_bos;
+}
+
+modm_weak const uint8_t desc_ms_os_20[] =
+{
+	// Set header: length, type, windows version, total length
+	U16_TO_U8S_LE(0x000A), U16_TO_U8S_LE(MS_OS_20_SET_HEADER_DESCRIPTOR), U32_TO_U8S_LE(0x06030000), U16_TO_U8S_LE(MS_OS_20_DESC_LEN),
+
+	// MS OS 2.0 Compatible ID descriptor: length, type, compatible ID, sub compatible ID
+	U16_TO_U8S_LE(0x0014), U16_TO_U8S_LE(MS_OS_20_FEATURE_COMPATBLE_ID), 'W', 'I', 'N', 'U', 'S', 'B', 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,// sub-compatible
+
+	// MS OS 2.0 Registry property descriptor: length, type
+	U16_TO_U8S_LE(MS_OS_20_DESC_LEN - 0x0A - 0x14), U16_TO_U8S_LE(MS_OS_20_FEATURE_REG_PROPERTY),
+	U16_TO_U8S_LE(0x0007), U16_TO_U8S_LE(0x002A),// wPropertyDataType, wPropertyNameLength and PropertyName "DeviceInterfaceGUIDs\0" in UTF-16
+	'D', 0x00, 'e', 0x00, 'v', 0x00, 'i', 0x00, 'c', 0x00, 'e', 0x00, 'I', 0x00, 'n', 0x00, 't', 0x00, 'e', 0x00,
+	'r', 0x00, 'f', 0x00, 'a', 0x00, 'c', 0x00, 'e', 0x00, 'G', 0x00, 'U', 0x00, 'I', 0x00, 'D', 0x00, 's', 0x00, 0x00, 0x00,
+	U16_TO_U8S_LE(0x0050),// wPropertyDataLength
+	//bPropertyData: {F7CC2C68-3B14-4D72-B876-1A981AD2C9E5}.
+	'{', 0x00, 'F', 0x00, '7', 0x00, 'C', 0x00, 'C', 0x00, '2', 0x00, 'C', 0x00, '6', 0x00, '8', 0x00, '-', 0x00,
+	'3', 0x00, 'B', 0x00, '1', 0x00, '4', 0x00, '-', 0x00, '4', 0x00, 'D', 0x00, '7', 0x00, '2', 0x00, '-', 0x00,
+	'B', 0x00, '8', 0x00, '7', 0x00, '6', 0x00, '-', 0x00, '1', 0x00, 'A', 0x00, '9', 0x00, '8', 0x00, '1', 0x00,
+	'A', 0x00, 'D', 0x00, '2', 0x00, 'C', 0x00, '9', 0x00, 'E', 0x00, '5', 0x00, '}', 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "Incorrect size");
+
+// Invoked when a control transfer occurred on an interface of this class
+// Driver response accordingly to the request and the transfer stage (setup/data/ack)
+// return false to stall control endpoint (e.g unsupported request)
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const *request) {
+  // nothing to with DATA & ACK stage
+  if (stage != CONTROL_STAGE_SETUP) {
+    return true;
+  }
+
+  if (request->bmRequestType_bit.type == TUSB_REQ_TYPE_VENDOR) {
+    if (request->bRequest == VENDOR_REQUEST_MICROSOFT) {
+      if (request->wIndex == 7) {
+        return tud_control_xfer(rhport, request, (void *)(uintptr_t)desc_ms_os_20, MS_OS_20_DESC_LEN);
+      } else {
+        return false;
+      }
+    }
+  }
+
+  switch (request->bmRequestType_bit.type) {
+    case TUSB_REQ_TYPE_VENDOR:
+      switch (request->bRequest) {
+        case VENDOR_REQUEST_MICROSOFT:
+          if (request->wIndex == 7) {
+            return tud_control_xfer(rhport, request, (void *) (uintptr_t) desc_ms_os_20, MS_OS_20_DESC_LEN);
+          } else {
+            return false;
+          }
+
+        default:
+          break;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  // stall unknown request
+  return false;
+}
+
 //--------------------------------------------------------------------+
 // String Descriptors
 //--------------------------------------------------------------------+


### PR DESCRIPTION
STLinkv3-MINIEs are out of stock everywhere, time to build our own. (I'm joking, but this is still useful).

- [x] Added cmsis-dap partial submodule
- [x] Configuration helper with sensive defaults
- [x] Condensed the pin macro hell to use weakly linked functions. No other way to use C++ code.
- [x] DAP UART and SWO support depends on CMSIS-Driver and CMSIS-OS2 APIs, neither of which we support or plan to.
- [x] Extensive testing in hardware on more boards.
- [x] Implement custom command to switch to a different pair of pins to allow multiple SWD connections in one probe.
- [x] Documentation