### PR TITLE
[stm32] Fix STM32H5 32-bit timer counter size

### DIFF
--- a/src/modm/platform/timer/stm32/general_purpose.hpp.in
+++ b/src/modm/platform/timer/stm32/general_purpose.hpp.in
@@ -110,7 +110,7 @@ public:
 	};
 
 	// This type is the internal size of the counter.
-%% if id in [2, 5, 23, 24] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4", "g4", "h7"])
+%% if id in [2, 5, 23, 24] and (target["family"] in ["f2", "f3", "f4", "f7", "l1", "l4", "g4", "h7", "h5"])
 	// Timer 2, 5, 23 and 24 are the only ones which have a 32 bit counter
 	using Value = uint32_t;
 


### PR DESCRIPTION
TIM2 and TIM5 are 32-bit timers on STM32H5, but `general_purpose.hpp.in` omitted `"h5"` from the family whitelist used to select `TimerN::Value`.

- [x] Tested on NUCLEO-H563ZI