### PR TITLE
[RP] RP2040 Flash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Please [discover modm's peripheral drivers for your specific device][discover].
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>
-<td align="center">✕</td>
+<td align="center">✅</td>
 <td align="center">○</td>
 <td align="center">○</td>
 <td align="center">○</td>

--- a/examples/rp_pico/flash/main.cpp
+++ b/examples/rp_pico/flash/main.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026, Andrey Kunitsyn
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <modm/board.hpp>
+#include <modm/platform/flash/flash.hpp>
+
+extern "C" void
+putchar_(char c)
+{ UsbUart0::write(uint8_t(c)); }
+
+using Flash = modm::platform::Flash;
+
+// Standard Read JEDEC ID instruction: 9Fh command prefix, 24 data bits.
+static constexpr uint8_t FLASH_RDID_CMD = 0x9F;
+static constexpr size_t FLASH_RDID_DATA_BYTES = 3;
+static constexpr size_t FLASH_RDID_TOTAL_BYTES = (1 + FLASH_RDID_DATA_BYTES);
+
+static uint64_t capacity = 0;
+
+static uint32_t
+read_jedec_id()
+{
+	uint8_t tx[FLASH_RDID_TOTAL_BYTES] = {FLASH_RDID_CMD, 0x00, 0x00, 0x00};
+	uint8_t rx[FLASH_RDID_TOTAL_BYTES];
+	Flash::doCmd(tx, rx, FLASH_RDID_TOTAL_BYTES);
+	return (uint32_t(rx[1]) << 16) | (uint32_t(rx[2]) << 8) | rx[3];
+}
+
+static void
+decode_jedec_id(uint32_t jedec_id)
+{
+
+	if (jedec_id == 0x1F8901)
+	{
+		printf("Found AT25SF128A (16M)\n");
+	} else if (jedec_id == 0x9D6014)
+	{
+		printf("Found IS25LP080D (8M)\n");
+	} else if (jedec_id == 0xEF5014)
+	{
+		printf("Found W25Q80 (1M)\n");
+	} else if (jedec_id == 0xEF3011)
+	{
+		printf("Found W25X10CL (128K)\n");
+	} else if (jedec_id == 0x684015)
+	{
+		printf("Found BY25Q16BS (2M)\n");
+	} else if (jedec_id == 0x5e4016)
+	{
+		printf("Found ZB25VQ32 (4M)\n");
+	} else if (jedec_id == 0xef4015)
+	{
+		printf("Found W25Q16DV (2M)\n");
+	} else
+	{
+		printf("JEDEC code : 0x%06lx\n", jedec_id);
+	}
+	tud_task();
+	uint8_t id3 = jedec_id & 0xFF;
+	if (id3 >= 0x10 && id3 <= 0x20)
+	{
+		capacity = 1llu << id3;
+		if (capacity >= (1024 * 1024))
+		{
+			printf("Decoded Size:  %ld MB\n", uint32_t(capacity / (1024 * 1024)));
+		} else
+		{
+			printf("Decoded Size:  %ld kB\n", uint32_t(capacity / 1024));
+		}
+	} else
+	{
+		printf("Decoded Size:    Unknown / Non-standard\n");
+	}
+	tud_task();
+}
+
+static size_t
+get_sector()
+{
+	// use last sector
+	return size_t(capacity / Flash::SectorSize) - 1;
+}
+
+static size_t
+get_page()
+{
+	// use first page of last sector
+	return size_t(capacity / Flash::PageSize) - (Flash::SectorSize / Flash::PageSize);
+}
+
+static void
+dump_page()
+{
+	printf("\n");
+	const uint8_t* data =
+		reinterpret_cast<const uint8_t*>(0x10000000) + get_page() * Flash::PageSize;
+	for (size_t i = 0; i < Flash::PageSize; ++i)
+	{
+		printf("%02x ", data[i]);
+		if ((i + 1) % 16 == 0) tud_task();
+		if ((i + 1) % 32 == 0) printf("\n");
+	}
+}
+
+static void
+erase_sector()
+{
+	auto s = get_sector();
+	printf("\nErasing sector %x\n", s);
+	Flash::eraseSectors(s, 1);
+	printf("\nDone\n");
+}
+
+static uint8_t data[Flash::PageSize];
+static void
+program_page()
+{
+	for (size_t i = 0; i < Flash::PageSize; ++i) { data[i] = i; }
+	auto p = get_page();
+	printf("\nProgramming page %x\n", p);
+	Flash::programPages(p, data, 1);
+	printf("\nDone\n");
+}
+
+int
+main()
+{
+	Board::initialize();
+	Board::initializeUsb();
+	tusb_init();
+
+	bool cdc_connected = false;
+
+	while (true)
+	{
+		if (!cdc_connected && tud_cdc_n_connected(0))
+		{
+			cdc_connected = true;
+
+			auto jedec_id = read_jedec_id();
+			decode_jedec_id(jedec_id);
+			tud_task();
+
+			auto id = Flash::getUniqueId();
+			printf("Flash unique id: 0x%08lx%08lx\n", uint32_t(id >> 32),
+				   uint32_t(id & 0xffffffff));
+			tud_task();
+			if (capacity)
+			{
+				printf("'p' - dump page\n");
+				tud_task();
+				printf("'e' - erase sector\n");
+				tud_task();
+				printf("'w' - program page\n");
+				tud_task();
+			}
+
+		} else if (!tud_cdc_n_connected(0))
+		{
+			cdc_connected = false;
+		}
+
+		if (cdc_connected && capacity)
+		{
+			auto ch = tud_cdc_n_read_char(0);
+			if (ch == 'p' || ch == 'P')
+			{
+				dump_page();
+			} else if (ch == 'e' || ch == 'E')
+			{
+				erase_sector();
+			} else if (ch == 'w' || ch == 'W')
+			{
+				program_page();
+			}
+		}
+
+		tud_task();
+	}
+
+	return 0;
+}

--- a/examples/rp_pico/flash/project.xml
+++ b/examples/rp_pico/flash/project.xml
@@ -1,0 +1,16 @@
+<library>
+  <extends>modm:rp-pico</extends>
+  <options>
+    <option name="modm:build:build.path">../../../build/rp_pico/flash</option>
+    <option name="modm:tinyusb:config">device.cdc</option>
+  </options>
+  <modules>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:dma</module>
+    <module>modm:platform:spi:0</module>
+    <module>modm:platform:flash</module>
+    <module>modm:tinyusb</module>
+    <module>modm:printf</module>
+    <module>modm:build:scons</module>
+  </modules>
+</library>

--- a/src/modm/platform/core/rp/module.lb
+++ b/src/modm/platform/core/rp/module.lb
@@ -62,12 +62,15 @@ def build(env):
         "loop": tuning[0],
         "shift": int(math.log2(tuning[1])),
         "us_shift": us_shift,
-        "with_assert": env.has_module(":architecture:assert")
+        "with_assert": env.has_module(":architecture:assert"),
+        "family": target.family
     })
     env.template("../cortex/delay_ns.cpp.in", "delay_ns.cpp")
     env.template("../cortex/delay_ns.hpp.in", "delay_ns.hpp")
     env.template("../cortex/delay_impl.hpp.in", "delay_impl.hpp")
     env.copy("resets.hpp")
+    if target.family == "20":
+        env.copy("rom.hpp")
 
     env.copy(repopath("ext/rp/pico-sdk/src/boot2_{}.cpp".format(env["boot2"])),"boot2.cpp")
 

--- a/src/modm/platform/core/rp/rom.hpp
+++ b/src/modm/platform/core/rp/rom.hpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, Andrey Kunitsyn
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+#pragma once
+
+#include <modm/platform/device.hpp>
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_core
+/**
+ * Give access to functions from masked ROM
+ */
+struct ROM
+{
+
+
+	static constexpr uint16_t FuncTableOffset = 0x0014;
+	static constexpr uint16_t TableLookupOffset = 0x0018;
+
+	using TableLookupFn = void *(*)(const uint16_t *table, uint32_t code);
+	static modm_always_inline void *
+	getRomPtr(uint16_t romAddress)
+	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+		return reinterpret_cast<void *>(*reinterpret_cast<const uint16_t *>(romAddress));
+#pragma GCC diagnostic pop
+	}
+	template<uint8_t c1, uint8_t c2, typename Signature>
+	struct Func
+	{
+		static constexpr uint32_t Code = uint32_t(c1) | (uint32_t(c2) << 8);
+		using Prot = Signature;
+		static modm_always_inline Signature
+		get()
+		{
+			auto lookup = reinterpret_cast<TableLookupFn>(getRomPtr(TableLookupOffset));
+			auto table = static_cast<const uint16_t *>(getRomPtr(FuncTableOffset));
+			return reinterpret_cast<Signature>(lookup(table, Code));
+		}
+	};
+
+	// Common
+
+	/**
+	 * void _connect_internal_flash(void)
+	 * Restore all QSPI pad controls to their default state, and connect the SSI to the QSPI pads
+	 */
+	using connect_internal_flash = Func<'I', 'F', void (*)(void)>;
+
+	/**
+	 * void _flash_exit_xip(void)
+	 * First set up the SSI for serial-mode operations, then issue the fixed XIP exit sequence
+	 * described in Section 2.8.1.2. Note that the bootrom code uses the IO forcing logic to drive
+	 * the CS pin, which must be cleared before returning the SSI to XIP mode (e.g. by a call to
+	 * _flash_flush_cache). This function configures the SSI with a fixed SCK clock divisor of /6.
+	 */
+	using flash_exit_xip = Func<'E', 'X', void (*)(void)>;
+
+	/**
+	 * void _flash_range_erase(uint32_t addr, size_t count, uint32_t block_size, uint8_t block_cmd)
+	 * Erase a count bytes, starting at addr (offset from start of flash). Optionally, pass a block
+	 * erase command e.g. D8h block erase, and the size of the block erased by this command — this
+	 * function will use the larger block erase where possible, for much higher erase speed. addr
+	 * must be aligned to a 4096-byte sector, and count must be a multiple of 4096 bytes.
+	 */
+	using flash_range_erase = Func<'R', 'E', void (*)(uint32_t, size_t, uint32_t, uint8_t)>;
+
+	/**
+	 * void _flash_range_program(uint32_t addr, const uint8_t *data, size_t count)
+	 * Program data to a range of flash addresses starting at addr (offset from the start of flash)
+	 * and count bytes in size. addr must be aligned to a 256-byte boundary, and count must be a
+	 * multiple of 256.
+	 */
+	using flash_range_program = Func<'R', 'P', void (*)(uint32_t, const uint8_t *, size_t)>;
+
+	/**
+	 * void _flash_flush_cache(void)
+	 * Flush and enable the XIP cache. Also clears the IO forcing on QSPI CSn, so that the SSI can
+	 * drive the flash chip select as normal.
+	 */
+	using flash_flush_cache = Func<'F', 'C', void (*)(void)>;
+
+	/**
+	 * void _flash_enter_cmd_xip(void)
+	 * Configure the SSI to generate a standard 03h serial read command, with 24 address bits, upon
+	 * each XIP access. This is a very slow XIP configuration, but is very widely supported. The
+	 * debugger calls this function after performing a flash erase/programming operation, so that
+	 * the freshly-programmed code and data is visible to the debug host, without having to know
+	 * exactly what kind of flash device is connected.
+	 */
+	using flash_enter_cmd_xip = Func<'C', 'X', void (*)(void)>;
+
+	// RP2040 specific
+
+	/**
+	 * uint32_t _popcount32(uint32_t value)
+	 * Return a count of the number of 1 bits in value.
+	 */
+	using popcount32 = Func<'P', '3', uint32_t (*)(uint32_t)>;
+
+	/**
+	 * uint32_t _reverse32(uint32_t value)
+	 * Return the bits of value in the reverse order.
+	 */
+	using reverse32 = Func<'R', '3', uint32_t (*)(uint32_t)>;
+
+	/**
+	 * uint32_t _clz32(uint32_t value)
+	 * Return the number of consecutive high order 0 bits of value. If value is zero, returns 32.
+	 */
+	using clz32 = Func<'L', '3', uint32_t (*)(uint32_t)>;
+
+	/**
+	 * uint32_t _ctz32(uint32_t value)
+	 * Return the number of consecutive low order 0 bits of value. If value is zero, returns 32.
+	 */
+	using ctz32 = Func<'T', '3', uint32_t (*)(uint32_t)>;
+
+	/**
+	 * uint8_t *_memset(uint8_t *ptr, uint8_t c, uint32_t n)
+	 * Sets n bytes start at ptr to the value c and returns ptr.
+	 */
+	using memset = Func<'M', 'S', uint8_t *(*)(uint8_t *, uint8_t, uint32_t)>;
+
+	/**
+	 * uint32_t *_memset4(uint32_t *ptr, uint8_t c, uint32_t n)
+	 * Sets n bytes start at ptr to the value c and returns ptr. Note this is a slightly more
+	 * efficient variant of _memset that may only be used if ptr is word aligned.
+	 */
+	using memset4 = Func<'S', '4', uint32_t *(*)(uint32_t *, uint8_t, uint32_t)>;
+
+	/**
+	 * uint8_t *_memcpy(uint8_t *dest, uint8_t *src, uint32_t n)
+	 * Copies n bytes starting at src to dest and returns dest. The results are undefined if the
+	 * regions overlap.
+	 */
+	using memcpy = Func<'M', 'C', uint32_t *(*)(uint8_t *, const uint8_t *, uint32_t)>;
+
+	/**
+	 * uint8_t *_memcpy44(uint32_t *dest, uint32_t *src, uint32_t n)
+	 * Copies n bytes starting at src to dest and returns dest. The results are undefined if the
+	 * regions overlap. Note this is a slightly more efficient variant of _memcpy that may only be
+	 * used if dest and src are word aligned.
+	 */
+	using memcpy44 = Func<'C', '4', uint32_t *(*)(uint32_t *, const uint32_t *, uint32_t)>;
+
+	/**
+	 * void _reset_to_usb_boot(uint32_t gpio_activity_pin_mask, uint32_t disable_interface_mask)
+	 * Resets the RP2040 and uses the watchdog facility to re-start in BOOTSEL mode:
+	 * gpio_activity_pin_mask is provided to enable an "activity light" via GPIO attached LED for
+	 * the USB Mass Storage Device:
+	 * - 0 No pins are used as per a cold boot.
+	 * - Otherwise a single bit set indicating which GPIO pin should be set to output and raised
+	 * whenever there is mass storage activity from the host.
+	 * disable_interface_mask may be used to control the exposed USB interfaces:
+	 * - 0 To enable both interfaces (as per a cold boot)
+	 * - 1 To disable the USB Mass Storage Interface (see Section 2.8.4)
+	 * - 2 To disable the USB PICOBOOT Interface (see Section 2.8.5)
+	 */
+	using reset_to_usb_boot = Func<'U', 'B', void (*)(uint32_t, uint32_t)>;
+
+};
+
+}  // namespace modm::platform

--- a/src/modm/platform/flash/rp/flash.cpp
+++ b/src/modm/platform/flash/rp/flash.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026, Andrey Kunitsyn
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include "flash.hpp"
+
+#include <hardware/regs/io_qspi.h>
+#include <hardware/regs/ssi.h>
+#include <hardware/structs/ioqspi.h>
+#include <hardware/structs/pads_qspi.h>
+#include <hardware/structs/ssi.h>
+
+#include <modm/platform/core/rom.hpp>
+
+namespace modm::platform
+{
+
+// code proted from
+// https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_flash/flash.c
+
+static constexpr size_t FLASH_UNIQUE_ID_SIZE_BYTES = 8;
+
+static constexpr uint8_t FLASH_BLOCK_ERASE_CMD = 0xd8;
+static constexpr uint8_t FLASH_SECTOR_ERASE_CMD = 0x20;
+// Standard RUID instruction: 4Bh command prefix, 32 dummy bits, 64 data bits.
+static constexpr uint8_t FLASH_RUID_CMD = 0x4b;
+static constexpr size_t FLASH_RUID_DUMMY_BYTES = 4;
+static constexpr size_t FLASH_RUID_DATA_BYTES = FLASH_UNIQUE_ID_SIZE_BYTES;
+static constexpr size_t FLASH_RUID_TOTAL_BYTES =
+	(1 + FLASH_RUID_DUMMY_BYTES + FLASH_RUID_DATA_BYTES);
+
+static constexpr size_t BOOT2_SIZE_WORDS = 64;
+
+static uint32_t boot2_copyout[BOOT2_SIZE_WORDS];
+static bool boot2_copyout_valid = false;
+
+struct flash_hardware_save_state_t
+{
+	uint32_t qspi_pads[NUM_QSPI_GPIOS];
+};
+
+
+modm_ramcode static void
+flash_init_boot2_copyout(void)
+{
+	if (boot2_copyout_valid) return;
+	// todo we may want the option of boot2 just being a free function in
+	//      user RAM, e.g. if it is larger than 256 bytes
+	const volatile uint32_t *copy_from = reinterpret_cast<uint32_t *>(XIP_BASE);
+	for (size_t i = 0; i < BOOT2_SIZE_WORDS; ++i) boot2_copyout[i] = copy_from[i];
+	asm inline("" ::: "memory");
+	boot2_copyout_valid = true;
+}
+
+modm_ramcode static void
+flash_enable_xip_via_boot2(void)
+{ ((void (*)(void))((intptr_t)boot2_copyout + 1))(); }
+
+modm_ramcode static void
+flash_save_hardware_state(flash_hardware_save_state_t *state)
+{
+	for (size_t i = 0; i < NUM_QSPI_GPIOS; ++i) { state->qspi_pads[i] = pads_qspi_hw->io[i]; }
+}
+
+modm_ramcode static void
+flash_restore_hardware_state(flash_hardware_save_state_t *state)
+{
+	for (size_t i = 0; i < NUM_QSPI_GPIOS; ++i) { pads_qspi_hw->io[i] = state->qspi_pads[i]; }
+}
+
+modm_ramcode static void
+flash_cs_force(bool high)
+{
+	uint32_t field_val = high ? IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_VALUE_HIGH
+							  : IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_VALUE_LOW;
+	hw_write_masked(&ioqspi_hw->io[1].ctrl, field_val << IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_LSB,
+					IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_BITS);
+}
+
+modm_ramcode void
+Flash::eraseBlocks(size_t startBlock, size_t count)
+{
+	auto connect_internal_flash_func = ROM::connect_internal_flash::get();
+	auto flash_exit_xip_func = ROM::flash_exit_xip::get();
+	auto flash_range_erase_func = ROM::flash_range_erase::get();
+	auto flash_flush_cache_func = ROM::flash_flush_cache::get();
+
+	flash_init_boot2_copyout();
+	flash_hardware_save_state_t state;
+	flash_save_hardware_state(&state);
+
+	// No flash accesses after this point
+	asm inline("" ::: "memory");
+
+	connect_internal_flash_func();
+	flash_exit_xip_func();
+	flash_range_erase_func(startBlock * BlockSize, count * BlockSize, BlockSize,
+						   FLASH_BLOCK_ERASE_CMD);
+	flash_flush_cache_func();
+	flash_enable_xip_via_boot2();
+	flash_restore_hardware_state(&state);
+}
+
+modm_ramcode void
+Flash::eraseSectors(size_t startSertor, size_t count)
+{
+	auto connect_internal_flash_func = ROM::connect_internal_flash::get();
+	auto flash_exit_xip_func = ROM::flash_exit_xip::get();
+	auto flash_range_erase_func = ROM::flash_range_erase::get();
+	auto flash_flush_cache_func = ROM::flash_flush_cache::get();
+
+	flash_init_boot2_copyout();
+	flash_hardware_save_state_t state;
+	flash_save_hardware_state(&state);
+
+	// No flash accesses after this point
+	asm inline("" ::: "memory");
+
+	connect_internal_flash_func();
+	flash_exit_xip_func();
+	flash_range_erase_func(startSertor * SectorSize, count * SectorSize, SectorSize,
+						   FLASH_SECTOR_ERASE_CMD);
+	flash_flush_cache_func();
+	flash_enable_xip_via_boot2();
+	flash_restore_hardware_state(&state);
+}
+
+modm_ramcode void
+Flash::programPages(size_t startPage, const void *data, size_t count)
+{
+	auto connect_internal_flash_func = ROM::connect_internal_flash::get();
+	auto flash_exit_xip_func = ROM::flash_exit_xip::get();
+	auto flash_range_program_func = ROM::flash_range_program::get();
+	auto flash_flush_cache_func = ROM::flash_flush_cache::get();
+
+	flash_init_boot2_copyout();
+	flash_hardware_save_state_t state;
+	flash_save_hardware_state(&state);
+
+	asm inline("" ::: "memory");
+
+	connect_internal_flash_func();
+	flash_exit_xip_func();
+	flash_range_program_func(startPage * PageSize, static_cast<const uint8_t *>(data),
+							 count * PageSize);
+	flash_flush_cache_func();  // Note this is needed to remove CSn IO force as well as cache
+							   // flushing
+	flash_enable_xip_via_boot2();
+
+	flash_restore_hardware_state(&state);
+}
+
+modm_ramcode void
+Flash::doCmd(const void *txData, void *rxData, size_t count)
+{
+	auto connect_internal_flash_func = ROM::connect_internal_flash::get();
+	auto flash_exit_xip_func = ROM::flash_exit_xip::get();
+	auto flash_flush_cache_func = ROM::flash_flush_cache::get();
+
+	flash_init_boot2_copyout();
+	flash_hardware_save_state_t state;
+	flash_save_hardware_state(&state);
+
+	asm inline("" ::: "memory");
+	connect_internal_flash_func();
+	flash_exit_xip_func();
+
+	flash_cs_force(false);
+	size_t tx_remaining = count;
+	size_t rx_remaining = count;
+
+	const uint8_t *txbuf = static_cast<const uint8_t *>(txData);
+	uint8_t *rxbuf = static_cast<uint8_t *>(rxData);
+
+	// Synopsys SSI version
+	// We may be interrupted -- don't want FIFO to overflow if we're distracted.
+	const size_t max_in_flight = 16 - 2;
+	while (tx_remaining || rx_remaining)
+	{
+		uint32_t flags = ssi_hw->sr;
+		bool can_put = flags & SSI_SR_TFNF_BITS;
+		bool can_get = flags & SSI_SR_RFNE_BITS;
+		if (can_put && tx_remaining && rx_remaining - tx_remaining < max_in_flight)
+		{
+			ssi_hw->dr0 = *txbuf++;
+			--tx_remaining;
+		}
+		if (can_get && rx_remaining)
+		{
+			*rxbuf++ = (uint8_t)ssi_hw->dr0;
+			--rx_remaining;
+		}
+	}
+	flash_cs_force(true);
+
+	flash_flush_cache_func();
+	flash_enable_xip_via_boot2();
+	flash_restore_hardware_state(&state);
+}
+
+modm_ramcode void
+Flash::flush()
+{
+	auto func = ROM::flash_flush_cache::get();
+	func();
+}
+
+uint64_t
+Flash::getUniqueId()
+{
+	union {
+		uint64_t id;
+		uint8_t d[FLASH_RUID_DATA_BYTES];
+	} id_out;
+	uint8_t txbuf[FLASH_RUID_TOTAL_BYTES] = {0};
+	uint8_t rxbuf[FLASH_RUID_TOTAL_BYTES] = {0};
+	txbuf[0] = FLASH_RUID_CMD;
+	doCmd(txbuf, rxbuf, FLASH_RUID_TOTAL_BYTES);
+	for (size_t i = 0; i < FLASH_RUID_DATA_BYTES; i++)
+		id_out.d[i] = rxbuf[i + 1 + FLASH_RUID_DUMMY_BYTES];
+	return id_out.id;
+}
+
+}  // namespace modm::platform

--- a/src/modm/platform/flash/rp/flash.hpp
+++ b/src/modm/platform/flash/rp/flash.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Andrey Kunitsyn
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <cstring>
+
+#include "../device.hpp"
+
+namespace modm::platform
+{
+
+/// @ingroup modm_platform_flash
+class Flash
+{
+public:
+	static constexpr size_t BlockSize = 0x10000;
+	static constexpr size_t SectorSize = 0x1000;
+	static constexpr size_t PageSize = 0x100;
+
+	static void
+	eraseBlocks(size_t startBlock, size_t count);
+	static void
+	eraseSectors(size_t startSertor, size_t count);
+
+	static void
+	programPages(size_t startPage, const void *data, size_t count);
+
+	static uint64_t
+	getUniqueId();
+
+	static void
+	doCmd(const void *txbuf, void *rxbuf, size_t count);
+
+	static void
+	flush();
+};
+
+}  // namespace modm::platform

--- a/src/modm/platform/flash/rp/module.lb
+++ b/src/modm/platform/flash/rp/module.lb
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2026 Andrey Kunitsyn
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# -----------------------------------------------------------------------------
+
+def init(module):
+    module.name = ":platform:flash"
+    module.description = "Flash Memory"
+
+def prepare(module, options):
+    device = options[":target"]
+    if device.identifier.platform != "rp" or device.identifier.family != "20":
+        return False
+
+    module.depends(":cmsis:device", ":platform:core",
+                   ":architecture:register")
+    return True
+
+def build(env):
+    target = env[":target"].identifier
+
+    env.outbasepath = "modm/src/modm/platform/flash"
+    env.copy("flash.hpp")
+    env.copy("flash.cpp")


### PR DESCRIPTION
Added access to masked ROM functions.
Added functionality for in program flash access.
Example for working with flash.

Because XIP must be disabled to perform flash operations, any code interacting with the flash cannot reside within the flash memory itself. Utilizing functions from ROM allows for a reduction in RAM consumption by this functionality.